### PR TITLE
Remove duplicated code due to merge issue

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5181,13 +5181,11 @@ static void vehicle_kill_all_passengers(Vehicle* vehicle)
 
     if (numFatalities != 0)
     {
-        ride->FormatNameTo(gCommonFormatArgs + 2);
-        news_item_add_to_queue(
-            NEWS_ITEM_RIDE, numFatalities == 1 ? STR_X_PERSON_DIED_ON_X : STR_X_PEOPLE_DIED_ON_X, vehicle->ride);
         if (gConfigNotifications.ride_casualties)
         {
             ride->FormatNameTo(gCommonFormatArgs + 2);
-            news_item_add_to_queue(NEWS_ITEM_RIDE, STR_X_PEOPLE_DIED_ON_X, vehicle->ride);
+            news_item_add_to_queue(
+                NEWS_ITEM_RIDE, numFatalities == 1 ? STR_X_PERSON_DIED_ON_X : STR_X_PEOPLE_DIED_ON_X, vehicle->ride);
         }
 
         if (gParkRatingCasualtyPenalty < 500)


### PR DESCRIPTION
Due to bad merge between a81488d704e04f8b0a82a6dcc95f2b19df59b096 and 163119ea3be94ded7be1706b7b4353f6dd2dc78d the code that prints the message got duplicated.