### PR TITLE
Use Formatter to handle argument formatting for tooltips

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1082,7 +1082,8 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
     int32_t cursorId;
 
     cursorId = CURSOR_ARROW;
-    set_map_tooltip_format_arg(0, rct_string_id, STR_NONE);
+    auto ft = Formatter::MapTooltip();
+    ft.Add<rct_string_id>(STR_NONE);
     window = window_find_from_point(screenCoords);
 
     if (window != nullptr)

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -99,8 +99,9 @@ int32_t viewport_interaction_get_item_left(const ScreenCoordsXY& screenCoords, v
             auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
             auto parkName = park.Name.c_str();
 
-            set_map_tooltip_format_arg(0, rct_string_id, STR_STRING);
-            set_map_tooltip_format_arg(2, const char*, parkName);
+            auto ft = Formatter::MapTooltip();
+            ft.Add<rct_string_id>(STR_STRING);
+            ft.Add<const char*>(parkName);
             break;
         }
         default:
@@ -233,8 +234,9 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
             ride = get_ride(sprite->vehicle.ride);
             if (ride != nullptr && ride->status == RIDE_STATUS_CLOSED)
             {
-                set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                ride->FormatNameTo(gMapTooltipFormatArgs + 2);
+                auto ft = Formatter::MapTooltip();
+                ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+                ride->FormatNameTo(ft);
             }
             return info->type;
 
@@ -252,7 +254,8 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
             if (ride->status != RIDE_STATUS_CLOSED)
                 return info->type;
 
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+            auto ft = Formatter::MapTooltip();
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
 
             if (tileElement->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)
             {
@@ -279,7 +282,7 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
                         stringId = STR_RIDE_EXIT;
                     }
                 }
-                set_map_tooltip_format_arg(2, rct_string_id, stringId);
+                ft.Add<rct_string_id>(stringId);
             }
             else if (track_element_is_station(tileElement))
             {
@@ -292,7 +295,7 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
                 {
                     stringId = STR_RIDE_STATION;
                 }
-                set_map_tooltip_format_arg(2, rct_string_id, stringId);
+                ft.Add<rct_string_id>(stringId);
             }
             else
             {
@@ -302,14 +305,12 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
                     return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
                 }
 
-                ride->FormatNameTo(gMapTooltipFormatArgs + 2);
+                ride->FormatNameTo(ft);
                 return info->type;
             }
 
-            auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 4);
-            set_map_tooltip_format_arg(
-                4 + nameArgLen, rct_string_id,
-                RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.station].capitalised);
+            ride->FormatNameTo(ft);
+            ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.station].capitalised);
 
             if (tileElement->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)
                 stationIndex = tileElement->AsEntrance()->GetStationIndex();
@@ -320,7 +321,7 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
                 if (ride->stations[i].Start.isNull())
                     stationIndex--;
             stationIndex++;
-            set_map_tooltip_format_arg(4 + nameArgLen + 2, uint16_t, stationIndex);
+            ft.Add<uint16_t>(stationIndex);
             return info->type;
         }
         case VIEWPORT_INTERACTION_ITEM_WALL:
@@ -330,13 +331,11 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
                 auto banner = tileElement->AsWall()->GetBanner();
                 if (banner != nullptr)
                 {
-                    size_t argPos = 0;
-                    set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
-                    argPos += sizeof(rct_string_id);
-                    argPos += banner->FormatTextTo(gMapTooltipFormatArgs + argPos);
-                    set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                    argPos += sizeof(rct_string_id);
-                    set_map_tooltip_format_arg(argPos, rct_string_id, sceneryEntry->name);
+                    auto ft = Formatter::MapTooltip();
+                    ft.Add<rct_string_id>(STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+                    banner->FormatTextTo(ft);
+                    ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+                    ft.Add<rct_string_id>(sceneryEntry->name);
                     return info->type;
                 }
             }
