### PR TITLE
Fix build error on Windows

### DIFF
--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -691,7 +691,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 break;
             case INFORMATION_TYPE_RUNNING_COST:
                 formatSecondary = STR_RIDE_LIST_RUNNING_COST_UNKNOWN;
-                if (ride->upkeep_cost != static_cast<money16>(0xFFFF))
+                if (ride->upkeep_cost != MONEY16_UNDEFINED)
                 {
                     formatSecondary = STR_RIDE_LIST_RUNNING_COST_LABEL;
                     set_format_arg(2, int32_t, ride->upkeep_cost * 16);


### PR DESCRIPTION
Running `msbuild openrct2.proj /t:build /p:platform=x64` gave warning
C4309, which is to do with narrowing on a type conversion. This replaces
`static_cast<money16>(0xFFFF)` with `MONEY16_UNDEFINED` (which is
`static_cast<money16>(static_cast<uint16_t>(0xFFFF))`).