### PR TITLE
Fix #8110: Use a single name for the title sequences directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ libversion
 
 # Downloaded or built data files
 data/g2.dat
-data/title
+data/sequence
 data/object
 
 #################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,14 +299,14 @@ list(APPEND DOC_FILES "${ROOT_DIR}/contributors.md"
 # targets, like `install`, so we have to trick it and execute dependency ourselves.
 install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
 if (DOWNLOAD_TITLE_SEQUENCES)
-    # If openrct2.parkseq or data/title/ exists, assume all the title sequences are already present
+    # If openrct2.parkseq or data/sequence/ exists, assume all the title sequences are already present
     install(CODE
-        "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/title/openrct2.parkseq\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/title/)\n\
+        "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/sequence/openrct2.parkseq\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/sequence/)\n\
             message(\"Using cached title sequences\")\n\
         else () \n\
-            file(DOWNLOAD ${TITLE_SEQUENCE_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/title/title-sequences.zip EXPECTED_HASH SHA1=${TITLE_SEQUENCE_SHA1} SHOW_PROGRESS)\n\
-            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/title/ \"${CMAKE_COMMAND}\" -E tar xf title-sequences.zip)\n\
-            file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/title/title-sequences.zip)\n\
+            file(DOWNLOAD ${TITLE_SEQUENCE_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/sequence/title-sequences.zip EXPECTED_HASH SHA1=${TITLE_SEQUENCE_SHA1} SHOW_PROGRESS)\n\
+            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/sequence/ \"${CMAKE_COMMAND}\" -E tar xf title-sequences.zip)\n\
+            file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT}/sequence/title-sequences.zip)\n\
         endif ()")
 endif ()
 if (DOWNLOAD_OBJECTS)

--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -451,7 +451,7 @@
 		D4A8B4B51DB4188D007A2F29 /* libpng16.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4A8B4B31DB41873007A2F29 /* libpng16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D4EC48E61C2637710024B507 /* g2.dat in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E31C2637710024B507 /* g2.dat */; };
 		D4EC48E71C2637710024B507 /* language in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E41C2637710024B507 /* language */; };
-		D4EC48E81C2637710024B507 /* title in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* title */; };
+		D4EC48E81C2637710024B507 /* sequence in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* sequence */; };
 		F70839931FFC0B61002DCEFA /* Scenario.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F70839911FFC0AFF002DCEFA /* Scenario.cpp */; };
 		F76C85B41EC4E88300FA49E2 /* AudioMixer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C835B1EC4E7CC00FA49E2 /* AudioMixer.cpp */; };
 		F76C85B71EC4E88300FA49E2 /* NullAudioSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C835E1EC4E7CC00FA49E2 /* NullAudioSource.cpp */; };
@@ -568,7 +568,7 @@
 		F7D774A21EC6715C00BE6EBC /* libSDL2.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B81CF3006400659A24 /* libSDL2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F7D774AC1EC6741D00BE6EBC /* language in CopyFiles */ = {isa = PBXBuildFile; fileRef = D4EC48E41C2637710024B507 /* language */; };
 		F7D774AD1EC6741D00BE6EBC /* shaders in CopyFiles */ = {isa = PBXBuildFile; fileRef = D43407E11D0E14CE00C2B3D4 /* shaders */; };
