### PR TITLE
Fix #11572 create gfx_draw_string() overload

### DIFF
--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -304,7 +304,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
         INSET_RECT_FLAG_BORDER_INSET);
 
     std::string lineBuffer;
-    ScreenCoordsXY screenCoords(_consoleLeft + CONSOLE_EDGE_PADDING, _consoleTop + CONSOLE_EDGE_PADDING);
+    auto screenCoords = ScreenCoordsXY{_consoleLeft + CONSOLE_EDGE_PADDING, _consoleTop + CONSOLE_EDGE_PADDING};
 
     // Draw text inside console
     for (std::size_t i = 0; i < _consoleLines.size() && i < static_cast<size_t>(maxLines); i++)

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -304,29 +304,28 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
         INSET_RECT_FLAG_BORDER_INSET);
 
     std::string lineBuffer;
-    int32_t x = _consoleLeft + CONSOLE_EDGE_PADDING;
-    int32_t y = _consoleTop + CONSOLE_EDGE_PADDING;
+    ScreenCoordsXY screenCoords(_consoleLeft + CONSOLE_EDGE_PADDING, _consoleTop + CONSOLE_EDGE_PADDING);
 
     // Draw text inside console
     for (std::size_t i = 0; i < _consoleLines.size() && i < static_cast<size_t>(maxLines); i++)
     {
         const size_t index = i + _consoleScrollPos;
         lineBuffer = colourFormatStr + _consoleLines[index];
-        gfx_draw_string(dpi, lineBuffer.c_str(), textColour, x, y);
-        y += lineHeight;
+        gfx_draw_string(dpi, lineBuffer.c_str(), textColour, screenCoords);
+        screenCoords.y += lineHeight;
     }
 
-    y = _consoleBottom - lineHeight - CONSOLE_EDGE_PADDING - 1;
+    screenCoords.y = _consoleBottom - lineHeight - CONSOLE_EDGE_PADDING - 1;
 
     // Draw current line
     lineBuffer = colourFormatStr + _consoleCurrentLine;
-    gfx_draw_string(dpi, lineBuffer.c_str(), TEXT_COLOUR_255, x, y);
+    gfx_draw_string(dpi, lineBuffer.c_str(), TEXT_COLOUR_255, screenCoords);
 
     // Draw caret
     if (_consoleCaretTicks < CONSOLE_CARET_FLASH_THRESHOLD)
     {
-        int32_t caretX = x + gfx_get_string_width(_consoleCurrentLine);
-        int32_t caretY = y + lineHeight;
+        int32_t caretX = screenCoords.x + gfx_get_string_width(_consoleCurrentLine);
+        int32_t caretY = screenCoords.y + lineHeight;
 
         uint8_t caretColour = ColourMapA[BASE_COLOUR(textColour)].lightest;
         gfx_fill_rect(dpi, caretX, caretY, caretX + CONSOLE_CARET_WIDTH, caretY, caretColour);

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -304,7 +304,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
         INSET_RECT_FLAG_BORDER_INSET);
 
     std::string lineBuffer;
-    auto screenCoords = ScreenCoordsXY{_consoleLeft + CONSOLE_EDGE_PADDING, _consoleTop + CONSOLE_EDGE_PADDING};
+    auto screenCoords = ScreenCoordsXY{ _consoleLeft + CONSOLE_EDGE_PADDING, _consoleTop + CONSOLE_EDGE_PADDING };
 
     // Draw text inside console
     for (std::size_t i = 0; i < _consoleLines.size() && i < static_cast<size_t>(maxLines); i++)

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -638,8 +638,7 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     if (widget_is_pressed(w, widgetIndex))
     {
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-        gfx_draw_string(
-            dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), { l, yMid - 5 });
+        gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), { l, yMid - 5 });
     }
 
     // draw the text

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -638,7 +638,8 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     if (widget_is_pressed(w, widgetIndex))
     {
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-        gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), ScreenCoordsXY(l, yMid - 5));
+        gfx_draw_string(
+            dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), ScreenCoordsXY(l, yMid - 5));
     }
 
     // draw the text

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -639,7 +639,7 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     {
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
         gfx_draw_string(
-            dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), ScreenCoordsXY(l, yMid - 5));
+            dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), { l, yMid - 5 });
     }
 
     // draw the text