@@ -349,13 +348,11 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
                 auto banner = tileElement->AsLargeScenery()->GetBanner();
                 if (banner != nullptr)
                 {
-                    size_t argPos = 0;
-                    set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
-                    argPos += sizeof(rct_string_id);
-                    argPos += banner->FormatTextTo(gMapTooltipFormatArgs + argPos);
-                    set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                    argPos += sizeof(rct_string_id);
-                    set_map_tooltip_format_arg(argPos, rct_string_id, sceneryEntry->name);
+                    auto ft = Formatter::MapTooltip();
+                    ft.Add<rct_string_id>(STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+                    banner->FormatTextTo(ft);
+                    ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+                    ft.Add<rct_string_id>(sceneryEntry->name);
                     return info->type;
                 }
             }
@@ -366,13 +363,11 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
             auto banner = tileElement->AsBanner()->GetBanner();
             sceneryEntry = get_banner_entry(banner->type);
 
-            size_t argPos = 0;
-            set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
-            argPos += sizeof(rct_string_id);
-            argPos += banner->FormatTextTo(gMapTooltipFormatArgs + argPos, /*addColour*/ true);
-            set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-            argPos += sizeof(rct_string_id);
-            set_map_tooltip_format_arg(argPos, rct_string_id, sceneryEntry->name);
+            auto ft = Formatter::MapTooltip();
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
+            banner->FormatTextTo(ft, /*addColour*/ true);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
+            ft.Add<rct_string_id>(sceneryEntry->name);
             return info->type;
         }
     }
@@ -385,33 +380,31 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
         }
     }
 
