### PR TITLE
[Plugin] Add a script hook for ride ratings calculation

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -33,7 +33,7 @@ declare global {
     var network: Network;
     /** APIs for the park and management of it. */
     var park: Park;
-    /** 
+    /**
      * APIs for controlling the user interface.
      * These will only be available to servers and clients that are not running headless mode.
      * Plugin writers should check if ui is available using `typeof ui !== 'undefined'`.
@@ -112,7 +112,7 @@ declare global {
          * Executes a command using the legacy console REPL. This should not be used
          * by plugins, and exists only for servers to continue using old commands until
          * all functionality can be accomplished with this scripting API.
-         * 
+         *
          * @deprecated
          * @param command The command and arguments to execute.
          */
@@ -211,6 +211,7 @@ declare global {
         subscribe(hook: "network.authenticate", callback: (e: NetworkAuthenticateEventArgs) => void): IDisposable;
         subscribe(hook: "network.join", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
+        subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
     }
 
     interface Configuration {
@@ -275,7 +276,8 @@ declare global {
 
     type HookType =
         "interval.tick" | "interval.day" |
-        "network.chat" | "network.action" | "network.join" | "network.leave";
+        "network.chat" | "network.action" | "network.join" | "network.leave" |
+        "ride.ratings.calculate";
 
     type ExpenditureType =
         "ride_construction" |
@@ -327,6 +329,13 @@ declare global {
         readonly ipAddress: string;
         readonly publicKeyHash: string;
         cancel: boolean;
+    }
+
+    interface RideRatingsCalculateArgs {
+        readonly rideId: number;
+        excitement: number;
+        intensity: number;
+        nausea: number;
     }
 
     /**

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -19,16 +19,16 @@ using namespace OpenRCT2::Scripting;
 
 HOOK_TYPE OpenRCT2::Scripting::GetHookType(const std::string& name)
 {
-    static const std::unordered_map<std::string, HOOK_TYPE> LookupTable({
-        { "action.query", HOOK_TYPE::ACTION_QUERY },
-        { "action.execute", HOOK_TYPE::ACTION_EXECUTE },
-        { "interval.tick", HOOK_TYPE::INTERVAL_TICK },
-        { "interval.day", HOOK_TYPE::INTERVAL_DAY },
-        { "network.chat", HOOK_TYPE::NETWORK_CHAT },
-        { "network.authenticate", HOOK_TYPE::NETWORK_AUTHENTICATE },
-        { "network.join", HOOK_TYPE::NETWORK_JOIN },
-        { "network.leave", HOOK_TYPE::NETWORK_LEAVE },
-    });
+    static const std::unordered_map<std::string, HOOK_TYPE> LookupTable(
+        { { "action.query", HOOK_TYPE::ACTION_QUERY },
+          { "action.execute", HOOK_TYPE::ACTION_EXECUTE },
+          { "interval.tick", HOOK_TYPE::INTERVAL_TICK },
+          { "interval.day", HOOK_TYPE::INTERVAL_DAY },
+          { "network.chat", HOOK_TYPE::NETWORK_CHAT },
+          { "network.authenticate", HOOK_TYPE::NETWORK_AUTHENTICATE },
+          { "network.join", HOOK_TYPE::NETWORK_JOIN },
+          { "network.leave", HOOK_TYPE::NETWORK_LEAVE },
+          { "ride.ratings.calculate", HOOK_TYPE::RIDE_RATINGS_CALCULATE } });
     auto result = LookupTable.find(name);
     return (result != LookupTable.end()) ? result->second : HOOK_TYPE::UNDEFINED;
 }

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -36,6 +36,7 @@ namespace OpenRCT2::Scripting
         NETWORK_AUTHENTICATE,
         NETWORK_JOIN,
         NETWORK_LEAVE,
+        RIDE_RATINGS_CALCULATE,
         COUNT,
         UNDEFINED = -1,
     };


### PR DESCRIPTION
I've been playing OpenRCT2 for a little while now and I occasionally lurk on the forums. I got quite excited when I saw the plugin system had been added and thought I would try it out by building a plugin that can override ride ratings, since I've seen that feature requested at least once or twice.

I quickly found out that there really isn't a good place to set the ride ratings from the script, since it is regularly recalculated. I've had a go at adding a script hook for this event. It's called after rating calculations for a ride finish and allows scripts to override the ratings.

C++ is not my speciality and I am unfamiliar with the code base, so I do have a few questions:

- Is `ride_ratings_calculate` in `RideRatings.cpp` an appropriate place to add the hook, or is there somewhere else that would fit better conceptually? I put it there because it seems like all paths through the ride ratings states exit through the calculate state, and I wanted overrides to be able to affect the ride value calculations, but it is possible that I misread something.
- I am not very clear on how the plugin system interacts with the networking code. As best as I could tell, it looked like other spots dealing with plugin interaction (e.g. setting peep clothing colours) don't do anything special to keep things in sync. Is that correct?
- Is the name of the hook reasonable? Ride ratings seem fairly independent, so `rideRatings` is the category and `calculate` tries to follow the pattern of `action.query` or `network.authenticate`, but again, my understanding here is from a pretty shallow skim of the code.
- I used `GameState.cpp` as a reference for calling the hook. It has `using` statements. However, code dealing with some of the network hooks uses the full namespace `OpenRCT2::Scripting` instead. Which style is preferred?