@@ -737,16 +737,12 @@ static void widget_hscrollbar_draw(
     gfx_fill_rect(dpi, l + SCROLLBAR_WIDTH, t + 7, r - SCROLLBAR_WIDTH, t + 7, ColourMapA[colour].mid_dark);
     gfx_fill_rect(dpi, l + SCROLLBAR_WIDTH, t + 8, r - SCROLLBAR_WIDTH, t + 8, ColourMapA[colour].lighter);
 
-    ScreenCoordsXY screenCoords;
-
     // Left button
     {
         uint8_t flags = (scroll->flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        screenCoords.x = l + 1;
-        screenCoords.y = t;
         gfx_fill_rect_inset(dpi, l, t, l + (SCROLLBAR_WIDTH - 1), b, colour, flags);
-        gfx_draw_string(dpi, static_cast<const char*>(BlackLeftArrowString), COLOUR_BLACK, screenCoords);
+        gfx_draw_string(dpi, static_cast<const char*>(BlackLeftArrowString), COLOUR_BLACK, { l + 1, t });
     }
 
     // Thumb
@@ -762,10 +758,8 @@ static void widget_hscrollbar_draw(
     {
         uint8_t flags = (scroll->flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        screenCoords.x = r - 6;
-        screenCoords.y = t;
         gfx_fill_rect_inset(dpi, r - (SCROLLBAR_WIDTH - 1), t, r, b, colour, flags);
-        gfx_draw_string(dpi, static_cast<const char*>(BlackRightArrowString), COLOUR_BLACK, screenCoords);
+        gfx_draw_string(dpi, static_cast<const char*>(BlackRightArrowString), COLOUR_BLACK, { r - 6, t });
     }
 }
 
@@ -785,8 +779,7 @@ static void widget_vscrollbar_draw(
     gfx_fill_rect_inset(
         dpi, l, t, r, t + (SCROLLBAR_WIDTH - 1), colour,
         ((scroll->flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    ScreenCoordsXY screenCoords(l + 1, t - 1);
-    gfx_draw_string(dpi, static_cast<const char*>(BlackUpArrowString), COLOUR_BLACK, screenCoords);
+    gfx_draw_string(dpi, static_cast<const char*>(BlackUpArrowString), COLOUR_BLACK, { l + 1, t - 1 });
 
     // Thumb
     gfx_fill_rect_inset(
@@ -798,8 +791,7 @@ static void widget_vscrollbar_draw(
     gfx_fill_rect_inset(
         dpi, l, b - (SCROLLBAR_WIDTH - 1), r, b, colour,
         ((scroll->flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    screenCoords.y = b - (SCROLLBAR_WIDTH - 1);
-    gfx_draw_string(dpi, static_cast<const char*>(BlackDownArrowString), COLOUR_BLACK, screenCoords);
+    gfx_draw_string(dpi, static_cast<const char*>(BlackDownArrowString), COLOUR_BLACK, { l + 1, b - (SCROLLBAR_WIDTH - 1) });
 }
 
 /**
@@ -1076,7 +1068,6 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     gCurrentFontFlags = 0;
-    ScreenCoordsXY screenCoords(l + 2, t);
 
     if (!active || gTextInput == nullptr)
     {
@@ -1084,7 +1075,7 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
         {
             safe_strcpy(wrapped_string, w->widgets[widgetIndex].string, 512);
             gfx_wrap_string(wrapped_string, r - l - 5, &no_lines, &font_height);
-            gfx_draw_string(dpi, wrapped_string, w->colours[1], screenCoords);
+            gfx_draw_string(dpi, wrapped_string, w->colours[1], { l + 2, t });
         }
         return;
     }
@@ -1095,7 +1086,7 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     // +13 for cursor when max length.
     gfx_wrap_string(wrapped_string, r - l - 5 - 6, &no_lines, &font_height);
 
-    gfx_draw_string(dpi, wrapped_string, w->colours[1], screenCoords);
+    gfx_draw_string(dpi, wrapped_string, w->colours[1], { l + 2, t });
 
     size_t string_length = get_string_size(wrapped_string) - 1;
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -638,7 +638,7 @@ static void widget_checkbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     if (widget_is_pressed(w, widgetIndex))
     {
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-        gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), l, yMid - 5);
+        gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), ScreenCoordsXY(l, yMid - 5));
     }
 
     // draw the text
@@ -736,12 +736,16 @@ static void widget_hscrollbar_draw(
     gfx_fill_rect(dpi, l + SCROLLBAR_WIDTH, t + 7, r - SCROLLBAR_WIDTH, t + 7, ColourMapA[colour].mid_dark);
     gfx_fill_rect(dpi, l + SCROLLBAR_WIDTH, t + 8, r - SCROLLBAR_WIDTH, t + 8, ColourMapA[colour].lighter);
 
+    ScreenCoordsXY screenCoords;
+
     // Left button
     {
         uint8_t flags = (scroll->flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
+        screenCoords.x = l + 1;
+        screenCoords.y = t;
         gfx_fill_rect_inset(dpi, l, t, l + (SCROLLBAR_WIDTH - 1), b, colour, flags);
-        gfx_draw_string(dpi, static_cast<const char*>(BlackLeftArrowString), COLOUR_BLACK, l + 1, t);
+        gfx_draw_string(dpi, static_cast<const char*>(BlackLeftArrowString), COLOUR_BLACK, screenCoords);
     }
 
     // Thumb
@@ -757,8 +761,10 @@ static void widget_hscrollbar_draw(
     {
         uint8_t flags = (scroll->flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
+        screenCoords.x = r - 6;
+        screenCoords.y = t;
         gfx_fill_rect_inset(dpi, r - (SCROLLBAR_WIDTH - 1), t, r, b, colour, flags);
-        gfx_draw_string(dpi, static_cast<const char*>(BlackRightArrowString), COLOUR_BLACK, r - 6, t);
+        gfx_draw_string(dpi, static_cast<const char*>(BlackRightArrowString), COLOUR_BLACK, screenCoords);
     }
 }
 
@@ -778,7 +784,8 @@ static void widget_vscrollbar_draw(
     gfx_fill_rect_inset(
         dpi, l, t, r, t + (SCROLLBAR_WIDTH - 1), colour,
         ((scroll->flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    gfx_draw_string(dpi, static_cast<const char*>(BlackUpArrowString), COLOUR_BLACK, l + 1, t - 1);
+    ScreenCoordsXY screenCoords(l + 1, t - 1);
+    gfx_draw_string(dpi, static_cast<const char*>(BlackUpArrowString), COLOUR_BLACK, screenCoords);
 
     // Thumb
     gfx_fill_rect_inset(
@@ -790,7 +797,8 @@ static void widget_vscrollbar_draw(
     gfx_fill_rect_inset(
         dpi, l, b - (SCROLLBAR_WIDTH - 1), r, b, colour,
         ((scroll->flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    gfx_draw_string(dpi, static_cast<const char*>(BlackDownArrowString), COLOUR_BLACK, l + 1, b - (SCROLLBAR_WIDTH - 1));
+    screenCoords.y = b - (SCROLLBAR_WIDTH - 1);
+    gfx_draw_string(dpi, static_cast<const char*>(BlackDownArrowString), COLOUR_BLACK, screenCoords);
 }
 
 /**
@@ -1067,6 +1075,7 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     gCurrentFontFlags = 0;
+    ScreenCoordsXY screenCoords(l + 2, t);
 
     if (!active || gTextInput == nullptr)
     {
@@ -1074,7 +1083,7 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
         {
             safe_strcpy(wrapped_string, w->widgets[widgetIndex].string, 512);
             gfx_wrap_string(wrapped_string, r - l - 5, &no_lines, &font_height);
-            gfx_draw_string(dpi, wrapped_string, w->colours[1], l + 2, t);
+            gfx_draw_string(dpi, wrapped_string, w->colours[1], screenCoords);
         }
         return;
     }
@@ -1085,7 +1094,7 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     // +13 for cursor when max length.
     gfx_wrap_string(wrapped_string, r - l - 5 - 6, &no_lines, &font_height);
 
-    gfx_draw_string(dpi, wrapped_string, w->colours[1], l + 2, t);
+    gfx_draw_string(dpi, wrapped_string, w->colours[1], screenCoords);
 
     size_t string_length = get_string_size(wrapped_string) - 1;
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -191,15 +191,14 @@ static void window_changelog_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
 
     const int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
-    int32_t x = 3;
-    int32_t y = 3 - lineHeight;
+    ScreenCoordsXY screenCoords(3, 3 - lineHeight);
     for (auto line : _changelogLines)
     {
-        y += lineHeight;
-        if (y + lineHeight < dpi->y || y >= dpi->y + dpi->height)
+        screenCoords.y += lineHeight;
+        if (screenCoords.y + lineHeight < dpi->y || screenCoords.y >= dpi->y + dpi->height)
             continue;
 
-        gfx_draw_string(dpi, static_cast<const char*>(line), w->colours[0], x, y);
+        gfx_draw_string(dpi, static_cast<const char*>(line), w->colours[0], screenCoords);
     }
 }
 

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -231,29 +231,29 @@ static void custom_currency_window_text_input([[maybe_unused]] struct rct_window
 
 static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t x, y;
+    ScreenCoordsXY screenCoords;
 
     set_format_arg(0, int32_t, 100);
 
     window_draw_widgets(w, dpi);
 
-    x = w->windowPos.x + 10;
-    y = w->windowPos.y + 30;
+    screenCoords.x = w->windowPos.x + 10;
+    screenCoords.y = w->windowPos.y + 30;
 
-    gfx_draw_string_left(dpi, STR_RATE, nullptr, w->colours[1], x, y);
+    gfx_draw_string_left(dpi, STR_RATE, nullptr, w->colours[1], screenCoords.x, screenCoords.y);
 
     int32_t baseExchange = CurrencyDescriptors[CURRENCY_POUNDS].rate;
     set_format_arg(0, int32_t, baseExchange);
-    gfx_draw_string_left(dpi, STR_CUSTOM_CURRENCY_EQUIVALENCY, gCommonFormatArgs, w->colours[1], x + 200, y);
+    gfx_draw_string_left(dpi, STR_CUSTOM_CURRENCY_EQUIVALENCY, gCommonFormatArgs, w->colours[1], screenCoords.x + 200, screenCoords.y);
 
-    y += 20;
+    screenCoords.y += 20;
 
-    gfx_draw_string_left(dpi, STR_CURRENCY_SYMBOL_TEXT, nullptr, w->colours[1], x, y);
+    gfx_draw_string_left(dpi, STR_CURRENCY_SYMBOL_TEXT, nullptr, w->colours[1], screenCoords.x, screenCoords.y);
 
-    gfx_draw_string(
-        dpi, CurrencyDescriptors[CURRENCY_CUSTOM].symbol_unicode, w->colours[1],
-        w->windowPos.x + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].left + 1,
-        w->windowPos.y + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].top);
+    screenCoords.x = w->windowPos.x + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].left + 1;
+    screenCoords.y = w->windowPos.y + window_custom_currency_widgets[WIDX_SYMBOL_TEXT].top;
+
+    gfx_draw_string(dpi, CurrencyDescriptors[CURRENCY_CUSTOM].symbol_unicode, w->colours[1], screenCoords);
 
     if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CURRENCY_PREFIX)
     {

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -244,7 +244,8 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     int32_t baseExchange = CurrencyDescriptors[CURRENCY_POUNDS].rate;
     set_format_arg(0, int32_t, baseExchange);
-    gfx_draw_string_left(dpi, STR_CUSTOM_CURRENCY_EQUIVALENCY, gCommonFormatArgs, w->colours[1], screenCoords.x + 200, screenCoords.y);
+    gfx_draw_string_left(
+        dpi, STR_CUSTOM_CURRENCY_EQUIVALENCY, gCommonFormatArgs, w->colours[1], screenCoords.x + 200, screenCoords.y);
 
     screenCoords.y += 20;
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -706,19 +706,15 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
             vehicleNamePtr = nullptr;
         }
 
-        ScreenCoordsXY screenCoords(1, itemY);
-
         // Draw group name
         gfx_clip_string(groupNameBuffer, columnSplitOffset);
-        gfx_draw_string(dpi, groupNameBuffer, colour, screenCoords);
+        gfx_draw_string(dpi, groupNameBuffer, colour, { 1, itemY });
 
         // Draw vehicle name
         if (vehicleNamePtr)
         {
-            screenCoords.x = columnSplitOffset + 1;
-            screenCoords.y = itemY;
             gfx_clip_string(vehicleNameBuffer, columnSplitOffset - 11);
-            gfx_draw_string(dpi, vehicleNameBuffer, colour, screenCoords);
+            gfx_draw_string(dpi, vehicleNameBuffer, colour, { columnSplitOffset + 1, itemY });
         }
     }
 }

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -706,15 +706,19 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
             vehicleNamePtr = nullptr;
         }
 
+        ScreenCoordsXY screenCoords(1, itemY);
+
         // Draw group name
         gfx_clip_string(groupNameBuffer, columnSplitOffset);
-        gfx_draw_string(dpi, groupNameBuffer, colour, 1, itemY);
+        gfx_draw_string(dpi, groupNameBuffer, colour, screenCoords);
 
         // Draw vehicle name
         if (vehicleNamePtr)
         {
+            screenCoords.x = columnSplitOffset + 1;
+            screenCoords.y = itemY;
             gfx_clip_string(vehicleNameBuffer, columnSplitOffset - 11);
-            gfx_draw_string(dpi, vehicleNameBuffer, colour, columnSplitOffset + 1, itemY);
+            gfx_draw_string(dpi, vehicleNameBuffer, colour, screenCoords);
         }
     }
 }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1108,44 +1108,45 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
  */
 static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t x, y, colour, colour2;
+    int32_t colour, colour2;
+    ScreenCoordsXY screenCoords;
 
     bool ridePage = (get_selected_object_type(w) == OBJECT_TYPE_RIDE);
 
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     gfx_clear(dpi, paletteIndex);
 
-    y = 0;
+    screenCoords.y = 0;
     for (const auto& listItem : _listItems)
     {
-        if (y + 12 >= dpi->y && y <= dpi->y + dpi->height)
+        if (screenCoords.y + 12 >= dpi->y && screenCoords.y <= dpi->y + dpi->height)
         {
             // Draw checkbox
             if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && !(*listItem.flags & 0x20))
-                gfx_fill_rect_inset(dpi, 2, y, 11, y + 10, w->colours[1], INSET_RECT_F_E0);
+                gfx_fill_rect_inset(dpi, 2, screenCoords.y, 11, screenCoords.y + 10, w->colours[1], INSET_RECT_F_E0);
 
             // Highlight background
             colour = COLOUR_BRIGHT_GREEN | COLOUR_FLAG_TRANSLUCENT;
             if (listItem.entry == w->object_entry && !(*listItem.flags & OBJECT_SELECTION_FLAG_6))
             {
-                gfx_filter_rect(dpi, 0, y, w->width, y + 11, PALETTE_DARKEN_1);
+                gfx_filter_rect(dpi, 0, screenCoords.y, w->width, screenCoords.y + 11, PALETTE_DARKEN_1);
                 colour = COLOUR_BRIGHT_GREEN;
             }
 
             // Draw checkmark
             if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && (*listItem.flags & OBJECT_SELECTION_FLAG_SELECTED))
             {
-                x = 2;
+                screenCoords.x = 2;
                 gCurrentFontSpriteBase = colour == COLOUR_BRIGHT_GREEN ? FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK
                                                                        : FONT_SPRITE_BASE_MEDIUM_DARK;
                 colour2 = NOT_TRANSLUCENT(w->colours[1]);
                 if (*listItem.flags & (OBJECT_SELECTION_FLAG_IN_USE | OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED))
                     colour2 |= COLOUR_FLAG_INSET;
 
-                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), colour2, x, y);
+                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), colour2, screenCoords);
             }
 
-            x = gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER ? 0 : 15;
+            screenCoords.x = gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER ? 0 : 15;
 
             char* bufferWithColour = gCommonStringFormatBuffer;
             char* buffer = utf8_write_codepoint(bufferWithColour, colour);
@@ -1160,7 +1161,7 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
                 gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
             }
 
-            int32_t width_limit = w->widgets[WIDX_LIST].right - w->widgets[WIDX_LIST].left - x;
+            int32_t width_limit = w->widgets[WIDX_LIST].right - w->widgets[WIDX_LIST].left - screenCoords.x;
 
             if (ridePage)
             {
@@ -1168,8 +1169,8 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
                 // Draw ride type
                 rct_string_id rideTypeStringId = get_ride_type_string_id(listItem.repositoryItem);
                 safe_strcpy(buffer, language_get_string(rideTypeStringId), 256 - (buffer - bufferWithColour));
-                gfx_draw_string_left_clipped(dpi, STR_STRING, &bufferWithColour, colour, x, y, width_limit - 15);
-                x = w->widgets[WIDX_LIST_SORT_RIDE].left - w->widgets[WIDX_LIST].left;
+                gfx_draw_string_left_clipped(dpi, STR_STRING, &bufferWithColour, colour, screenCoords.x, screenCoords.y, width_limit - 15);
+                screenCoords.x = w->widgets[WIDX_LIST_SORT_RIDE].left - w->widgets[WIDX_LIST].left;
             }
 
             // Draw text
@@ -1181,9 +1182,9 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
 
                 *buffer = 0;
             }
-            gfx_draw_string_left_clipped(dpi, STR_STRING, &bufferWithColour, colour, x, y, width_limit);
+            gfx_draw_string_left_clipped(dpi, STR_STRING, &bufferWithColour, colour, screenCoords.x, screenCoords.y, width_limit);
         }
-        y += 12;
+        screenCoords.y += 12;
     }
 }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1169,7 +1169,8 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
                 // Draw ride type
                 rct_string_id rideTypeStringId = get_ride_type_string_id(listItem.repositoryItem);
                 safe_strcpy(buffer, language_get_string(rideTypeStringId), 256 - (buffer - bufferWithColour));
-                gfx_draw_string_left_clipped(dpi, STR_STRING, &bufferWithColour, colour, screenCoords.x, screenCoords.y, width_limit - 15);
+                gfx_draw_string_left_clipped(
+                    dpi, STR_STRING, &bufferWithColour, colour, screenCoords.x, screenCoords.y, width_limit - 15);
                 screenCoords.x = w->widgets[WIDX_LIST_SORT_RIDE].left - w->widgets[WIDX_LIST].left;
             }
 
@@ -1182,7 +1183,8 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
 
                 *buffer = 0;
             }
