### PR TITLE
Fix #11695. Mechanics walking to 0,0 on entrance only

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#11455] Object Selection window cuts off scenery names.
 - Fix: [#11640] Objects with a blank description in one language do not fall back to other languages anymore.
 - Fix: [#11676] Spiral Roller Coaster has regular lift hill available.
+- Fix: [#11695] Mechanics walk to tile 0, 0 at entrance only stations when trying to fix them.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -254,6 +254,13 @@ struct TileCoordsXY
 
     CoordsXY ToCoordsXY() const
     {
+        if (isNull())
+        {
+            CoordsXY ret{};
+            ret.setNull();
+            return ret;
+        }
+
         return { x * COORDS_XY_STEP, y * COORDS_XY_STEP };
     }
 
@@ -404,6 +411,12 @@ struct TileCoordsXYZ : public TileCoordsXY
 
     CoordsXYZ ToCoordsXYZ() const
     {
+        if (isNull())
+        {
+            CoordsXYZ ret{};
+            ret.setNull();
+            return ret;
+        }
         return { x * COORDS_XY_STEP, y * COORDS_XY_STEP, z * COORDS_Z_STEP };
     }
 };
@@ -562,6 +575,12 @@ struct TileCoordsXYZD : public TileCoordsXYZ
 
     CoordsXYZD ToCoordsXYZD() const
     {
+        if (isNull())
+        {
+            CoordsXYZD ret{};
+            ret.setNull();
+            return ret;
+        }
         return { x * COORDS_XY_STEP, y * COORDS_XY_STEP, z * COORDS_Z_STEP, direction };
     }
 };


### PR DESCRIPTION
Fix #11695. Mechanics walking to 0,0 on entrance only

Mistake made when refactoring that meant that null locations were converted into tile 0, 0. I've fixed the general case but it is preferred to try avoid using null states for coordinates if at all possible.

I haven't tested to see when the regression happened but as this would affect a whole bunch of different things I think it safe to assume these changes will fix a lot of them.

Note. This doesn't fix mechanics walking to middle of rides if a ride is fixed whilst the mechanic is heading to the ride.