### PR TITLE
Fix Text Input window colours

### DIFF
--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -173,9 +173,9 @@ void window_text_input_raw_open(
     }
     else
     {
-        w->colours[0] = call_w->colours[0];
+        w->colours[0] = call_w->colours[1];
         w->colours[1] = call_w->colours[1];
-        w->colours[2] = call_w->colours[2];
+        w->colours[2] = call_w->colours[1];
     }
 }
 


### PR DESCRIPTION
Fixes this problem: ![](https://media.discordapp.net/attachments/691735032531779684/709844377039536218/Capture1.PNG?width=1150&height=654)

Text Input uses one colour, specifically the body colour of the calling window. This was previously handles by a modified window shim, but https://github.com/OpenRCT2/OpenRCT2/pull/11653 changed this and this window now uses the standard window shim. This is why it now needs to change the colour assignment.

