### PR TITLE
Fix #11667: Memory dumps being generated every time the game is closed

### DIFF
--- a/src/openrct2/interface/StdInOutConsole.cpp
+++ b/src/openrct2/interface/StdInOutConsole.cpp
@@ -7,6 +7,11 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+// Ignore isatty warning on WIN32
+#ifndef _CRT_NONSTDC_NO_WARNINGS
+#    define _CRT_NONSTDC_NO_WARNINGS
+#endif
+
 #include "../Context.h"
 #include "../OpenRCT2.h"
 #include "../platform/Platform2.h"
@@ -19,6 +24,12 @@ using namespace OpenRCT2;
 
 void StdInOutConsole::Start()
 {
+    // Only start if stdin is a TTY
+    if (!isatty(fileno(stdin)))
+    {
+        return;
+    }
+
     std::thread replThread([this]() -> void {
         linenoise::SetMultiLine(true);
         linenoise::SetHistoryMaxLen(32);


### PR DESCRIPTION
Only provide interactive console if there is a TTY attached to stdin.