-            gfx_draw_string_left_clipped(dpi, STR_STRING, &bufferWithColour, colour, screenCoords.x, screenCoords.y, width_limit);
+            gfx_draw_string_left_clipped(
+                dpi, STR_STRING, &bufferWithColour, colour, screenCoords.x, screenCoords.y, width_limit);
         }
         screenCoords.y += 12;
     }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1175,7 +1175,7 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
             {
                 gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK
                                                                                   : FONT_SPRITE_BASE_MEDIUM_DARK;
-                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, ScreenCoordsXY(2, y));
+                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, { 2, y });
             }
 
             // Ride name

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1175,7 +1175,7 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
             {
                 gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK
                                                                                   : FONT_SPRITE_BASE_MEDIUM_DARK;
-                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, 2, y);
+                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, ScreenCoordsXY(2, y));
             }
 
             // Ride name

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2077,18 +2077,19 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_guest_debug_tab_paint(w, dpi);
 
     auto peep = GET_PEEP(w->number);
-    auto x = w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    auto y = w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    ScreenCoordsXY screenCoords;
+    screenCoords.x = w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
+    screenCoords.y = w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, x, y);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);
     }
-    y += LIST_ROW_HEIGHT;
+    screenCoords.y += LIST_ROW_HEIGHT;
     {
         int32_t args[] = { peep->x, peep->y, peep->x };
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_POSITION, args, 0, x, y);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_POSITION, args, 0, screenCoords.x, screenCoords.y);
     }
-    y += LIST_ROW_HEIGHT;
+    screenCoords.y += LIST_ROW_HEIGHT;
     {
         int32_t args[] = { peep->NextLoc.x, peep->NextLoc.y, peep->NextLoc.z };
         format_string(buffer, sizeof(buffer), STR_PEEP_DEBUG_NEXT, args);
@@ -2103,28 +2104,28 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
             format_string(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SLOPE, args2);
             safe_strcat(buffer, buffer2, sizeof(buffer));
         }
-        gfx_draw_string(dpi, buffer, 0, x, y);
+        gfx_draw_string(dpi, buffer, 0, screenCoords);
     }
-    y += LIST_ROW_HEIGHT;
+    screenCoords.y += LIST_ROW_HEIGHT;
     {
         int32_t args[] = { peep->destination_x, peep->destination_y, peep->destination_tolerance };
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_DEST, args, 0, x, y);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_DEST, args, 0, screenCoords.x, screenCoords.y);
     }
-    y += LIST_ROW_HEIGHT;
+    screenCoords.y += LIST_ROW_HEIGHT;
     {
         int32_t args[] = { peep->pathfind_goal.x, peep->pathfind_goal.y, peep->pathfind_goal.z, peep->pathfind_goal.direction };
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_GOAL, args, 0, x, y);
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_GOAL, args, 0, screenCoords.x, screenCoords.y);
     }
-    y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_HISTORY, nullptr, 0, x, y);
-    y += LIST_ROW_HEIGHT;
+    screenCoords.y += LIST_ROW_HEIGHT;
+    gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_HISTORY, nullptr, 0, screenCoords.x, screenCoords.y);
+    screenCoords.y += LIST_ROW_HEIGHT;
 
-    x += 10;
+    screenCoords.x += 10;
     for (auto& point : peep->pathfind_history)
     {
         int32_t args[] = { point.x, point.y, point.z, point.direction };
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM, args, 0, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM, args, 0, screenCoords.x, screenCoords.y);
+        screenCoords.y += LIST_ROW_HEIGHT;
     }
-    x -= 10;
+    screenCoords.x -= 10;
 }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2077,7 +2077,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_guest_debug_tab_paint(w, dpi);
 
     auto peep = GET_PEEP(w->number);