-		F7D774AE1EC6741D00BE6EBC /* title in CopyFiles */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* title */; };
+		F7D774AE1EC6741D00BE6EBC /* sequence in CopyFiles */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* sequence */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -648,7 +648,7 @@
 			files = (
 				F7D774AC1EC6741D00BE6EBC /* language in CopyFiles */,
 				F7D774AD1EC6741D00BE6EBC /* shaders in CopyFiles */,
-				F7D774AE1EC6741D00BE6EBC /* title in CopyFiles */,
+				F7D774AE1EC6741D00BE6EBC /* sequence in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1625,7 +1625,7 @@
 		D4A8B4B31DB41873007A2F29 /* libpng16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpng16.dylib; sourceTree = "<group>"; };
 		D4EC48E31C2637710024B507 /* g2.dat */ = {isa = PBXFileReference; lastKnownFileType = file; name = g2.dat; path = data/g2.dat; sourceTree = SOURCE_ROOT; };
 		D4EC48E41C2637710024B507 /* language */ = {isa = PBXFileReference; lastKnownFileType = folder; name = language; path = data/language; sourceTree = SOURCE_ROOT; };
-		D4EC48E51C2637710024B507 /* title */ = {isa = PBXFileReference; lastKnownFileType = folder; name = title; path = data/title; sourceTree = SOURCE_ROOT; };
+		D4EC48E51C2637710024B507 /* sequence */ = {isa = PBXFileReference; lastKnownFileType = folder; name = sequence; path = data/sequence; sourceTree = SOURCE_ROOT; };
 		F70839911FFC0AFF002DCEFA /* Scenario.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Scenario.cpp; sourceTree = "<group>"; };
 		F73E320B2011589E00C4D975 /* RideRatings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RideRatings.cpp; sourceTree = "<group>"; };
 		F73E320C2011589F00C4D975 /* RideRatings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RideRatings.h; sourceTree = "<group>"; };
@@ -2611,7 +2611,7 @@
 				D4EC48E31C2637710024B507 /* g2.dat */,
 				D4EC48E41C2637710024B507 /* language */,
 				D43407E11D0E14CE00C2B3D4 /* shaders */,
-				D4EC48E51C2637710024B507 /* title */,
+				D4EC48E51C2637710024B507 /* sequence */,
 			);
 			name = data;
 			path = ../data;
@@ -3830,7 +3830,7 @@
 				D4EC48E71C2637710024B507 /* language in Resources */,
 				F79F428F1F3260F1009E42F8 /* changelog.txt in Resources */,
 				D43407E21D0E14CE00C2B3D4 /* shaders in Resources */,
-				D4EC48E81C2637710024B507 /* title in Resources */,
+				D4EC48E81C2637710024B507 /* sequence in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3917,7 +3917,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "version=\"0.1.2c\"\nzipname=\"title-sequences.zip\"\nliburl=\"https://github.com/OpenRCT2/title-sequences/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/title\" || ! -e \"${SRCROOT}/sequencesversion\" || $(head -n 1 \"${SRCROOT}/sequencesversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/title\" ]]; then rm -r \"${SRCROOT}/data/title\"; fi\nmkdir -p \"${SRCROOT}/data/title\"\n\ncurl -L -o \"${SRCROOT}/data/title/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/title\" \"${SRCROOT}/data/title/$zipname\"\nrm \"${SRCROOT}/data/title/$zipname\"\n\necho $version > \"${SRCROOT}/sequencesversion\"\nfi";
+			shellScript = "version=\"0.1.2c\"\nzipname=\"title-sequences.zip\"\nliburl=\"https://github.com/OpenRCT2/title-sequences/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/sequence\" || ! -e \"${SRCROOT}/sequencesversion\" || $(head -n 1 \"${SRCROOT}/sequencesversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/sequence\" ]]; then rm -r \"${SRCROOT}/data/sequence\"; fi\nmkdir -p \"${SRCROOT}/data/sequence\"\n\ncurl -L -o \"${SRCROOT}/data/sequence/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/sequence\" \"${SRCROOT}/data/sequence/$zipname\"\nrm \"${SRCROOT}/data/sequence/$zipname\"\n\necho $version > \"${SRCROOT}/sequencesversion\"\nfi";
 		};
 		D4EC012A1C25532B00DAFE69 /* Setup AppIcon */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.
