### PR TITLE
Fix #11526: Plugin: Crash when using sprite type in park.postMessage

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -652,6 +652,13 @@ declare global {
     interface ParkMessage {
         type: ParkMessageType;
         text: string;
+
+        /**
+         * Ride ID for attraction.
+         * Entity ID for peep_on_attraction or peep.
+         * Researched item for research.
+         */
+        subject?: number;
     }
 
     interface Park {

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -604,7 +604,14 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
                 break;
             }
 
-            Peep* peep = GET_PEEP(newsItem->Assoc);
+            auto sprite = try_get_sprite(newsItem->Assoc);
+            if (sprite == nullptr)
+                break;
+
+            auto peep = sprite->AsPeep();
+            if (peep == nullptr)
+                return;
+
             int32_t clip_x = 10, clip_y = 19;
 
             if (peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_ENTERTAINER)

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -320,7 +320,14 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
                         break;
                     }
 
-                    Peep* peep = GET_PEEP(newsItem->Assoc);
+                    auto sprite = try_get_sprite(newsItem->Assoc);
+                    if (sprite == nullptr)
+                        break;
+
+                    auto peep = sprite->AsPeep();
+                    if (peep == nullptr)
+                        break;
+
                     int32_t clip_x = 10, clip_y = 19;
 
                     // If normal peep set sprite to normal (no food)

--- a/src/openrct2/scripting/ScPark.hpp
+++ b/src/openrct2/scripting/ScPark.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2018 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -80,18 +80,29 @@ namespace OpenRCT2::Scripting
             ThrowIfGameStateNotMutable();
             try
             {
+                uint32_t assoc = std::numeric_limits<uint32_t>::max();
                 uint8_t type = NEWS_ITEM_BLANK;
                 std::string text;
                 if (message.type() == DukValue::Type::STRING)
                 {
-                    text = message.as_string();
+                    text = language_convert_string(message.as_string());
                 }
                 else
                 {
                     type = GetParkMessageType(message["type"].as_string());
-                    text = message["text"].as_string();
+                    text = language_convert_string(message["text"].as_string());
+                    if (type == NEWS_ITEM_BLANK)
+                    {
+                        assoc = static_cast<uint32_t>(((COORDS_NULL & 0xFFFF) << 16) | (COORDS_NULL & 0xFFFF));
+                    }
+
+                    auto dukSubject = message["subject"];
+                    if (dukSubject.type() == DukValue::Type::NUMBER)
+                    {
+                        assoc = static_cast<uint32_t>(dukSubject.as_int());
+                    }
                 }
-                news_item_add_to_queue_raw(type, text.c_str(), static_cast<uint32_t>(-1));
+                news_item_add_to_queue_raw(type, text.c_str(), assoc);
             }
             catch (const DukException&)
             {


### PR DESCRIPTION
- Add safety checks for subject.
- Implement subject as another property in `postMessage`.
- Support formatted strings in `postMessage`.