-    auto screenCoords  = ScreenCoordsXY{ w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
+    auto screenCoords = ScreenCoordsXY{ w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
                                          w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
     {
         set_format_arg(0, uint32_t, peep->sprite_index);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2077,9 +2077,8 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_guest_debug_tab_paint(w, dpi);
 
     auto peep = GET_PEEP(w->number);
-    auto screenCoords  = ScreenCoordsXY{
-        w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
-        w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4};
+    auto screenCoords  = ScreenCoordsXY{ w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
+                                         w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
         gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2077,9 +2077,9 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_guest_debug_tab_paint(w, dpi);
 
     auto peep = GET_PEEP(w->number);
-    ScreenCoordsXY screenCoords;
-    screenCoords.x = w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4;
-    screenCoords.y = w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4;
+    auto screenCoords  = ScreenCoordsXY{
+        w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
+        w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4};
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
         gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2078,7 +2078,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto peep = GET_PEEP(w->number);
     auto screenCoords = ScreenCoordsXY{ w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
-                                         w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
+                                        w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
     {
         set_format_arg(0, uint32_t, peep->sprite_index);
         gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -643,15 +643,16 @@ static void window_multiplayer_players_paint(rct_window* w, rct_drawpixelinfo* d
 
 static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t y = 0;
+    ScreenCoordsXY screenCoords;
+    screenCoords.y = 0;
     for (int32_t i = 0; i < network_get_num_players(); i++)
     {
-        if (y > dpi->y + dpi->height)
+        if (screenCoords.y > dpi->y + dpi->height)
         {
             break;
         }
 
-        if (y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
         {
             char buffer[300];
 
@@ -660,7 +661,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             int32_t colour = COLOUR_BLACK;
             if (i == w->selected_list_item)
             {
-                gfx_filter_rect(dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
+                gfx_filter_rect(dpi, 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
                 safe_strcpy(buffer, network_get_player_name(i), sizeof(buffer));
                 colour = w->colours[2];
             }
@@ -676,8 +677,9 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
                 }
                 safe_strcpy(lineCh, network_get_player_name(i), sizeof(buffer) - (lineCh - buffer));
             }
+            screenCoords.x = 0;
             gfx_clip_string(buffer, 230);
-            gfx_draw_string(dpi, buffer, colour, 0, y);
+            gfx_draw_string(dpi, buffer, colour, screenCoords);
 
             // Draw group name
             lineCh = buffer;
@@ -685,9 +687,10 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             if (group != -1)
             {
                 lineCh = utf8_write_codepoint(lineCh, FORMAT_BLACK);
+                screenCoords.x = 173;
                 safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
                 gfx_clip_string(buffer, 80);
-                gfx_draw_string(dpi, buffer, colour, 173, y);
+                gfx_draw_string(dpi, buffer, colour, screenCoords);
             }
 
             // Draw last action
@@ -697,7 +700,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             {
                 set_format_arg(0, rct_string_id, network_get_action_name_string_id(action));
             }
-            gfx_draw_string_left_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, 256, y, 100);
+            gfx_draw_string_left_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, 256, screenCoords.y, 100);
 
             // Draw ping
             lineCh = buffer;
@@ -715,9 +718,10 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
                 lineCh = utf8_write_codepoint(lineCh, FORMAT_RED);
             }
             snprintf(lineCh, sizeof(buffer) - (lineCh - buffer), "%d ms", ping);
-            gfx_draw_string(dpi, buffer, colour, 356, y);
+            screenCoords.x = 356;
+            gfx_draw_string(dpi, buffer, colour, screenCoords);
         }
-        y += SCROLLABLE_ROW_HEIGHT;
+        screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }
 }
 
@@ -938,7 +942,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
 
 static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t y = 0;
+    ScreenCoordsXY sreenCoords(0, 0);
 
     gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1, ColourMapA[w->colours[1]].mid_light);
 
@@ -946,14 +950,14 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
     {
         if (i == w->selected_list_item)
         {
-            gfx_filter_rect(dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
+            gfx_filter_rect(dpi, 0, sreenCoords.y, 800, sreenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
         }
-        if (y > dpi->y + dpi->height)
+        if (sreenCoords.y > dpi->y + dpi->height)
         {
             break;
         }
 
-        if (y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        if (sreenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
         {
             char buffer[300] = { 0 };
             int32_t groupindex = network_get_group_index(_selectedGroup);
@@ -964,15 +968,15 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
                     char* lineCh = buffer;
                     lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
                     lineCh = utf8_write_codepoint(lineCh, UnicodeChar::tick);
-                    gfx_draw_string(dpi, buffer, COLOUR_BLACK, 0, y);
+                    gfx_draw_string(dpi, buffer, COLOUR_BLACK, sreenCoords);
                 }
             }
 
             // Draw action name
             set_format_arg(0, uint16_t, network_get_action_name_string_id(i));
-            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, y);
+            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, sreenCoords.y);
         }
-        y += SCROLLABLE_ROW_HEIGHT;
+        sreenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }
 }
 

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -395,41 +395,40 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
     {
         dpi = &clippedDPI;
 
-        int32_t x = padding;
-        int32_t y = heightTab + padding;
+        ScreenCoordsXY screenCoords(padding, heightTab + padding);
 
         // Received stats.
         {
-            gfx_draw_string_left(dpi, STR_NETWORK_RECEIVE, nullptr, PALETTE_INDEX_10, x, y);
+            gfx_draw_string_left(dpi, STR_NETWORK_RECEIVE, nullptr, PALETTE_INDEX_10, screenCoords.x, screenCoords.y);
 
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesInSec);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, x + 70, y);
+            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
 
-            gfx_draw_string_left(dpi, STR_NETWORK_TOTAL_RECEIVED, nullptr, PALETTE_INDEX_10, x + 200, y);
+            gfx_draw_string_left(dpi, STR_NETWORK_TOTAL_RECEIVED, nullptr, PALETTE_INDEX_10, screenCoords.x + 200, screenCoords.y);
 
             format_readable_size(textBuffer, sizeof(textBuffer), _networkStats.bytesReceived[NETWORK_STATISTICS_GROUP_TOTAL]);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, x + 300, y);
-            y += textHeight + padding;
+            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(300, 0));
+            screenCoords.y += textHeight + padding;
 
-            window_network_draw_graph(w, dpi, x, y, graphHeight, w->width - (padding * 2), graphBarWidth, true);
-            y += graphHeight + padding;
+            window_network_draw_graph(w, dpi, screenCoords.x, screenCoords.y, graphHeight, w->width - (padding * 2), graphBarWidth, true);
+            screenCoords.y += graphHeight + padding;
         }
 
         // Sent stats.
         {
-            gfx_draw_string_left(dpi, STR_NETWORK_SEND, nullptr, PALETTE_INDEX_10, x, y);
+            gfx_draw_string_left(dpi, STR_NETWORK_SEND, nullptr, PALETTE_INDEX_10, screenCoords.x, screenCoords.y);
 
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesOutSec);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, x + 70, y);
+            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
 
-            gfx_draw_string_left(dpi, STR_NETWORK_TOTAL_SENT, nullptr, PALETTE_INDEX_10, x + 200, y);
+            gfx_draw_string_left(dpi, STR_NETWORK_TOTAL_SENT, nullptr, PALETTE_INDEX_10, screenCoords.x + 200, screenCoords.y);
 
             format_readable_size(textBuffer, sizeof(textBuffer), _networkStats.bytesSent[NETWORK_STATISTICS_GROUP_TOTAL]);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, x + 300, y);
-            y += textHeight + padding;
+            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(300, 0));
+            screenCoords.y += textHeight + padding;
 
-            window_network_draw_graph(w, dpi, x, y, graphHeight, w->width - (padding * 2), graphBarWidth, false);
-            y += graphHeight + padding;
+            window_network_draw_graph(w, dpi, screenCoords.x, screenCoords.y, graphHeight, w->width - (padding * 2), graphBarWidth, false);
+            screenCoords.y += graphHeight + padding;
         }
 
         // Draw legend
@@ -439,14 +438,14 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
                 format_string(textBuffer, sizeof(textBuffer), NetworkTrafficGroupNames[i], nullptr);
 
                 // Draw color stripe.
-                gfx_fill_rect(dpi, x, y + 4, x + 4, y + 6, NetworkTrafficGroupColors[i]);
+                gfx_fill_rect(dpi, screenCoords.x, screenCoords.y + 4, screenCoords.x + 4, screenCoords.y + 6, NetworkTrafficGroupColors[i]);
 
                 // Draw text.
-                gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, x + 10, y);
+                gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(10, 0));
 
                 gfx_get_string_width(textBuffer);
 
-                x += gfx_get_string_width(textBuffer) + 20;
+                screenCoords.x += gfx_get_string_width(textBuffer) + 20;
             }
         }
     }

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -404,13 +404,15 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesInSec);
             gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
 
-            gfx_draw_string_left(dpi, STR_NETWORK_TOTAL_RECEIVED, nullptr, PALETTE_INDEX_10, screenCoords.x + 200, screenCoords.y);
+            gfx_draw_string_left(
+                dpi, STR_NETWORK_TOTAL_RECEIVED, nullptr, PALETTE_INDEX_10, screenCoords.x + 200, screenCoords.y);
 
             format_readable_size(textBuffer, sizeof(textBuffer), _networkStats.bytesReceived[NETWORK_STATISTICS_GROUP_TOTAL]);
             gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(300, 0));
             screenCoords.y += textHeight + padding;
 
-            window_network_draw_graph(w, dpi, screenCoords.x, screenCoords.y, graphHeight, w->width - (padding * 2), graphBarWidth, true);
+            window_network_draw_graph(
+                w, dpi, screenCoords.x, screenCoords.y, graphHeight, w->width - (padding * 2), graphBarWidth, true);
             screenCoords.y += graphHeight + padding;
         }
 
@@ -427,7 +429,8 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
             gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(300, 0));
             screenCoords.y += textHeight + padding;
 
-            window_network_draw_graph(w, dpi, screenCoords.x, screenCoords.y, graphHeight, w->width - (padding * 2), graphBarWidth, false);
+            window_network_draw_graph(
+                w, dpi, screenCoords.x, screenCoords.y, graphHeight, w->width - (padding * 2), graphBarWidth, false);
             screenCoords.y += graphHeight + padding;
         }
 