+    auto ft = Formatter::MapTooltip();
     switch (info->type)
     {
         case VIEWPORT_INTERACTION_ITEM_SCENERY:
             sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
-            set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
+            ft.Add<rct_string_id>(sceneryEntry->name);
             return info->type;
 
         case VIEWPORT_INTERACTION_ITEM_FOOTPATH:
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
-            set_map_tooltip_format_arg(2, rct_string_id, STR_FOOTPATH_MAP_TIP);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
             if (tileElement->AsPath()->IsQueue())
-                set_map_tooltip_format_arg(2, rct_string_id, STR_QUEUE_LINE_MAP_TIP);
+                ft.Add<rct_string_id>(STR_QUEUE_LINE_MAP_TIP);
+            else
+                ft.Add<rct_string_id>(STR_FOOTPATH_MAP_TIP);
             return info->type;
 
         case VIEWPORT_INTERACTION_ITEM_FOOTPATH_ITEM:
             sceneryEntry = tileElement->AsPath()->GetAdditionEntry();
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
             if (tileElement->AsPath()->IsBroken())
             {
-                set_map_tooltip_format_arg(2, rct_string_id, STR_BROKEN);
-                set_map_tooltip_format_arg(4, rct_string_id, sceneryEntry->name);
+                ft.Add<rct_string_id>(STR_BROKEN);
             }
-            else
-            {
-                set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
-            }
+            ft.Add<rct_string_id>(sceneryEntry->name);
             return info->type;
 
         case VIEWPORT_INTERACTION_ITEM_PARK:
@@ -421,20 +414,20 @@ int32_t viewport_interaction_get_item_right(const ScreenCoordsXY& screenCoords, 
             if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
                 break;
 
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
-            set_map_tooltip_format_arg(2, rct_string_id, STR_OBJECT_SELECTION_PARK_ENTRANCE);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
+            ft.Add<rct_string_id>(STR_OBJECT_SELECTION_PARK_ENTRANCE);
             return info->type;
 
         case VIEWPORT_INTERACTION_ITEM_WALL:
             sceneryEntry = tileElement->AsWall()->GetEntry();
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
-            set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
+            ft.Add<rct_string_id>(sceneryEntry->name);
             return info->type;
 
         case VIEWPORT_INTERACTION_ITEM_LARGE_SCENERY:
             sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
-            set_map_tooltip_format_arg(0, rct_string_id, STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
-            set_map_tooltip_format_arg(2, rct_string_id, sceneryEntry->name);
+            ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
+            ft.Add<rct_string_id>(sceneryEntry->name);
             return info->type;
     }
 

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -98,13 +98,6 @@ template<typename T> void constexpr set_format_arg(uint8_t* args, size_t offset,
         set_format_arg_body(gCommonFormatArgs, offset, (uintptr_t)(value), sizeof(type));                                      \
     } while (false)
 
-#define set_map_tooltip_format_arg(offset, type, value)                                                                        \
-    do                                                                                                                         \
-    {                                                                                                                          \
-        static_assert(sizeof(type) <= sizeof(uintptr_t), "Type too large");                                                    \
-        set_format_arg_body(gMapTooltipFormatArgs, offset, (uintptr_t)(value), sizeof(type));                                  \
-    } while (false)
-
 class Formatter
 {
     const uint8_t* StartBuf;
@@ -117,9 +110,19 @@ public:
     {
     }
 
+    static Formatter MapTooltip()
+    {
+        return Formatter(gMapTooltipFormatArgs);
+    }
+
     auto Buf()
     {
         return CurrentBuf;
+    }
+
+    void Increment(std::size_t count)
+    {
+        CurrentBuf += count;
     }
 
     std::size_t NumBytes() const
@@ -129,6 +132,8 @@ public:
 
     template<typename TSpecified, typename TDeduced> Formatter& Add(TDeduced value)
     {
+        static_assert(sizeof(TSpecified) <= sizeof(uintptr_t), "Type too large");
+        static_assert(sizeof(TDeduced) <= sizeof(uintptr_t), "Type too large");
         uintptr_t convertedValue;
         if constexpr (std::is_integral_v<TSpecified>)
         {
@@ -139,7 +144,7 @@ public:
             convertedValue = reinterpret_cast<uintptr_t>(value);
         }
         set_format_arg_body(CurrentBuf, 0, convertedValue, sizeof(TSpecified));
-        CurrentBuf += sizeof(TSpecified);
+        Increment(sizeof(TSpecified));
         return *this;
     }
 };

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1784,6 +1784,11 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     return peep;
 }
 
+void Peep::FormatActionTo(Formatter& ft) const
+{
+    FormatActionTo(ft.Buf());
+}
+
 void Peep::FormatActionTo(void* argsV) const
 {
     Formatter ft((uint8_t*)argsV);
@@ -1956,6 +1961,11 @@ void Peep::FormatActionTo(void* argsV) const
             break;
         }
     }
+}
+
+void Peep::FormatNameTo(Formatter& ft) const
+{
+    ft.Increment(FormatNameTo(ft.Buf()));
 }
 
 size_t Peep::FormatNameTo(void* argsV) const
@@ -2205,19 +2215,19 @@ int32_t get_peep_face_sprite_large(Peep* peep)
 
 void peep_set_map_tooltip(Peep* peep)
 {
+    auto ft = Formatter::MapTooltip();
     if (peep->type == PEEP_TYPE_GUEST)
     {
-        set_map_tooltip_format_arg(
-            0, rct_string_id, (peep->peep_flags & PEEP_FLAGS_TRACKING) ? STR_TRACKED_GUEST_MAP_TIP : STR_GUEST_MAP_TIP);
-        set_map_tooltip_format_arg(2, uint32_t, get_peep_face_sprite_small(peep));
-        auto nameArgLen = peep->FormatNameTo(gMapTooltipFormatArgs + 6);
-        peep->FormatActionTo(gMapTooltipFormatArgs + 6 + nameArgLen);
+        ft.Add<rct_string_id>((peep->peep_flags & PEEP_FLAGS_TRACKING) ? STR_TRACKED_GUEST_MAP_TIP : STR_GUEST_MAP_TIP);
+        ft.Add<uint32_t>(get_peep_face_sprite_small(peep));
+        peep->FormatNameTo(ft);
+        peep->FormatActionTo(ft);
     }
     else
     {
-        set_map_tooltip_format_arg(0, rct_string_id, STR_STAFF_MAP_TIP);
-        auto nameArgLen = peep->FormatNameTo(gMapTooltipFormatArgs + 2);
-        peep->FormatActionTo(gMapTooltipFormatArgs + 2 + nameArgLen);
+        ft.Add<rct_string_id>(STR_STAFF_MAP_TIP);
+        peep->FormatNameTo(ft);
+        peep->FormatActionTo(ft);
     }
 }
 

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -44,6 +44,7 @@
 
 constexpr auto PEEP_CLEARANCE_HEIGHT = 4 * COORDS_Z_STEP;
 
