### PR TITLE
Fix #11405: Building path through walls does not always remove them

### DIFF
--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -130,7 +130,7 @@ public:
                 auto zLow = _loc.z;
                 auto zHigh = zLow + PATH_CLEARANCE;
                 wall_remove_intersecting_walls(
-                    { _loc, zLow, zHigh + (_slope & TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK) ? 16 : 0 },
+                    { _loc, zLow, zHigh + ((_slope & TILE_ELEMENT_SURFACE_RAISED_CORNERS_MASK) ? 16 : 0) },
                     direction_reverse(_direction));
                 wall_remove_intersecting_walls(
                     { _loc.x - CoordsDirectionDelta[_direction].x, _loc.y - CoordsDirectionDelta[_direction].y, zLow, zHigh },


### PR DESCRIPTION
"Parentheses are maths' condoms. You can never use too many of them, but you can use too few." - My maths teacher in secondary school.