@@ -438,7 +441,9 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
                 format_string(textBuffer, sizeof(textBuffer), NetworkTrafficGroupNames[i], nullptr);
 
                 // Draw color stripe.
-                gfx_fill_rect(dpi, screenCoords.x, screenCoords.y + 4, screenCoords.x + 4, screenCoords.y + 6, NetworkTrafficGroupColors[i]);
+                gfx_fill_rect(
+                    dpi, screenCoords.x, screenCoords.y + 4, screenCoords.x + 4, screenCoords.y + 6,
+                    NetworkTrafficGroupColors[i]);
 
                 // Draw text.
                 gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(10, 0));

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -182,8 +182,7 @@ static void window_network_status_paint(rct_window* w, rct_drawpixelinfo* dpi)
     lineCh = utf8_write_codepoint(lineCh, FORMAT_BLACK);
     safe_strcpy(lineCh, window_network_status_text, sizeof(buffer) - (lineCh - buffer));
     gfx_clip_string(buffer, w->widgets[WIDX_BACKGROUND].right - 50);
-    int32_t x = w->windowPos.x + (w->width / 2);
-    int32_t y = w->windowPos.y + (w->height / 2);
-    x -= gfx_get_string_width(buffer) / 2;
-    gfx_draw_string(dpi, buffer, COLOUR_BLACK, x, y);
+    ScreenCoordsXY screenCoords(w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2));
+    screenCoords.x -= gfx_get_string_width(buffer) / 2;
+    gfx_draw_string(dpi, buffer, COLOUR_BLACK, screenCoords);
 }

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -586,11 +586,17 @@ static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinf
 
         // If hovering over item, change the color and fill the backdrop.
         if (i == w->selected_list_item)
-            gfx_fill_rect(dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].darker);
+            gfx_fill_rect(
+                dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1,
+                ColourMapA[w->colours[1]].darker);
         else if (i == highlighted_index)
-            gfx_fill_rect(dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].mid_dark);
+            gfx_fill_rect(
+                dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1,
+                ColourMapA[w->colours[1]].mid_dark);
         else if ((i & 1) != 0) // odd / even check
-            gfx_fill_rect(dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].light);
+            gfx_fill_rect(
+                dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1,
+                ColourMapA[w->colours[1]].light);
 
         // Draw the actual object entry's name...
         screenCoords.x = NAME_COL_LEFT - 3;

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -576,32 +576,34 @@ static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinf
 
     for (int32_t i = 0; i < w->no_list_items; i++)
     {
-        int32_t y = i * SCROLLABLE_ROW_HEIGHT;
-        if (y > dpi->y + dpi->height)
+        ScreenCoordsXY screenCoords;
+        screenCoords.y = i * SCROLLABLE_ROW_HEIGHT;
+        if (screenCoords.y > dpi->y + dpi->height)
             break;
 
-        if (y + SCROLLABLE_ROW_HEIGHT < dpi->y)
+        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT < dpi->y)
             continue;
 
         // If hovering over item, change the color and fill the backdrop.
         if (i == w->selected_list_item)
-            gfx_fill_rect(dpi, 0, y, list_width, y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].darker);
+            gfx_fill_rect(dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].darker);
         else if (i == highlighted_index)
-            gfx_fill_rect(dpi, 0, y, list_width, y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].mid_dark);
+            gfx_fill_rect(dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].mid_dark);
         else if ((i & 1) != 0) // odd / even check
-            gfx_fill_rect(dpi, 0, y, list_width, y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].light);
+            gfx_fill_rect(dpi, 0, screenCoords.y, list_width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, ColourMapA[w->colours[1]].light);
 
         // Draw the actual object entry's name...
-        gfx_draw_string(dpi, strndup(_invalid_entries[i].name, 8), COLOUR_DARK_GREEN, NAME_COL_LEFT - 3, y);
+        screenCoords.x = NAME_COL_LEFT - 3;
+        gfx_draw_string(dpi, strndup(_invalid_entries[i].name, 8), COLOUR_DARK_GREEN, screenCoords);
 
         // ... source game ...
         rct_string_id sourceStringId = object_manager_get_source_game_string(
             object_entry_get_source_game_legacy(&_invalid_entries[i]));
-        gfx_draw_string_left(dpi, sourceStringId, nullptr, COLOUR_DARK_GREEN, SOURCE_COL_LEFT - 3, y);
+        gfx_draw_string_left(dpi, sourceStringId, nullptr, COLOUR_DARK_GREEN, SOURCE_COL_LEFT - 3, screenCoords.y);
 
         // ... and type
         rct_string_id type = get_object_type_string(&_invalid_entries[i]);
-        gfx_draw_string_left(dpi, type, nullptr, COLOUR_DARK_GREEN, TYPE_COL_LEFT - 3, y);
+        gfx_draw_string_left(dpi, type, nullptr, COLOUR_DARK_GREEN, TYPE_COL_LEFT - 3, screenCoords.y);
     }
 }
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -400,7 +400,8 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         set_format_arg(0, rct_string_id, network_get_action_name_string_id(lastaction));
     }
-    gfx_draw_string_centred_clipped(dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords.x, screenCoords.y, width);
+    gfx_draw_string_centred_clipped(
+        dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords.x, screenCoords.y, width);
 
     if (w->viewport != nullptr && w->var_492 != -1)
     {

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -382,7 +382,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Draw ping
-    ScreenCoordsXY screenCoords(w->windowPos.x + 90, w->windowPos.y + 24);
+    auto screenCoords = ScreenCoordsXY{ w->windowPos.x + 90, w->windowPos.y + 24 };
 
     set_format_arg(0, rct_string_id, STR_PING);
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);
@@ -391,8 +391,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_draw_string(dpi, ping, w->colours[2], screenCoords + ScreenCoordsXY(30, 0));
 
     // Draw last action
-    screenCoords.x = w->windowPos.x + (w->width / 2);
-    screenCoords.y = w->windowPos.y + w->height - 13;
+    screenCoords = { w->windowPos.x + (w->width / 2), w->windowPos.y + w->height - 13 };
     int32_t width = w->width - 8;
     int32_t lastaction = network_get_player_last_action(player, 0);
     set_format_arg(0, rct_string_id, STR_ACTION_NA);

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -382,18 +382,17 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Draw ping
-    int32_t x = w->windowPos.x + 90;
-    int32_t y = w->windowPos.y + 24;
+    ScreenCoordsXY screenCoords(w->windowPos.x + 90, w->windowPos.y + 24);
 
     set_format_arg(0, rct_string_id, STR_PING);
-    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, 0, x, y);
+    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);
     char ping[64];
     snprintf(ping, 64, "%d ms", network_get_player_ping(player));
-    gfx_draw_string(dpi, ping, w->colours[2], x + 30, y);
+    gfx_draw_string(dpi, ping, w->colours[2], screenCoords + ScreenCoordsXY(30, 0));
 
     // Draw last action
-    x = w->windowPos.x + (w->width / 2);
-    y = w->windowPos.y + w->height - 13;
+    screenCoords.x = w->windowPos.x + (w->width / 2);
+    screenCoords.y = w->windowPos.y + w->height - 13;
     int32_t width = w->width - 8;
     int32_t lastaction = network_get_player_last_action(player, 0);
     set_format_arg(0, rct_string_id, STR_ACTION_NA);
@@ -401,7 +400,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         set_format_arg(0, rct_string_id, network_get_action_name_string_id(lastaction));
     }
-    gfx_draw_string_centred_clipped(dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    gfx_draw_string_centred_clipped(dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords.x, screenCoords.y, width);
 
     if (w->viewport != nullptr && w->var_492 != -1)
     {

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -459,19 +459,17 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         }
 
         screenCoords.x = 3;
-        screenCoords.y += 3;
 
         // Draw server information
         if (highlighted && !serverDetails.description.empty())
         {
-            gfx_draw_string(dpi, serverDetails.description.c_str(), colour, screenCoords);
+            gfx_draw_string(dpi, serverDetails.description.c_str(), colour, screenCoords + ScreenCoordsXY{ 0, 3 });
         }
         else
         {
-            gfx_draw_string(dpi, serverDetails.name.c_str(), colour, screenCoords);
+            gfx_draw_string(dpi, serverDetails.name.c_str(), colour, screenCoords + ScreenCoordsXY{ 0, 3 });
         }
 
-        screenCoords.y -= 3;
         int32_t right = width - 3 - 14;
 
         // Draw compatibility icon
@@ -508,9 +506,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         }
         int32_t numPlayersStringWidth = gfx_get_string_width(players);
         screenCoords.x = right - numPlayersStringWidth;
-        screenCoords.y += 3;
-        gfx_draw_string(dpi, players, w->colours[1], screenCoords);
-        screenCoords.y -= 3;
+        gfx_draw_string(dpi, players, w->colours[1], screenCoords + ScreenCoordsXY{ 0, 3 });
 
         screenCoords.y += ITEM_HEIGHT;
     }

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -428,11 +428,12 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
 
     int32_t width = w->widgets[WIDX_LIST].right - w->widgets[WIDX_LIST].left;
 
