### PR TITLE
[Plugin] Add named parameters for ride related game actions

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -254,6 +254,7 @@ declare global {
         readonly player: number;
         readonly type: string;
         readonly isClientOnly: boolean;
+        readonly args: object;
         result: GameActionResult;
     }
 
@@ -268,28 +269,6 @@ declare global {
 
     interface RideCreateGameActionResult extends GameActionResult {
         readonly ride: number;
-    }
-
-    interface RideCreateActionEventArgs extends GameActionEventArgs {
-        readonly rideType: number;
-        readonly rideObject: number;
-        result: RideCreateGameActionResult;
-    }
-
-    interface SmallSceneryPlaceEventArgs extends GameActionEventArgs {
-        readonly x: number;
-        readonly y: number;
-        readonly z: number;
-        readonly direction: number;
-        readonly quadrant: number;
-        readonly object: number;
-        readonly primaryColour: number;
-        readonly secondaryColour: number;
-    }
-
-    interface GuestSetNameActionEventArgs extends GameActionEventArgs {
-        readonly id: number;
-        readonly name: number;
     }
 
     interface NetworkEventArgs {

--- a/src/openrct2/actions/CustomAction.hpp
+++ b/src/openrct2/actions/CustomAction.hpp
@@ -29,6 +29,16 @@ public:
     {
     }
 
+    std::string GetId() const
+    {
+        return _id;
+    }
+
+    std::string GetJson() const
+    {
+        return _json;
+    }
+
     uint16_t GetActionFlags() const override
     {
         return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -148,12 +148,22 @@ class GameActionParameterVisitor
 public:
     virtual ~GameActionParameterVisitor() = default;
 
+    virtual void Visit(const std::string_view& name, bool& param)
+    {
+    }
+
     virtual void Visit(const std::string_view& name, int32_t& param)
     {
     }
 
     virtual void Visit(const std::string_view& name, std::string& param)
     {
+    }
+
+    void Visit(CoordsXY& param)
+    {
+        Visit("x", param.x);
+        Visit("y", param.y);
     }
 
     void Visit(CoordsXYZD& param)
@@ -170,6 +180,11 @@ public:
         auto value = static_cast<int32_t>(param);
         Visit(name, value);
         param = static_cast<T>(value);
+    }
+
+    template<typename T, size_t _TypeID> void Visit(const std::string_view& name, NetworkObjectId_t<T, _TypeID>& param)
+    {
+        Visit(name, param.id);
     }
 };
 

--- a/src/openrct2/actions/GuestSetNameAction.hpp
+++ b/src/openrct2/actions/GuestSetNameAction.hpp
@@ -39,7 +39,7 @@ public:
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override
     {
-        visitor.Visit("id", _spriteIndex);
+        visitor.Visit("peep", _spriteIndex);
         visitor.Visit("name", _name);
     }
 

--- a/src/openrct2/actions/MazePlaceTrackAction.hpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -28,6 +28,13 @@ public:
         , _rideIndex(rideIndex)
         , _mazeEntry(mazeEntry)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("mazeEntry", _mazeEntry);
     }
 
     void Serialise(DataSerialiser & stream) override

--- a/src/openrct2/actions/MazeSetTrackAction.hpp
+++ b/src/openrct2/actions/MazeSetTrackAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -65,6 +65,14 @@ public:
         , _rideIndex(rideIndex)
         , _mode(mode)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("mode", _mode);
+        visitor.Visit("isInitialPlacement", _initialPlacement);
     }
 
     void Serialise(DataSerialiser & stream) override

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -43,6 +43,12 @@ public:
         : _rideIndex(rideIndex)
         , _modifyType(modifyType)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("modifyType", _modifyType);
     }
 
     uint32_t GetCooldownTime() const override

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -38,6 +38,15 @@ public:
         , _stationNum(stationNum)
         , _isExit(isExit)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("direction", _direction);
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("station", _stationNum);
+        visitor.Visit("isExit", _isExit);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.hpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -31,6 +31,14 @@ public:
         , _stationNum(stationNum)
         , _isExit(isExit)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("station", _stationNum);
+        visitor.Visit("isExit", _isExit);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetAppearanceAction.hpp
+++ b/src/openrct2/actions/RideSetAppearanceAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -53,6 +53,14 @@ public:
         , _value(value)
         , _index(index)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("type", _type);
+        visitor.Visit("value", _value);
+        visitor.Visit("index", _index);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetColourScheme.hpp
+++ b/src/openrct2/actions/RideSetColourScheme.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -35,6 +35,13 @@ public:
         , _trackType(trackType)
         , _newColourScheme(newColourScheme)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("trackType", _trackType);
+        visitor.Visit("colourScheme", _newColourScheme);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetName.hpp
+++ b/src/openrct2/actions/RideSetName.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -36,6 +36,12 @@ public:
         : _rideIndex(rideIndex)
         , _name(name)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("name", _name);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetPriceAction.hpp
+++ b/src/openrct2/actions/RideSetPriceAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -39,6 +39,13 @@ public:
         , _price(price)
         , _primaryPrice(primaryPrice)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("price", _price);
+        visitor.Visit("isPrimaryPrice", _primaryPrice);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetSetting.hpp
+++ b/src/openrct2/actions/RideSetSetting.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -44,6 +44,13 @@ public:
         , _setting(static_cast<uint8_t>(setting))
         , _value(value)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("setting", _setting);
+        visitor.Visit("value", _value);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -44,6 +44,12 @@ public:
         : _rideIndex(rideIndex)
         , _status(status)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("status", _status);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/RideSetVehiclesAction.hpp
