### PR TITLE
Rename MoneyEffect member variables to prevent shadowing

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -400,12 +400,12 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     void CompareSpriteDataMoneyEffect(
         const MoneyEffect& spriteBase, const MoneyEffect& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
-        COMPARE_FIELD(MoneyEffect, move_delay);
-        COMPARE_FIELD(MoneyEffect, num_movements);
-        COMPARE_FIELD(MoneyEffect, vertical);
-        COMPARE_FIELD(MoneyEffect, value);
-        COMPARE_FIELD(MoneyEffect, offset_x);
-        COMPARE_FIELD(MoneyEffect, wiggle);
+        COMPARE_FIELD(MoneyEffect, MoveDelay);
+        COMPARE_FIELD(MoneyEffect, NumMovements);
+        COMPARE_FIELD(MoneyEffect, Vertical);
+        COMPARE_FIELD(MoneyEffect, Value);
+        COMPARE_FIELD(MoneyEffect, OffsetX);
+        COMPARE_FIELD(MoneyEffect, Wiggle);
     }
 
     void CompareSpriteDataSteamParticle(

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -53,7 +53,7 @@ void misc_paint(paint_session* session, const rct_sprite* misc, int32_t imageDir
             auto [stringId, value] = moneyEffect->GetStringId();
             paint_floating_money_effect(
                 session, value, stringId, moneyEffect->y, moneyEffect->z,
-                const_cast<int8_t*>(&money_wave[moneyEffect->wiggle % 22]), moneyEffect->offset_x, session->CurrentRotation);
+                const_cast<int8_t*>(&money_wave[moneyEffect->Wiggle % 22]), moneyEffect->OffsetX, session->CurrentRotation);
             break;
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1705,11 +1705,11 @@ private:
 
     void ImportMoneyEffect(MoneyEffect* dst, MoneyEffect* src)
     {
-        dst->move_delay = src->move_delay;
-        dst->num_movements = src->num_movements;
-        dst->value = src->value;
-        dst->offset_x = src->offset_x;
-        dst->wiggle = src->wiggle;
+        dst->MoveDelay = src->MoveDelay;
+        dst->NumMovements = src->NumMovements;
+        dst->Value = src->Value;
+        dst->OffsetX = src->OffsetX;
+        dst->Wiggle = src->Wiggle;
     }
 
     void ImportSteamParticle(SteamParticle* dst, SteamParticle* src)

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1260,12 +1260,12 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
         {
             auto src = static_cast<const MoneyEffect*>(csrc);
             auto dst = static_cast<RCT12SpriteMoneyEffect*>(cdst);
-            dst->move_delay = src->move_delay;
-            dst->num_movements = src->num_movements;
-            dst->vertical = src->vertical;
-            dst->value = src->value;
-            dst->offset_x = src->offset_x;
-            dst->wiggle = src->wiggle;
+            dst->move_delay = src->MoveDelay;
+            dst->num_movements = src->NumMovements;
+            dst->vertical = src->Vertical;
+            dst->value = src->Value;
+            dst->offset_x = src->OffsetX;
+            dst->wiggle = src->Wiggle;
             break;
         }
         case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1525,12 +1525,12 @@ public:
             {
                 auto src = static_cast<const RCT12SpriteMoneyEffect*>(csrc);
                 auto dst = static_cast<MoneyEffect*>(cdst);
-                dst->move_delay = src->move_delay;
-                dst->num_movements = src->num_movements;
-                dst->vertical = src->vertical;
-                dst->value = src->value;
-                dst->offset_x = src->offset_x;
-                dst->wiggle = src->wiggle;
+                dst->MoveDelay = src->move_delay;
+                dst->NumMovements = src->num_movements;
+                dst->Vertical = src->vertical;
+                dst->Value = src->value;
+                dst->OffsetX = src->offset_x;
+                dst->Wiggle = src->wiggle;
                 break;
             }
             case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -47,16 +47,16 @@ void MoneyEffect::CreateAt(money32 value, int32_t x, int32_t y, int32_t z, bool 
     if (moneyEffect == nullptr)
         return;
 
-    moneyEffect->value = value;
-    moneyEffect->vertical = (vertical ? 1 : 0);
+    moneyEffect->Value = value;
+    moneyEffect->Vertical = (vertical ? 1 : 0);
     moneyEffect->sprite_width = 64;
     moneyEffect->sprite_height_negative = 20;
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SPRITE_IDENTIFIER_MISC;
     moneyEffect->MoveTo({ x, y, z });
     moneyEffect->type = SPRITE_MISC_MONEY_EFFECT;
-    moneyEffect->num_movements = 0;
-    moneyEffect->move_delay = 0;
+    moneyEffect->NumMovements = 0;
+    moneyEffect->MoveDelay = 0;
 
     int16_t offsetX = 0;
     if (!gOpenRCT2NoGraphics)
@@ -67,8 +67,8 @@ void MoneyEffect::CreateAt(money32 value, int32_t x, int32_t y, int32_t z, bool 
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
         offsetX = -(gfx_get_string_width(buffer) / 2);
     }
-    moneyEffect->offset_x = offsetX;
-    moneyEffect->wiggle = 0;
+    moneyEffect->OffsetX = offsetX;
+    moneyEffect->Wiggle = 0;
 }
 
 /**
@@ -110,14 +110,14 @@ void MoneyEffect::Create(money32 value, CoordsXYZ loc)
 void MoneyEffect::Update()
 {
     invalidate_sprite_2(this);
-    wiggle++;
-    if (wiggle >= 22)
+    Wiggle++;
+    if (Wiggle >= 22)
     {
-        wiggle = 0;
+        Wiggle = 0;
     }
 
-    move_delay++;
-    if (move_delay < 2)
+    MoveDelay++;
+    if (MoveDelay < 2)
     {
         return;
     }
@@ -125,9 +125,9 @@ void MoneyEffect::Update()
     int32_t newX = x;
     int32_t newY = y;
     int32_t newZ = z;
-    move_delay = 0;
+    MoveDelay = 0;
 
-    if (vertical)
+    if (Vertical)
     {
         newZ += 1;
     }
@@ -136,8 +136,8 @@ void MoneyEffect::Update()
 
     MoveTo({ newX, newY, newZ });
 
-    num_movements++;
-    if (num_movements < 55)
+    NumMovements++;
+    if (NumMovements < 55)
     {
         return;
     }
@@ -147,11 +147,11 @@ void MoneyEffect::Update()
 
 std::pair<rct_string_id, money32> MoneyEffect::GetStringId() const
 {
-    rct_string_id spentStringId = vertical ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
-    rct_string_id receiveStringId = vertical ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
+    rct_string_id spentStringId = Vertical ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
+    rct_string_id receiveStringId = Vertical ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
     rct_string_id stringId = receiveStringId;
-    money32 outValue = value;
-    if (value < 0)
+    money32 outValue = Value;
+    if (Value < 0)
     {
         outValue *= -1;
         stringId = spentStringId;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -74,12 +74,12 @@ struct Duck : SpriteGeneric
 
 struct MoneyEffect : SpriteBase
 {
-    uint16_t move_delay;
-    uint8_t num_movements;
-    uint8_t vertical;
-    money32 value;
-    int16_t offset_x;
-    uint16_t wiggle;
+    uint16_t MoveDelay;
+    uint8_t NumMovements;
+    uint8_t Vertical;
+    money32 Value;
+    int16_t OffsetX;
+    uint16_t Wiggle;
 
     static void CreateAt(money32 value, int32_t x, int32_t y, int32_t z, bool vertical);
     static void Create(money32 value, CoordsXYZ loc);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -355,12 +355,12 @@ static void CompareSpriteDataSteamParticle(const SteamParticle& left, const Stea
 
 static void CompareSpriteDataMoneyEffect(const MoneyEffect& left, const MoneyEffect& right)
 {
-    COMPARE_FIELD(move_delay);
-    COMPARE_FIELD(num_movements);
-    COMPARE_FIELD(vertical);
-    COMPARE_FIELD(value);
-    COMPARE_FIELD(offset_x);
-    COMPARE_FIELD(wiggle);
+    COMPARE_FIELD(MoveDelay);
+    COMPARE_FIELD(NumMovements);
+    COMPARE_FIELD(Vertical);
+    COMPARE_FIELD(Value);
+    COMPARE_FIELD(OffsetX);
+    COMPARE_FIELD(Wiggle);
 }
 
 static void CompareSpriteDataCrashedVehicleParticle(const VehicleCrashParticle& left, const VehicleCrashParticle& right)


### PR DESCRIPTION
Continues #10653