+class Formatter;
 struct TileElement;
 struct Ride;
 
@@ -720,7 +721,9 @@ public: // Peep
     void RemoveFromQueue();
     void RemoveFromRide();
     void InsertNewThought(PeepThoughtType thought_type, uint8_t thought_arguments);
+    void FormatActionTo(Formatter&) const;
     void FormatActionTo(void* args) const;
+    void FormatNameTo(Formatter&) const;
     size_t FormatNameTo(void* args) const;
     std::string GetName() const;
     bool SetName(const std::string_view& value);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -751,6 +751,11 @@ int32_t ride_find_track_gap(const Ride* ride, CoordsXYE* input, CoordsXYE* outpu
     return 0;
 }
 
+void Ride::FormatStatusTo(Formatter& ft) const
+{
+    FormatStatusTo(ft.Buf());
+}
+
 void Ride::FormatStatusTo(void* argsV) const
 {
     Formatter ft(static_cast<uint8_t*>(argsV));
@@ -3294,9 +3299,10 @@ static void ride_track_set_map_tooltip(TileElement* tileElement)
     auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
-        set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-        auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 2);
-        ride->FormatStatusTo(gMapTooltipFormatArgs + 2 + nameArgLen);
+        auto ft = Formatter::MapTooltip();
+        ft.Add<rct_string_id>(STR_RIDE_MAP_TIP);
+        ride->FormatNameTo(ft);
+        ride->FormatStatusTo(ft);
     }
 }
 
@@ -3306,9 +3312,10 @@ static void ride_queue_banner_set_map_tooltip(TileElement* tileElement)
     auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
-        set_map_tooltip_format_arg(0, rct_string_id, STR_RIDE_MAP_TIP);
-        auto nameArgLen = ride->FormatNameTo(gMapTooltipFormatArgs + 2);
-        ride->FormatStatusTo(gMapTooltipFormatArgs + 2 + nameArgLen);
+        auto ft = Formatter::MapTooltip();
+        ft.Add<rct_string_id>(STR_RIDE_MAP_TIP);
+        ride->FormatNameTo(ft);
+        ride->FormatStatusTo(ft);
     }
 }
 
@@ -3323,18 +3330,13 @@ static void ride_station_set_map_tooltip(TileElement* tileElement)
             if (ride->stations[i].Start.isNull())
                 stationIndex--;
 
-        size_t argPos = 0;
-        set_map_tooltip_format_arg(argPos, rct_string_id, STR_RIDE_MAP_TIP);
-        argPos += sizeof(rct_string_id);
-        set_map_tooltip_format_arg(argPos, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_STATION : STR_RIDE_STATION_X);
-        argPos += sizeof(rct_string_id);
-        argPos += ride->FormatNameTo(gMapTooltipFormatArgs + argPos);
-        set_map_tooltip_format_arg(
-            argPos, rct_string_id, RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.station].capitalised);
-        argPos += sizeof(rct_string_id);
-        set_map_tooltip_format_arg(argPos, uint16_t, stationIndex + 1);
-        argPos += sizeof(uint16_t);
-        ride->FormatStatusTo(gMapTooltipFormatArgs + argPos);
+        auto ft = Formatter::MapTooltip();
+        ft.Add<rct_string_id>(STR_RIDE_MAP_TIP);
+        ft.Add<rct_string_id>(ride->num_stations <= 1 ? STR_RIDE_STATION : STR_RIDE_STATION_X);
+        ride->FormatNameTo(ft);
+        ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.station].capitalised);
+        ft.Add<uint16_t>(stationIndex + 1);
+        ride->FormatStatusTo(ft);
     }
 }
 
