### PR TITLE
 Close #11209: Show a warning when the user is running OpenRCT2 in Wine

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3681,6 +3681,7 @@ STR_6364    :{RED}{COMMA16} person has died in an accident on {STRINGID}
 STR_6365    :Ride casualties
 STR_6366    :Stuck or stalled vehicles
 STR_6367    :{WINDOW_COLOUR_2}Animation frame:
+STR_6368    :For compatibility reasons, it is not recommended to run OpenRCT2 with Wine. OpenRCT2 has native support for macOS, Linux, FreeBSD and OpenBSD.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#9029] Open doors with the tile inspector.
 - Feature: [#11231] Change shortcut window list order to be more intuitive, and split it into logical sections.
 - Feature: [#11306] Path additions are now kept when replacing the path.
+- Change: [#11209] Warn when user is running OpenRCT2 through Wine.
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Fix: [#1148] Research funding dropdown not shown in finances window.
 - Fix: [#6119] Advertising campaign for ride window not updated properly (original bug).

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -52,6 +52,7 @@
 #include "object/ObjectRepository.h"
 #include "paint/Painter.h"
 #include "platform/Crash.h"
+#include "platform/Platform2.h"
 #include "platform/platform.h"
 #include "ride/TrackDesignRepository.h"
 #include "scenario/Scenario.h"
@@ -386,6 +387,19 @@ namespace OpenRCT2
                 else
                 {
                     _uiContext->ShowMessageBox(elevationWarning);
+                }
+            }
+
+            if (Platform::IsRunningInWine())
+            {
+                std::string wineWarning = _localisationService->GetString(STR_WINE_NOT_RECOMMENDED);
+                if (gOpenRCT2Headless)
+                {
+                    Console::Error::WriteLine(wineWarning.c_str());
+                }
+                else
+                {
+                    _uiContext->ShowMessageBox(wineWarning);
                 }
             }
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3918,6 +3918,8 @@ enum
 
     STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME = 6367,
 
+    STR_WINE_NOT_RECOMMENDED = 6368,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -99,6 +99,11 @@ namespace Platform
         }
         return isSupported;
     }
+
+    bool IsRunningInWine()
+    {
+        return false;
+    }
 } // namespace Platform
 
 #endif

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -241,6 +241,17 @@ namespace Platform
         return result;
     }
 
+    bool IsRunningInWine()
+    {
+        HMODULE ntdllMod = GetModuleHandleW(L"ntdll.dll");
+
+        if (ntdllMod && GetProcAddress(ntdllMod, "wine_get_version"))
+        {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Checks if the current version of Windows supports ANSI colour codes.
      * From Windows 10, build 10586 ANSI escape colour codes can be used on stdout.

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -45,6 +45,7 @@ namespace Platform
     bool IsOSVersionAtLeast(uint32_t major, uint32_t minor, uint32_t build);
 #endif
 
+    bool IsRunningInWine();
     bool IsColourTerminalSupported();
     bool HandleSpecialCommandLineArgument(const char* argument);
     uintptr_t StrDecompToPrecomp(utf8* input);


### PR DESCRIPTION
Adds functionality to display a warning (similar to that of the warning displayed when running on root) when the user is detected to be using Wine to run the application instead of the better supported Linux per Issue #11209 

