### PR TITLE
Refactored gfx_draw_string_right (Issue 11569)

### DIFF
--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -15,6 +15,7 @@
 #include "../interface/ZoomLevel.hpp"
 
 #include <vector>
+struct ScreenCoordsXY;
 
 namespace OpenRCT2
 {
@@ -534,6 +535,8 @@ void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t co
 void gfx_draw_string_left(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y);
 void gfx_draw_string_centred(
     rct_drawpixelinfo* dpi, rct_string_id format, int32_t x, int32_t y, uint8_t colour, const void* args);
+void gfx_draw_string_right(
+    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords);
 void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y);
 
 void draw_string_left_underline(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -164,9 +164,13 @@ void gfx_draw_string_centred(
 
 void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y)
 {
-    DrawTextCompat(dpi, x, y, format, args, colour, TextAlignment::RIGHT);
+    gfx_draw_string_right(dpi, format, args, colour, { x, y });
 }
 
+void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
+{
+    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::RIGHT);
+}
 // Underline
 void draw_string_left_underline(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y)
 {

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -167,7 +167,8 @@ void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* a
     gfx_draw_string_right(dpi, format, args, colour, { x, y });
 }
 
-void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
+void gfx_draw_string_right(
+    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
     DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::RIGHT);
 }


### PR DESCRIPTION
Refactored gfx_draw_string_right to use ScreenCoordsXY in Text.cpp and Drawing.h. Changed old function to call new function instead. 