### PR TITLE
Prototype Commit Lint integration

### DIFF
--- a/.commitlint.json
+++ b/.commitlint.json
@@ -32,8 +32,7 @@
           20
       ],
       "scope-empty": [
-          2,
-          "always"
+          0
       ],
       "subject-case": [
           0

--- a/.commitlint.json
+++ b/.commitlint.json
@@ -27,9 +27,9 @@
           72
       ],
       "header-min-length": [
-          1,
+          2,
           "always",
-          20
+          10
       ],
       "scope-empty": [
           0

--- a/.commitlint.json
+++ b/.commitlint.json
@@ -1,0 +1,69 @@
+
+{
+  "rules": {
+      "body-leading-blank": [
+          2,
+          "always"
+      ],
+      "body-max-length": [
+          0
+      ],
+      "body-min-length": [
+          0
+      ],
+      "footer-leading-blank": [
+          2,
+          "always"
+      ],
+      "footer-max-length": [
+          0
+      ],
+      "footer-min-length": [
+          0
+      ],
+      "header-max-length": [
+          2,
+          "always",
+          72
+      ],
+      "header-min-length": [
+          1,
+          "always",
+          20
+      ],
+      "scope-empty": [
+          2,
+          "always"
+      ],
+      "subject-case": [
+          0
+      ],
+      "subject-empty": [
+          0
+      ],
+      "subject-full-stop": [
+          0
+      ],
+      "subject-max-length": [
+          0
+      ],
+      "subject-min-length": [
+          0
+      ],
+      "type-case": [
+          0
+      ],
+      "type-empty": [
+          0
+      ],
+      "type-enum": [
+          0
+      ],
+      "type-max-length": [
+          0
+      ],
+      "type-min-length": [
+          0
+      ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   OPENRCT2_VERSION: 0.2.6
 jobs:
   lint-commit:
-    name: Lint Commit Message
+    name: Lint Commit Message 
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ env:
   BACKTRACE_IO_TOKEN: ${{ secrets.BACKTRACE_IO_TOKEN }}
   OPENRCT2_VERSION: 0.2.6
 jobs:
-  lint:
+  lint-commit:
+    name: Check Commit Message Formatting
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ env:
   BACKTRACE_IO_TOKEN: ${{ secrets.BACKTRACE_IO_TOKEN }}
   OPENRCT2_VERSION: 0.2.6
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Lint Commit Messages
+        uses: wagoid/commitlint-github-action@v1
+        with:
+          configFile: .commitlint.json
   check-code-formatting:
     name: Check code formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   OPENRCT2_VERSION: 0.2.6
 jobs:
   lint-commit:
-    name: Check Commit Message Formatting
+    name: Lint Commit Message
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   OPENRCT2_VERSION: 0.2.6
 jobs:
   lint-commit:
-    name: Lint Commit Message 
+    name: Lint Commit Message
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
~I have no clue whether this will work or not, so I'm opening a draft PR to prototype~
**DON'T MERGE, IF WE SETTLE ON THIS I'LL REBASE AND SQUASH :D**

Apparently we can have a good control over commit messages with this `commitlint` extension, made possible through the `commitlint-github-action`. The rules are on [commitlint](https://commitlint.js.org/#/reference-rules), but I'm basically:

1. Erroring out if the commit message exceeds 72 chars
2. ~Warning~ Erroring if it's smaller than ~20~ 10 chars.
3. Making sure there is a line break between the message and the body and the footer.

This PR has 5 commits, some intentionally long/short just to test that it works.
```
Prototype Commit Lint integration
A very long commit message just to see how the lint reports failures when there are multiple patches in the PR
Short commit
Some normal commit with a regular size
Enable commitlint for pull requests and commits
```

This is the output of the CI job:
```
⧗   input: Short commit
⚠   header must not be shorter than 20 characters, current length is 12 [header-min-length]

⚠   found 0 problems, 1 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

⧗   input: A very long commit message just to see how the lint reports failures when there are multiple patches in the PR
✖   header must not be longer than 72 characters, current length is 110 [header-max-length]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```