### PR TITLE
Fix plugin dropdown widget items not appearing

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -163,6 +163,11 @@ namespace OpenRCT2::Ui::Windows
             }
             else if (result.Type == "dropdown")
             {
+                auto dukItems = desc["items"].as_array();
+                for (const auto& dukItem : dukItems)
+                {
+                    result.Items.push_back(ProcessString(dukItem));
+                }
                 result.SelectedIndex = desc["selectedIndex"].as_int();
                 result.OnChange = desc["onChange"];
             }


### PR DESCRIPTION
Commit e182791 (mistakenly?) removed the code to populate the custom
dropdown widget's items from the list of strings passed in from the
plugin. This replaces that code.