### PR TITLE
Fix #11490: Crash with error message titles

### DIFF
--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -59,7 +59,7 @@ std::string GameActionResult::GetErrorTitle() const
     }
     else
     {
-        title = format_string(ErrorTitle.GetStringId(), nullptr);
+        title = format_string(ErrorTitle.GetStringId(), ErrorMessageArgs.data());
     }
     return title;
 }


### PR DESCRIPTION
Fix #11490. Crash with error message titles

Error message titles for rides are composed from the ride name string id and therefore require passing the error message args.

Also fixes:
#11501 
#11500 
#11491 
#11488 