### PR TITLE
Fix #11450: Can't open rides with "Enable all drawable track pieces"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#11290] Perform funds checking for all peeps entering a ride.
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.
 - Fix: [#11405] Building a path through walls does not always remove the walls.
+- Fix: [#11450] Rides with unsuitable track can't be opened even with "Enable all drawable track pieces" cheat.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -5275,7 +5275,7 @@ int32_t ride_is_valid_for_open(Ride* ride, int32_t goingToBeOpen, bool isApplyin
         }
     }
 
-    if (ride->subtype != RIDE_ENTRY_INDEX_NULL)
+    if (ride->subtype != RIDE_ENTRY_INDEX_NULL && !gCheatsEnableAllDrawableTrackPieces)
     {
         rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
         if (rideEntry->flags & RIDE_ENTRY_FLAG_NO_INVERSIONS)


### PR DESCRIPTION
This PR addresses #11450 and #10923 where a ride with unsuitable track (e.g. Hyper-Twister with a vertical loop) cannot be opened even if the "Enable all drawable track pieces" cheat is enabled.