-    int32_t y = 0;
+    ScreenCoordsXY screenCoords;
+    screenCoords.y = 0;
     w->widgets[WIDX_LIST].tooltip = STR_NONE;
     for (int32_t i = 0; i < w->no_list_items; i++)
     {
-        if (y >= dpi->y + dpi->height)
+        if (screenCoords.y >= dpi->y + dpi->height)
             continue;
         // if (y + ITEM_HEIGHT < dpi->y) continue;
 
@@ -442,7 +443,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         // Draw hover highlight
         if (highlighted)
         {
-            gfx_filter_rect(dpi, 0, y, width, y + ITEM_HEIGHT, PALETTE_DARKEN_1);
+            gfx_filter_rect(dpi, 0, screenCoords.y, width, screenCoords.y + ITEM_HEIGHT, PALETTE_DARKEN_1);
             _version = serverDetails.version;
             w->widgets[WIDX_LIST].tooltip = STR_NETWORK_VERSION_TIP;
         }
@@ -457,16 +458,20 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
             colour = COLOUR_MOSS_GREEN;
         }
 
+        screenCoords.x = 3;
+        screenCoords.y += 3;
+
         // Draw server information
         if (highlighted && !serverDetails.description.empty())
         {
-            gfx_draw_string(dpi, serverDetails.description.c_str(), colour, 3, y + 3);
+            gfx_draw_string(dpi, serverDetails.description.c_str(), colour, screenCoords);
         }
         else
         {
-            gfx_draw_string(dpi, serverDetails.name.c_str(), colour, 3, y + 3);
+            gfx_draw_string(dpi, serverDetails.name.c_str(), colour, screenCoords);
         }
 
+        screenCoords.y -= 3;
         int32_t right = width - 3 - 14;
 
         // Draw compatibility icon
@@ -483,14 +488,14 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
             bool correctVersion = serverDetails.version == network_get_version();
             compatibilitySpriteId = correctVersion ? SPR_G2_RCT1_OPEN_BUTTON_2 : SPR_G2_RCT1_CLOSE_BUTTON_2;
         }
-        gfx_draw_sprite(dpi, compatibilitySpriteId, right, y + 1, 0);
+        gfx_draw_sprite(dpi, compatibilitySpriteId, right, screenCoords.y + 1, 0);
         right -= 4;
 
         // Draw lock icon
         right -= 8;
         if (serverDetails.requiresPassword)
         {
-            gfx_draw_sprite(dpi, SPR_G2_LOCKED, right, y + 4, 0);
+            gfx_draw_sprite(dpi, SPR_G2_LOCKED, right, screenCoords.y + 4, 0);
         }
         right -= 6;
 
@@ -502,9 +507,12 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
             snprintf(players, 32, "%d/%d", serverDetails.players, serverDetails.maxplayers);
         }
         int32_t numPlayersStringWidth = gfx_get_string_width(players);
-        gfx_draw_string(dpi, players, w->colours[1], right - numPlayersStringWidth, y + 3);
+        screenCoords.x = right - numPlayersStringWidth;
+        screenCoords.y += 3;
+        gfx_draw_string(dpi, players, w->colours[1], screenCoords);
+        screenCoords.y -= 3;
 
-        y += ITEM_HEIGHT;
+        screenCoords.y += ITEM_HEIGHT;
     }
 }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -198,7 +198,8 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t no_lines = 0;
     int32_t font_height = 0;
 
-    gfx_draw_string_centred(dpi, input_text_description, w->windowPos.x + WW / 2, screenCoords.y, w->colours[1], &TextInputDescriptionArgs);
+    gfx_draw_string_centred(
+        dpi, input_text_description, w->windowPos.x + WW / 2, screenCoords.y, w->colours[1], &TextInputDescriptionArgs);
 
     screenCoords.y += 25;
 
@@ -213,7 +214,8 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_wrap_string(wrapped_string, WW - (24 + 13), &no_lines, &font_height);
 
     gfx_fill_rect_inset(
-        dpi, w->windowPos.x + 10, screenCoords.y, w->windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3, w->colours[1], INSET_RECT_F_60);
+        dpi, w->windowPos.x + 10, screenCoords.y, w->windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3,
+        w->colours[1], INSET_RECT_F_60);
 
     screenCoords.y += 1;
 
@@ -367,7 +369,8 @@ static void draw_ime_composition(rct_drawpixelinfo* dpi, int cursorX, int cursor
     int width = compositionWidth;
     int height = 10;
 
-    gfx_fill_rect(dpi, screenCoords.x - 1, screenCoords.y - 1, screenCoords.x + width + 1, screenCoords.y + height + 1, PALETTE_INDEX_12);
+    gfx_fill_rect(
+        dpi, screenCoords.x - 1, screenCoords.y - 1, screenCoords.x + width + 1, screenCoords.y + height + 1, PALETTE_INDEX_12);
     gfx_fill_rect(dpi, screenCoords.x, screenCoords.y, screenCoords.x + width, screenCoords.y + height, PALETTE_INDEX_0);
     gfx_draw_string(dpi, static_cast<const char*>(gTextInput->ImeBuffer), COLOUR_DARK_GREEN, screenCoords);
 }

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -192,14 +192,15 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    int32_t y = w->windowPos.y + 25;
+    ScreenCoordsXY screenCoords;
+    screenCoords.y = w->windowPos.y + 25;
 
     int32_t no_lines = 0;
     int32_t font_height = 0;
 
-    gfx_draw_string_centred(dpi, input_text_description, w->windowPos.x + WW / 2, y, w->colours[1], &TextInputDescriptionArgs);
+    gfx_draw_string_centred(dpi, input_text_description, w->windowPos.x + WW / 2, screenCoords.y, w->colours[1], &TextInputDescriptionArgs);
 
-    y += 25;
+    screenCoords.y += 25;
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     gCurrentFontFlags = 0;
@@ -212,9 +213,9 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_wrap_string(wrapped_string, WW - (24 + 13), &no_lines, &font_height);
 
     gfx_fill_rect_inset(
-        dpi, w->windowPos.x + 10, y, w->windowPos.x + WW - 10, y + 10 * (no_lines + 1) + 3, w->colours[1], INSET_RECT_F_60);
+        dpi, w->windowPos.x + 10, screenCoords.y, w->windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3, w->colours[1], INSET_RECT_F_60);
 
-    y += 1;
+    screenCoords.y += 1;
 
     char* wrap_pointer = wrapped_string;
     size_t char_count = 0;
@@ -224,7 +225,8 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t cursorY = 0;
     for (int32_t line = 0; line <= no_lines; line++)
     {
-        gfx_draw_string(dpi, wrap_pointer, w->colours[1], w->windowPos.x + 12, y);
+        screenCoords.x = w->windowPos.x + 12;
+        gfx_draw_string(dpi, wrap_pointer, w->colours[1], screenCoords);
 
         size_t string_length = get_string_size(wrap_pointer) - 1;
 
@@ -234,7 +236,7 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
             char temp_string[TEXT_INPUT_SIZE] = { 0 };
             std::memcpy(temp_string, wrap_pointer, gTextInput->SelectionStart - char_count);
             cursorX = w->windowPos.x + 13 + gfx_get_string_width(temp_string);
-            cursorY = y;
+            cursorY = screenCoords.y;
 
             int32_t width = 6;
             if (gTextInput->SelectionStart < strlen(text_input))
@@ -251,7 +253,7 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
             {
                 uint8_t colour = ColourMapA[w->colours[1]].mid_light;
                 // TODO: palette index addition
-                gfx_fill_rect(dpi, cursorX, y + 9, cursorX + width, y + 9, colour + 5);
+                gfx_fill_rect(dpi, cursorX, screenCoords.y + 9, cursorX + width, screenCoords.y + 9, colour + 5);
             }
 
             cur_drawn++;
@@ -263,13 +265,13 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
             char_count++;
         char_count += string_length;
 
-        y += 10;
+        screenCoords.y += 10;
     }
 
     if (!cur_drawn)
     {
         cursorX = gLastDrawStringX;
-        cursorY = y - 10;
+        cursorY = screenCoords.y - 10;
     }
 
     // IME composition
@@ -361,12 +363,11 @@ static void window_text_input_invalidate(rct_window* w)
 static void draw_ime_composition(rct_drawpixelinfo* dpi, int cursorX, int cursorY)
 {
     int compositionWidth = gfx_get_string_width(gTextInput->ImeBuffer);
-    int x = cursorX - (compositionWidth / 2);
-    int y = cursorY + 13;
+    ScreenCoordsXY screenCoords(cursorX - (compositionWidth / 2), cursorY + 13);
     int width = compositionWidth;
     int height = 10;
 
-    gfx_fill_rect(dpi, x - 1, y - 1, x + width + 1, y + height + 1, PALETTE_INDEX_12);
-    gfx_fill_rect(dpi, x, y, x + width, y + height, PALETTE_INDEX_0);
-    gfx_draw_string(dpi, static_cast<const char*>(gTextInput->ImeBuffer), COLOUR_DARK_GREEN, x, y);
+    gfx_fill_rect(dpi, screenCoords.x - 1, screenCoords.y - 1, screenCoords.x + width + 1, screenCoords.y + height + 1, PALETTE_INDEX_12);
+    gfx_fill_rect(dpi, screenCoords.x, screenCoords.y, screenCoords.x + width, screenCoords.y + height, PALETTE_INDEX_0);
+    gfx_draw_string(dpi, static_cast<const char*>(gTextInput->ImeBuffer), COLOUR_DARK_GREEN, screenCoords);
 }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -920,7 +920,7 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
                     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