+- Technical: [#8110] OpenRCT2 now uses a single directory name for title sequences instead of three.
 - Technical: [#11517] Windows Vista is supported again (libzip regression in the previous release).
 - Technical: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.
 

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -129,7 +129,7 @@
                         Url="$(TitleSequencesUrl)"
                         Sha1="$(TitleSequencesSha1)"
                         CheckFile="$(DependenciesCheckFile)"
-                        OutputDirectory="$(TargetDir)data\title" />
+                        OutputDirectory="$(TargetDir)data\sequence" />
   </Target>
 
   <!-- Target to download the objects -->

--- a/shell.nix
+++ b/shell.nix
@@ -38,7 +38,7 @@ pkgs.stdenv.mkDerivation {
 
   postUnpack = ''
     cp -r ${objects-src}         $sourceRoot/data/object
-    cp -r ${title-sequences-src} $sourceRoot/data/title
+    cp -r ${title-sequences-src} $sourceRoot/data/sequence
   '';
   preFixup = "ln -s $out/share/openrct2 $out/bin/data";
 

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -9,7 +9,9 @@
 
 #include "TitleSequenceManager.h"
 
+#include "../Context.h"
 #include "../OpenRCT2.h"
+#include "../PlatformEnvironment.h"
 #include "../core/Collections.hpp"
 #include "../core/FileScanner.h"
 #include "../core/Memory.hpp"
@@ -48,8 +50,8 @@ namespace TitleSequenceManager
     static void AddSequence(const utf8* scanPath);
     static void SortSequences();
     static std::string GetNameFromSequencePath(const std::string& path);
-    static void GetDataSequencesPath(utf8* buffer, size_t bufferSize);
-    static void GetUserSequencesPath(utf8* buffer, size_t bufferSize);
+    static std::string GetDataSequencesPath();
+    static std::string GetUserSequencesPath();
     static bool IsNameReserved(const std::string& name);
 
     size_t GetCount()
@@ -158,15 +160,12 @@ namespace TitleSequenceManager
 
     static std::string GetNewTitleSequencePath(const std::string& name, bool isZip)
     {
-        utf8 path[MAX_PATH];
-        GetUserSequencesPath(path, sizeof(path));
-        platform_ensure_directory_exists(path);
-        Path::Append(path, sizeof(path), name.c_str());
+        auto path = Path::Combine(GetUserSequencesPath(), name);
         if (isZip)
         {
-            String::Append(path, sizeof(path), TITLE_SEQUENCE_EXTENSION);
+            path = Path::Combine(path, TITLE_SEQUENCE_EXTENSION);
         }
-        return std::string(path);
+        return path;
     }
 
     static size_t GetPredefinedIndex(const std::string& path)
@@ -201,17 +200,15 @@ namespace TitleSequenceManager
 
     void Scan()
     {
-        utf8 path[MAX_PATH];
-
         _items.clear();
 
         // Scan data path
-        GetDataSequencesPath(path, sizeof(path));
-        Scan(path);
+        auto path = GetDataSequencesPath();
+        Scan(path.c_str());
 
         // Scan user path
-        GetUserSequencesPath(path, sizeof(path));
-        Scan(path);
+        path = GetUserSequencesPath();
+        Scan(path.c_str());
 
         SortSequences();
     }
@@ -277,15 +274,16 @@ namespace TitleSequenceManager
         return result;
     }
 
-    static void GetDataSequencesPath(utf8* buffer, size_t bufferSize)
+    static std::string GetDataSequencesPath()
     {
-        platform_get_openrct_data_path(buffer, bufferSize);
-        Path::Append(buffer, bufferSize, "title");
+        auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+        return env->GetDirectoryPath(OpenRCT2::DIRBASE::OPENRCT2, OpenRCT2::DIRID::SEQUENCE);
     }
 
-    static void GetUserSequencesPath(utf8* buffer, size_t bufferSize)
+    static std::string GetUserSequencesPath()
     {
-        platform_get_user_directory(buffer, "title sequences", bufferSize);
+        auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+        return env->GetDirectoryPath(OpenRCT2::DIRBASE::USER, OpenRCT2::DIRID::SEQUENCE);
     }
 
     static bool IsNameReserved(const std::string& name)


### PR DESCRIPTION
Review note: I would appreciate a good look at how I handled strings.

I have checked the x86_64 MSVC, Xcode and x86 Linux artifacts. These all contain the title sequences, and in the correct place.