### PR TITLE
Fixed logic with returned screamId. Refactored to use enums.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.14/objects.zip")
 set(OBJECTS_SHA1 "31a0ed0047b4bdb1428071044130192b3c0a30fa")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.11/replays.zip")
-set(REPLAYS_SHA1 "9647497B413B780EBC54C732ADF2A575E453125A")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.12/replays.zip")
+set(REPLAYS_SHA1 "E85C23FB63AD6C7344AA80779C6CE03FAC2A7100")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/contributors.md
+++ b/contributors.md
@@ -140,6 +140,7 @@ The following people are not part of the development team, but have been contrib
 * (WantDiscussion)
 * Tomáš Žilínek (TomasZilinek)
 * Mustapha Elghoul (mustaphaelghoul)
+* Tyler Leamon (tylerleamon)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,11 +9,12 @@
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Change: [#11449] Remove complete circuit requirement from Air Powered Vertical Coaster (for RCT1 parity).
 - Fix: [#1148] Research funding dropdown not shown in finances window.
+- Fix: [#5451] Guests scream on every descent, no matter how small.
 - Fix: [#6119] Advertising campaign for ride window not updated properly (original bug).
 - Fix: [#7006] Submarine Ride is in the wrong research group.
 - Fix: [#11072] Land and water tools working out of bounds (original bug).
 - Fix: [#11259] Custom JSON object breaks saves.
-- Fix: [#11290] Perform funds checking for all peeps entering a ride. 
+- Fix: [#11290] Perform funds checking for all peeps entering a ride.
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.
 - Fix: [#11405] Building a path through walls does not always remove the walls.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
@@ -35,7 +36,7 @@
 - Fix: [#6123, #7907, #9472, #11028] Cannot build some track designs with 4 stations (original bug).
 - Fix: [#6238] Invalid tile elem iteration in Guest::UpdateUsingBin
 - Fix: [#7094] Back wall edge texture in water missing.
-- Fix: [#9719] Hacked walls in RCT1 saves are imported incorrectly. 
+- Fix: [#9719] Hacked walls in RCT1 saves are imported incorrectly.
 - Fix: [#10372, #10509, #10806] Lift base sections incorrectly exporting, causing various lift related bugs.
 - Fix: [#10928] File browser's date column is too narrow.
 - Fix: [#10951, #11160] Attempting to place park entrances creates ghost entrances in random locations.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.14/objects.zip</ObjectsUrl>
     <ObjectsSha1>31a0ed0047b4bdb1428071044130192b3c0a30fa</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.11/replays.zip</ReplaysUrl>
-    <ReplaysSha1>9647497B413B780EBC54C732ADF2A575E453125A</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.12/replays.zip</ReplaysUrl>
+    <ReplaysSha1>E85C23FB63AD6C7344AA80779C6CE03FAC2A7100</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -198,7 +198,8 @@ static ScenerySelection window_scenery_tab_entries[SCENERY_WINDOW_TABS][SCENERY_
  * Was part of 0x006DFA00
  * The same code repeated five times for every scenery entry type
  */
-static void init_scenery_entry(rct_scenery_entry* sceneryEntry, const ScenerySelection& selection, uint8_t sceneryTabId)
+static void init_scenery_entry(
+    rct_scenery_entry* sceneryEntry, const ScenerySelection& selection, ObjectEntryIndex sceneryTabId)
 {
     Guard::ArgumentInRange<int32_t>(selection.EntryIndex, 0, WINDOW_SCENERY_TAB_SELECTION_UNDEFINED);
     if (scenery_is_invented(selection) || gCheatsIgnoreResearchStatus)
@@ -278,7 +279,7 @@ void window_scenery_init()
     }
 
     // small scenery
-    for (uint16_t sceneryId = 0; sceneryId < MAX_SMALL_SCENERY_OBJECTS; sceneryId++)
+    for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_SMALL_SCENERY_OBJECTS; sceneryId++)
     {
         rct_scenery_entry* sceneryEntry = get_small_scenery_entry(sceneryId);
         if (sceneryEntry == nullptr)
@@ -288,7 +289,7 @@ void window_scenery_init()
     }
 
     // large scenery
-    for (uint16_t sceneryId = 0; sceneryId < MAX_LARGE_SCENERY_OBJECTS; sceneryId++)
+    for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_LARGE_SCENERY_OBJECTS; sceneryId++)
     {
         rct_scenery_entry* sceneryEntry = get_large_scenery_entry(sceneryId);
         if (sceneryEntry == nullptr)
@@ -298,7 +299,7 @@ void window_scenery_init()
     }
 
     // walls
-    for (uint16_t sceneryId = 0; sceneryId < MAX_WALL_SCENERY_OBJECTS; sceneryId++)
+    for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_WALL_SCENERY_OBJECTS; sceneryId++)
     {
         rct_scenery_entry* sceneryEntry = get_wall_entry(sceneryId);
         if (sceneryEntry == nullptr)
@@ -308,7 +309,7 @@ void window_scenery_init()
     }
 
     // banners
-    for (uint16_t sceneryId = 0; sceneryId < MAX_BANNER_OBJECTS; sceneryId++)
+    for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_BANNER_OBJECTS; sceneryId++)
     {
         rct_scenery_entry* sceneryEntry = get_banner_entry(sceneryId);
         if (sceneryEntry == nullptr)
@@ -318,7 +319,7 @@ void window_scenery_init()
     }
 
     // path bits
-    for (uint16_t sceneryId = 0; sceneryId < MAX_PATH_ADDITION_OBJECTS; sceneryId++)
+    for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_PATH_ADDITION_OBJECTS; sceneryId++)
     {
         rct_scenery_entry* sceneryEntry = get_footpath_item_entry(sceneryId);
         if (sceneryEntry == nullptr)

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -298,7 +298,7 @@ namespace Editor
         for (BannerIndex i = 0; i < MAX_BANNERS; i++)
         {
             auto banner = GetBanner(i);
-            if (banner->type == BANNER_NULL)
+            if (banner->IsNull())
             {
                 banner->flags &= ~BANNER_FLAG_LINKED_TO_RIDE;
             }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -125,7 +125,7 @@ void setup_in_use_selection_flags()
     tile_element_iterator_begin(&iter);
     do
     {
-        uint16_t type;
+        ObjectEntryIndex type;
 
         switch (iter.element->GetType())
         {

--- a/src/openrct2/actions/BannerPlaceAction.hpp
+++ b/src/openrct2/actions/BannerPlaceAction.hpp
@@ -19,7 +19,7 @@ DEFINE_GAME_ACTION(BannerPlaceAction, GAME_COMMAND_PLACE_BANNER, GameActionResul
 {
 private:
     CoordsXYZD _loc;
-    uint8_t _bannerType{ std::numeric_limits<uint8_t>::max() };
+    ObjectEntryIndex _bannerType{ BANNER_NULL };
     BannerIndex _bannerIndex{ BANNER_INDEX_NULL };
     uint8_t _primaryColour;
 
@@ -91,7 +91,7 @@ public:
         }
 
         auto banner = GetBanner(_bannerIndex);
-        if (banner->type != BANNER_NULL)
+        if (!banner->IsNull())
         {
             log_error("Banner index in use, bannerIndex = %u", _bannerIndex);
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_POSITION_THIS_HERE);
@@ -129,7 +129,7 @@ public:
         }
 
         auto banner = GetBanner(_bannerIndex);
-        if (banner->type != BANNER_NULL)
+        if (!banner->IsNull())
         {
             log_error("Banner index in use, bannerIndex = %u", _bannerIndex);
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_POSITION_THIS_HERE);

--- a/src/openrct2/actions/FootpathPlaceAction.hpp
+++ b/src/openrct2/actions/FootpathPlaceAction.hpp
@@ -28,12 +28,12 @@ DEFINE_GAME_ACTION(FootpathPlaceAction, GAME_COMMAND_PLACE_PATH, GameActionResul
 private:
     CoordsXYZ _loc;
     uint8_t _slope;
-    uint8_t _type;
+    ObjectEntryIndex _type;
     Direction _direction = INVALID_DIRECTION;
 
 public:
     FootpathPlaceAction() = default;
-    FootpathPlaceAction(const CoordsXYZ& loc, uint8_t slope, uint8_t type, Direction direction = INVALID_DIRECTION)
+    FootpathPlaceAction(const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, Direction direction = INVALID_DIRECTION)
         : _loc(loc)
         , _slope(slope)
         , _type(type)

--- a/src/openrct2/actions/LargeSceneryPlaceAction.hpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.hpp
@@ -48,7 +48,7 @@ DEFINE_GAME_ACTION(LargeSceneryPlaceAction, GAME_COMMAND_PLACE_LARGE_SCENERY, La
 {
 private:
     CoordsXYZD _loc;
-    uint8_t _sceneryType{ std::numeric_limits<uint8_t>::max() };
+    ObjectEntryIndex _sceneryType{ OBJECT_ENTRY_INDEX_NULL };
     uint8_t _primaryColour;
     uint8_t _secondaryColour;
     BannerIndex _bannerId{ BANNER_INDEX_NULL };
@@ -56,7 +56,7 @@ private:
 public:
     LargeSceneryPlaceAction() = default;
 
-    LargeSceneryPlaceAction(const CoordsXYZD& loc, uint8_t sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
+    LargeSceneryPlaceAction(const CoordsXYZD& loc, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
         : _loc(loc)
         , _sceneryType(sceneryType)
         , _primaryColour(primaryColour)
@@ -138,7 +138,7 @@ public:
             }
 
             auto banner = GetBanner(_bannerId);
-            if (banner->type != BANNER_NULL)
+            if (!banner->IsNull())
             {
                 log_error("No free banners available");
                 return std::make_unique<LargeSceneryPlaceActionResult>(GA_ERROR::NO_FREE_ELEMENTS);
@@ -253,7 +253,7 @@ public:
             }
 
             auto banner = GetBanner(_bannerId);
-            if (banner->type != BANNER_NULL)
+            if (!banner->IsNull())
             {
                 log_error("No free banners available");
                 return std::make_unique<LargeSceneryPlaceActionResult>(GA_ERROR::NO_FREE_ELEMENTS);

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -140,7 +140,7 @@ private:
         for (BannerIndex i = 0; i < MAX_BANNERS; i++)
         {
             auto banner = GetBanner(i);
-            if (banner->type != BANNER_NULL && banner->flags & BANNER_FLAG_LINKED_TO_RIDE && banner->ride_index == _rideIndex)
+            if (!banner->IsNull() && banner->flags & BANNER_FLAG_LINKED_TO_RIDE && banner->ride_index == _rideIndex)
             {
                 banner->flags &= ~BANNER_FLAG_LINKED_TO_RIDE;
                 banner->text = {};

--- a/src/openrct2/actions/SmallSceneryRemoveAction.hpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.hpp
@@ -28,12 +28,12 @@ DEFINE_GAME_ACTION(SmallSceneryRemoveAction, GAME_COMMAND_REMOVE_SCENERY, GameAc
 private:
     CoordsXYZ _loc;
     uint8_t _quadrant;
-    uint8_t _sceneryType;
+    ObjectEntryIndex _sceneryType;
 
 public:
     SmallSceneryRemoveAction() = default;
 
-    SmallSceneryRemoveAction(const CoordsXYZ& location, uint8_t quadrant, uint8_t sceneryType)
+    SmallSceneryRemoveAction(const CoordsXYZ& location, uint8_t quadrant, ObjectEntryIndex sceneryType)
         : _loc(location)
         , _quadrant(quadrant)
         , _sceneryType(sceneryType)

--- a/src/openrct2/actions/SmallScenerySetColourAction.hpp
+++ b/src/openrct2/actions/SmallScenerySetColourAction.hpp
@@ -32,7 +32,7 @@ DEFINE_GAME_ACTION(SmallScenerySetColourAction, GAME_COMMAND_SET_SCENERY_COLOUR,
 private:
     CoordsXYZ _loc;
     uint8_t _quadrant;
-    uint8_t _sceneryType;
+    ObjectEntryIndex _sceneryType;
     uint8_t _primaryColour;
     uint8_t _secondaryColour;
 
@@ -40,7 +40,7 @@ public:
     SmallScenerySetColourAction() = default;
 
     SmallScenerySetColourAction(
-        const CoordsXYZ& loc, uint8_t quadrant, uint8_t sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
+        const CoordsXYZ& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
         : _loc(loc)
         , _quadrant(quadrant)
         , _sceneryType(sceneryType)

--- a/src/openrct2/actions/WallPlaceAction.hpp
+++ b/src/openrct2/actions/WallPlaceAction.hpp
@@ -260,7 +260,7 @@ public:
             }
 
             auto banner = GetBanner(_bannerId);
-            if (banner->type != BANNER_NULL)
+            if (!banner->IsNull())
             {
                 log_error("No free banners available");
                 return std::make_unique<WallPlaceActionResult>(GA_ERROR::NO_FREE_ELEMENTS);
@@ -351,7 +351,7 @@ public:
             }
 
             auto banner = GetBanner(_bannerId);
-            if (banner->type != BANNER_NULL)
+            if (!banner->IsNull())
             {
                 log_error("No free banners available");
                 return std::make_unique<WallPlaceActionResult>(GA_ERROR::NO_FREE_ELEMENTS);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1251,7 +1251,7 @@ static int32_t cc_show_limits(InteractiveConsole& console, [[maybe_unused]] cons
     for (BannerIndex i = 0; i < MAX_BANNERS; ++i)
     {
         auto banner = GetBanner(i);
-        if (banner->type != BANNER_NULL)
+        if (!banner->IsNull())
         {
             bannerCount++;
         }

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -23,8 +23,8 @@ void BannerObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
     _legacyType.banner.scrolling_mode = stream->ReadValue<uint8_t>();
     _legacyType.banner.flags = stream->ReadValue<uint8_t>();
     _legacyType.banner.price = stream->ReadValue<int16_t>();
-    _legacyType.banner.scenery_tab_id = stream->ReadValue<uint8_t>();
-    stream->Seek(1, STREAM_SEEK_CURRENT);
+    _legacyType.banner.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
+    stream->Seek(2, STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
 

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -27,8 +27,8 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext* context, IStream* stream
     _legacyType.path_bit.draw_type = stream->ReadValue<uint8_t>();
     _legacyType.path_bit.tool_id = stream->ReadValue<uint8_t>();
     _legacyType.path_bit.price = stream->ReadValue<int16_t>();
-    _legacyType.path_bit.scenery_tab_id = stream->ReadValue<uint8_t>();
-    stream->Seek(1, STREAM_SEEK_CURRENT);
+    _legacyType.path_bit.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
+    stream->Seek(2, STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
 

--- a/src/openrct2/object/ObjectList.h
+++ b/src/openrct2/object/ObjectList.h
@@ -17,7 +17,7 @@
 #include "../world/Water.h"
 #include "ObjectLimits.h"
 
-void get_type_entry_index(size_t index, uint8_t* outObjectType, uint16_t* outEntryIndex);
+void get_type_entry_index(size_t index, uint8_t* outObjectType, ObjectEntryIndex* outEntryIndex);
 const rct_object_entry* get_loaded_object_entry(size_t index);
 void* get_loaded_object_chunk(size_t index);
 uint8_t object_entry_get_type(const rct_object_entry* objectEntry);

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -25,7 +25,8 @@ void WallObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
     _legacyType.wall.height = stream->ReadValue<uint8_t>();
     _legacyType.wall.flags2 = stream->ReadValue<uint8_t>();
     _legacyType.wall.price = stream->ReadValue<uint16_t>();
-    _legacyType.wall.scenery_tab_id = stream->ReadValue<uint8_t>();
+    _legacyType.wall.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
+    stream->Seek(1, STREAM_SEEK_CURRENT);
     _legacyType.wall.scrolling_mode = stream->ReadValue<uint8_t>();
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -971,7 +971,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
                         // Check if the footpath has a queue line TV monitor on it
                         if (tileElement->AsPath()->HasAddition() && !tileElement->AsPath()->AdditionIsGhost())
                         {
-                            uint8_t pathSceneryIndex = tileElement->AsPath()->GetAdditionEntryIndex();
+                            auto pathSceneryIndex = tileElement->AsPath()->GetAdditionEntryIndex();
                             rct_scenery_entry* sceneryEntry = get_footpath_item_entry(pathSceneryIndex);
                             if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN)
                             {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2063,7 +2063,7 @@ private:
                 }
                 else
                 {
-                    uint8_t railingsEntryIndex;
+                    ObjectEntryIndex railingsEntryIndex;
                     switch (src2->GetRCT1SupportType())
                     {
                         case RCT1_PATH_SUPPORT_TYPE_COATED_WOOD:
@@ -2083,10 +2083,10 @@ private:
                 }
 
                 // Additions
-                uint8_t additionType = dst2->GetAddition();
+                ObjectEntryIndex additionType = dst2->GetAddition();
                 if (additionType != RCT1_PATH_ADDITION_NONE)
                 {
-                    uint8_t normalisedType = RCT1::NormalisePathAddition(additionType);
+                    ObjectEntryIndex normalisedType = RCT1::NormalisePathAddition(additionType);
                     entryIndex = _pathAdditionTypeToEntryMap[normalisedType];
                     if (additionType != normalisedType)
                     {

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -57,6 +57,9 @@ constexpr const uint8_t RCT12_TILE_ELEMENT_SURFACE_TERRAIN_MASK = 0xE0;      // 
 
 constexpr uint16_t const RCT12_XY8_UNDEFINED = 0xFFFF;
 
+using RCT12ObjectEntryIndex = uint8_t;
+constexpr const RCT12ObjectEntryIndex RCT12_OBJECT_ENTRY_INDEX_NULL = 255;
+
 // Everything before this point has been researched
 constexpr const uint32_t RCT12_RESEARCHED_ITEMS_SEPARATOR = 0xFFFFFFFF;
 // Everything before this point and after separator still requires research
@@ -357,7 +360,7 @@ private:
     };
 
 public:
-    uint8_t GetEntryIndex() const;
+    RCT12ObjectEntryIndex GetEntryIndex() const;
     uint8_t GetQueueBannerDirection() const;
     bool IsSloped() const;
     uint8_t GetSlopeDirection() const;
@@ -374,7 +377,7 @@ public:
     uint8_t GetRCT1PathType() const;
     uint8_t GetRCT1SupportType() const;
 
-    void SetPathEntryIndex(uint8_t newIndex);
+    void SetPathEntryIndex(RCT12ObjectEntryIndex newIndex);
     void SetQueueBannerDirection(uint8_t direction);
     void SetSloped(bool isSloped);
     void SetSlopeDirection(uint8_t newSlope);
@@ -468,14 +471,14 @@ private:
     uint8_t colour_1;   // 6
     uint8_t colour_2;   // 7
 public:
-    uint8_t GetEntryIndex() const;
+    RCT12ObjectEntryIndex GetEntryIndex() const;
     uint8_t GetAge() const;
     uint8_t GetSceneryQuadrant() const;
     colour_t GetPrimaryColour() const;
     colour_t GetSecondaryColour() const;
     bool NeedsSupports() const;
 
-    void SetEntryIndex(uint8_t newIndex);
+    void SetEntryIndex(RCT12ObjectEntryIndex newIndex);
     void SetAge(uint8_t newAge);
     void SetSceneryQuadrant(uint8_t newQuadrant);
     void SetPrimaryColour(colour_t colour);
@@ -514,7 +517,7 @@ private:
     uint8_t colour_1;  // 6 0b_2221_1111 2 = colour_2 (uses flags for rest of colour2), 1 = colour_1
     uint8_t animation; // 7 0b_dfff_ft00 d = direction, f = frame num, t = across track flag (not used)
 public:
-    uint8_t GetEntryIndex() const;
+    RCT12ObjectEntryIndex GetEntryIndex() const;
     uint8_t GetSlope() const;
     colour_t GetPrimaryColour() const;
     colour_t GetSecondaryColour() const;
@@ -527,7 +530,7 @@ public:
     int32_t GetRCT1WallType(int32_t edge) const;
     colour_t GetRCT1WallColour() const;
 
-    void SetEntryIndex(uint8_t newIndex);
+    void SetEntryIndex(RCT12ObjectEntryIndex newIndex);
     void SetSlope(uint8_t newslope);
     void SetPrimaryColour(colour_t newColour);
     void SetSecondaryColour(colour_t newColour);
@@ -777,7 +780,7 @@ struct RCT12ResearchItem
         uint32_t rawValue;
         struct
         {
-            uint8_t entryIndex;
+            RCT12ObjectEntryIndex entryIndex;
             uint8_t baseRideType;
             uint8_t type; // 0: scenery entry, 1: ride entry
             uint8_t flags;
@@ -792,9 +795,6 @@ struct RCT12ResearchItem
 assert_struct_size(RCT12ResearchItem, 5);
 
 #pragma pack(pop)
-
-using RCT12ObjectEntryIndex = uint8_t;
-constexpr const RCT12ObjectEntryIndex RCT12_OBJECT_ENTRY_INDEX_NULL = 255;
 
 ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(RCT12ObjectEntryIndex index);
 RCT12ObjectEntryIndex OpenRCT2EntryIndexToRCTEntryIndex(ObjectEntryIndex index);

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -103,7 +103,7 @@ struct rct2_ride
     uint8_t type; // 0x000
     // pointer to static info. for example, wild mouse type is 0x36, subtype is
     // 0x4c.
-    uint8_t subtype;                                             // 0x001
+    RCT12ObjectEntryIndex subtype;                               // 0x001
     uint16_t pad_002;                                            // 0x002
     uint8_t mode;                                                // 0x004
     uint8_t colour_scheme_type;                                  // 0x005

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5467,7 +5467,7 @@ void Vehicle::UpdateSound()
 
     switch (vehicleEntry->sound_range)
     {
-        case 3:
+        case SOUND_RANGE_WHISTLE:
             screamId = scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
@@ -5486,7 +5486,7 @@ void Vehicle::UpdateSound()
             screamVolume = 255;
             break;
 
-        case 4:
+        case SOUND_RANGE_BELL:
             screamId = scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
@@ -5511,7 +5511,7 @@ void Vehicle::UpdateSound()
                 screamId = UpdateScreamSound();
                 if (screamId == SoundId::NoScream)
                     screamId = SoundId::Null;
-                if (screamId == SoundId::Null)
+                else if (screamId == SoundId::Null)
                     goto loc_6D7A97;
                 break;
             }
@@ -5612,13 +5612,13 @@ produceScream:
         {
             switch (vehicleEntry->sound_range)
             {
-                case 0:
+                case SOUND_RANGE_SCREAMS_0:
                     scream_sound_id = byte_9A3A14[r % 2];
                     break;
-                case 1:
+                case SOUND_RANGE_SCREAMS_1:
                     scream_sound_id = byte_9A3A18[r % 7];
                     break;
-                case 2:
+                case SOUND_RANGE_SCREAMS_2:
                     scream_sound_id = byte_9A3A16[r % 2];
                     break;
                 default:

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -21,7 +21,7 @@ struct WallElement;
 
 using BannerIndex = uint16_t;
 
-constexpr uint8_t BANNER_NULL = 255;
+constexpr ObjectEntryIndex BANNER_NULL = OBJECT_ENTRY_INDEX_NULL;
 constexpr size_t MAX_BANNERS = 250;
 constexpr BannerIndex BANNER_INDEX_NULL = static_cast<BannerIndex>(-1);
 
@@ -29,7 +29,7 @@ constexpr uint8_t SCROLLING_MODE_NONE = 255;
 
 struct Banner
 {
-    uint8_t type = BANNER_NULL;
+    ObjectEntryIndex type = BANNER_NULL;
     uint8_t flags{};
     std::string text;
     uint8_t colour{};

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1535,7 +1535,7 @@ uint8_t PathElement::GetAddition() const
     return Additions;
 }
 
-uint8_t PathElement::GetAdditionEntryIndex() const
+ObjectEntryIndex PathElement::GetAdditionEntryIndex() const
 {
     return GetAddition() - 1;
 }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -263,7 +263,7 @@ bool JumpingFountain::IsJumpingFountain(const int32_t newType, const CoordsXYZ& 
         if (!tileElement->AsPath()->HasAddition())
             continue;
 
-        const uint8_t additionIndex = tileElement->AsPath()->GetAdditionEntryIndex();
+        const auto additionIndex = tileElement->AsPath()->GetAdditionEntryIndex();
         rct_scenery_entry* sceneryEntry = get_footpath_item_entry(additionIndex);
         if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & pathBitFlagMask)
         {

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -229,7 +229,7 @@ void scenery_remove_ghost_tool_placement()
     }
 }
 
-rct_scenery_entry* get_wall_entry(int32_t entryIndex)
+rct_scenery_entry* get_wall_entry(ObjectEntryIndex entryIndex)
 {
     rct_scenery_entry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
@@ -241,7 +241,7 @@ rct_scenery_entry* get_wall_entry(int32_t entryIndex)
     return result;
 }
 
-rct_scenery_entry* get_banner_entry(int32_t entryIndex)
+rct_scenery_entry* get_banner_entry(ObjectEntryIndex entryIndex)
 {
     rct_scenery_entry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
@@ -253,7 +253,7 @@ rct_scenery_entry* get_banner_entry(int32_t entryIndex)
     return result;
 }
 
-rct_scenery_entry* get_footpath_item_entry(int32_t entryIndex)
+rct_scenery_entry* get_footpath_item_entry(ObjectEntryIndex entryIndex)
 {
     rct_scenery_entry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
@@ -265,7 +265,7 @@ rct_scenery_entry* get_footpath_item_entry(int32_t entryIndex)
     return result;
 }
 
-rct_scenery_group_entry* get_scenery_group_entry(int32_t entryIndex)
+rct_scenery_group_entry* get_scenery_group_entry(ObjectEntryIndex entryIndex)
 {
     rct_scenery_group_entry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -23,20 +23,17 @@
 #pragma pack(push, 1)
 struct rct_small_scenery_entry
 {
-    uint32_t flags;           // 0x06
-    uint8_t height;           // 0x0A
-    uint8_t tool_id;          // 0x0B
-    int16_t price;            // 0x0C
-    int16_t removal_price;    // 0x0E
-    uint8_t* frame_offsets;   // 0x10
-    uint16_t animation_delay; // 0x14
-    uint16_t animation_mask;  // 0x16
-    uint16_t num_frames;      // 0x18
-    uint8_t scenery_tab_id;   // 0x1A
+    uint32_t flags;                  // 0x06
+    uint8_t height;                  // 0x0A
+    uint8_t tool_id;                 // 0x0B
+    int16_t price;                   // 0x0C
+    int16_t removal_price;           // 0x0E
+    uint8_t* frame_offsets;          // 0x10
+    uint16_t animation_delay;        // 0x14
+    uint16_t animation_mask;         // 0x16
+    uint16_t num_frames;             // 0x18
+    ObjectEntryIndex scenery_tab_id; // 0x1A
 };
-#ifdef PLATFORM_32BIT
-assert_struct_size(rct_small_scenery_entry, 21);
-#endif
 
 struct rct_large_scenery_tile
 {
@@ -83,19 +80,16 @@ enum LARGE_SCENERY_TEXT_FLAGS
 
 struct rct_large_scenery_entry
 {
-    uint8_t tool_id;               // 0x06
-    uint8_t flags;                 // 0x07
-    int16_t price;                 // 0x08
-    int16_t removal_price;         // 0x0A
-    rct_large_scenery_tile* tiles; // 0x0C
-    uint8_t scenery_tab_id;        // 0x10
-    uint8_t scrolling_mode;        // 0x11
-    rct_large_scenery_text* text;  // 0x12
-    uint32_t text_image;           // 0x16
+    uint8_t tool_id;
+    uint8_t flags;
+    int16_t price;
+    int16_t removal_price;
+    rct_large_scenery_tile* tiles;
+    ObjectEntryIndex scenery_tab_id;
+    uint8_t scrolling_mode;
+    rct_large_scenery_text* text;
+    uint32_t text_image;
 };
-#ifdef PLATFORM_32BIT
-assert_struct_size(rct_large_scenery_entry, 20);
-#endif
 
 enum LARGE_SCENERY_FLAGS
 {
@@ -108,15 +102,14 @@ enum LARGE_SCENERY_FLAGS
 
 struct rct_wall_scenery_entry
 {
-    uint8_t tool_id;        // 0x06
-    uint8_t flags;          // 0x07
-    uint8_t height;         // 0x08
-    uint8_t flags2;         // 0x09
-    int16_t price;          // 0x0A
-    uint8_t scenery_tab_id; // 0x0C
-    uint8_t scrolling_mode; // 0x0D 0xFF if no scrolling
+    uint8_t tool_id;
+    uint8_t flags;
+    uint8_t height;
+    uint8_t flags2;
+    int16_t price;
+    ObjectEntryIndex scenery_tab_id;
+    uint8_t scrolling_mode;
 };
-assert_struct_size(rct_wall_scenery_entry, 8);
 
 enum WALL_SCENERY_FLAGS
 {
@@ -141,22 +134,20 @@ enum WALL_SCENERY_2_FLAGS
 
 struct rct_path_bit_scenery_entry
 {
-    uint16_t flags;         // 0x06
-    uint8_t draw_type;      // 0x08
-    uint8_t tool_id;        // 0x09
-    int16_t price;          // 0x0A
-    uint8_t scenery_tab_id; // 0x0C
+    uint16_t flags;                  // 0x06
+    uint8_t draw_type;               // 0x08
+    uint8_t tool_id;                 // 0x09
+    int16_t price;                   // 0x0A
+    ObjectEntryIndex scenery_tab_id; // 0x0C
 };
-assert_struct_size(rct_path_bit_scenery_entry, 7);
 
 struct rct_banner_scenery_entry
 {
-    uint8_t scrolling_mode; // 0x06
-    uint8_t flags;          // 0x07
-    int16_t price;          // 0x08
-    uint8_t scenery_tab_id; // 0x0A
+    uint8_t scrolling_mode;          // 0x06
+    uint8_t flags;                   // 0x07
+    int16_t price;                   // 0x08
+    ObjectEntryIndex scenery_tab_id; // 0x0A
 };
-assert_struct_size(rct_banner_scenery_entry, 5);
 
 struct rct_scenery_entry
 {
@@ -171,9 +162,6 @@ struct rct_scenery_entry
         rct_banner_scenery_entry banner;
     };
 };
-#ifdef PLATFORM_32BIT
-assert_struct_size(rct_scenery_entry, 6 + 21);
-#endif
 
 #pragma pack(pop)
 
@@ -269,10 +257,10 @@ void scenery_update_tile(const CoordsXY& sceneryPos);
 void scenery_set_default_placement_configuration();
 void scenery_remove_ghost_tool_placement();
 
-rct_scenery_entry* get_wall_entry(int32_t entryIndex);
-rct_scenery_entry* get_banner_entry(int32_t entryIndex);
-rct_scenery_entry* get_footpath_item_entry(int32_t entryIndex);
-rct_scenery_group_entry* get_scenery_group_entry(int32_t entryIndex);
+rct_scenery_entry* get_wall_entry(ObjectEntryIndex entryIndex);
+rct_scenery_entry* get_banner_entry(ObjectEntryIndex entryIndex);
+rct_scenery_entry* get_footpath_item_entry(ObjectEntryIndex entryIndex);
+rct_scenery_group_entry* get_scenery_group_entry(ObjectEntryIndex entryIndex);
 
 int32_t wall_entry_get_door_sound(const rct_scenery_entry* wallEntry);
 

--- a/src/openrct2/world/ScenerySelection.h
+++ b/src/openrct2/world/ScenerySelection.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "../object/Object.h"
+
 #include <cstdint>
 #include <limits>
 
@@ -17,7 +19,7 @@ constexpr auto WINDOW_SCENERY_TAB_SELECTION_UNDEFINED = std::numeric_limits<uint
 struct ScenerySelection
 {
     uint8_t SceneryType;
-    uint16_t EntryIndex;
+    ObjectEntryIndex EntryIndex;
 
     inline bool operator==(const ScenerySelection& rhs)
     {

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -258,7 +258,7 @@ public:
 
     bool HasAddition() const;
     uint8_t GetAddition() const;
-    uint8_t GetAdditionEntryIndex() const;
+    ObjectEntryIndex GetAdditionEntryIndex() const;
     rct_scenery_entry* GetAdditionEntry() const;
     void SetAddition(uint8_t newAddition);
 


### PR DESCRIPTION
When UpdateScreamSound() was called, the random number generated would return a NoScream SoundID. The two resulting if statements would be executed, causing a SoundId::NoScream to be read as Null instead. This Null would cause the UpdateScreamSound() to be called continually on the same drop until a Scream was generated from RNG. The resulting code fix assumes one scream check per drop.

Also updated some case statements for enum use.