### PR TITLE
Improve network plugin APIs

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -562,13 +562,16 @@ declare global {
      */
     interface Network {
         readonly mode: NetworkMode;
-        readonly groups: number;
-        readonly players: number;
+        readonly numGroups: number;
+        readonly numPlayers: number;
+        readonly groups: PlayerGroup[];
+        readonly players: Player[];
         defaultGroup: number;
 
         getServerInfo(): ServerInfo;
+        addGroup(): void;
         getGroup(index: number): PlayerGroup;
-        setGroups(groups: PlayerGroup[]): void;
+        removeGroup(index: number): void;
         getPlayer(index: number): Player;
         kickPlayer(index: number): void;
         sendMessage(message: string): void;

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -590,6 +590,8 @@ declare global {
         readonly ping: number;
         readonly commandsRan: number;
         readonly moneySpent: number;
+        readonly ipAddress: string;
+        readonly publicKeyHash: string;
     }
 
     interface PlayerGroup {

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -175,6 +175,7 @@ declare global {
         subscribe(hook: "interval.tick", callback: () => void): IDisposable;
         subscribe(hook: "interval.day", callback: () => void): IDisposable;
         subscribe(hook: "network.chat", callback: (e: NetworkChatEventArgs) => void): IDisposable;
+        subscribe(hook: "network.authenticate", callback: (e: NetworkAuthenticateEventArgs) => void): IDisposable;
         subscribe(hook: "network.join", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
     }
@@ -255,6 +256,13 @@ declare global {
 
     interface NetworkChatEventArgs extends NetworkEventArgs {
         message: string;
+    }
+
+    interface NetworkAuthenticateEventArgs {
+        readonly name: number;
+        readonly ipAddress: string;
+        readonly publicKeyHash: string;
+        cancel: boolean;
     }
 
     /**

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -672,8 +672,8 @@ NetworkConnection* Network::GetPlayerConnection(uint8_t id)
     if (player != nullptr)
     {
         auto clientIt = std::find_if(
-                   client_connection_list.begin(), client_connection_list.end(),
-                   [player](const auto& conn) -> bool { return conn->Player == player; });
+            client_connection_list.begin(), client_connection_list.end(),
+            [player](const auto& conn) -> bool { return conn->Player == player; });
         return clientIt != client_connection_list.end() ? clientIt->get() : nullptr;
     }
     return nullptr;

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -1676,6 +1676,7 @@ void Network::Server_Send_CHAT(const char* text, const std::vector<uint8_t>& pla
 
     if (playerIds.empty())
     {
+        // Empty players / default value means send to all players
         SendPacketToClients(*packet);
     }
     else
@@ -3522,7 +3523,7 @@ money32 network_get_player_money_spent(uint32_t index)
 std::string network_get_player_ip_address(uint32_t id)
 {
     auto conn = gNetwork.GetPlayerConnection(id);
-    if (conn != nullptr)
+    if (conn != nullptr && conn->Socket != nullptr)
     {
         return conn->Socket->GetIpAddress();
     }
@@ -4002,6 +4003,7 @@ void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds)
                 if (playerIds.empty()
                     || std::find(playerIds.begin(), playerIds.end(), gNetwork.GetPlayerID()) != playerIds.end())
                 {
+                    // Server is one of the recipients
                     chat_history_add(formatted);
                 }
                 gNetwork.Server_Send_CHAT(formatted, playerIds);

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -671,10 +671,10 @@ NetworkConnection* Network::GetPlayerConnection(uint8_t id)
     auto player = GetPlayerByID(id);
     if (player != nullptr)
     {
-        return std::find_if(
+        auto clientIt = std::find_if(
                    client_connection_list.begin(), client_connection_list.end(),
-                   [player](const auto& conn) -> bool { return conn->Player == player; })
-            ->get();
+                   [player](const auto& conn) -> bool { return conn->Player == player; });
+        return clientIt != client_connection_list.end() ? clientIt->get() : nullptr;
     }
     return nullptr;
 }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -671,13 +671,10 @@ NetworkConnection* Network::GetPlayerConnection(uint8_t id)
     auto player = GetPlayerByID(id);
     if (player != nullptr)
     {
-        for (auto& connection : client_connection_list)
-        {
-            if (connection->Player == player)
-            {
-                return connection.get();
-            }
-        }
+        return std::find_if(
+                   client_connection_list.begin(), client_connection_list.end(),
+                   [player](const auto& conn) -> bool { return conn->Player == player; })
+            ->get();
     }
     return nullptr;
 }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -136,6 +136,7 @@ public:
     void ProcessDisconnectedClients();
     std::vector<std::unique_ptr<NetworkPlayer>>::iterator GetPlayerIteratorByID(uint8_t id);
     NetworkPlayer* GetPlayerByID(uint8_t id);
+    NetworkConnection* GetPlayerConnection(uint8_t id);
     std::vector<std::unique_ptr<NetworkGroup>>::iterator GetGroupIteratorByID(uint8_t id);
     NetworkGroup* GetGroupByID(uint8_t id);
     static const char* FormatChat(NetworkPlayer* fromplayer, const char* text);
@@ -663,6 +664,22 @@ uint32_t Network::GetServerTick()
 uint8_t Network::GetPlayerID()
 {
     return player_id;
+}
+
+NetworkConnection* Network::GetPlayerConnection(uint8_t id)
+{
+    auto player = GetPlayerByID(id);
+    if (player != nullptr)
+    {
+        for (auto& connection : client_connection_list)
+        {
+            if (connection->Player == player)
+            {
+                return connection.get();
+            }
+        }
+    }
+    return nullptr;
 }
 
 void Network::Update()
@@ -3385,6 +3402,26 @@ money32 network_get_player_money_spent(uint32_t index)
     return gNetwork.player_list[index]->MoneySpent;
 }
 
+std::string network_get_player_ip_address(uint32_t id)
+{
+    auto conn = gNetwork.GetPlayerConnection(id);
+    if (conn != nullptr)
+    {
+        return conn->Socket->GetIpAddress();
+    }
+    return {};
+}
+
+std::string network_get_player_public_key_hash(uint32_t id)
+{
+    auto player = gNetwork.GetPlayerByID(id);
+    if (player != nullptr)
+    {
+        return player->KeyHash;
+    }
+    return {};
+}
+
 void network_add_player_money_spent(uint32_t index, money32 cost)
 {
     gNetwork.player_list[index]->AddMoneySpent(cost);
@@ -4053,6 +4090,14 @@ int32_t network_get_player_id(uint32_t index)
 money32 network_get_player_money_spent(uint32_t index)
 {
     return MONEY(0, 0);
+}
+std::string network_get_player_ip_address(uint32_t id)
+{
+    return {};
+}
+std::string network_get_player_public_key_hash(uint32_t id)
+{
+    return {};
 }
 void network_add_player_money_spent(uint32_t index, money32 cost)
 {

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -55,6 +55,7 @@ public:
     virtual SOCKET_STATUS GetStatus() const abstract;
     virtual const char* GetError() const abstract;
     virtual const char* GetHostName() const abstract;
+    virtual std::string GetIpAddress() const abstract;
 
     virtual void Listen(uint16_t port) abstract;
     virtual void Listen(const std::string& address, uint16_t port) abstract;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -61,6 +61,8 @@ uint32_t network_get_player_flags(uint32_t index);
 int32_t network_get_player_ping(uint32_t index);
 int32_t network_get_player_id(uint32_t index);
 money32 network_get_player_money_spent(uint32_t index);
+std::string network_get_player_ip_address(uint32_t id);
+std::string network_get_player_public_key_hash(uint32_t id);
 void network_add_player_money_spent(uint32_t index, money32 cost);
 int32_t network_get_player_last_action(uint32_t index, int32_t time);
 void network_set_player_last_action(uint32_t index, int32_t command);

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 struct json_t;
 struct GameAction;
@@ -94,7 +95,7 @@ void network_set_pickup_peep_old_x(uint8_t playerid, int32_t x);
 int32_t network_get_pickup_peep_old_x(uint8_t playerid);
 
 void network_send_map();
-void network_send_chat(const char* text);
+void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds = {});
 void network_send_game_action(const GameAction* action);
 void network_enqueue_game_action(const GameAction* action);
 void network_send_password(const std::string& password);

--- a/src/openrct2/scripting/Duktape.hpp
+++ b/src/openrct2/scripting/Duktape.hpp
@@ -37,6 +37,11 @@ namespace OpenRCT2::Scripting
         return value.type() == DukValue::NUMBER ? value.as_int() : defaultValue;
     }
 
+    template<> inline bool AsOrDefault(const DukValue& value, const bool& defaultValue)
+    {
+        return value.type() == DukValue::BOOLEAN ? value.as_bool() : defaultValue;
+    }
+
     /**
      * Allows creation of an object on the duktape stack and setting properties on it before
      * retrieving the DukValue instance of it.

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -25,6 +25,9 @@ HOOK_TYPE OpenRCT2::Scripting::GetHookType(const std::string& name)
         { "interval.tick", HOOK_TYPE::INTERVAL_TICK },
         { "interval.day", HOOK_TYPE::INTERVAL_DAY },
         { "network.chat", HOOK_TYPE::NETWORK_CHAT },
+        { "network.authenticate", HOOK_TYPE::NETWORK_AUTHENTICATE },
+        { "network.join", HOOK_TYPE::NETWORK_JOIN },
+        { "network.leave", HOOK_TYPE::NETWORK_LEAVE },
     });
     auto result = LookupTable.find(name);
     return (result != LookupTable.end()) ? result->second : HOOK_TYPE::UNDEFINED;

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -33,6 +33,9 @@ namespace OpenRCT2::Scripting
         INTERVAL_TICK,
         INTERVAL_DAY,
         NETWORK_CHAT,
+        NETWORK_AUTHENTICATE,
+        NETWORK_JOIN,
+        NETWORK_LEAVE,
         COUNT,
         UNDEFINED = -1,
     };

--- a/src/openrct2/scripting/ScNetwork.hpp
+++ b/src/openrct2/scripting/ScNetwork.hpp
@@ -408,7 +408,26 @@ namespace OpenRCT2::Scripting
 #    ifndef DISABLE_NETWORK
             if (players.is_array())
             {
-                duk_error(players.context(), DUK_ERR_ERROR, "Not yet supported");
+                if (network_get_mode() == NETWORK_MODE_SERVER)
+                {
+                    std::vector<uint8_t> playerIds;
+                    auto playerArray = players.as_array();
+                    for (const auto& item : playerArray)
+                    {
+                        if (item.type() == DukValue::Type::NUMBER)
+                        {
+                            playerIds.push_back(static_cast<uint8_t>(item.as_int()));
+                        }
+                    }
+                    if (!playerArray.empty())
+                    {
+                        network_send_chat(message.c_str(), playerIds);
+                    }
+                }
+                else
+                {
+                    duk_error(players.context(), DUK_ERR_ERROR, "Only servers can send private messages.");
+                }
             }
             else
             {

--- a/src/openrct2/scripting/ScNetwork.hpp
+++ b/src/openrct2/scripting/ScNetwork.hpp
@@ -233,6 +233,16 @@ namespace OpenRCT2::Scripting
 #    endif
         }
 
+        std::string ipAddress_get() const
+        {
+            return network_get_player_ip_address(_id);
+        }
+
+        std::string publicKeyHash_get() const
+        {
+            return network_get_player_public_key_hash(_id);
+        }
+
         static void Register(duk_context* ctx)
         {
             dukglue_register_property(ctx, &ScPlayer::id_get, nullptr, "id");
@@ -241,6 +251,8 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScPlayer::ping_get, nullptr, "ping");
             dukglue_register_property(ctx, &ScPlayer::commandsRan_get, nullptr, "commandsRan");
             dukglue_register_property(ctx, &ScPlayer::moneySpent_get, nullptr, "moneySpent");
+            dukglue_register_property(ctx, &ScPlayer::ipAddress_get, nullptr, "ipAddress");
+            dukglue_register_property(ctx, &ScPlayer::publicKeyHash_get, nullptr, "publicKeyHash");
         }
     };
 


### PR DESCRIPTION
* Add `network.addGroup`, `network.removeGroup`.
* Add `network.numGroups` and `network.numPlayers`.
* Change `network.groups` and `network.players` to return a list.
* Add `player.ipAddress` and `player.publicKeyHash`.
* Call network.chat hook for server's chat messages.
* Implement `network.authenticate`, `network.join` and `network.leave` hooks.
* Implement `network.sendMessage(msg, players)`.