-                    screenCoords = { _button_offset_x + 12 * j, screenCoords.y + _check_offset_y};
+                    screenCoords = { _button_offset_x + 12 * j, screenCoords.y + _check_offset_y };
                     gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, screenCoords);
                 }
             }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -920,8 +920,7 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
                     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
-                    screenCoords.x = _button_offset_x + 12 * j;
-                    screenCoords.y = screenCoords.y + _check_offset_y;
+                    screenCoords = { _button_offset_x + 12 * j, screenCoords.y + _check_offset_y};
                     gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, screenCoords);
                 }
             }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -922,8 +922,7 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
                     screenCoords.x = _button_offset_x + 12 * j;
                     screenCoords.y = screenCoords.y + _check_offset_y;
-                    gfx_draw_string(
-                        dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, screenCoords);
+                    gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, screenCoords);
                 }
             }
         }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -855,7 +855,7 @@ void window_themes_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t y;
+    ScreenCoordsXY screenCoords;
 
     if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS || _selected_tab == WINDOW_THEMES_TAB_FEATURES)
         return;
@@ -864,14 +864,14 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
         // gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1,
         // ColourMapA[w->colours[1]].mid_light);
         gfx_clear(dpi, ColourMapA[w->colours[1]].mid_light);
-    y = 0;
+    screenCoords.y = 0;
     for (int32_t i = 0; i < get_colour_scheme_tab_count(); i++)
     {
-        if (y > dpi->y + dpi->height)
+        if (screenCoords.y > dpi->y + dpi->height)
         {
             break;
         }
-        if (y + _row_height >= dpi->y)
+        if (screenCoords.y + _row_height >= dpi->y)
         {
             if (i + 1 < get_colour_scheme_tab_count())
             {
@@ -881,22 +881,22 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                     translucent_window_palette windowPalette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
 
                     gfx_filter_rect(
-                        dpi, 0, y + _row_height - 2, window_themes_widgets[WIDX_THEMES_LIST].right, y + _row_height - 2,
-                        windowPalette.highlight);
+                        dpi, 0, screenCoords.y + _row_height - 2, window_themes_widgets[WIDX_THEMES_LIST].right,
+                        screenCoords.y + _row_height - 2, windowPalette.highlight);
                     gfx_filter_rect(
-                        dpi, 0, y + _row_height - 1, window_themes_widgets[WIDX_THEMES_LIST].right, y + _row_height - 1,
-                        windowPalette.shadow);
+                        dpi, 0, screenCoords.y + _row_height - 1, window_themes_widgets[WIDX_THEMES_LIST].right,
+                        screenCoords.y + _row_height - 1, windowPalette.shadow);
                 }
                 else
                 {
                     colour = ColourMapA[w->colours[1]].mid_dark;
                     gfx_fill_rect(
-                        dpi, 0, y + _row_height - 2, window_themes_widgets[WIDX_THEMES_LIST].right, y + _row_height - 2,
-                        colour);
+                        dpi, 0, screenCoords.y + _row_height - 2, window_themes_widgets[WIDX_THEMES_LIST].right,
+                        screenCoords.y + _row_height - 2, colour);
                     colour = ColourMapA[w->colours[1]].lightest;
                     gfx_fill_rect(
-                        dpi, 0, y + _row_height - 1, window_themes_widgets[WIDX_THEMES_LIST].right, y + _row_height - 1,
-                        colour);
+                        dpi, 0, screenCoords.y + _row_height - 1, window_themes_widgets[WIDX_THEMES_LIST].right,
+                        screenCoords.y + _row_height - 1, colour);
                 }
             }
 
@@ -904,7 +904,7 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
             int32_t numColours = theme_desc_get_num_colours(wc);
             for (uint8_t j = 0; j < numColours; j++)
             {
-                gfx_draw_string_left(dpi, theme_desc_get_name(wc), nullptr, w->colours[1], 2, y + 4);
+                gfx_draw_string_left(dpi, theme_desc_get_name(wc), nullptr, w->colours[1], 2, screenCoords.y + 4);
 
                 uint8_t colour = theme_get_colour(wc, j);
                 uint32_t image = SPRITE_ID_PALETTE_COLOUR_1(colour & ~COLOUR_FLAG_TRANSLUCENT) | SPR_PALETTE_BTN;
@@ -912,21 +912,22 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 {
                     image = SPRITE_ID_PALETTE_COLOUR_1(colour & ~COLOUR_FLAG_TRANSLUCENT) | SPR_PALETTE_BTN_PRESSED;
                 }
-                gfx_draw_sprite(dpi, image, _button_offset_x + 12 * j, y + _button_offset_y, 0);
+                gfx_draw_sprite(dpi, image, _button_offset_x + 12 * j, screenCoords.y + _button_offset_y, 0);
 
                 gfx_fill_rect_inset(
-                    dpi, _button_offset_x + 12 * j, y + _check_offset_y, _button_offset_x + 12 * j + 9,
-                    y + _check_offset_y + 10, w->colours[1], INSET_RECT_F_E0);
+                    dpi, _button_offset_x + 12 * j, screenCoords.y + _check_offset_y, _button_offset_x + 12 * j + 9,
+                    screenCoords.y + _check_offset_y + 10, w->colours[1], INSET_RECT_F_E0);
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
                     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
+                    screenCoords.x = _button_offset_x + 12 * j;
+                    screenCoords.y = screenCoords.y + _check_offset_y;
                     gfx_draw_string(
-                        dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, _button_offset_x + 12 * j,
-                        y + _check_offset_y);
+                        dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, screenCoords);
                 }
             }
         }
 
-        y += _row_height;
+        screenCoords.y += _row_height;
     }
 }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1782,9 +1782,11 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
             w->windowPos.y + widget->top + 1, widget->right - widget->left);
     }
 
+    ScreenCoordsXY screenCoords(w->windowPos.x, w->windowPos.y);
+
     // Draw coordinates
-    gfx_draw_string(dpi, (char*)"X:", COLOUR_WHITE, w->windowPos.x + 5, w->windowPos.y + 24);
-    gfx_draw_string(dpi, (char*)"Y:", COLOUR_WHITE, w->windowPos.x + 74, w->windowPos.y + 24);
+    gfx_draw_string(dpi, (char*)"X:", COLOUR_WHITE, screenCoords + ScreenCoordsXY(5, 24));
+    gfx_draw_string(dpi, (char*)"Y:", COLOUR_WHITE, screenCoords + ScreenCoordsXY(74, 24));
     if (windowTileInspectorTileSelected)
     {
         auto tileCoords = TileCoordsXY{ windowTileInspectorToolMap };
@@ -1793,8 +1795,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
     else
     {
-        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, w->windowPos.x + 43 - 7, w->windowPos.y + 24);
-        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, w->windowPos.x + 113 - 7, w->windowPos.y + 24);
+        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, screenCoords + ScreenCoordsXY(43 - 7, 24));
+        gfx_draw_string(dpi, (char*)"-", COLOUR_WHITE, screenCoords + ScreenCoordsXY(113, 24));
     }
 
     if (windowTileInspectorSelectedIndex != -1)

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -251,7 +251,7 @@ void gfx_draw_string_left_centred(
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, format, args);
     int32_t height = string_get_height_raw(buffer);
-    gfx_draw_string(dpi, buffer, colour, x, y - (height / 2));
+    gfx_draw_string(dpi, buffer, colour, ScreenCoordsXY(x, y - (height / 2)));
 }
 
 /**
@@ -311,14 +311,17 @@ static void colour_char_window(uint8_t colour, const uint16_t* current_font_flag
  */
 void draw_string_centred_raw(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t numLines, char* text)
 {
+    ScreenCoordsXY screenCoords(dpi->x, dpi->y);
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    gfx_draw_string(dpi, (char*)"", COLOUR_BLACK, dpi->x, dpi->y);
+    gfx_draw_string(dpi, (char*)"", COLOUR_BLACK, screenCoords);
+    screenCoords.y = y;
     gCurrentFontFlags = 0;
 
     for (int32_t i = 0; i <= numLines; i++)
     {
         int32_t width = gfx_get_string_width(text);
-        gfx_draw_string(dpi, text, TEXT_COLOUR_254, x - (width / 2), y);
+        screenCoords.x = x - (width / 2);
+        gfx_draw_string(dpi, text, TEXT_COLOUR_254, screenCoords);
 
         const utf8* ch = text;
         const utf8* nextCh = nullptr;
@@ -329,7 +332,7 @@ void draw_string_centred_raw(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32
         }
         text = const_cast<char*>(ch + 1);
 
-        y += font_get_line_height(gCurrentFontSpriteBase);
+        screenCoords.y += font_get_line_height(gCurrentFontSpriteBase);
     }
 }
 
