### PR TITLE
Update brew dependency list in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ The recommended way of building OpenRCT2 for macOS is with Xcode. The Xcode buil
 #### CMake:
 A command line version of OpenRCT2 can be built using CMake. This type of build requires you to provide the dependencies yourself. The supported method of doing this is with [Homebrew](http://brew.sh). Once you have Homebrew installed, you can download all the required libraries with this command:
 ```
-brew install cmake openssl jansson libpng sdl2 speexdsp libzip freetype pkg-config
+brew install cmake duktape freetype icu4c jansson libpng libzip openssl pkg-config sdl2 speexdsp
 ```
 
 Once you have the dependencies installed, you can build the project using CMake using the following commands:


### PR DESCRIPTION
This updates the line with Homebrew dependencies for macOS in readme.md. Note that `duktape` has been added, as well as `icu4c`.

Pending https://github.com/Homebrew/homebrew-core/pull/54089