### PR TITLE
Fix Android filesystem compilation error when using NDK revision 19+

### DIFF
--- a/src/openrct2/core/FileSystem.hpp
+++ b/src/openrct2/core/FileSystem.hpp
@@ -19,6 +19,8 @@
 #    define HAVE_STD_FILESYSTEM 1
 #elif defined(__APPLE__) // XCode has the header, but reports error when included.
 #    define HAVE_STD_FILESYSTEM 0
+#elif defined(__ANDROID__)
+#    define HAVE_STD_FILESYSTEM 0
 #elif defined(__has_include) // For GCC/Clang check if the header exists.
 #    if __has_include(<filesystem>)
 #        define HAVE_STD_FILESYSTEM 1


### PR DESCRIPTION
When attemping to build with ndk 19+ I get the following error: error: undefined reference to 'std::__ndk1::__fs::filesystem::path::__extension() const'

Looking at this issue here https://github.com/android/ndk/issues/609 and https://android.googlesource.com/platform/ndk/+/master/docs/Roadmap.md#package-management it's stated that the ndk does not support std::filesystem

This only fixes one of the compilation errors on ndk 19+ though. I still get this error when trying to compile

```Build command failed.
Error while executing process C:\Users\Fluki\AppData\Local\Android\Sdk\cmake\3.6.4111459\bin\cmake.exe with arguments {--build C:\Users\Fluki\Documents\GitHub\OpenRCT2\src\openrct2-android\app\.cxx\cmake\armDebug\arm64-v8a --target openrct2-cli}
[1/3] Running utility command for libs
[2/3] Building CXX object CMakeFiles/openrct2-cli.dir/C_/Users/Fluki/Documents/GitHub/OpenRCT2/src/openrct2-cli/Cli.cpp.o
[3/3] Linking CXX executable openrct2-cli
FAILED: cmd.exe /C "cd . && C:\Users\Fluki\AppData\Local\Android\Sdk\ndk\19.2.5345600\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe  --target=aarch64-none-linux-android21 --gcc-toolchain=C:/Users/Fluki/AppData/Local/Android/Sdk/ndk/19.2.5345600/toolchains/llvm/prebuilt/windows-x86_64 --sysroot=C:/Users/Fluki/AppData/Local/Android/Sdk/ndk/19.2.5345600/toolchains/llvm/prebuilt/windows-x86_64/sysroot  -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fno-addrsig -Wa,--noexecstack -Wformat -Werror=format-security -stdlib=libc++  -DDEBUG=0 -std=gnu++1z  -fstrict-aliasing -Wundef -Wmissing-declarations -Winit-self  -Wno-unknown-pragmas -Wno-unused-function -Wno-missing-braces  -Wno-comment -Wshadow  -Wmissing-declarations -Wnonnull -fPIC -Wnon-virtual-dtor -O0 -fno-limit-debug-info  -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libatomic.a -Wl,--build-id -Wl,--warn-shared-textrel -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--gc-sections CMakeFiles/openrct2-cli.dir/C_/Users/Fluki/Documents/GitHub/OpenRCT2/src/openrct2-cli/Cli.cpp.o  -o openrct2-cli  C:/Users/Fluki/Documents/GitHub/OpenRCT2/src/openrct2-android/app/build/intermediates/cmake/armDebug/obj/arm64-v8a/libopenrct2.so -landroid -lstdc++ -lGLESv1_CM -lGLESv2 -llog -ldl -lz libs/lib/libSDL2-2.0.so libs/lib/libpng16.so libs/lib/libjansson.so libs/lib/libicui18n.a libs/lib/libicuuc.a libs/lib/libicudata.a libs/lib/libssl.so libs/lib/libcrypto.so -latomic -lm && cd ."
C:/Users/Fluki/AppData/Local/Android/Sdk/ndk/19.2.5345600/toolchains/llvm/prebuilt/windows-x86_64/lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin\ld: warning: libstdc++.so, needed by libs/lib/libssl.so, not found (try using -rpath or -rpath-link)

clang++.exe: error: linker command failed with exit code 1 (use -v to see invocation)

ninja: build stopped: subcommand failed.