### PR TITLE
en-GB: Change "plug-in objects" to "custom objects"

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2421,8 +2421,8 @@ STR_3329    :Park entrance not yet built
 STR_3330    :Park must own some land
 STR_3331    :Path from park entrance to map edge either not complete or too complex - Path must be single-width with as few junctions and corners as possible
 STR_3332    :Park entrance is the wrong way round or has no path leading to the map edge
-STR_3333    :Export plug-in objects with saved games
-STR_3334    :{SMALLFONT}{BLACK}Select whether to save any additional plug-in object data required (add-in data not supplied with the main product) in saved game or scenario files, allowing them to be loaded by someone who doesn't have the additional object data
+STR_3333    :Export custom objects with saved games
+STR_3334    :{SMALLFONT}{BLACK}Select whether to save any additional custom object data required (add-in data not supplied with the main product) in saved game or scenario files, allowing them to be loaded by someone who doesn't have the additional object data
 STR_3335    :Track Designer - Select Ride Types & Vehicles
 STR_3336    :Track Designs Manager - Select Ride Type
 STR_3338    :{BLACK}Custom-designed layout


### PR DESCRIPTION
This change is to avoid confusion with the upcoming plug-in system. Additionally, "custom objects" is what most people would call these anyway.