### PR TITLE
Fix drawing of walls with incorrect scrolling modes

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -426,6 +426,11 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     }
 
     uint16_t scrollingMode = sceneryEntry->wall.scrolling_mode + ((direction + 1) & 0x3);
+    if (scrollingMode >= MAX_SCROLLING_TEXT_MODES)
+    {
+        return;
+    }
+
     auto banner = tile_element->AsWall()->GetBanner();
     if (banner != nullptr && !banner->IsNull())
     {


### PR DESCRIPTION
When attempting to place some of the walls in https://github.com/OpenRCT2/OpenRCT2/files/4366456/tile-element-limit-hit.191017-rct2-coasterbill-emerald_pointe.zip , an assertion gets hits because one of the walls in the save specifies an incorrect scrolling mode.

This fix is basically the same as the one employed for Paint.Banner.cpp