@@ -424,9 +427,10 @@ void gfx_draw_string_centred_wrapped_partial(
 {
     int32_t numLines, fontSpriteBase, lineHeight, lineY;
     utf8* buffer = gCommonStringFormatBuffer;
+    ScreenCoordsXY screenCoords(dpi->x, dpi->y);
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    gfx_draw_string(dpi, (char*)"", colour, dpi->x, dpi->y);
+    gfx_draw_string(dpi, (char*)"", colour, screenCoords);
     format_string(buffer, 256, format, args);
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
@@ -459,7 +463,9 @@ void gfx_draw_string_centred_wrapped_partial(
             ch = nextCh;
         }
 
-        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, x - halfWidth, lineY);
+        screenCoords.x = x - halfWidth;
+        screenCoords.y = lineY;
+        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, screenCoords);
 
         if (numCharactersDrawn > numCharactersToDraw)
         {

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -251,7 +251,7 @@ void gfx_draw_string_left_centred(
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, format, args);
     int32_t height = string_get_height_raw(buffer);
-    gfx_draw_string(dpi, buffer, colour, ScreenCoordsXY(x, y - (height / 2)));
+    gfx_draw_string(dpi, buffer, colour, { x, y - (height / 2) });
 }
 
 /**
@@ -320,8 +320,7 @@ void draw_string_centred_raw(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32
     for (int32_t i = 0; i <= numLines; i++)
     {
         int32_t width = gfx_get_string_width(text);
-        screenCoords.x = x - (width / 2);
-        gfx_draw_string(dpi, text, TEXT_COLOUR_254, screenCoords);
+        gfx_draw_string(dpi, text, TEXT_COLOUR_254, screenCoords - ScreenCoordsXY{ width / 2, 0 });
 
         const utf8* ch = text;
         const utf8* nextCh = nullptr;
@@ -463,8 +462,7 @@ void gfx_draw_string_centred_wrapped_partial(
             ch = nextCh;
         }
 
-        screenCoords.x = x - halfWidth;
-        screenCoords.y = lineY;
+        screenCoords = { x - halfWidth, lineY };
         gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, screenCoords);
 
         if (numCharactersDrawn > numCharactersToDraw)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -531,6 +531,7 @@ void FASTCALL
 
 // string
 void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, int32_t x, int32_t y);
+void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
 
 void gfx_draw_string_left(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y);
 void gfx_draw_string_centred(

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -530,7 +530,6 @@ void FASTCALL
     gfx_draw_sprite_raw_masked_software(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t maskImage, int32_t colourImage);
 
 // string
-void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, int32_t x, int32_t y);
 void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
 
 void gfx_draw_string_left(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -150,6 +150,15 @@ void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t co
     DrawText(dpi, x, y, &_legacyPaint, buffer);
 }
 
+void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords)
+{
+    _legacyPaint.UnderlineText = false;
+    _legacyPaint.Colour = colour;
+    _legacyPaint.Alignment = TextAlignment::LEFT;
+    _legacyPaint.SpriteBase = gCurrentFontSpriteBase;
+    DrawText(dpi, coords.x, coords.y, &_legacyPaint, buffer);
+}
+
 // Basic
 void gfx_draw_string_left(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y)
 {

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -141,15 +141,6 @@ static void DrawTextEllipsisedCompat(
     DrawText(dpi, x, y, &_legacyPaint, buffer);
 }
 
-void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, int32_t x, int32_t y)
-{
-    _legacyPaint.UnderlineText = false;
-    _legacyPaint.Colour = colour;
-    _legacyPaint.Alignment = TextAlignment::LEFT;
-    _legacyPaint.SpriteBase = gCurrentFontSpriteBase;
-    DrawText(dpi, x, y, &_legacyPaint, buffer);
-}
-
 void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords)
 {
     _legacyPaint.UnderlineText = false;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -281,7 +281,7 @@ int32_t chat_history_draw_string(rct_drawpixelinfo* dpi, void* args, const Scree
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    gfx_draw_string(dpi, (char*)"", TEXT_COLOUR_255, dpi->x, dpi->y);
+    gfx_draw_string(dpi, (char*)"", TEXT_COLOUR_255, ScreenCoordsXY(dpi->x, dpi->y));
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, STR_STRING, args);
 
@@ -300,7 +300,7 @@ int32_t chat_history_draw_string(rct_drawpixelinfo* dpi, void* args, const Scree
     lineY = screenCoords.y;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, screenCoords.x, lineY - (numLines * lineHeight));
+        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, ScreenCoordsXY(screenCoords.x, lineY - (numLines * lineHeight)));
         buffer = get_string_end(buffer) + 1;
         lineY += lineHeight;
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -281,7 +281,7 @@ int32_t chat_history_draw_string(rct_drawpixelinfo* dpi, void* args, const Scree
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    gfx_draw_string(dpi, (char*)"", TEXT_COLOUR_255, ScreenCoordsXY(dpi->x, dpi->y));
+    gfx_draw_string(dpi, (char*)"", TEXT_COLOUR_255, { dpi->x, dpi->y });
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, STR_STRING, args);
 
@@ -300,7 +300,7 @@ int32_t chat_history_draw_string(rct_drawpixelinfo* dpi, void* args, const Scree
     lineY = screenCoords.y;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, ScreenCoordsXY(screenCoords.x, lineY - (numLines * lineHeight)));
+        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, { screenCoords.x, lineY - (numLines * lineHeight) });
         buffer = get_string_end(buffer) + 1;
         lineY += lineHeight;
     }

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -81,8 +81,7 @@ void Painter::Paint(IDrawingEngine& de)
 
 void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
 {
-    int32_t x = _uiContext->GetWidth() / 2;
-    int32_t y = _uiContext->GetHeight() - 44;
+    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, _uiContext->GetHeight() - 44);
 
     // Format string
     utf8 buffer[64] = { 0 };
@@ -94,19 +93,18 @@ void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
     snprintf(ch, 64 - (ch - buffer), "%s", text);
 
     int32_t stringWidth = gfx_get_string_width(buffer);
-    x = x - stringWidth;
+    screenCoords.x = screenCoords.x - stringWidth;
 
     if (((gCurrentTicks >> 1) & 0xF) > 4)
-        gfx_draw_string(dpi, buffer, COLOUR_SATURATED_RED, x, y);
+        gfx_draw_string(dpi, buffer, COLOUR_SATURATED_RED, screenCoords);
 
     // Make area dirty so the text doesn't get drawn over the last
-    gfx_set_dirty_blocks(x, y, x + stringWidth, y + 16);
+    gfx_set_dirty_blocks(screenCoords.x, screenCoords.y, screenCoords.x + stringWidth, screenCoords.y + 16);
 }
 
 void Painter::PaintFPS(rct_drawpixelinfo* dpi)
 {
-    int32_t x = _uiContext->GetWidth() / 2;
-    int32_t y = 2;
+    ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
 
     // Measure FPS
     MeasureFPS();
@@ -122,11 +120,11 @@ void Painter::PaintFPS(rct_drawpixelinfo* dpi)
 
     // Draw Text
     int32_t stringWidth = gfx_get_string_width(buffer);
-    x = x - (stringWidth / 2);
-    gfx_draw_string(dpi, buffer, 0, x, y);
+    screenCoords.x = screenCoords.x - (stringWidth / 2);
+    gfx_draw_string(dpi, buffer, 0, screenCoords);
 
     // Make area dirty so the text doesn't get drawn over the last
-    gfx_set_dirty_blocks(x - 16, y - 4, gLastDrawStringX + 16, 16);
+    gfx_set_dirty_blocks(screenCoords.x - 16, screenCoords.y - 4, gLastDrawStringX + 16, 16);
 }
 
 void Painter::MeasureFPS()

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -430,6 +430,7 @@ bool title_is_previewing_sequence()
 void DrawOpenRCT2(rct_drawpixelinfo* dpi, int32_t x, int32_t y)
 {
     utf8 buffer[256];
+    ScreenCoordsXY screenCoords(x, y);
 
     // Write format codes
     utf8* ch = buffer;
@@ -439,7 +440,7 @@ void DrawOpenRCT2(rct_drawpixelinfo* dpi, int32_t x, int32_t y)
 
     // Write name and version information
     openrct2_write_full_version_info(ch, sizeof(buffer) - (ch - buffer));
-    gfx_draw_string(dpi, buffer, COLOUR_BLACK, x + 5, y + 5 - 13);
+    gfx_draw_string(dpi, buffer, COLOUR_BLACK, screenCoords + ScreenCoordsXY(5, 5 - 13));
 
     // Invalidate screen area
     int16_t width = static_cast<int16_t>(gfx_get_string_width(buffer));
@@ -447,5 +448,5 @@ void DrawOpenRCT2(rct_drawpixelinfo* dpi, int32_t x, int32_t y)
 
     // Write platform information
     snprintf(ch, 256 - (ch - buffer), "%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);
-    gfx_draw_string(dpi, buffer, COLOUR_BLACK, x + 5, y + 5);
+    gfx_draw_string(dpi, buffer, COLOUR_BLACK, screenCoords + ScreenCoordsXY(5, 5));
 }


### PR DESCRIPTION
created the overload and changed all calls of the old function to the new (using const ScreenCoordsXY&).

This is a new pull request regarding this issue. The old one was closed: https://github.com/OpenRCT2/OpenRCT2/pull/11673