@@ -3357,33 +3359,28 @@ static void ride_entrance_set_map_tooltip(TileElement* tileElement)
             if (!ride_get_entrance_location(ride, stationIndex).isNull())
                 queueLength = ride->stations[stationIndex].QueueLength;
 
-            size_t argPos = 0;
-            set_map_tooltip_format_arg(argPos, rct_string_id, STR_RIDE_MAP_TIP);
-            argPos += sizeof(rct_string_id);
-            set_map_tooltip_format_arg(
-                argPos, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_ENTRANCE : STR_RIDE_STATION_X_ENTRANCE);
-            argPos += sizeof(rct_string_id);
-            argPos += ride->FormatNameTo(gMapTooltipFormatArgs + argPos);
+            auto ft = Formatter::MapTooltip();
+            ft.Add<rct_string_id>(STR_RIDE_MAP_TIP);
+            ft.Add<rct_string_id>(ride->num_stations <= 1 ? STR_RIDE_ENTRANCE : STR_RIDE_STATION_X_ENTRANCE);
+            ride->FormatNameTo(ft);
 
             // String IDs have an extra pop16 for some reason
-            argPos += sizeof(uint16_t);
+            ft.Increment(sizeof(uint16_t));
 
-            set_map_tooltip_format_arg(argPos, uint16_t, stationIndex + 1);
-            argPos += sizeof(uint16_t);
+            ft.Add<uint16_t>(stationIndex + 1);
             if (queueLength == 0)
             {
-                set_map_tooltip_format_arg(argPos, rct_string_id, STR_QUEUE_EMPTY);
+                ft.Add<rct_string_id>(STR_QUEUE_EMPTY);
             }
             else if (queueLength == 1)
             {
-                set_map_tooltip_format_arg(argPos, rct_string_id, STR_QUEUE_ONE_PERSON);
+                ft.Add<rct_string_id>(STR_QUEUE_ONE_PERSON);
             }
             else
             {
-                set_map_tooltip_format_arg(argPos, rct_string_id, STR_QUEUE_PEOPLE);
+                ft.Add<rct_string_id>(STR_QUEUE_PEOPLE);
             }
-            argPos += sizeof(rct_string_id);
-            set_map_tooltip_format_arg(argPos, uint16_t, queueLength);
+            ft.Add<uint16_t>(queueLength);
         }
         else
         {
@@ -3393,16 +3390,14 @@ static void ride_entrance_set_map_tooltip(TileElement* tileElement)
                 if (ride->stations[i].Start.isNull())
                     stationIndex--;
 
-            size_t argPos = 0;
-            set_map_tooltip_format_arg(
-                argPos, rct_string_id, ride->num_stations <= 1 ? STR_RIDE_EXIT : STR_RIDE_STATION_X_EXIT);
-            argPos += sizeof(rct_string_id);
-            argPos += ride->FormatNameTo(gMapTooltipFormatArgs + 2);
+            auto ft = Formatter::MapTooltip();
+            ft.Add<rct_string_id>(ride->num_stations <= 1 ? STR_RIDE_EXIT : STR_RIDE_STATION_X_EXIT);
+            ride->FormatNameTo(ft);
 
             // String IDs have an extra pop16 for some reason
-            argPos += sizeof(uint16_t);
+            ft.Increment(sizeof(uint16_t));
 
-            set_map_tooltip_format_arg(argPos, uint16_t, stationIndex + 1);
+            ft.Add<uint16_t>(stationIndex + 1);
         }
     }
 }
