### PR TITLE
Move upkeep costs to RTD

### DIFF
--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -110,100 +110,6 @@
 #include <iterator>
 
 // clang-format off
-const UpkeepCosts UpkeepCostsDescriptor[RIDE_TYPE_COUNT] = {
-    {    41,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_SPIRAL_ROLLER_COASTER          
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_STAND_UP_ROLLER_COASTER        
-    {    40,    20,   80,   20,   3,   10,     }, // RIDE_TYPE_SUSPENDED_SWINGING_COASTER     
-    {    40,    20,   80,   13,   3,   10,     }, // RIDE_TYPE_INVERTED_ROLLER_COASTER        
-    {    40,    20,   80,   8,    3,   5,      }, // RIDE_TYPE_JUNIOR_ROLLER_COASTER          
-    {    60,    20,   0,    10,   3,   5,      }, // RIDE_TYPE_MINIATURE_RAILWAY              
-    {    65,    20,   0,    10,   3,   10,     }, // RIDE_TYPE_MONORAIL                       
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_MINI_SUSPENDED_COASTER         
-    {    50,    1,    0,    4,    0,   0,     } , // RIDE_TYPE_BOAT_HIRE                      
-    {    40,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_WOODEN_WILD_MOUSE              
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_STEEPLECHASE                   
-    {    70,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_CAR_RIDE                       
-    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_LAUNCHED_FREEFALL              
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_BOBSLEIGH_COASTER              
-    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_OBSERVATION_TOWER              
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_LOOPING_ROLLER_COASTER         
-    {    40,    20,   80,   4,    3,   10,     }, // RIDE_TYPE_DINGHY_SLIDE                   
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_MINE_TRAIN_COASTER             
-    {    60,    20,   0,    4,    3,   10,     }, // RIDE_TYPE_CHAIRLIFT                      
-    {    40,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_CORKSCREW_ROLLER_COASTER       
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MAZE                           
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SPIRAL_SLIDE                   
-    {    50,    20,   0,    8,    0,   0,      }, // RIDE_TYPE_GO_KARTS                       
-    {    80,    20,   0,    9,    0,   10,     }, // RIDE_TYPE_LOG_FLUME                      
-    {    82,    20,   0,    10,   0,   10,     }, // RIDE_TYPE_RIVER_RAPIDS                   
-    {    50,    1,    0,    5,    0,   0,     } , // RIDE_TYPE_DODGEMS                        
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SWINGING_SHIP                  
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SWINGING_INVERTER_SHIP         
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_FOOD_STALL                     
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_1D                             
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_DRINK_STALL                    
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_1F                             
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SHOP                           
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MERRY_GO_ROUND                 
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_22                             
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_INFORMATION_KIOSK              
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_TOILETS                        
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_FERRIS_WHEEL                   
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MOTION_SIMULATOR               
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_3D_CINEMA                      
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_TOP_SPIN                       
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SPACE_RINGS                    
-    {    80,    20,   0,    0,    0,   10,     }, // RIDE_TYPE_REVERSE_FREEFALL_COASTER       
-    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_LIFT                           
-    {    44,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER   
-    {    40,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_CASH_MACHINE                   
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_TWIST                          
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_HAUNTED_HOUSE                  
-    {    45,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_FIRST_AID                      
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_CIRCUS                         
-    {    80,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_GHOST_TRAIN                    
-    {    43,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_TWISTER_ROLLER_COASTER         
-    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_WOODEN_ROLLER_COASTER          
-    {    39,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_SIDE_FRICTION_ROLLER_COASTER   
-    {    40,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_STEEL_WILD_MOUSE               
-    {    75,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER 
-    {    75,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER_
-    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_FLYING_ROLLER_COASTER          
-    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_FLYING_ROLLER_COASTER_ALT      
-    {    39,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_VIRGINIA_REEL                  
-    {    70,    20,   0,    9,    0,   10,     }, // RIDE_TYPE_SPLASH_BOATS                   
-    {    70,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_MINI_HELICOPTERS               
-    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER        
-    {    70,    20,   0,    10,   3,   10,     }, // RIDE_TYPE_SUSPENDED_MONORAIL             
-    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER_ALT    
-    {    39,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_REVERSER_ROLLER_COASTER        
-    {    47,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_HEARTLINE_TWISTER_COASTER      
-    {    30,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_MINI_GOLF                      
-    {    10,    20,   80,   12,   3,   40,     }, // RIDE_TYPE_GIGA_COASTER                   
-    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_ROTO_DROP                      
-    {    90,    1,    0,    5,    0,   0,     } , // RIDE_TYPE_FLYING_SAUCERS                 
-    {    30,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_CROOKED_HOUSE                  
-    {    47,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_MONORAIL_CYCLES                
-    {    40,    20,   80,   13,   3,   10,     }, // RIDE_TYPE_COMPACT_INVERTED_COASTER       
-    {    60,    20,   80,   8,    3,   10,     }, // RIDE_TYPE_WATER_COASTER                  
-    {    90,    20,   0,    0,    0,   10,     }, // RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER   
-    {    40,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_INVERTED_HAIRPIN_COASTER       
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MAGIC_CARPET                   
-    {    50,    1,    0,    4,    0,   0,     } , // RIDE_TYPE_SUBMARINE_RIDE                 
-    {    50,    20,   0,    9,    0,   10,     }, // RIDE_TYPE_RIVER_RAFTS                    
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_50                             
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_ENTERPRISE                     
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_52                             
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_53                             
-    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_54                             
-    {    40,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_55                             
-    {   180,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_INVERTED_IMPULSE_COASTER       
-    {    35,    20,   80,   8,    3,   10,     }, // RIDE_TYPE_MINI_ROLLER_COASTER            
-    {    50,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_MINE_RIDE                      
-    {    42,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_59                             
-    {    42,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER    
-};
-
 // Data at 0x0097D21E
 const uint8_t rideBonusValue[RIDE_TYPE_COUNT] = {
     85,  // 00 Spiral Roller coaster
@@ -1726,6 +1632,7 @@ static constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on
 

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -110,583 +110,98 @@
 #include <iterator>
 
 // clang-format off
-const bool hasRunningTrack[RIDE_TYPE_COUNT] = {
-    true,   // 0 Spiral Roller coaster
-    true,   // 1 Stand Up Coaster
-    true,   // 2 Suspended Swinging
-    true,   // 3 Inverted
-    true,   // 4 Steel Mini Coaster
-    true,   // 5 Mini Railway
-    true,   // 6 Monorail
-    true,   // 7 Mini Suspended Coaster
-    false,  // 8 Boat Hire
-    true,   // 9 Wooden Wild Mine/Mouse
-    true,   // a Steeplechase/Motorbike/Soap Box Derby
-    true,   // b Car Ride
-    true,   // c Launched Freefall
-    true,   // d Bobsleigh Coaster
-    true,   // e Observation Tower
-    true,   // f Looping Roller Coaster
-    true,   // 10 Dinghy Slide
-    true,   // 11 Mine Train Coaster
-    true,   // 12 Chairlift
-    true,   // 13 Corkscrew Roller Coaster
-    false,  // 14 Maze
-    false,  // 15 Spiral Slide
-    true,   // 16 Go Karts
-    true,   // 17 Log Flume
-    true,   // 18 River Rapids
-    false,  // 19 Dodgems
-    false,  // 1a Pirate Ship
-    false,  // 1b Swinging Inverter Ship
-    false,  // 1c Food Stall
-    false,  // 1d (none)
-    false,  // 1e Drink Stall
-    false,  // 1f (none)
-    false,  // 20 Shop (all types)
-    false,  // 21 Merry Go Round
-    false,  // 22 Balloon Stall (maybe)
-    false,  // 23 Information Kiosk
-    false,  // 24 Bathroom
-    false,  // 25 Ferris Wheel
-    false,  // 26 Motion Simulator
-    false,  // 27 3D Cinema
-    false,  // 28 Topspin
-    false,  // 29 Space Rings
-    true,   // 2a Reverse Freefall Coaster
-    true,   // 2b Elevator
-    true,   // 2c Vertical Drop Roller Coaster
-    false,  // 2d ATM
-    false,  // 2e Twist
-    false,  // 2f Haunted House
-    false,  // 30 First Aid
-    false,  // 31 Circus Show
-    true,   // 32 Ghost Train
-    true,   // 33 Twister Roller Coaster
-    true,   // 34 Wooden Roller Coaster
-    true,   // 35 Side-Friction Roller Coaster
-    true,   // 36 Wild Mouse
-    true,   // 37 Multi Dimension Coaster
-    true,   // 38 (none)
-    true,   // 39 Flying Roller Coaster
-    true,   // 3a (none)
-    true,   // 3b Virginia Reel
-    true,   // 3c Splash Boats
-    true,   // 3d Mini Helicopters
-    true,   // 3e Lay-down Roller Coaster
-    true,   // 3f Suspended Monorail
-    true,   // 40 (none)
-    true,   // 41 Reverser Roller Coaster
-    true,   // 42 Heartline Twister Roller Coaster
-    true,   // 43 Mini Golf
-    true,   // 44 Giga Coaster
-    true,   // 45 Roto-Drop
-    false,  // 46 Flying Saucers
-    false,  // 47 Crooked House
-    true,   // 48 Monorail Cycles
-    true,   // 49 Compact Inverted Coaster
-    true,   // 4a Water Coaster
-    true,   // 4b Air Powered Vertical Coaster
-    true,   // 4c Inverted Hairpin Coaster
-    false,  // 4d Magic Carpet
-    false,  // 4e Submarine Ride
-    true,   // 4f River Rafts
-    false,  // 50 (none)
-    false,  // 51 Enterprise
-    false,  // 52 (none)
-    false,  // 53 (none)
-    false,  // 54 (none)
-    true,   // 55 (none)
-    true,   // 56 Inverted Impulse Coaster
-    true,   // 57 Mini Roller Coaster
-    true,   // 58 Mine Ride
-    true,   // 59 (none)
-    true,   // 5a LIM Launched Roller Coaster
-};
-
-/**
- * Data about ride running costs. This is widely adjusted by the upkeep
- * function, so values that don't make much sense here (a roller coaster having
- * cheaper upkeep than a car ride) are fixed later on.
- *
- * data generation script: https://gist.github.com/kevinburke/6bcf4a8fcc95faad7bac
- */
-const uint8_t initialUpkeepCosts[RIDE_TYPE_COUNT] = {
-    41, // 00 Spiral Roller coaster
-    40, // 01 Stand Up Coaster
-    40, // 02 Suspended Swinging
-    40, // 03 Inverted
-    40, // 04 Steel Mini Coaster
-    60, // 05 Mini Railway
-    65, // 06 Monorail
-    40, // 07 Mini Suspended Coaster
-    50, // 08 Boat Hire
-    40, // 09 Wooden Wild Mine/Mouse
-    40, // 0a Steeplechase/Motorbike/Soap Box Derby
-    70, // 0b Car Ride
-    50, // 0c Launched Freefall
-    40, // 0d Bobsleigh Coaster
-    50, // 0e Observation Tower
-    40, // 0f Looping Roller Coaster
-    40, // 10 Dinghy Slide
-    40, // 11 Mine Train Coaster
-    60, // 12 Chairlift
-    40, // 13 Corkscrew Roller Coaster
-    50, // 14 Maze
-    50, // 15 Spiral Slide
-    50, // 16 Go Karts
-    80, // 17 Log Flume
-    82, // 18 River Rapids
-    50, // 19 Dodgems
-    50, // 1a Pirate Ship
-    50, // 1b Swinging Inverter Ship
-    50, // 1c Food Stall
-    50, // 1d (none)
-    50, // 1e Drink Stall
-    50, // 1f (none)
-    50, // 20 Shop (all types)
-    50, // 21 Merry Go Round
-    50, // 22 Balloon Stall (maybe)
-    50, // 23 Information Kiosk
-    50, // 24 Bathroom
-    50, // 25 Ferris Wheel
-    50, // 26 Motion Simulator
-    50, // 27 3D Cinema
-    50, // 28 Topspin
-    50, // 29 Space Rings
-    80, // 2a Reverse Freefall Coaster
-    50, // 2b Elevator
-    44, // 2c Vertical Drop Roller Coaster
-    40, // 2d ATM
-    50, // 2e Twist
-    50, // 2f Haunted House
-    45, // 30 First Aid
-    50, // 31 Circus Show
-    80, // 32 Ghost Train
-    43, // 33 Twister Roller Coaster
-    40, // 34 Wooden Roller Coaster
-    39, // 35 Side-Friction Roller Coaster
-    40, // 36 Wild Mouse
-    75, // 37 Multi Dimension Coaster
-    75, // 38 (none)
-    49, // 39 Flying Roller Coaster
-    49, // 3a (none)
-    39, // 3b Virginia Reel
-    70, // 3c Splash Boats
-    70, // 3d Mini Helicopters
-    49, // 3e Lay-down Roller Coaster
-    70, // 3f Suspended Monorail
-    49, // 40 (none)
-    39, // 41 Reverser Roller Coaster
-    47, // 42 Heartline Twister Roller Coaster
-    30, // 43 Mini Golf
-    10, // 44 Giga Coaster
-    50, // 45 Roto-Drop
-    90, // 46 Flying Saucers
-    30, // 47 Crooked House
-    47, // 48 Monorail Cycles
-    40, // 49 Compact Inverted Coaster
-    60, // 4a Water Coaster
-    90, // 4b Air Powered Vertical Coaster
-    40, // 4c Inverted Hairpin Coaster
-    50, // 4d Magic Carpet
-    50, // 4e Submarine Ride
-    50, // 4f River Rafts
-    50, // 50 (none)
-    50, // 51 Enterprise
-    50, // 52 (none)
-    50, // 53 (none)
-    50, // 54 (none)
-    40, // 55 (none)
-    180,// 56 Inverted Impulse Coaster
-    35, // 57 Mini Roller Coaster
-    50, // 58 Mine Ride
-    42, // 59 (none)
-    42, // 5a LIM Launched Roller Coaster
-};
-
-const uint8_t costPerTrackPiece[RIDE_TYPE_COUNT] = {
-    80, // 00 Spiral Roller coaster
-    80, // 01 Stand Up Coaster
-    80, // 02 Suspended Swinging
-    80, // 03 Inverted
-    80, // 04 Steel Mini Coaster
-    0,  // 05 Mini Railway
-    0,  // 06 Monorail
-    80, // 07 Mini Suspended Coaster
-    0,  // 08 Boat Hire
-    80, // 09 Wooden Wild Mine/Mouse
-    80, // 0a Steeplechase/Motorbike/Soap Box Derby
-    0,  // 0b Car Ride
-    0,  // 0c Launched Freefall
-    80, // 0d Bobsleigh Coaster
-    0,  // 0e Observation Tower
-    80, // 0f Looping Roller Coaster
-    80, // 10 Dinghy Slide
-    80, // 11 Mine Train Coaster
-    0,  // 12 Chairlift
-    80, // 13 Corkscrew Roller Coaster
-    0,  // 14 Maze
-    0,  // 15 Spiral Slide
-    0,  // 16 Go Karts
-    0,  // 17 Log Flume
-    0,  // 18 River Rapids
-    0,  // 19 Dodgems
-    0,  // 1a Pirate Ship
-    0,  // 1b Swinging Inverter Ship
-    0,  // 1c Food Stall
-    0,  // 1d (none)
-    0,  // 1e Drink Stall
-    0,  // 1f (none)
-    0,  // 20 Shop (all types)
-    0,  // 21 Merry Go Round
-    0,  // 22 Balloon Stall (maybe)
-    0,  // 23 Information Kiosk
-    0,  // 24 Bathroom
-    0,  // 25 Ferris Wheel
-    0,  // 26 Motion Simulator
-    0,  // 27 3D Cinema
-    0,  // 28 Topspin
-    0,  // 29 Space Rings
-    0,  // 2a Reverse Freefall Coaster
-    0,  // 2b Elevator
-    80, // 2c Vertical Drop Roller Coaster
-    0,  // 2d ATM
-    0,  // 2e Twist
-    0,  // 2f Haunted House
-    0,  // 30 First Aid
-    0,  // 31 Circus Show
-    0,  // 32 Ghost Train
-    80, // 33 Twister Roller Coaster
-    80, // 34 Wooden Roller Coaster
-    80, // 35 Side-Friction Roller Coaster
-    80, // 36 Wild Mouse
-    90, // 37 Multi Dimension Coaster
-    90, // 38 (none)
-    90, // 39 Flying Roller Coaster
-    90, // 3a (none)
-    80, // 3b Virginia Reel
-    0,  // 3c Splash Boats
-    0,  // 3d Mini Helicopters
-    90, // 3e Lay-down Roller Coaster
-    0,  // 3f Suspended Monorail
-    90, // 40 (none)
-    80, // 41 Reverser Roller Coaster
-    80, // 42 Heartline Twister Roller Coaster
-    80, // 43 Mini Golf
-    80, // 44 Giga Coaster
-    0,  // 45 Roto-Drop
-    0,  // 46 Flying Saucers
-    0,  // 47 Crooked House
-    0,  // 48 Monorail Cycles
-    80, // 49 Compact Inverted Coaster
-    80, // 4a Water Coaster
-    0,  // 4b Air Powered Vertical Coaster
-    80, // 4c Inverted Hairpin Coaster
-    0,  // 4d Magic Carpet
-    0,  // 4e Submarine Ride
-    0,  // 4f River Rafts
-    0,  // 50 (none)
-    0,  // 51 Enterprise
-    0,  // 52 (none)
-    0,  // 53 (none)
-    0,  // 54 (none)
-    80, // 55 (none)
-    80, // 56 Inverted Impulse Coaster
-    80, // 57 Mini Roller Coaster
-    80, // 58 Mine Ride
-    80, // 59 (none)
-    80, // 5a LIM Launched Roller Coaster
-};
-
-/**
- * Data initially at 0x0097E3B4
- */
-const uint8_t costPerVehicle[RIDE_TYPE_COUNT] = {
-    10, // 00 Spiral Roller coaster
-    10, // 01 Stand Up Coaster
-    20, // 02 Suspended Swinging
-    13, // 03 Inverted
-    8,  // 04 Steel Mini Coaster
-    10, // 05 Mini Railway
-    10, // 06 Monorail
-    10, // 07 Mini Suspended Coaster
-    4,  // 08 Boat Hire
-    9,  // 09 Wooden Wild Mine/Mouse
-    10, // 0a Steeplechase/Motorbike/Soap Box Derby
-    8,  // 0b Car Ride
-    10, // 0c Launched Freefall
-    10, // 0d Bobsleigh Coaster
-    10, // 0e Observation Tower
-    10, // 0f Looping Roller Coaster
-    4,  // 10 Dinghy Slide
-    10, // 11 Mine Train Coaster
-    4,  // 12 Chairlift
-    11, // 13 Corkscrew Roller Coaster
-    0,  // 14 Maze
-    0,  // 15 Spiral Slide
-    8,  // 16 Go Karts
-    9,  // 17 Log Flume
-    10, // 18 River Rapids
-    5,  // 19 Dodgems
-    0,  // 1a Pirate Ship
-    0,  // 1b Swinging Inverter Ship
-    0,  // 1c Food Stall
-    0,  // 1d (none)
-    0,  // 1e Drink Stall
-    0,  // 1f (none)
-    0,  // 20 Shop (all types)
-    0,  // 21 Merry Go Round
-    0,  // 22 Balloon Stall (maybe)
-    0,  // 23 Information Kiosk
-    0,  // 24 Bathroom
-    0,  // 25 Ferris Wheel
-    0,  // 26 Motion Simulator
-    0,  // 27 3D Cinema
-    0,  // 28 Topspin
-    0,  // 29 Space Rings
-    0,  // 2a Reverse Freefall Coaster
-    10, // 2b Elevator
-    11, // 2c Vertical Drop Roller Coaster
-    0,  // 2d ATM
-    0,  // 2e Twist
-    0,  // 2f Haunted House
-    0,  // 30 First Aid
-    0,  // 31 Circus Show
-    8,  // 32 Ghost Train
-    11, // 33 Twister Roller Coaster
-    10, // 34 Wooden Roller Coaster
-    10, // 35 Side-Friction Roller Coaster
-    9,  // 36 Wild Mouse
-    11, // 37 Multi Dimension Coaster
-    11, // 38 (none)
-    11, // 39 Flying Roller Coaster
-    11, // 3a (none)
-    10, // 3b Virginia Reel
-    9,  // 3c Splash Boats
-    8,  // 3d Mini Helicopters
-    11, // 3e Lay-down Roller Coaster
-    10, // 3f Suspended Monorail
-    11, // 40 (none)
-    10, // 41 Reverser Roller Coaster
-    11, // 42 Heartline Twister Roller Coaster
-    11, // 43 Mini Golf
-    12, // 44 Giga Coaster
-    10, // 45 Roto-Drop
-    5,  // 46 Flying Saucers
-    0,  // 47 Crooked House
-    8,  // 48 Monorail Cycles
-    13, // 49 Compact Inverted Coaster
-    8,  // 4a Water Coaster
-    0,  // 4b Air Powered Vertical Coaster
-    9,  // 4c Inverted Hairpin Coaster
-    0,  // 4d Magic Carpet
-    4,  // 4e Submarine Ride
-    9,  // 4f River Rafts
-    0,  // 50 (none)
-    0,  // 51 Enterprise
-    0,  // 52 (none)
-    0,  // 53 (none)
-    0,  // 54 (none)
-    11, // 55 (none)
-    11, // 56 Inverted Impulse Coaster
-    8,  // 57 Mini Roller Coaster
-    10, // 58 Mine Ride
-    9,  // 59 (none)
-    9,  // 5a LIM Launched Roller Coaster
-};
-
-/**
- * Data at 0x0097E3B6, originally set to either be 3 or 0 and replaced here by
- * a boolean table. This may be exactly the same as hasRunningTrack above.
- */
-const bool chargeUpkeepForTrainLength[RIDE_TYPE_COUNT] = {
-    true,   // 00 Spiral Roller coaster
-    true,   // 01 Stand Up Coaster
-    true,   // 02 Suspended Swinging
-    true,   // 03 Inverted
-    true,   // 04 Steel Mini Coaster
-    true,   // 05 Mini Railway
-    true,   // 06 Monorail
-    true,   // 07 Mini Suspended Coaster
-    false,  // 08 Boat Hire
-    true,   // 09 Wooden Wild Mine/Mouse
-    true,   // 0a Steeplechase/Motorbike/Soap Box Derby
-    true,   // 0b Car Ride
-    false,  // 0c Launched Freefall
-    true,   // 0d Bobsleigh Coaster
-    false,  // 0e Observation Tower
-    true,   // 0f Looping Roller Coaster
-    true,   // 10 Dinghy Slide
-    true,   // 11 Mine Train Coaster
-    true,   // 12 Chairlift
-    true,   // 13 Corkscrew Roller Coaster
-    false,  // 14 Maze
-    false,  // 15 Spiral Slide
-    false,  // 16 Go Karts
-    false,  // 17 Log Flume
-    false,  // 18 River Rapids
-    false,  // 19 Dodgems
-    false,  // 1a Pirate Ship
-    false,  // 1b Swinging Inverter Ship
-    false,  // 1c Food Stall
-    false,  // 1d (none)
-    false,  // 1e Drink Stall
-    false,  // 1f (none)
-    false,  // 20 Shop (all types)
-    false,  // 21 Merry Go Round
-    false,  // 22 Balloon Stall (maybe)
-    false,  // 23 Information Kiosk
-    false,  // 24 Bathroom
-    false,  // 25 Ferris Wheel
-    false,  // 26 Motion Simulator
-    false,  // 27 3D Cinema
-    false,  // 28 Topspin
-    false,  // 29 Space Rings
-    false,  // 2a Reverse Freefall Coaster
-    false,  // 2b Elevator
-    true,   // 2c Vertical Drop Roller Coaster
-    false,  // 2d ATM
-    false,  // 2e Twist
-    false,  // 2f Haunted House
-    false,  // 30 First Aid
-    false,  // 31 Circus Show
-    true,   // 32 Ghost Train
-    true,   // 33 Twister Roller Coaster
-    true,   // 34 Wooden Roller Coaster
-    true,   // 35 Side-Friction Roller Coaster
-    true,   // 36 Wild Mouse
-    true,   // 37 Multi Dimension Coaster
-    true,   // 38 (none)
-    true,   // 39 Flying Roller Coaster
-    true,   // 3a (none)
-    true,   // 3b Virginia Reel
-    false,  // 3c Splash Boats
-    true,   // 3d Mini Helicopters
-    true,   // 3e Lay-down Roller Coaster
-    true,   // 3f Suspended Monorail
-    true,   // 40 (none)
-    true,   // 41 Reverser Roller Coaster
-    true,   // 42 Heartline Twister Roller Coaster
-    true,   // 43 Mini Golf
-    true,   // 44 Giga Coaster
-    false,  // 45 Roto-Drop
-    false,  // 46 Flying Saucers
-    false,  // 47 Crooked House
-    true,   // 48 Monorail Cycles
-    true,   // 49 Compact Inverted Coaster
-    true,   // 4a Water Coaster
-    false,  // 4b Air Powered Vertical Coaster
-    true,   // 4c Inverted Hairpin Coaster
-    false,  // 4d Magic Carpet
-    false,  // 4e Submarine Ride
-    false,  // 4f River Rafts
-    false,  // 50 (none)
-    false,  // 51 Enterprise
-    false,  // 52 (none)
-    false,  // 53 (none)
-    false,  // 54 (none)
-    true,   // 55 (none)
-    true,   // 56 Inverted Impulse Coaster
-    true,   // 57 Mini Roller Coaster
-    true,   // 58 Mine Ride
-    true,   // 59 (none)
-    true,   // 5a LIM Launched Roller Coaster
-};
-
-/* Data at 0x0097E3B8 */
-const uint8_t costPerStation[RIDE_TYPE_COUNT] = {
-    10, // 00 Spiral Roller coaster
-    10, // 01 Stand Up Coaster
-    10, // 02 Suspended Swinging
-    10, // 03 Inverted
-    5,  // 04 Steel Mini Coaster
-    5,  // 05 Mini Railway
-    10, // 06 Monorail
-    10, // 07 Mini Suspended Coaster
-    0,  // 08 Boat Hire
-    10, // 09 Wooden Wild Mine/Mouse
-    10, // 0a Steeplechase/Motorbike/Soap Box Derby
-    5,  // 0b Car Ride
-    0,  // 0c Launched Freefall
-    10, // 0d Bobsleigh Coaster
-    0,  // 0e Observation Tower
-    10, // 0f Looping Roller Coaster
-    10, // 10 Dinghy Slide
-    10, // 11 Mine Train Coaster
-    10, // 12 Chairlift
-    10, // 13 Corkscrew Roller Coaster
-    0,  // 14 Maze
-    0,  // 15 Spiral Slide
-    0,  // 16 Go Karts
-    10, // 17 Log Flume
-    10, // 18 River Rapids
-    0,  // 19 Dodgems
-    0,  // 1a Pirate Ship
-    0,  // 1b Swinging Inverter Ship
-    0,  // 1c Food Stall
-    0,  // 1d (none)
-    0,  // 1e Drink Stall
-    0,  // 1f (none)
-    0,  // 20 Shop (all types)
-    0,  // 21 Merry Go Round
-    0,  // 22 Balloon Stall (maybe)
-    0,  // 23 Information Kiosk
-    0,  // 24 Bathroom
-    0,  // 25 Ferris Wheel
-    0,  // 26 Motion Simulator
-    0,  // 27 3D Cinema
-    0,  // 28 Topspin
-    0,  // 29 Space Rings
-    10, // 2a Reverse Freefall Coaster
-    0,  // 2b Elevator
-    10, // 2c Vertical Drop Roller Coaster
-    0,  // 2d ATM
-    0,  // 2e Twist
-    0,  // 2f Haunted House
-    0,  // 30 First Aid
-    0,  // 31 Circus Show
-    5,  // 32 Ghost Train
-    10, // 33 Twister Roller Coaster
-    10, // 34 Wooden Roller Coaster
-    10, // 35 Side-Friction Roller Coaster
-    10, // 36 Wild Mouse
-    15, // 37 Multi Dimension Coaster
-    15, // 38 (none)
-    15, // 39 Flying Roller Coaster
-    15, // 3a (none)
-    10, // 3b Virginia Reel
-    10, // 3c Splash Boats
-    5,  // 3d Mini Helicopters
-    15, // 3e Lay-down Roller Coaster
-    10, // 3f Suspended Monorail
-    15, // 40 (none)
-    10, // 41 Reverser Roller Coaster
-    10, // 42 Heartline Twister Roller Coaster
-    10, // 43 Mini Golf
-    40, // 44 Giga Coaster
-    0,  // 45 Roto-Drop
-    0,  // 46 Flying Saucers
-    0,  // 47 Crooked House
-    5,  // 48 Monorail Cycles
-    10, // 49 Compact Inverted Coaster
-    10, // 4a Water Coaster
-    10, // 4b Air Powered Vertical Coaster
-    10, // 4c Inverted Hairpin Coaster
-    0,  // 4d Magic Carpet
-    0,  // 4e Submarine Ride
-    10, // 4f River Rafts
-    0,  // 50 (none)
-    0,  // 51 Enterprise
-    0,  // 52 (none)
-    0,  // 53 (none)
-    0,  // 54 (none)
-    10, // 55 (none)
-    10, // 56 Inverted Impulse Coaster
-    10, // 57 Mini Roller Coaster
-    10, // 58 Mine Ride
-    10, // 59 (none)
-    10, // 5a LIM Launched Roller Coaster
+const UpkeepCosts UpkeepCostsDescriptor[RIDE_TYPE_COUNT] = {
+    {    41,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_SPIRAL_ROLLER_COASTER          
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_STAND_UP_ROLLER_COASTER        
+    {    40,    20,   80,   20,   3,   10,     }, // RIDE_TYPE_SUSPENDED_SWINGING_COASTER     
+    {    40,    20,   80,   13,   3,   10,     }, // RIDE_TYPE_INVERTED_ROLLER_COASTER        
+    {    40,    20,   80,   8,    3,   5,      }, // RIDE_TYPE_JUNIOR_ROLLER_COASTER          
+    {    60,    20,   0,    10,   3,   5,      }, // RIDE_TYPE_MINIATURE_RAILWAY              
+    {    65,    20,   0,    10,   3,   10,     }, // RIDE_TYPE_MONORAIL                       
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_MINI_SUSPENDED_COASTER         
+    {    50,    1,    0,    4,    0,   0,     } , // RIDE_TYPE_BOAT_HIRE                      
+    {    40,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_WOODEN_WILD_MOUSE              
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_STEEPLECHASE                   
+    {    70,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_CAR_RIDE                       
+    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_LAUNCHED_FREEFALL              
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_BOBSLEIGH_COASTER              
+    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_OBSERVATION_TOWER              
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_LOOPING_ROLLER_COASTER         
+    {    40,    20,   80,   4,    3,   10,     }, // RIDE_TYPE_DINGHY_SLIDE                   
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_MINE_TRAIN_COASTER             
+    {    60,    20,   0,    4,    3,   10,     }, // RIDE_TYPE_CHAIRLIFT                      
+    {    40,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_CORKSCREW_ROLLER_COASTER       
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MAZE                           
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SPIRAL_SLIDE                   
+    {    50,    20,   0,    8,    0,   0,      }, // RIDE_TYPE_GO_KARTS                       
+    {    80,    20,   0,    9,    0,   10,     }, // RIDE_TYPE_LOG_FLUME                      
+    {    82,    20,   0,    10,   0,   10,     }, // RIDE_TYPE_RIVER_RAPIDS                   
+    {    50,    1,    0,    5,    0,   0,     } , // RIDE_TYPE_DODGEMS                        
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SWINGING_SHIP                  
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SWINGING_INVERTER_SHIP         
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_FOOD_STALL                     
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_1D                             
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_DRINK_STALL                    
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_1F                             
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SHOP                           
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MERRY_GO_ROUND                 
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_22                             
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_INFORMATION_KIOSK              
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_TOILETS                        
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_FERRIS_WHEEL                   
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MOTION_SIMULATOR               
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_3D_CINEMA                      
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_TOP_SPIN                       
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_SPACE_RINGS                    
+    {    80,    20,   0,    0,    0,   10,     }, // RIDE_TYPE_REVERSE_FREEFALL_COASTER       
+    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_LIFT                           
+    {    44,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER   
+    {    40,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_CASH_MACHINE                   
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_TWIST                          
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_HAUNTED_HOUSE                  
+    {    45,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_FIRST_AID                      
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_CIRCUS                         
+    {    80,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_GHOST_TRAIN                    
+    {    43,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_TWISTER_ROLLER_COASTER         
+    {    40,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_WOODEN_ROLLER_COASTER          
+    {    39,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_SIDE_FRICTION_ROLLER_COASTER   
+    {    40,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_STEEL_WILD_MOUSE               
+    {    75,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER 
+    {    75,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_MULTI_DIMENSION_ROLLER_COASTER_
+    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_FLYING_ROLLER_COASTER          
+    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_FLYING_ROLLER_COASTER_ALT      
+    {    39,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_VIRGINIA_REEL                  
+    {    70,    20,   0,    9,    0,   10,     }, // RIDE_TYPE_SPLASH_BOATS                   
+    {    70,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_MINI_HELICOPTERS               
+    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER        
+    {    70,    20,   0,    10,   3,   10,     }, // RIDE_TYPE_SUSPENDED_MONORAIL             
+    {    49,    20,   90,   11,   3,   15,     }, // RIDE_TYPE_LAY_DOWN_ROLLER_COASTER_ALT    
+    {    39,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_REVERSER_ROLLER_COASTER        
+    {    47,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_HEARTLINE_TWISTER_COASTER      
+    {    30,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_MINI_GOLF                      
+    {    10,    20,   80,   12,   3,   40,     }, // RIDE_TYPE_GIGA_COASTER                   
+    {    50,    20,   0,    10,   0,   0,      }, // RIDE_TYPE_ROTO_DROP                      
+    {    90,    1,    0,    5,    0,   0,     } , // RIDE_TYPE_FLYING_SAUCERS                 
+    {    30,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_CROOKED_HOUSE                  
+    {    47,    20,   0,    8,    3,   5,      }, // RIDE_TYPE_MONORAIL_CYCLES                
+    {    40,    20,   80,   13,   3,   10,     }, // RIDE_TYPE_COMPACT_INVERTED_COASTER       
+    {    60,    20,   80,   8,    3,   10,     }, // RIDE_TYPE_WATER_COASTER                  
+    {    90,    20,   0,    0,    0,   10,     }, // RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER   
+    {    40,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_INVERTED_HAIRPIN_COASTER       
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_MAGIC_CARPET                   
+    {    50,    1,    0,    4,    0,   0,     } , // RIDE_TYPE_SUBMARINE_RIDE                 
+    {    50,    20,   0,    9,    0,   10,     }, // RIDE_TYPE_RIVER_RAFTS                    
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_50                             
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_ENTERPRISE                     
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_52                             
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_53                             
+    {    50,    1,    0,    0,    0,   0,     } , // RIDE_TYPE_54                             
+    {    40,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_55                             
+    {   180,    20,   80,   11,   3,   10,     }, // RIDE_TYPE_INVERTED_IMPULSE_COASTER       
+    {    35,    20,   80,   8,    3,   10,     }, // RIDE_TYPE_MINI_ROLLER_COASTER            
+    {    50,    20,   80,   10,   3,   10,     }, // RIDE_TYPE_MINE_RIDE                      
+    {    42,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_59                             
+    {    42,    20,   80,   9,    3,   10,     }, // RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER    
 };
 
 // Data at 0x0097D21E

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -197,13 +197,29 @@ constexpr const uint64_t RIDE_TYPE_FLAGS_COMMON_COASTER = RIDE_TYPE_FLAG_HAS_G_F
 constexpr const uint64_t RIDE_TYPE_FLAGS_COMMON_COASTER_NON_ALT = RIDE_TYPE_FLAG_SHOW_IN_TRACK_DESIGNER
     | RIDE_TYPE_FLAG_HAS_AIR_TIME | RIDE_TYPE_FLAG_HAS_ENTRANCE_EXIT;
 
-extern const bool hasRunningTrack[RIDE_TYPE_COUNT];
-extern const uint8_t initialUpkeepCosts[RIDE_TYPE_COUNT];
-extern const uint8_t costPerTrackPiece[RIDE_TYPE_COUNT];
+struct UpkeepCosts
+{
+    /**
+     * Data about ride running costs. This is widely adjusted by the upkeep
+     * function, so values that don't make much sense here (a roller coaster having
+     * cheaper upkeep than a car ride) are fixed later on.
+     *
+     * Data generation script: https://gist.github.com/kevinburke/6bcf4a8fcc95faad7bac
+     */
+    uint8_t BaseCost;
+    /** rct2: 0x0097E3AC */
+    uint8_t TrackLengthMultiplier;
+    uint8_t CostPerTrackPiece;
+    /** rct2: 0x0097E3B4 */
+    uint8_t CostPerTrain;
+    /** rct2: 0x0097E3B6 */
+    uint8_t CostPerCar;
+    /** rct2: 0x0097E3B8 */
+    uint8_t CostPerStation;
+};
 
-extern const uint8_t costPerVehicle[RIDE_TYPE_COUNT];
-extern const bool chargeUpkeepForTrainLength[RIDE_TYPE_COUNT];
-extern const uint8_t costPerStation[RIDE_TYPE_COUNT];
+extern const UpkeepCosts UpkeepCostsDescriptor[RIDE_TYPE_COUNT];
+
 extern const uint8_t rideBonusValue[RIDE_TYPE_COUNT];
 
 // clang-format off

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -82,6 +82,27 @@ struct rct_ride_lift_data
     uint8_t maximum_speed;
 };
 
+struct UpkeepCostsDescriptor
+{
+    /**
+     * Data about ride running costs. This is widely adjusted by the upkeep
+     * function, so values that don't make much sense here (a roller coaster having
+     * cheaper upkeep than a car ride) are fixed later on.
+     *
+     * Data generation script: https://gist.github.com/kevinburke/6bcf4a8fcc95faad7bac
+     */
+    uint8_t BaseCost;
+    /** rct2: 0x0097E3AC */
+    uint8_t TrackLengthMultiplier;
+    uint8_t CostPerTrackPiece;
+    /** rct2: 0x0097E3B4 */
+    uint8_t CostPerTrain;
+    /** rct2: 0x0097E3B6 */
+    uint8_t CostPerCar;
+    /** rct2: 0x0097E3B8 */
+    uint8_t CostPerStation;
+};
+
 struct RideTypeDescriptor
 {
     uint8_t AlternateType;
@@ -99,6 +120,7 @@ struct RideTypeDescriptor
     uint8_t AvailableBreakdowns;
     /* rct2: 0x0097D7C8, 0x0097D7C9, 0x0097D7CA */
     rct_ride_lift_data LiftData;
+    UpkeepCostsDescriptor UpkeepCosts;
 
     bool HasFlag(uint64_t flag) const;
     uint64_t GetAvailableTrackPieces() const;
@@ -196,29 +218,6 @@ constexpr const uint64_t RIDE_TYPE_FLAGS_COMMON_COASTER = RIDE_TYPE_FLAG_HAS_G_F
 // Set on all roller coaster ride types, excluding the _ALT types used for constructing upside down.
 constexpr const uint64_t RIDE_TYPE_FLAGS_COMMON_COASTER_NON_ALT = RIDE_TYPE_FLAG_SHOW_IN_TRACK_DESIGNER
     | RIDE_TYPE_FLAG_HAS_AIR_TIME | RIDE_TYPE_FLAG_HAS_ENTRANCE_EXIT;
-
-struct UpkeepCosts
-{
-    /**
-     * Data about ride running costs. This is widely adjusted by the upkeep
-     * function, so values that don't make much sense here (a roller coaster having
-     * cheaper upkeep than a car ride) are fixed later on.
-     *
-     * Data generation script: https://gist.github.com/kevinburke/6bcf4a8fcc95faad7bac
-     */
-    uint8_t BaseCost;
-    /** rct2: 0x0097E3AC */
-    uint8_t TrackLengthMultiplier;
-    uint8_t CostPerTrackPiece;
-    /** rct2: 0x0097E3B4 */
-    uint8_t CostPerTrain;
-    /** rct2: 0x0097E3B6 */
-    uint8_t CostPerCar;
-    /** rct2: 0x0097E3B8 */
-    uint8_t CostPerStation;
-};
-
-extern const UpkeepCosts UpkeepCostsDescriptor[RIDE_TYPE_COUNT];
 
 extern const uint8_t rideBonusValue[RIDE_TYPE_COUNT];
 

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -867,9 +867,9 @@ static void ride_ratings_calculate_value(Ride* ride)
 static uint16_t ride_compute_upkeep(Ride* ride)
 {
     // data stored at 0x0057E3A8, incrementing 18 bytes at a time
-    uint16_t upkeep = UpkeepCostsDescriptor[ride->type].BaseCost;
+    uint16_t upkeep = RideTypeDescriptors[ride->type].UpkeepCosts.BaseCost;
 
-    uint16_t trackCost = UpkeepCostsDescriptor[ride->type].CostPerTrackPiece;
+    uint16_t trackCost = RideTypeDescriptors[ride->type].UpkeepCosts.CostPerTrackPiece;
     uint8_t dropFactor = ride->drops;
 
     dropFactor >>= 6;
@@ -882,7 +882,7 @@ static uint16_t ride_compute_upkeep(Ride* ride)
     // rides that had tracks. The 0's were fixed rides like crooked house or
     // dodgems.
     // Data source is 0x0097E3AC
-    totalLength *= UpkeepCostsDescriptor[ride->type].TrackLengthMultiplier;
+    totalLength *= RideTypeDescriptors[ride->type].UpkeepCosts.TrackLengthMultiplier;
     upkeep += static_cast<uint16_t>(totalLength >> 10);
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_RIDE_PHOTO)
@@ -909,12 +909,12 @@ static uint16_t ride_compute_upkeep(Ride* ride)
     // various variables set on the ride itself.
 
     // https://gist.github.com/kevinburke/e19b803cd2769d96c540
-    upkeep += UpkeepCostsDescriptor[ride->type].CostPerTrain * ride->num_vehicles;
-    upkeep += UpkeepCostsDescriptor[ride->type].CostPerCar * ride->num_cars_per_train;
+    upkeep += RideTypeDescriptors[ride->type].UpkeepCosts.CostPerTrain * ride->num_vehicles;
+    upkeep += RideTypeDescriptors[ride->type].UpkeepCosts.CostPerCar * ride->num_cars_per_train;
 
     // slight upkeep boosts for some rides - 5 for mini railway, 10 for log
     // flume/rapids, 10 for roller coaster, 28 for giga coaster
-    upkeep += UpkeepCostsDescriptor[ride->type].CostPerStation * ride->num_stations;
+    upkeep += RideTypeDescriptors[ride->type].UpkeepCosts.CostPerStation * ride->num_stations;
 
     if (ride->mode == RIDE_MODE_REVERSE_INCLINE_LAUNCHED_SHUTTLE)
     {

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -867,9 +867,9 @@ static void ride_ratings_calculate_value(Ride* ride)
 static uint16_t ride_compute_upkeep(Ride* ride)
 {
     // data stored at 0x0057E3A8, incrementing 18 bytes at a time
-    uint16_t upkeep = initialUpkeepCosts[ride->type];
+    uint16_t upkeep = UpkeepCostsDescriptor[ride->type].BaseCost;
 
-    uint16_t trackCost = costPerTrackPiece[ride->type];
+    uint16_t trackCost = UpkeepCostsDescriptor[ride->type].CostPerTrackPiece;
     uint8_t dropFactor = ride->drops;
 
     dropFactor >>= 6;
@@ -882,10 +882,7 @@ static uint16_t ride_compute_upkeep(Ride* ride)
     // rides that had tracks. The 0's were fixed rides like crooked house or
     // dodgems.
     // Data source is 0x0097E3AC
-    if (hasRunningTrack[ride->type])
-    {
-        totalLength *= 20;
-    }
+    totalLength *= UpkeepCostsDescriptor[ride->type].TrackLengthMultiplier;
     upkeep += static_cast<uint16_t>(totalLength >> 10);
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_RIDE_PHOTO)
@@ -912,17 +909,12 @@ static uint16_t ride_compute_upkeep(Ride* ride)
     // various variables set on the ride itself.
 
     // https://gist.github.com/kevinburke/e19b803cd2769d96c540
-    upkeep += costPerVehicle[ride->type] * ride->num_vehicles;
-
-    // either set to 3 or 0, extra boosts for some rides including mini golf
-    if (chargeUpkeepForTrainLength[ride->type])
-    {
-        upkeep += 3 * ride->num_cars_per_train;
-    }
+    upkeep += UpkeepCostsDescriptor[ride->type].CostPerTrain * ride->num_vehicles;
+    upkeep += UpkeepCostsDescriptor[ride->type].CostPerCar * ride->num_cars_per_train;
 
     // slight upkeep boosts for some rides - 5 for mini railway, 10 for log
     // flume/rapids, 10 for roller coaster, 28 for giga coaster
-    upkeep += costPerStation[ride->type] * ride->num_stations;
+    upkeep += UpkeepCostsDescriptor[ride->type].CostPerStation * ride->num_stations;
 
     if (ride->mode == RIDE_MODE_REVERSE_INCLINE_LAUNCHED_SHUTTLE)
     {

--- a/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
@@ -25,5 +25,6 @@ constexpr const RideTypeDescriptor AirPoweredVerticalCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 90, 20, 0, 0, 0, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
+++ b/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor BobsleighCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 5 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor CompactInvertedCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 13, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor CorkscrewRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftArrow, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 11, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
@@ -29,6 +29,7 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftBM, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 49, 20, 90, 11, 3, 15 }),
 };
 
 // Inverted variant
@@ -46,5 +47,6 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterAltRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftBM, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 49, 20, 90, 11, 3, 15 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/GigaCoaster.h
+++ b/src/openrct2/ride/coaster/meta/GigaCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor GigaCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 5, 8 }),
+    SET_FIELD(UpkeepCosts, { 10, 20, 80, 12, 3, 40 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
@@ -26,5 +26,6 @@ constexpr const RideTypeDescriptor HeartlineTwisterCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 47, 20, 80, 11, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor InvertedHairpinCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftWildMouse, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 9, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor InvertedImpulseCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 7 }),
+    SET_FIELD(UpkeepCosts, { 180, 20, 80, 11, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor InvertedRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftBM, 5, 7 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 13, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor JuniorRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 8, 3, 5 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor LIMLaunchedRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::Null, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 42, 20, 80, 9, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
@@ -27,6 +27,7 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 49, 20, 90, 11, 3, 15 }),
 };
 
 constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
@@ -42,5 +43,6 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 49, 20, 90, 11, 3, 15 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor LoopingRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineRide.h
+++ b/src/openrct2/ride/coaster/meta/MineRide.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor MineRideRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor MineTrainCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftArrow, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor MiniRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 35, 20, 80, 8, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor MiniSuspendedCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 5 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
@@ -28,6 +28,7 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 75, 20, 90, 11, 3, 15 }),
 };
 
 constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
@@ -43,5 +44,6 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 75, 20, 90, 11, 3, 15 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
@@ -25,5 +25,6 @@ constexpr const RideTypeDescriptor ReverseFreefallCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 80, 20, 0, 0, 0, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -26,5 +26,6 @@ constexpr const RideTypeDescriptor ReverserRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 3, 4 }),
+    SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor SideFrictionRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftWood, 3, 4 }),
+    SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor SpiralRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 7, 7 }),
+    SET_FIELD(UpkeepCosts, { 41, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor StandUpRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SteelWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SteelWildMouse.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor SteelWildMouseRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftWildMouse, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 9, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Steeplechase.h
+++ b/src/openrct2/ride/coaster/meta/Steeplechase.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor SteeplechaseRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 5 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor SuspendedSwingingCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 20, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor TwisterRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftBM, 5, 8 }),
+    SET_FIELD(UpkeepCosts, { 43, 20, 80, 11, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
+++ b/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor VerticalDropCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftBM, 4, 5 }),
+    SET_FIELD(UpkeepCosts, { 44, 20, 80, 11, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VirginiaReel.h
+++ b/src/openrct2/ride/coaster/meta/VirginiaReel.h
@@ -26,5 +26,6 @@ constexpr const RideTypeDescriptor VirginiaReelRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 3, 4 }),
+    SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WaterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WaterCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor WaterCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
+    SET_FIELD(UpkeepCosts, { 60, 20, 80, 8, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor WoodenRollerCoasterRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftWood, 5, 7 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor WoodenWildMouseRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 5 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 9, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CarRide.h
+++ b/src/openrct2/ride/gentle/meta/CarRide.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor CarRideRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 70, 20, 0, 8, 3, 5 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CrookedHouse.h
+++ b/src/openrct2/ride/gentle/meta/CrookedHouse.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor CrookedHouseRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 30, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Dodgems.h
+++ b/src/openrct2/ride/gentle/meta/Dodgems.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor DodgemsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 5, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FerrisWheel.h
+++ b/src/openrct2/ride/gentle/meta/FerrisWheel.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor FerrisWheelRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_WHEEL, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FlyingSaucers.h
+++ b/src/openrct2/ride/gentle/meta/FlyingSaucers.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor FlyingSaucersRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 90, 1, 0, 5, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/GhostTrain.h
+++ b/src/openrct2/ride/gentle/meta/GhostTrain.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 80, 20, 0, 8, 3, 5 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/HauntedHouse.h
+++ b/src/openrct2/ride/gentle/meta/HauntedHouse.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor HauntedHouseRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -26,5 +26,6 @@ constexpr const RideTypeDescriptor MazeRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MerryGoRound.h
+++ b/src/openrct2/ride/gentle/meta/MerryGoRound.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor MerryGoRoundRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_CONTROL_FAILURE)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_PLAYER, RIDE_COMPONENT_TYPE_COURSE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 30, 20, 80, 11, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 70, 20, 0, 8, 3, 5 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonorailCycles.h
+++ b/src/openrct2/ride/gentle/meta/MonorailCycles.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 47, 20, 0, 8, 3, 5 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/ObservationTower.h
+++ b/src/openrct2/ride/gentle/meta/ObservationTower.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor ObservationTowerRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CABIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 0, 10, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpaceRings.h
+++ b/src/openrct2/ride/gentle/meta/SpaceRings.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor SpaceRingsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_RING, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -26,5 +26,6 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 40, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 45, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, 0),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/3DCinema.h
+++ b/src/openrct2/ride/thrill/meta/3DCinema.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor CinemaRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BUILDING, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Enterprise.h
+++ b/src/openrct2/ride/thrill/meta/Enterprise.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor EnterpriseRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_WHEEL, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/GoKarts.h
+++ b/src/openrct2/ride/thrill/meta/GoKarts.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor GoKartsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 0, 8, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
+++ b/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor LaunchedFreefallRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 0, 10, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MagicCarpet.h
+++ b/src/openrct2/ride/thrill/meta/MagicCarpet.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor MagicCarpetRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MotionSimulator.h
+++ b/src/openrct2/ride/thrill/meta/MotionSimulator.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor MotionSimulatorRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/RotoDrop.h
+++ b/src/openrct2/ride/thrill/meta/RotoDrop.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor RotoDropRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 0, 10, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor SwingingInverterShipRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_SHIP, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingShip.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor SwingingShipRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_SHIP, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/TopSpin.h
+++ b/src/openrct2/ride/thrill/meta/TopSpin.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor TopSpinRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor TwistRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STRUCTURE, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 0, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Chairlift.h
+++ b/src/openrct2/ride/transport/meta/Chairlift.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor ChairliftRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CAR, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 60, 20, 0, 4, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Lift.h
+++ b/src/openrct2/ride/transport/meta/Lift.h
@@ -28,5 +28,6 @@ constexpr const RideTypeDescriptor LiftRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_CABIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_DOORS_STUCK_CLOSED) | (1 << BREAKDOWN_DOORS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 0, 10, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/MiniatureRailway.h
+++ b/src/openrct2/ride/transport/meta/MiniatureRailway.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 60, 20, 0, 10, 3, 5 }),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Monorail.h
+++ b/src/openrct2/ride/transport/meta/Monorail.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor MonorailRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_DOORS_STUCK_CLOSED) | (1 << BREAKDOWN_DOORS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 65, 20, 0, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/SuspendedMonorail.h
+++ b/src/openrct2/ride/transport/meta/SuspendedMonorail.h
@@ -31,5 +31,6 @@ constexpr const RideTypeDescriptor SuspendedMonorailRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_TRAIN, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_DOORS_STUCK_CLOSED) | (1 << BREAKDOWN_DOORS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 70, 20, 0, 10, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -27,5 +27,6 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_DOCKING_PLATFORM, RIDE_COMPONENT_TYPE_DOCKING_PLATFORM }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 4, 0, 0 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/DinghySlide.h
+++ b/src/openrct2/ride/water/meta/DinghySlide.h
@@ -31,5 +31,6 @@ constexpr const RideTypeDescriptor DinghySlideRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 5 }),
+    SET_FIELD(UpkeepCosts, { 40, 20, 80, 4, 3, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/LogFlume.h
+++ b/src/openrct2/ride/water/meta/LogFlume.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_CONTROL_FAILURE)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 80, 20, 0, 9, 0, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRafts.h
+++ b/src/openrct2/ride/water/meta/RiverRafts.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor RiverRaftsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 20, 0, 9, 0, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRapids.h
+++ b/src/openrct2/ride/water/meta/RiverRapids.h
@@ -31,5 +31,6 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_CONTROL_FAILURE)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 82, 20, 0, 10, 0, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SplashBoats.h
+++ b/src/openrct2/ride/water/meta/SplashBoats.h
@@ -30,5 +30,6 @@ constexpr const RideTypeDescriptor SplashBoatsRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_STATION }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_CONTROL_FAILURE)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 70, 20, 0, 9, 0, 10 }),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -29,5 +29,6 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     SET_FIELD(NameConvention, { RIDE_COMPONENT_TYPE_BOAT, RIDE_COMPONENT_TYPE_TRACK, RIDE_COMPONENT_TYPE_DOCKING_PLATFORM }),
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION)),
     SET_FIELD(LiftData, { SoundId::Null, 5, 5 }),
+    SET_FIELD(UpkeepCosts, { 50, 1, 0, 4, 0, 0 }),
 };
 // clang-format on


### PR DESCRIPTION
This saves quite a considerable amount of lines in RideData.cpp.

Kevin Burke had changed some tables that only used two different values to use true/false. I opted to change this back, because they're not really true/false values anyway and it makes the code easier to read. Additionally, it increases possibilities.

There should be no functional change.