### PR TITLE
Fix #11705: Drawing tooltips out of box

### DIFF
--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -233,14 +233,11 @@ static void custom_currency_window_text_input([[maybe_unused]] struct rct_window
 
 static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    ScreenCoordsXY screenCoords;
-
     set_format_arg(0, int32_t, 100);
 
     window_draw_widgets(w, dpi);
 
-    screenCoords.x = w->windowPos.x + 10;
-    screenCoords.y = w->windowPos.y + 30;
+    auto screenCoords = ScreenCoordsXY{ w->windowPos.x + 10, w->windowPos.y + 30 };
 
     gfx_draw_string_left(dpi, STR_RATE, nullptr, w->colours[1], screenCoords.x, screenCoords.y);
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -942,7 +942,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
 
 static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    ScreenCoordsXY sreenCoords(0, 0);
+    ScreenCoordsXY screenCoords(0, 0);
 
     gfx_fill_rect(dpi, dpi->x, dpi->y, dpi->x + dpi->width - 1, dpi->y + dpi->height - 1, ColourMapA[w->colours[1]].mid_light);
 
@@ -950,14 +950,14 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
     {
         if (i == w->selected_list_item)
         {
-            gfx_filter_rect(dpi, 0, sreenCoords.y, 800, sreenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
+            gfx_filter_rect(dpi, 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, PALETTE_DARKEN_1);
         }
-        if (sreenCoords.y > dpi->y + dpi->height)
+        if (screenCoords.y > dpi->y + dpi->height)
         {
             break;
         }
 
-        if (sreenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
         {
             char buffer[300] = { 0 };
             int32_t groupindex = network_get_group_index(_selectedGroup);
@@ -968,15 +968,16 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
                     char* lineCh = buffer;
                     lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
                     lineCh = utf8_write_codepoint(lineCh, UnicodeChar::tick);
-                    gfx_draw_string(dpi, buffer, COLOUR_BLACK, sreenCoords);
+                    screenCoords.x = 0;
+                    gfx_draw_string(dpi, buffer, COLOUR_BLACK, screenCoords);
                 }
             }
 
             // Draw action name
             set_format_arg(0, uint16_t, network_get_action_name_string_id(i));
-            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, sreenCoords.y);
+            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, screenCoords.y);
         }
-        sreenCoords.y += SCROLLABLE_ROW_HEIGHT;
+        screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }
 }
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -920,8 +920,9 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
                     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
-                    screenCoords = { _button_offset_x + 12 * j, screenCoords.y + _check_offset_y };
-                    gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, screenCoords);
+                    gfx_draw_string(
+                        dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F,
+                        { _button_offset_x + 12 * j, screenCoords.y + _check_offset_y });
                 }
             }
         }

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -314,7 +314,7 @@ void draw_string_centred_raw(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32
     ScreenCoordsXY screenCoords(dpi->x, dpi->y);
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     gfx_draw_string(dpi, (char*)"", COLOUR_BLACK, screenCoords);
-    screenCoords.y = y;
+    screenCoords = { x, y };
     gCurrentFontFlags = 0;
 
     for (int32_t i = 0; i <= numLines; i++)


### PR DESCRIPTION
FYI @TomasZilinek 

The breaking change was only on `Drawing.String` but the others are safer and I fixed a typo