### PR TITLE
Fix: Silent replay record message gets overwritten

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -882,7 +882,7 @@ void start_silent_record()
         replayManager->GetCurrentReplayInfo(info);
         safe_strcpy(gSilentRecordingName, info.FilePath.c_str(), MAX_PATH);
 
-        const char* logFmt = "Silent replay recording started: (%s) %s";
+        const char* logFmt = "Silent replay recording started: (%s) %s\n";
         printf(logFmt, info.Name.c_str(), info.FilePath.c_str());
     }
 }


### PR DESCRIPTION
A minor thing that I just noticed. The moment you start typing in the console, this line gets overwritten by linenoise's output.