### PR TITLE
Create constants for both tile element limits

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -98,7 +98,7 @@ int16_t gMapSize;
 int16_t gMapSizeMaxXY;
 int16_t gMapBaseZ;
 
-TileElement gTileElements[MAX_TILE_TILE_ELEMENT_POINTERS * 3];
+TileElement gTileElements[MAX_TILE_ELEMENTS_WITH_SPARE_ROOM];
 TileElement* gTileElementTilePointers[MAX_TILE_TILE_ELEMENT_POINTERS];
 std::vector<CoordsXY> gMapSelectionTiles;
 std::vector<PeepSpawn> gPeepSpawns;
@@ -1076,8 +1076,7 @@ void map_reorganise_elements()
 {
     context_setcurrentcursor(CURSOR_ZZZ);
 
-    TileElement* new_tile_elements = static_cast<TileElement*>(
-        malloc(3 * (MAXIMUM_MAP_SIZE_TECHNICAL * MAXIMUM_MAP_SIZE_TECHNICAL) * sizeof(TileElement)));
+    TileElement* new_tile_elements = static_cast<TileElement*>(malloc(MAX_TILE_ELEMENTS_WITH_SPARE_ROOM * sizeof(TileElement)));
     TileElement* new_elements_pointer = new_tile_elements;
 
     if (new_tile_elements == nullptr)
@@ -1107,9 +1106,7 @@ void map_reorganise_elements()
 
     num_elements = static_cast<uint32_t>(new_elements_pointer - new_tile_elements);
     std::memcpy(gTileElements, new_tile_elements, num_elements * sizeof(TileElement));
-    std::memset(
-        gTileElements + num_elements, 0,
-        (3 * (MAXIMUM_MAP_SIZE_TECHNICAL * MAXIMUM_MAP_SIZE_TECHNICAL) - num_elements) * sizeof(TileElement));
+    std::memset(gTileElements + num_elements, 0, (MAX_TILE_ELEMENTS_WITH_SPARE_ROOM - num_elements) * sizeof(TileElement));
 
     free(new_tile_elements);
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -33,7 +33,8 @@ constexpr const int32_t MINIMUM_LAND_HEIGHT_BIG = MINIMUM_LAND_HEIGHT * COORDS_Z
 
 #define MAP_MINIMUM_X_Y (-MAXIMUM_MAP_SIZE_TECHNICAL)
 
-#define MAX_TILE_ELEMENTS 196096 // 0x30000
+constexpr const uint32_t MAX_TILE_ELEMENTS_WITH_SPARE_ROOM = 0x30000;
+constexpr const uint32_t MAX_TILE_ELEMENTS = MAX_TILE_ELEMENTS_WITH_SPARE_ROOM - 512;
 #define MAX_TILE_TILE_ELEMENT_POINTERS (MAXIMUM_MAP_SIZE_TECHNICAL * MAXIMUM_MAP_SIZE_TECHNICAL)
 #define MAX_PEEP_SPAWNS 2
 #define PEEP_SPAWN_UNDEFINED 0xFFFF
@@ -119,7 +120,7 @@ extern uint8_t gMapSelectArrowDirection;
 
 extern uint8_t gMapGroundFlags;
 
-extern TileElement gTileElements[MAX_TILE_TILE_ELEMENT_POINTERS * 3];
+extern TileElement gTileElements[MAX_TILE_ELEMENTS_WITH_SPARE_ROOM];
 extern TileElement* gTileElementTilePointers[MAX_TILE_TILE_ELEMENT_POINTERS];
 
 extern std::vector<CoordsXY> gMapSelectionTiles;


### PR DESCRIPTION
This uses some information from https://github.com/OpenRCT2/OpenRCT2/pull/7637 .

Basically, it seems that RCT2 reserves some room for defragmenting the tile element list. This also provides an answer to the question why `map_check_free_elements_and_reorganise()` does `auto tileElementEnd = &gTileElements[MAX_TILE_ELEMENTS];` - it's the start of the spare element room.