@@ -7780,6 +7775,11 @@ std::string Ride::GetName() const
     uint8_t args[32]{};
     FormatNameTo(args);
     return format_string(STR_STRINGID, args);
+}
+
+void Ride::FormatNameTo(Formatter& ft) const
+{
+    ft.Increment(FormatNameTo(ft.Buf()));
 }
 
 size_t Ride::FormatNameTo(void* argsV) const

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -22,6 +22,7 @@
 #include <string_view>
 
 interface IObjectManager;
+class Formatter;
 class StationObject;
 struct Peep;
 struct Ride;
@@ -439,7 +440,9 @@ public:
 
     void SetNameToDefault();
     std::string GetName() const;
+    void FormatNameTo(Formatter&) const;
     size_t FormatNameTo(void* args) const;
+    void FormatStatusTo(Formatter&) const;
     void FormatStatusTo(void* args) const;
 
     static void UpdateAll();

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6178,18 +6178,13 @@ void vehicle_set_map_toolbar(const Vehicle* vehicle)
             if (ride->vehicles[vehicleIndex] == vehicle->sprite_index)
                 break;
 
-        size_t argPos = 0;
-        set_map_tooltip_format_arg(argPos, rct_string_id, STR_RIDE_MAP_TIP);
-        argPos += sizeof(rct_string_id);
-        set_map_tooltip_format_arg(argPos, rct_string_id, STR_MAP_TOOLTIP_STRINGID_STRINGID);
-        argPos += sizeof(rct_string_id);
-        argPos += ride->FormatNameTo(gMapTooltipFormatArgs + argPos);
-        set_map_tooltip_format_arg(
-            argPos, rct_string_id, RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].capitalised);
-        argPos += sizeof(rct_string_id);
-        set_map_tooltip_format_arg(argPos, uint16_t, vehicleIndex + 1);
-        argPos += sizeof(uint16_t);
-        ride->FormatStatusTo(gMapTooltipFormatArgs + argPos);
+        auto ft = Formatter::MapTooltip();
+        ft.Add<rct_string_id>(STR_RIDE_MAP_TIP);
+        ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_STRINGID);
+        ride->FormatNameTo(ft);
+        ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].capitalised);
+        ft.Add<uint16_t>(vehicleIndex + 1);
+        ride->FormatStatusTo(ft);
     }
 }
 

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -64,6 +64,11 @@ std::string Banner::GetText() const
     return format_string(STR_STRINGID, args);
 }
 
+void Banner::FormatTextTo(Formatter& ft, bool addColour) const
+{
+    ft.Increment(FormatTextTo(ft.Buf(), addColour));
+}
+
 size_t Banner::FormatTextTo(void* argsV, bool addColour) const
 {
     Formatter ft(static_cast<uint8_t*>(argsV));
@@ -74,6 +79,11 @@ size_t Banner::FormatTextTo(void* argsV, bool addColour) const
     }
 
     return ft.NumBytes() + FormatTextTo(ft.Buf());
+}
+
+void Banner::FormatTextTo(Formatter& ft) const
+{
+    ft.Increment(FormatTextTo(ft.Buf()));
 }
 
 size_t Banner::FormatTextTo(void* argsV) const

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -15,6 +15,7 @@
 
 #include <string>
 
+class Formatter;
 struct TileElement;
 struct WallElement;
 
@@ -42,6 +43,8 @@ struct Banner
     }
 
     std::string GetText() const;
+    void FormatTextTo(Formatter&, bool addColour) const;
+    void FormatTextTo(Formatter&) const;
     size_t FormatTextTo(void* args, bool addColour) const;
     size_t FormatTextTo(void* args) const;
 };


### PR DESCRIPTION
In this patch I remove the usage of `set_map_tooltip_format_arg`. A few `Format*To` methods got a new overload that takes a  `Formatter`. The overload that takes a `void*` will be eventually retired as `Formatter` spreads through the codebase. 