### PR TITLE
Mark getters in audio layer as [[nodiscard]]

### DIFF
--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -66,12 +66,12 @@ namespace OpenRCT2::Audio
             }
         }
 
-        IAudioSource* GetSource() const override
+        [[nodiscard]] IAudioSource* GetSource() const override
         {
             return _source;
         }
 
-        SpeexResamplerState* GetResampler() const override
+        [[nodiscard]] SpeexResamplerState* GetResampler() const override
         {
             return _resampler;
         }
@@ -81,7 +81,7 @@ namespace OpenRCT2::Audio
             _resampler = value;
         }
 
-        int32_t GetGroup() const override
+        [[nodiscard]] int32_t GetGroup() const override
         {
             return _group;
         }
@@ -91,7 +91,7 @@ namespace OpenRCT2::Audio
             _group = group;
         }
 
-        double GetRate() const override
+        [[nodiscard]] double GetRate() const override
         {
             return _rate;
         }
@@ -101,7 +101,7 @@ namespace OpenRCT2::Audio
             _rate = std::max(0.001, rate);
         }
 
-        uint64_t GetOffset() const override
+        [[nodiscard]] uint64_t GetOffset() const override
         {
             return _offset;
         }
@@ -118,7 +118,7 @@ namespace OpenRCT2::Audio
             return false;
         }
 
-        virtual int32_t GetLoop() const override
+        [[nodiscard]] virtual int32_t GetLoop() const override
         {
             return _loop;
         }
@@ -128,32 +128,32 @@ namespace OpenRCT2::Audio
             _loop = value;
         }
 
-        int32_t GetVolume() const override
+        [[nodiscard]] int32_t GetVolume() const override
         {
             return _volume;
         }
 
-        float GetVolumeL() const override
+        [[nodiscard]] float GetVolumeL() const override
         {
             return _volume_l;
         }
 
-        float GetVolumeR() const override
+        [[nodiscard]] float GetVolumeR() const override
         {
             return _volume_r;
         }
 
-        float GetOldVolumeL() const override
+        [[nodiscard]] float GetOldVolumeL() const override
         {
             return _oldvolume_l;
         }
 
-        float GetOldVolumeR() const override
+        [[nodiscard]] float GetOldVolumeR() const override
         {
             return _oldvolume_r;
         }
 
-        int32_t GetOldVolume() const override
+        [[nodiscard]] int32_t GetOldVolume() const override
         {
             return _oldvolume;
         }
@@ -163,7 +163,7 @@ namespace OpenRCT2::Audio
             _volume = std::clamp(volume, 0, MIXER_VOLUME_MAX);
         }
 
-        float GetPan() const override
+        [[nodiscard]] float GetPan() const override
         {
             return _pan;
         }
@@ -185,7 +185,7 @@ namespace OpenRCT2::Audio
             }
         }
 
-        bool IsStopping() const override
+        [[nodiscard]] bool IsStopping() const override
         {
             return _stopping;
         }
@@ -195,7 +195,7 @@ namespace OpenRCT2::Audio
             _stopping = value;
         }
 
-        bool IsDone() const override
+        [[nodiscard]] bool IsDone() const override
         {
             return _done;
         }
@@ -205,7 +205,7 @@ namespace OpenRCT2::Audio
             _done = value;
         }
 
-        bool DeleteOnDone() const override
+        [[nodiscard]] bool DeleteOnDone() const override
         {
             return _deleteondone;
         }
@@ -220,7 +220,7 @@ namespace OpenRCT2::Audio
             _deletesourceondone = value;
         }
 
-        bool IsPlaying() const override
+        [[nodiscard]] bool IsPlaying() const override
         {
             return !_done;
         }
@@ -240,7 +240,7 @@ namespace OpenRCT2::Audio
             _oldvolume_r = _volume_r;
         }
 
-        AudioFormat GetFormat() const override
+        [[nodiscard]] AudioFormat GetFormat() const override
         {
             AudioFormat result = {};
             // The second check is there because NullAudioSource does not implement GetFormat. Avoid calling it.

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -50,13 +50,13 @@ namespace OpenRCT2::Audio
 
     interface ISDLAudioSource : public IAudioSource
     {
-        virtual AudioFormat GetFormat() const abstract;
+        [[nodiscard]] virtual AudioFormat GetFormat() const abstract;
     };
 
     interface ISDLAudioChannel : public IAudioChannel
     {
-        virtual AudioFormat GetFormat() const abstract;
-        virtual SpeexResamplerState* GetResampler() const abstract;
+        [[nodiscard]] virtual AudioFormat GetFormat() const abstract;
+        [[nodiscard]] virtual SpeexResamplerState* GetResampler() const abstract;
         virtual void SetResampler(SpeexResamplerState * value) abstract;
     };
 

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -24,12 +24,12 @@ namespace OpenRCT2::Audio
         SDL_AudioFormat format;
         int32_t channels;
 
-        int32_t BytesPerSample() const
+        [[nodiscard]] int32_t BytesPerSample() const
         {
             return (SDL_AUDIO_BITSIZE(format)) / 8;
         }
 
-        int32_t GetByteRate() const
+        [[nodiscard]] int32_t GetByteRate() const
         {
             return BytesPerSample() * channels;
         }

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -42,12 +42,12 @@ namespace OpenRCT2::Audio
             Unload();
         }
 
-        uint64_t GetLength() const override
+        [[nodiscard]] uint64_t GetLength() const override
         {
             return _length;
         }
 
-        AudioFormat GetFormat() const override
+        [[nodiscard]] AudioFormat GetFormat() const override
         {
             return _format;
         }


### PR DESCRIPTION
Split off from #10115.