### PR TITLE
Entity cleanup

### DIFF
--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -620,7 +620,7 @@ static void window_title_command_editor_tool_down(
         uint16_t spriteIndex = info.sprite->generic.sprite_index;
         uint16_t spriteIdentifier = info.sprite->generic.sprite_identifier;
         bool validSprite = false;
-        if (spriteIdentifier == SPRITE_IDENTIFIER_PEEP)
+        if (info.sprite->IsPeep())
         {
             validSprite = true;
             auto peep = GET_PEEP(spriteIndex);

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -158,8 +158,6 @@ private:
         }
         else
         {
-            move_sprite_to_list(newPeep, SPRITE_LIST_PEEP);
-
             newPeep->sprite_identifier = 1;
             newPeep->window_invalidate_flags = 0;
             newPeep->action = PEEP_ACTION_NONE_2;

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -56,7 +56,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
 
         if (highlightPathIssues)
         {
-            if (spr->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+            if (spr->IsPeep())
             {
                 Peep* peep = (Peep*)spr;
                 if (!(peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_HANDYMAN))

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5482,7 +5482,7 @@ void Guest::UpdateWalking()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
+        if (!sprite->IsPeep())
             continue;
 
         if (sprite->peep.state != PEEP_STATE_WATCHING)
@@ -6068,7 +6068,7 @@ bool Guest::UpdateWalkingFindBench()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
+        if (!sprite->IsPeep())
             continue;
 
         if (sprite->peep.state != PEEP_STATE_SITTING)
@@ -6262,8 +6262,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if ((sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP) || (sprite->peep.state != PEEP_STATE_SITTING)
-            || (peep->z != sprite->peep.z))
+        if (!sprite->IsPeep() || (sprite->peep.state != PEEP_STATE_SITTING) || (peep->z != sprite->peep.z))
         {
             continue;
         }

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5482,7 +5482,7 @@ void Guest::UpdateWalking()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
+        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
             continue;
 
         if (sprite->peep.state != PEEP_STATE_WATCHING)
@@ -6068,7 +6068,7 @@ bool Guest::UpdateWalkingFindBench()
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
+        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
             continue;
 
         if (sprite->peep.state != PEEP_STATE_SITTING)
@@ -6262,7 +6262,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if ((sprite->generic.linked_list_index != SPRITE_LIST_PEEP) || (sprite->peep.state != PEEP_STATE_SITTING)
+        if ((sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP) || (sprite->peep.state != PEEP_STATE_SITTING)
             || (peep->z != sprite->peep.z))
         {
             continue;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -324,7 +324,7 @@ const bool gSpriteTypeToSlowWalkMap[] = {
 
 // clang-format on
 
-bool rct_sprite::IsPeep()
+bool rct_sprite::IsPeep() const
 {
     return peep.sprite_identifier == SPRITE_IDENTIFIER_PEEP;
 }
@@ -388,7 +388,7 @@ Peep* try_get_guest(uint16_t spriteIndex)
     rct_sprite* sprite = try_get_sprite(spriteIndex);
     if (sprite == nullptr)
         return nullptr;
-    if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
+    if (!sprite->IsPeep())
         return nullptr;
     if (sprite->peep.type != PEEP_TYPE_GUEST)
         return nullptr;
@@ -2693,7 +2693,7 @@ static void peep_footpath_move_forward(Peep* peep, int16_t x, int16_t y, TileEle
     for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
-        if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+        if (sprite->IsPeep())
         {
             Peep* other_peep = reinterpret_cast<Peep*>(sprite);
             if (other_peep->state != PEEP_STATE_WALKING)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -434,7 +434,7 @@ void peep_update_all()
         else
         {
             peep_128_tick_update(peep, i);
-            if (peep->linked_list_index == SPRITE_LIST_PEEP)
+            if (peep->sprite_identifier == SPRITE_IDENTIFIER_PEEP)
             {
                 peep->Update();
             }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1813,7 +1813,7 @@ static int32_t peep_update_patrolling_find_sweeping(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if (sprite->generic.linked_list_index != SPRITE_LIST_LITTER)
+        if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_LITTER)
             continue;
 
         uint16_t z_diff = abs(peep->z - sprite->litter.z);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1122,17 +1122,14 @@ private:
                 rct1_vehicle* srcVehicle = &_s4.sprites[i].vehicle;
                 if (srcVehicle->x != LOCATION_NULL)
                 {
-                    Vehicle* vehicle = reinterpret_cast<Vehicle*>(create_sprite(SPRITE_IDENTIFIER_VEHICLE));
+                    // If vehicle is the first car on a train add to train list
+                    auto llt = srcVehicle->type == VEHICLE_TYPE_HEAD ? SPRITE_LIST_TRAIN_HEAD : SPRITE_LIST_VEHICLE;
+
+                    Vehicle* vehicle = reinterpret_cast<Vehicle*>(create_sprite(SPRITE_IDENTIFIER_VEHICLE, llt));
                     spriteIndexMap[i] = vehicle->sprite_index;
                     vehicles.push_back(vehicle);
 
                     ImportVehicle(vehicle, srcVehicle);
-
-                    // If vehicle is the first car on a train add to train list
-                    if (vehicle->IsHead())
-                    {
-                        move_sprite_to_list(vehicle, SPRITE_LIST_TRAIN_HEAD);
-                    }
                 }
             }
         }

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -23,13 +23,13 @@
 Vehicle* cable_lift_segment_create(
     Ride& ride, int32_t x, int32_t y, int32_t z, int32_t direction, uint16_t var_44, int32_t remaining_distance, bool head)
 {
-    Vehicle* current = &(create_sprite(SPRITE_IDENTIFIER_VEHICLE)->vehicle);
+    Vehicle* current = &(
+        create_sprite(SPRITE_IDENTIFIER_VEHICLE, head ? SPRITE_LIST_TRAIN_HEAD : SPRITE_LIST_VEHICLE)->vehicle);
     current->sprite_identifier = SPRITE_IDENTIFIER_VEHICLE;
     current->ride = ride.id;
     current->ride_subtype = RIDE_ENTRY_INDEX_NULL;
     if (head)
     {
-        move_sprite_to_list(current, SPRITE_LIST_TRAIN_HEAD);
         ride.cable_lift = current->sprite_index;
     }
     current->type = head ? VEHICLE_TYPE_HEAD : VEHICLE_TYPE_TAIL;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4324,7 +4324,8 @@ static Vehicle* vehicle_create_car(
         return nullptr;
 
     auto vehicleEntry = &rideEntry->vehicles[vehicleEntryIndex];
-    auto vehicle = &create_sprite(SPRITE_IDENTIFIER_VEHICLE)->vehicle;
+    auto vehicle = &create_sprite(SPRITE_IDENTIFIER_VEHICLE, carIndex == 0 ? SPRITE_LIST_TRAIN_HEAD : SPRITE_LIST_VEHICLE)
+                        ->vehicle;
     if (vehicle == nullptr)
         return nullptr;
 
@@ -4568,8 +4569,6 @@ static void vehicle_create_trains(ride_id_t rideIndex, int32_t x, int32_t y, int
         }
         lastTrain = train;
 
-        // Add train to ride vehicle list
-        move_sprite_to_list(train.head, SPRITE_LIST_TRAIN_HEAD);
         for (int32_t i = 0; i <= MAX_VEHICLES_PER_RIDE; i++)
         {
             if (ride->vehicles[i] == SPRITE_INDEX_NULL)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -324,8 +324,6 @@ void ride_update_favourited_stat()
 
     FOR_ALL_GUESTS (spriteIndex, peep)
     {
-        if (peep->linked_list_index != SPRITE_LIST_PEEP)
-            return;
         if (peep->favourite_ride != RIDE_ID_NULL)
         {
             auto ride = get_ride(peep->favourite_ride);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -419,7 +419,7 @@ void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
     {
         auto* entity = get_sprite(spriteIndex);
         uint16_t nextSpriteIndex = entity->generic.next_in_quadrant;
-        if (entity->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+        if (entity->IsPeep())
         {
             Peep* peep = &entity->peep;
             if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -395,7 +395,7 @@ void footpath_remove_litter(const CoordsXYZ& footpathPos)
     {
         Litter* sprite = &get_sprite(spriteIndex)->litter;
         uint16_t nextSpriteIndex = sprite->next_in_quadrant;
-        if (sprite->linked_list_index == SPRITE_LIST_LITTER)
+        if (sprite->sprite_identifier == SPRITE_IDENTIFIER_LITTER)
         {
             int32_t distanceZ = abs(sprite->z - footpathPos.z);
             if (distanceZ <= 32)
@@ -417,10 +417,11 @@ void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
     uint16_t spriteIndex = sprite_get_first_in_quadrant(footpathPos.x, footpathPos.y);
     while (spriteIndex != SPRITE_INDEX_NULL)
     {
-        Peep* peep = &get_sprite(spriteIndex)->peep;
-        uint16_t nextSpriteIndex = peep->next_in_quadrant;
-        if (peep->linked_list_index == SPRITE_LIST_PEEP)
+        auto* entity = get_sprite(spriteIndex);
+        uint16_t nextSpriteIndex = entity->generic.next_in_quadrant;
+        if (entity->generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
         {
+            Peep* peep = &entity->peep;
             if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING)
             {
                 if (peep->z == footpathPos.z)

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -202,7 +202,7 @@ static bool map_animation_invalidate_small_scenery(const CoordsXYZ& loc)
                 for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
                 {
                     sprite = get_sprite(spriteIdx);
-                    if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
+                    if (!sprite->IsPeep())
                         continue;
 
                     peep = &sprite->peep;

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -202,7 +202,7 @@ static bool map_animation_invalidate_small_scenery(const CoordsXYZ& loc)
                 for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
                 {
                     sprite = get_sprite(spriteIdx);
-                    if (sprite->generic.linked_list_index != SPRITE_LIST_PEEP)
+                    if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_PEEP)
                         continue;
 
                     peep = &sprite->peep;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -268,7 +268,7 @@ rct_sprite_checksum sprite_checksum()
                         break;
                 }
 
-                if (copy.generic.sprite_identifier == SPRITE_IDENTIFIER_PEEP)
+                if (copy.IsPeep())
                 {
                     // Name is pointer and will not be the same across clients
                     copy.peep.name = {};

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -50,6 +50,7 @@ static CoordsXYZ _spritelocations1[MAX_SPRITES];
 static CoordsXYZ _spritelocations2[MAX_SPRITES];
 
 static size_t GetSpatialIndexOffset(int32_t x, int32_t y);
+static void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newListIndex);
 
 std::string rct_sprite_checksum::ToString() const
 {
@@ -358,32 +359,12 @@ static void SpriteSpatialInsert(SpriteBase* sprite, const CoordsXY& newLoc);
 
 static constexpr uint16_t MAX_MISC_SPRITES = 300;
 
-rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier)
+rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier, SPRITE_LIST linkedListIndex)
 {
     if (gSpriteListCount[SPRITE_LIST_FREE] == 0)
     {
         // No free sprites.
         return nullptr;
-    }
-
-    SPRITE_LIST linkedListIndex;
-    switch (spriteIdentifier)
-    {
-        case SPRITE_IDENTIFIER_VEHICLE:
-            linkedListIndex = SPRITE_LIST_VEHICLE;
-            break;
-        case SPRITE_IDENTIFIER_PEEP:
-            linkedListIndex = SPRITE_LIST_PEEP;
-            break;
-        case SPRITE_IDENTIFIER_MISC:
-            linkedListIndex = SPRITE_LIST_MISC;
-            break;
-        case SPRITE_IDENTIFIER_LITTER:
-            linkedListIndex = SPRITE_LIST_LITTER;
-            break;
-        default:
-            Guard::Assert(false, "Invalid sprite identifier: 0x%02X", spriteIdentifier);
-            return nullptr;
     }
 
     if (linkedListIndex == SPRITE_LIST_MISC)
@@ -420,12 +401,36 @@ rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier)
     return reinterpret_cast<rct_sprite*>(sprite);
 }
 
+rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier)
+{
+    SPRITE_LIST linkedListIndex = SPRITE_LIST_FREE;
+    switch (spriteIdentifier)
+    {
+        case SPRITE_IDENTIFIER_VEHICLE:
+            linkedListIndex = SPRITE_LIST_VEHICLE;
+            break;
+        case SPRITE_IDENTIFIER_PEEP:
+            linkedListIndex = SPRITE_LIST_PEEP;
+            break;
+        case SPRITE_IDENTIFIER_MISC:
+            linkedListIndex = SPRITE_LIST_MISC;
+            break;
+        case SPRITE_IDENTIFIER_LITTER:
+            linkedListIndex = SPRITE_LIST_LITTER;
+            break;
+        default:
+            Guard::Assert(false, "Invalid sprite identifier: 0x%02X", spriteIdentifier);
+            return nullptr;
+    }
+    return create_sprite(spriteIdentifier, linkedListIndex);
+}
+
 /*
  * rct2: 0x0069ED0B
  * This function moves a sprite to the specified sprite linked list.
  * The game uses this list to categorise sprites by type.
  */
-void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newListIndex)
+static void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newListIndex)
 {
     int32_t oldListIndex = sprite->linked_list_index;
 

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -163,7 +163,7 @@ void reset_sprite_list()
         spr->generic.sprite_identifier = SPRITE_IDENTIFIER_NULL;
         spr->generic.sprite_index = i;
         spr->generic.next = SPRITE_INDEX_NULL;
-        spr->generic.linked_list_index = 0;
+        spr->generic.linked_list_index = SPRITE_LIST_FREE;
 
         if (previous_spr != nullptr)
         {
@@ -827,7 +827,7 @@ void litter_remove_at(int32_t x, int32_t y, int32_t z)
     {
         rct_sprite* sprite = get_sprite(spriteIndex);
         uint16_t nextSpriteIndex = sprite->generic.next_in_quadrant;
-        if (sprite->generic.linked_list_index == SPRITE_LIST_LITTER)
+        if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_LITTER)
         {
             Litter* litter = &sprite->litter;
 
@@ -884,11 +884,10 @@ uint16_t remove_floating_sprites()
  */
 static bool sprite_should_tween(rct_sprite* sprite)
 {
-    switch (sprite->generic.linked_list_index)
+    switch (sprite->generic.sprite_identifier)
     {
-        case SPRITE_LIST_PEEP:
-        case SPRITE_LIST_TRAIN_HEAD:
-        case SPRITE_LIST_VEHICLE:
+        case SPRITE_IDENTIFIER_PEEP:
+        case SPRITE_IDENTIFIER_VEHICLE:
             return true;
     }
     return false;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -133,7 +133,7 @@ union rct_sprite
     bool IsBalloon();
     bool IsDuck();
     bool IsMoneyEffect();
-    bool IsPeep();
+    bool IsPeep() const;
     Balloon* AsBalloon();
     Duck* AsDuck();
     MoneyEffect* AsMoneyEffect();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -204,10 +204,10 @@ extern uint16_t gSpriteSpatialIndex[SPATIAL_INDEX_SIZE];
 extern const rct_string_id litterNames[12];
 
 rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier);
+rct_sprite* create_sprite(SPRITE_IDENTIFIER spriteIdentifier, SPRITE_LIST linkedListIndex);
 void reset_sprite_list();
 void reset_sprite_spatial_index();
 void sprite_clear_all_unused();
-void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newList);
 void sprite_misc_update_all();
 void sprite_move(int16_t x, int16_t y, int16_t z, SpriteBase* sprite);
 void sprite_set_coordinates(int16_t x, int16_t y, int16_t z, SpriteBase* sprite);


### PR DESCRIPTION
A couple little refactors that are from my create sprite branch. These changes remove the ability for entities to change their list type after creation and also reduces the amount of code that actually uses the list type.