### PR TITLE
Fix #11494: Old console commands don't work at headless console since plugin system

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -91,6 +91,16 @@ declare global {
     interface Console {
         clear(): void;
         log(message?: any, ...optionalParams: any[]): void;
+
+        /**
+         * Executes a command using the legacy console REPL. This should not be used
+         * by plugins, and exists only for servers to continue using old commands until
+         * all functionality can be accomplished with this scripting API.
+         * 
+         * @deprecated
+         * @param command The command and arguments to execute.
+         */
+        executeLegacy(command: string): void;
     }
 
     /**

--- a/src/openrct2/scripting/ScConsole.hpp
+++ b/src/openrct2/scripting/ScConsole.hpp
@@ -51,10 +51,16 @@ namespace OpenRCT2::Scripting
             return 0;
         }
 
+        void executeLegacy(const std::string& command)
+        {
+            _console.Execute(command);
+        }
+
         static void Register(duk_context* ctx)
         {
             dukglue_register_method(ctx, &ScConsole::clear, "clear");
             dukglue_register_method_varargs(ctx, &ScConsole::log, "log");
+            dukglue_register_method(ctx, &ScConsole::executeLegacy, "executeLegacy");
         }
     };
 } // namespace OpenRCT2::Scripting


### PR DESCRIPTION
Add `console.executeLegacy(command: string)` API.

```
openrct2 $ console.executeLegacy('object_count')
Rides: 0/128
Small scenery: 0/252
Large scenery: 0/128
Walls: 0/128
Banners: 0/32
Paths: 0/16
Path Additions: 0/15
Scenery groups: 0/19
Park entrances: 0/1
Water: 0/1
```