### PR TITLE
Fix #11550. Use std::nullopt instead of empty brace

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -650,7 +650,7 @@ namespace OpenRCT2::Ui::Windows
             }
             widgetIndex++;
         }
-        return 0;
+        return std::nullopt;
     }
 
     static void window_custom_update_viewport(rct_window* w)
@@ -978,7 +978,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
         }
-        return {};
+        return std::nullopt;
     }
 
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/scripting/ScViewport.hpp
+++ b/src/openrct2-ui/scripting/ScViewport.hpp
@@ -299,7 +299,7 @@ namespace OpenRCT2::Scripting
                     }
                 }
             }
-            return {};
+            return std::nullopt;
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -141,7 +141,7 @@ static std::optional<std::string> screenshot_get_next_path()
     if (!platform_ensure_directory_exists(screenshotDirectory.c_str()))
     {
         log_error("Unable to save screenshots in OpenRCT2 screenshot directory.");
-        return {};
+        return std::nullopt;
     }
 
     auto parkName = screenshot_get_park_name();
@@ -165,7 +165,7 @@ static std::optional<std::string> screenshot_get_next_path()
     }
 
     log_error("You have too many saved screenshots saved at exactly the same date and time.");
-    return {};
+    return std::nullopt;
 };
 
 std::string screenshot_dump_png(rct_drawpixelinfo* dpi)

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -92,7 +92,7 @@ std::optional<ServerListEntry> ServerListEntry::FromJson(const json_t* server)
     if (name == nullptr || version == nullptr)
     {
         log_verbose("Cowardly refusing to add server without name or version specified.");
-        return {};
+        return std::nullopt;
     }
     else
     {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -610,7 +610,7 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
     {
         if (xy_distance <= destination_tolerance)
         {
-            return {};
+            return std::nullopt;
         }
         int32_t nextDirection = 0;
         if (x_delta < y_delta)

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1622,7 +1622,7 @@ std::optional<uint16_t> S6Exporter::AllocateUserString(const std::string_view& v
         _userStrings.emplace_back(value);
         return static_cast<uint16_t>(USER_STRING_START + nextId);
     }
-    return {};
+    return std::nullopt;
 }
 
 static std::string GetTruncatedRCT2String(const std::string_view& src)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2210,7 +2210,7 @@ static std::optional<uint32_t> ride_get_train_index_from_vehicle(Ride* ride, uin
         }
         else if (trainIndex >= std::size(ride->vehicles))
         {
-            return {};
+            return std::nullopt;
         }
     }
     return { trainIndex };


### PR DESCRIPTION
Fix #11550. Use std::nullopt instead of empty brace

This is technically a gcc bug from the looks of it but since std::nullopt is slightly easier to read I've gone through the codebase and used that over empty braces. In addition noticed a mistake on the scripting viewport get widgetIndex function where it would return an incorrect widgetIndex.