### PR TITLE
Refactor game action binding for plugins

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -259,6 +259,22 @@ declare global {
         result: RideCreateGameActionResult;
     }
 
+    interface SmallSceneryPlaceEventArgs extends GameActionEventArgs {
+        readonly x: number;
+        readonly y: number;
+        readonly z: number;
+        readonly direction: number;
+        readonly quadrant: number;
+        readonly object: number;
+        readonly primaryColour: number;
+        readonly secondaryColour: number;
+    }
+
+    interface GuestSetNameActionEventArgs extends GameActionEventArgs {
+        readonly id: number;
+        readonly name: number;
+    }
+
     interface NetworkEventArgs {
         readonly player: number;
     }

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -166,6 +166,7 @@ public:
 
     template<typename T> void Visit(const std::string_view& name, T& param)
     {
+        static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
         auto value = static_cast<int32_t>(param);
         Visit(name, value);
         param = static_cast<T>(value);

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -140,6 +140,38 @@ public:
     std::string GetErrorMessage() const;
 };
 
+/**
+ *
+ */
+class GameActionParameterVisitor
+{
+public:
+    virtual ~GameActionParameterVisitor() = default;
+
+    virtual void Visit(const std::string_view& name, int32_t& param)
+    {
+    }
+
+    virtual void Visit(const std::string_view& name, std::string& param)
+    {
+    }
+
+    void Visit(CoordsXYZD& param)
+    {
+        Visit("x", param.x);
+        Visit("y", param.y);
+        Visit("z", param.z);
+        Visit("direction", param.direction);
+    }
+
+    template<typename T> void Visit(const std::string_view& name, T& param)
+    {
+        auto value = static_cast<int32_t>(param);
+        Visit(name, value);
+        param = static_cast<T>(value);
+    }
+};
+
 struct GameAction
 {
 public:
@@ -163,6 +195,10 @@ public:
     virtual ~GameAction() = default;
 
     virtual const char* GetName() const = 0;
+
+    virtual void AcceptParameters(GameActionParameterVisitor&)
+    {
+    }
 
     NetworkPlayerId_t GetPlayer() const
     {

--- a/src/openrct2/actions/GuestSetNameAction.hpp
+++ b/src/openrct2/actions/GuestSetNameAction.hpp
@@ -37,6 +37,22 @@ public:
     {
     }
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("id", _spriteIndex);
+        visitor.Visit("name", _name);
+    }
+
+    uint16_t GetSpriteIndex() const
+    {
+        return _spriteIndex;
+    }
+
+    std::string GetGuestName() const
+    {
+        return _name;
+    }
+
     uint16_t GetActionFlags() const override
     {
         return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;

--- a/src/openrct2/actions/ParkSetNameAction.hpp
+++ b/src/openrct2/actions/ParkSetNameAction.hpp
@@ -37,6 +37,11 @@ public:
     {
     }
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("name", _name);
+    }
+
     uint16_t GetActionFlags() const override
     {
         return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -60,6 +60,14 @@ public:
     {
     }
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("rideType", _rideType);
+        visitor.Visit("rideObject", _subType);
+        visitor.Visit("colour1", _colour1);
+        visitor.Visit("colour2", _colour2);
+    }
+
     int32_t GetRideType() const
     {
         return _rideType;

--- a/src/openrct2/actions/SmallSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.hpp
@@ -73,6 +73,15 @@ public:
     {
     }
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("quadrant", _quadrant);
+        visitor.Visit("object", _sceneryType);
+        visitor.Visit("primaryColour", _primaryColour);
+        visitor.Visit("secondaryColour", _secondaryColour);
+    }
+
     uint32_t GetCooldownTime() const override
     {
         return 20;

--- a/src/openrct2/scripting/ScContext.hpp
+++ b/src/openrct2/scripting/ScContext.hpp
@@ -11,9 +11,7 @@
 
 #ifdef ENABLE_SCRIPTING
 
-#    include "../actions/CustomAction.hpp"
-#    include "../actions/ParkSetNameAction.hpp"
-#    include "../actions/SmallSceneryPlaceAction.hpp"
+#    include "../actions/GameAction.h"
 #    include "../object/ObjectManager.h"
 #    include "../scenario/Scenario.h"
 #    include "Duktape.hpp"
@@ -161,7 +159,7 @@ namespace OpenRCT2::Scripting
             auto ctx = scriptEngine.GetContext();
             try
             {
-                auto action = CreateGameAction(actionid, args);
+                auto action = scriptEngine.CreateGameAction(actionid, args);
                 if (action != nullptr)
                 {
                     auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
@@ -186,45 +184,6 @@ namespace OpenRCT2::Scripting
             catch (DukException&)
             {
                 duk_error(ctx, DUK_ERR_ERROR, "Invalid action parameters.");
-            }
-        }
-
-        std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args)
-        {
-            if (actionid == "parksetname")
-            {
-                auto name = args["name"].as_string();
-                return std::make_unique<ParkSetNameAction>(name);
-            }
-            else if (actionid == "smallsceneryplace")
-            {
-                CoordsXYZD loc;
-                loc.x = args["x"].as_int();
-                loc.y = args["y"].as_int();
-                loc.z = args["z"].as_int();
-                loc.direction = args["direction"].as_int();
-                uint8_t quadrant = args["quadrant"].as_int();
-                uint8_t sceneryType = args["object"].as_int();
-                uint8_t primaryColour = args["primaryColour"].as_int();
-                uint8_t secondaryColour = args["secondaryColour"].as_int();
-                return std::make_unique<SmallSceneryPlaceAction>(loc, quadrant, sceneryType, primaryColour, secondaryColour);
-            }
-            else
-            {
-                // Serialise args to json so that it can be sent
-                auto ctx = args.context();
-                if (args.type() == DukValue::Type::OBJECT)
-                {
-                    args.push();
-                }
-                else
-                {
-                    duk_push_object(ctx);
-                }
-                auto jsonz = duk_json_encode(ctx, -1);
-                auto json = std::string(jsonz);
-                duk_pop(ctx);
-                return std::make_unique<CustomAction>(actionid, json);
             }
         }
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -918,7 +918,7 @@ void ScriptEngine::RunGameActionHooks(const GameAction& action, std::unique_ptr<
 
 static std::unique_ptr<GameAction> CreateGameActionFromActionId(const std::string& actionid)
 {
-    const static std::map<std::string, uint32_t> ActionNameToType = {
+    const static std::unordered_map<std::string, uint32_t> ActionNameToType = {
         { "parksetname", GAME_COMMAND_SET_PARK_NAME },
         { "smallsceneryplace", GAME_COMMAND_PLACE_SCENERY },
         { "guestsetname", GAME_COMMAND_SET_GUEST_NAME },

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -123,7 +123,7 @@ namespace OpenRCT2::Scripting
         std::mutex _changedPluginFilesMutex;
         std::vector<std::function<void(std::shared_ptr<Plugin>)>> _pluginStoppedSubscriptions;
 
-        struct CustomAction
+        struct CustomActionInfo
         {
             std::shared_ptr<Plugin> Owner;
             std::string Name;
@@ -131,7 +131,7 @@ namespace OpenRCT2::Scripting
             DukValue Execute;
         };
 
-        std::unordered_map<std::string, CustomAction> _customActions;
+        std::unordered_map<std::string, CustomActionInfo> _customActions;
 
     public:
         ScriptEngine(InteractiveConsole& console, IPlatformEnvironment& env);
@@ -181,6 +181,7 @@ namespace OpenRCT2::Scripting
             const std::shared_ptr<Plugin>& plugin, const std::string_view& action, const DukValue& query,
             const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, std::unique_ptr<GameActionResult>& result, bool isExecute);
+        std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args);
 
         void SaveSharedStorage();
 


### PR DESCRIPTION
Adds parameter visiting for game actions to reduce code needed for binding game actions to JavaScript objects. This should make it much quicker now to support all the remaining game actions in the plugin system.