+++ b/src/openrct2/actions/RideSetVehiclesAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -55,6 +55,14 @@ public:
         , _value(value)
         , _colour(colour)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("type", _type);
+        visitor.Visit("value", _value);
+        visitor.Visit("colour", _colour);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/TrackDesignAction.h
+++ b/src/openrct2/actions/TrackDesignAction.h
@@ -53,6 +53,7 @@ public:
     void AcceptParameters(GameActionParameterVisitor & visitor) override
     {
         visitor.Visit(_loc);
+        // TODO visit the track design (it has a lot of sub fields)
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/TrackDesignAction.h
+++ b/src/openrct2/actions/TrackDesignAction.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -48,6 +48,11 @@ public:
         : _loc(location)
         , _td(td)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -72,6 +72,18 @@ public:
         , _fromTrackDesign(fromTrackDesign)
     {
         _origin.direction &= 3;
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_origin);
+        visitor.Visit("ride", _rideIndex);
+        visitor.Visit("trackType", _trackType);
+        visitor.Visit("brakeSpeed", _brakeSpeed);
+        visitor.Visit("colour", _colour);
+        visitor.Visit("seatRotation", _seatRotation);
+        visitor.Visit("trackPlaceFlags", _trackPlaceFlags);
+        visitor.Visit("isFromTrackDesign", _fromTrackDesign);
     }
 
     uint16_t GetActionFlags() const override final

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -37,6 +37,13 @@ public:
         , _origin(origin)
     {
         _origin.direction &= 3;
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_origin);
+        visitor.Visit("trackType", _trackType);
+        visitor.Visit("sequence", _sequence);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.hpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.hpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -26,6 +26,13 @@ public:
         , _trackType(trackType)
         , _brakeSpeed(brakeSpeed)
     {
+    }
+
+    void AcceptParameters(GameActionParameterVisitor & visitor) override
+    {
+        visitor.Visit(_loc);
+        visitor.Visit("trackType", _trackType);
+        visitor.Visit("brakeSpeed", _brakeSpeed);
     }
 
     uint16_t GetActionFlags() const override

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -899,6 +899,11 @@ public:
     {
     }
 
+    void Visit(const std::string_view& name, bool& param) override
+    {
+        param = _dukValue[name].as_bool();
+    }
+
     void Visit(const std::string_view& name, int32_t& param) override
     {
         param = _dukValue[name].as_int();
@@ -919,6 +924,12 @@ public:
     DukFromGameActionParameterVisitor(DukObject& dukObject)
         : _dukObject(dukObject)
     {
+    }
+
+    void Visit(const std::string_view& name, bool& param) override
+    {
+        std::string szName(name);
+        _dukObject.Set(szName.c_str(), param);
     }
 
     void Visit(const std::string_view& name, int32_t& param) override
@@ -976,9 +987,24 @@ void ScriptEngine::RunGameActionHooks(const GameAction& action, std::unique_ptr<
 static std::unique_ptr<GameAction> CreateGameActionFromActionId(const std::string& actionid)
 {
     const static std::unordered_map<std::string, uint32_t> ActionNameToType = {
-        { "parksetname", GAME_COMMAND_SET_PARK_NAME },
-        { "smallsceneryplace", GAME_COMMAND_PLACE_SCENERY },
         { "guestsetname", GAME_COMMAND_SET_GUEST_NAME },
+        { "parksetname", GAME_COMMAND_SET_PARK_NAME },
+        { "ridecreate", GAME_COMMAND_CREATE_RIDE },
+        { "ridedemolish", GAME_COMMAND_DEMOLISH_RIDE },
+        { "rideentranceexitplace", GAME_COMMAND_PLACE_RIDE_ENTRANCE_OR_EXIT },
+        { "rideentranceexitremove", GAME_COMMAND_REMOVE_RIDE_ENTRANCE_OR_EXIT },
+        { "ridesetappearance", GAME_COMMAND_SET_RIDE_APPEARANCE },
+        { "ridesetcolourscheme.hpp", GAME_COMMAND_SET_COLOUR_SCHEME },
+        { "ridesetname", GAME_COMMAND_SET_RIDE_NAME },
+        { "ridesetprice", GAME_COMMAND_SET_RIDE_PRICE },
+        { "ridesetsetting", GAME_COMMAND_SET_RIDE_SETTING },
+        { "ridesetstatus", GAME_COMMAND_SET_RIDE_STATUS },
+        { "ridesetvehicles", GAME_COMMAND_SET_RIDE_VEHICLES },
+        { "smallsceneryplace", GAME_COMMAND_PLACE_SCENERY },
+        { "trackdesign", GAME_COMMAND_PLACE_TRACK_DESIGN },
+        { "trackplace", GAME_COMMAND_PLACE_TRACK },
+        { "trackremove", GAME_COMMAND_REMOVE_TRACK },
+        { "tracksetbrakespeed", GAME_COMMAND_SET_BRAKES_SPEED },
     };
 
     auto result = ActionNameToType.find(actionid);


### PR DESCRIPTION
Also changes `GameActionResult` slightly. It will now look like this:
```
{ action: 'trackplace',
  args:
   { x: 1408,
     y: 2464,
     z: 112,
     direction: 0,
     id: 2,
     trackType: 0,
     brakeSpeed: 0,
     colour: 0,
     seatRotation: 4,
     trackPlaceFlags: 0,
     isFromTrackDesign: false },
  player: -1,
  type: 3,
  isClientOnly: false,
  result:
   { cost: 170,
     position:
      { x: 1424,
        y: 2480,
        z: 112 },
     expenditureType: 'ride_construction' } }
```