### PR TITLE
Renames some Peep member variables to prevent shadowing

### DIFF
--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -642,7 +642,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
             else if (image_id_base >= 0x2BBD && image_id_base < 0x2BDD)
             {
                 image_id_base += 32;
-                image_id_base |= SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour);
+                image_id_base |= SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour);
 
                 gfx_draw_sprite(&cliped_dpi, image_id_base, clip_x, clip_y, 0);
             }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -635,7 +635,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
             if (image_id_base >= 0x2A1D && image_id_base < 0x2A3D)
             {
                 image_id_base += 32;
-                image_id_base |= SPRITE_ID_PALETTE_COLOUR_1(peep->balloon_colour);
+                image_id_base |= SPRITE_ID_PALETTE_COLOUR_1(peep->BalloonColour);
 
                 gfx_draw_sprite(&cliped_dpi, image_id_base, clip_x, clip_y, 0);
             }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -649,7 +649,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
             else if (image_id_base >= 0x29DD && image_id_base < 0x29FD)
             {
                 image_id_base += 32;
-                image_id_base |= SPRITE_ID_PALETTE_COLOUR_1(peep->hat_colour);
+                image_id_base |= SPRITE_ID_PALETTE_COLOUR_1(peep->HatColour);
 
                 gfx_draw_sprite(&cliped_dpi, image_id_base, clip_x, clip_y, 0);
             }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -894,7 +894,7 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     if (animationFrame >= 0x2A1D && animationFrame < 0x2A3D)
     {
         animationFrame += 32;
-        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->balloon_colour);
+        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->BalloonColour);
         gfx_draw_sprite(&clip_dpi, animationFrame, x, y, 0);
     }
 
@@ -1943,7 +1943,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
     switch (item)
     {
         case SHOP_ITEM_BALLOON:
-            set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->balloon_colour) | ShopItems[item].Image);
+            set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->BalloonColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_PHOTO:
             ride = get_ride(peep->photo1_ride_ref);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -902,7 +902,7 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     if (animationFrame >= 0x2BBD && animationFrame < 0x2BDD)
     {
         animationFrame += 32;
-        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour);
+        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour);
         gfx_draw_sprite(&clip_dpi, animationFrame, x, y, 0);
     }
 
@@ -1951,7 +1951,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                 ride->FormatNameTo(gCommonFormatArgs + 6);
             break;
         case SHOP_ITEM_UMBRELLA:
-            set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour) | ShopItems[item].Image);
+            set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_VOUCHER:
             switch (peep->voucher_type)

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1698,9 +1698,9 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
     y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
     set_format_arg(0, rct_string_id, STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
-    if (peep->favourite_ride != RIDE_ID_NULL)
+    if (peep->FavouriteRide != RIDE_ID_NULL)
     {
-        auto ride = get_ride(peep->favourite_ride);
+        auto ride = get_ride(peep->FavouriteRide);
         if (ride != nullptr)
         {
             ride->FormatNameTo(gCommonFormatArgs);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -910,7 +910,7 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     if (animationFrame >= 0x29DD && animationFrame < 0x29FD)
     {
         animationFrame += 32;
-        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->hat_colour);
+        animationFrame |= SPRITE_ID_PALETTE_COLOUR_1(peep->HatColour);
         gfx_draw_sprite(&clip_dpi, animationFrame, x, y, 0);
     }
 }
@@ -1981,7 +1981,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
             }
             break;
         case SHOP_ITEM_HAT:
-            set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->hat_colour) | ShopItems[item].Image);
+            set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->HatColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_TSHIRT:
             set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->tshirt_colour) | ShopItems[item].Image);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1056,7 +1056,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ebx >= 0x2BBD && ebx < 0x2BDD)
     {
         ebx += 32;
-        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->umbrella_colour);
+        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour);
         gfx_draw_sprite(&clip_dpi, ebx, x, y, 0);
     }
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1064,7 +1064,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ebx >= 0x29DD && ebx < 0x29FD)
     {
         ebx += 32;
-        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->hat_colour);
+        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->HatColour);
         gfx_draw_sprite(&clip_dpi, ebx, x, y, 0);
     }
 }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1048,7 +1048,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ebx >= 0x2A1D && ebx < 0x2A3D)
     {
         ebx += 32;
-        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->balloon_colour);
+        ebx |= SPRITE_ID_PALETTE_COLOUR_1(peep->BalloonColour);
         gfx_draw_sprite(&clip_dpi, ebx, x, y, 0);
     }
 

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -304,7 +304,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, vandalism_seen);
         COMPARE_FIELD(Peep, voucher_type);
         COMPARE_FIELD(Peep, voucher_arguments);
-        COMPARE_FIELD(Peep, surroundings_thought_timeout);
+        COMPARE_FIELD(Peep, SurroundingsThoughtTimeout);
         COMPARE_FIELD(Peep, Angriness);
         COMPARE_FIELD(Peep, TimeLost);
         COMPARE_FIELD(Peep, DaysInQueue);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -309,7 +309,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, time_lost);
         COMPARE_FIELD(Peep, days_in_queue);
         COMPARE_FIELD(Peep, balloon_colour);
-        COMPARE_FIELD(Peep, umbrella_colour);
+        COMPARE_FIELD(Peep, UmbrellaColour);
         COMPARE_FIELD(Peep, HatColour);
         COMPARE_FIELD(Peep, FavouriteRide);
         COMPARE_FIELD(Peep, FavouriteRideRating);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -308,7 +308,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, angriness);
         COMPARE_FIELD(Peep, time_lost);
         COMPARE_FIELD(Peep, days_in_queue);
-        COMPARE_FIELD(Peep, balloon_colour);
+        COMPARE_FIELD(Peep, BalloonColour);
         COMPARE_FIELD(Peep, UmbrellaColour);
         COMPARE_FIELD(Peep, HatColour);
         COMPARE_FIELD(Peep, FavouriteRide);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -311,7 +311,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, balloon_colour);
         COMPARE_FIELD(Peep, umbrella_colour);
         COMPARE_FIELD(Peep, hat_colour);
-        COMPARE_FIELD(Peep, favourite_ride);
+        COMPARE_FIELD(Peep, FavouriteRide);
         COMPARE_FIELD(Peep, FavouriteRideRating);
         COMPARE_FIELD(Peep, ItemStandardFlags);
     }

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -310,7 +310,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, days_in_queue);
         COMPARE_FIELD(Peep, balloon_colour);
         COMPARE_FIELD(Peep, umbrella_colour);
-        COMPARE_FIELD(Peep, hat_colour);
+        COMPARE_FIELD(Peep, HatColour);
         COMPARE_FIELD(Peep, FavouriteRide);
         COMPARE_FIELD(Peep, FavouriteRideRating);
         COMPARE_FIELD(Peep, ItemStandardFlags);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -307,7 +307,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, surroundings_thought_timeout);
         COMPARE_FIELD(Peep, angriness);
         COMPARE_FIELD(Peep, time_lost);
-        COMPARE_FIELD(Peep, days_in_queue);
+        COMPARE_FIELD(Peep, DaysInQueue);
         COMPARE_FIELD(Peep, BalloonColour);
         COMPARE_FIELD(Peep, UmbrellaColour);
         COMPARE_FIELD(Peep, HatColour);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -305,7 +305,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, voucher_type);
         COMPARE_FIELD(Peep, voucher_arguments);
         COMPARE_FIELD(Peep, surroundings_thought_timeout);
-        COMPARE_FIELD(Peep, angriness);
+        COMPARE_FIELD(Peep, Angriness);
         COMPARE_FIELD(Peep, TimeLost);
         COMPARE_FIELD(Peep, DaysInQueue);
         COMPARE_FIELD(Peep, BalloonColour);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -312,7 +312,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, umbrella_colour);
         COMPARE_FIELD(Peep, hat_colour);
         COMPARE_FIELD(Peep, favourite_ride);
-        COMPARE_FIELD(Peep, favourite_ride_rating);
+        COMPARE_FIELD(Peep, FavouriteRideRating);
         COMPARE_FIELD(Peep, ItemStandardFlags);
     }
 

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -306,7 +306,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, voucher_arguments);
         COMPARE_FIELD(Peep, surroundings_thought_timeout);
         COMPARE_FIELD(Peep, angriness);
-        COMPARE_FIELD(Peep, time_lost);
+        COMPARE_FIELD(Peep, TimeLost);
         COMPARE_FIELD(Peep, DaysInQueue);
         COMPARE_FIELD(Peep, BalloonColour);
         COMPARE_FIELD(Peep, UmbrellaColour);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -313,7 +313,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, hat_colour);
         COMPARE_FIELD(Peep, favourite_ride);
         COMPARE_FIELD(Peep, favourite_ride_rating);
-        COMPARE_FIELD(Peep, item_standard_flags);
+        COMPARE_FIELD(Peep, ItemStandardFlags);
     }
 
     void CompareSpriteDataVehicle(

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -176,20 +176,20 @@ private:
             }
 
             // remove any free voucher for this ride from peep
-            if (peep->item_standard_flags & PEEP_ITEM_VOUCHER)
+            if (peep->ItemStandardFlags & PEEP_ITEM_VOUCHER)
             {
                 if (peep->voucher_type == VOUCHER_TYPE_RIDE_FREE && peep->voucher_arguments == _rideIndex)
                 {
-                    peep->item_standard_flags &= ~(PEEP_ITEM_VOUCHER);
+                    peep->ItemStandardFlags &= ~(PEEP_ITEM_VOUCHER);
                 }
             }
 
             // remove any photos of this ride from peep
-            if (peep->item_standard_flags & PEEP_ITEM_PHOTO)
+            if (peep->ItemStandardFlags & PEEP_ITEM_PHOTO)
             {
                 if (peep->photo1_ride_ref == _rideIndex)
                 {
-                    peep->item_standard_flags &= ~PEEP_ITEM_PHOTO;
+                    peep->ItemStandardFlags &= ~PEEP_ITEM_PHOTO;
                 }
             }
             if (peep->item_extra_flags & PEEP_ITEM_PHOTO2)

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -218,9 +218,9 @@ private:
             {
                 peep->guest_heading_to_ride_id = RIDE_ID_NULL;
             }
-            if (peep->favourite_ride == _rideIndex)
+            if (peep->FavouriteRide == _rideIndex)
             {
-                peep->favourite_ride = RIDE_ID_NULL;
+                peep->FavouriteRide = RIDE_ID_NULL;
             }
 
             for (int32_t i = 0; i < PEEP_MAX_THOUGHTS; i++)

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -633,15 +633,15 @@ private:
                     peep->cash_in_pocket = MONEY(1000, 00);
                     break;
                 case OBJECT_PARK_MAP:
-                    peep->item_standard_flags |= PEEP_ITEM_MAP;
+                    peep->ItemStandardFlags |= PEEP_ITEM_MAP;
                     break;
                 case OBJECT_BALLOON:
-                    peep->item_standard_flags |= PEEP_ITEM_BALLOON;
+                    peep->ItemStandardFlags |= PEEP_ITEM_BALLOON;
                     peep->balloon_colour = scenario_rand_max(COLOUR_COUNT - 1);
                     peep->UpdateSpriteType();
                     break;
                 case OBJECT_UMBRELLA:
-                    peep->item_standard_flags |= PEEP_ITEM_UMBRELLA;
+                    peep->ItemStandardFlags |= PEEP_ITEM_UMBRELLA;
                     peep->umbrella_colour = scenario_rand_max(COLOUR_COUNT - 1);
                     peep->UpdateSpriteType();
                     break;

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -637,7 +637,7 @@ private:
                     break;
                 case OBJECT_BALLOON:
                     peep->ItemStandardFlags |= PEEP_ITEM_BALLOON;
-                    peep->balloon_colour = scenario_rand_max(COLOUR_COUNT - 1);
+                    peep->BalloonColour = scenario_rand_max(COLOUR_COUNT - 1);
                     peep->UpdateSpriteType();
                     break;
                 case OBJECT_UMBRELLA:

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -588,7 +588,7 @@ private:
                     if (value > 0)
                     {
                         peep->peep_flags &= ~PEEP_FLAGS_ANGRY;
-                        peep->angriness = 0;
+                        peep->Angriness = 0;
                     }
                     break;
                 case GUEST_PARAMETER_ENERGY:

--- a/src/openrct2/actions/SetCheatAction.hpp
+++ b/src/openrct2/actions/SetCheatAction.hpp
@@ -642,7 +642,7 @@ private:
                     break;
                 case OBJECT_UMBRELLA:
                     peep->ItemStandardFlags |= PEEP_ITEM_UMBRELLA;
-                    peep->umbrella_colour = scenario_rand_max(COLOUR_COUNT - 1);
+                    peep->UmbrellaColour = scenario_rand_max(COLOUR_COUNT - 1);
                     peep->UpdateSpriteType();
                     break;
             }

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -173,7 +173,7 @@ private:
             newPeep->paid_on_rides = 0;
             newPeep->paid_on_food = 0;
             newPeep->paid_on_souvenirs = 0;
-            newPeep->favourite_ride = RIDE_ID_NULL;
+            newPeep->FavouriteRide = RIDE_ID_NULL;
             newPeep->staff_orders = _staffOrders;
 
             uint16_t idSearchSpriteIndex;

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -135,22 +135,22 @@ void marketing_set_guest_campaign(Peep* peep, int32_t campaignType)
     switch (campaign->Type)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
-            peep->item_standard_flags |= PEEP_ITEM_VOUCHER;
+            peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
             peep->voucher_type = VOUCHER_TYPE_PARK_ENTRY_FREE;
             break;
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
-            peep->item_standard_flags |= PEEP_ITEM_VOUCHER;
+            peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
             peep->voucher_type = VOUCHER_TYPE_RIDE_FREE;
             peep->voucher_arguments = campaign->RideId;
             peep->guest_heading_to_ride_id = campaign->RideId;
             peep->peep_is_lost_countdown = 240;
             break;
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
-            peep->item_standard_flags |= PEEP_ITEM_VOUCHER;
+            peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
             peep->voucher_type = VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE;
             break;
         case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
-            peep->item_standard_flags |= PEEP_ITEM_VOUCHER;
+            peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
             peep->voucher_type = VOUCHER_TYPE_FOOD_OR_DRINK_FREE;
             peep->voucher_arguments = campaign->ShopItemType;
             break;

--- a/src/openrct2/paint/sprite/Paint.Peep.cpp
+++ b/src/openrct2/paint/sprite/Paint.Peep.cpp
@@ -101,7 +101,7 @@ void peep_paint(paint_session* session, const Peep* peep, int32_t imageDirection
 
     if (baseImageId >= 11197 && baseImageId < 11229)
     {
-        imageId = (baseImageId + 32) | peep->umbrella_colour << 19 | IMAGE_TYPE_REMAP;
+        imageId = (baseImageId + 32) | peep->UmbrellaColour << 19 | IMAGE_TYPE_REMAP;
         sub_98199C(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
         return;
     }

--- a/src/openrct2/paint/sprite/Paint.Peep.cpp
+++ b/src/openrct2/paint/sprite/Paint.Peep.cpp
@@ -94,7 +94,7 @@ void peep_paint(paint_session* session, const Peep* peep, int32_t imageDirection
 
     if (baseImageId >= 10781 && baseImageId < 10813)
     {
-        imageId = (baseImageId + 32) | peep->balloon_colour << 19 | IMAGE_TYPE_REMAP;
+        imageId = (baseImageId + 32) | peep->BalloonColour << 19 | IMAGE_TYPE_REMAP;
         sub_98199C(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
         return;
     }

--- a/src/openrct2/paint/sprite/Paint.Peep.cpp
+++ b/src/openrct2/paint/sprite/Paint.Peep.cpp
@@ -87,7 +87,7 @@ void peep_paint(paint_session* session, const Peep* peep, int32_t imageDirection
 
     if (baseImageId >= 10717 && baseImageId < 10749)
     {
-        imageId = (baseImageId + 32) | peep->hat_colour << 19 | IMAGE_TYPE_REMAP;
+        imageId = (baseImageId + 32) | peep->HatColour << 19 | IMAGE_TYPE_REMAP;
         sub_98199C(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
         return;
     }

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -750,8 +750,8 @@ void Guest::Tick128UpdateGuest(int32_t index)
                 nausea = 130;
         }
 
-        if (angriness != 0)
-            angriness--;
+        if (Angriness != 0)
+            Angriness--;
 
         if (state == PEEP_STATE_WALKING || state == PEEP_STATE_SITTING)
         {
@@ -6292,7 +6292,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
 
     map_invalidate_tile_zoom1({ peep->NextLoc, tileElement->GetBaseZ(), tileElement->GetBaseZ() + 32 });
 
-    peep->angriness = 16;
+    peep->Angriness = 16;
 }
 
 /**

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1659,7 +1659,7 @@ loc_69B221:
         HatColour = ride->track_colour[0].main;
 
     if (shopItem == SHOP_ITEM_BALLOON)
-        balloon_colour = ride->track_colour[0].main;
+        BalloonColour = ride->track_colour[0].main;
 
     if (shopItem == SHOP_ITEM_UMBRELLA)
         UmbrellaColour = ride->track_colour[0].main;
@@ -6853,7 +6853,7 @@ void Guest::UpdateSpriteType()
                 isBalloonPopped = true;
                 audio_play_sound_at_location(SoundId::BalloonPop, { x, y, z });
             }
-            create_balloon(x, y, z + 9, balloon_colour, isBalloonPopped);
+            create_balloon(x, y, z + 9, BalloonColour, isBalloonPopped);
         }
         ItemStandardFlags &= ~PEEP_ITEM_BALLOON;
         window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1787,7 +1787,7 @@ void Guest::OnExitRide(ride_id_t rideIndex)
     if (peep_flags & PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE)
     {
         peep_flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
-        favourite_ride = rideIndex;
+        FavouriteRide = rideIndex;
         // TODO fix this flag name or add another one
         window_invalidate_flags |= PEEP_INVALIDATE_STAFF_STATS;
     }

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -446,10 +446,10 @@ void Guest::GivePassingPeepsPurpleClothes(Guest* passingPeep)
 
 void Guest::GivePassingPeepsPizza(Guest* passingPeep)
 {
-    if ((passingPeep->item_standard_flags & PEEP_ITEM_PIZZA))
+    if ((passingPeep->ItemStandardFlags & PEEP_ITEM_PIZZA))
         return;
 
-    passingPeep->item_standard_flags |= PEEP_ITEM_PIZZA;
+    passingPeep->ItemStandardFlags |= PEEP_ITEM_PIZZA;
 
     int32_t peepDirection = (sprite_direction >> 3) ^ 2;
     int32_t otherPeepOppositeDirection = passingPeep->sprite_direction >> 3;
@@ -485,10 +485,10 @@ void Guest::GivePassingPeepsIceCream(Guest* passingPeep)
 {
     if (this == passingPeep)
         return;
-    if (passingPeep->item_standard_flags & PEEP_ITEM_ICE_CREAM)
+    if (passingPeep->ItemStandardFlags & PEEP_ITEM_ICE_CREAM)
         return;
 
-    passingPeep->item_standard_flags |= PEEP_ITEM_ICE_CREAM;
+    passingPeep->ItemStandardFlags |= PEEP_ITEM_ICE_CREAM;
     passingPeep->UpdateSpriteType();
 }
 
@@ -822,7 +822,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
             }
         }
 
-        if ((scenario_rand() & 0xFFFF) <= ((item_standard_flags & PEEP_ITEM_MAP) ? 8192U : 2184U))
+        if ((scenario_rand() & 0xFFFF) <= ((ItemStandardFlags & PEEP_ITEM_MAP) ? 8192U : 2184U))
         {
             PickRideToGoOn();
         }
@@ -1085,12 +1085,12 @@ void Guest::Tick128UpdateGuest(int32_t index)
             int32_t chosen_food = bitscanforward(HasFoodStandardFlag());
             if (chosen_food != -1)
             {
-                item_standard_flags &= ~(1 << chosen_food);
+                ItemStandardFlags &= ~(1 << chosen_food);
 
                 uint8_t discard_container = peep_item_containers[chosen_food];
                 if (discard_container != 0xFF)
                 {
-                    item_standard_flags |= (1 << discard_container);
+                    ItemStandardFlags |= (1 << discard_container);
                 }
 
                 window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
@@ -1108,7 +1108,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
                         if (discard_container >= 32)
                             item_extra_flags |= (1 << (discard_container - 32));
                         else
-                            item_standard_flags |= (1 << discard_container);
+                            ItemStandardFlags |= (1 << discard_container);
                     }
 
                     window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
@@ -1320,7 +1320,7 @@ bool Guest::HasItem(int32_t peepItem) const
 {
     if (peepItem < 32)
     {
-        return item_standard_flags & (1u << peepItem);
+        return ItemStandardFlags & (1u << peepItem);
     }
     else
     {
@@ -1330,7 +1330,7 @@ bool Guest::HasItem(int32_t peepItem) const
 
 int32_t Guest::HasFoodStandardFlag() const
 {
-    return item_standard_flags
+    return ItemStandardFlags
         & (PEEP_ITEM_DRINK | PEEP_ITEM_BURGER | PEEP_ITEM_CHIPS | PEEP_ITEM_ICE_CREAM | PEEP_ITEM_CANDYFLOSS | PEEP_ITEM_PIZZA
            | PEEP_ITEM_POPCORN | PEEP_ITEM_HOT_DOG | PEEP_ITEM_TENTACLE | PEEP_ITEM_TOFFEE_APPLE | PEEP_ITEM_DOUGHNUT
            | PEEP_ITEM_COFFEE | PEEP_ITEM_CHICKEN | PEEP_ITEM_LEMONADE);
@@ -1347,7 +1347,7 @@ int32_t Guest::HasFoodExtraFlag() const
 
 bool Guest::HasDrinkStandardFlag() const
 {
-    return item_standard_flags & (PEEP_ITEM_DRINK | PEEP_ITEM_COFFEE | PEEP_ITEM_LEMONADE);
+    return ItemStandardFlags & (PEEP_ITEM_DRINK | PEEP_ITEM_COFFEE | PEEP_ITEM_LEMONADE);
 }
 
 bool Guest::HasDrinkExtraFlag() const
@@ -1367,7 +1367,7 @@ bool Guest::HasDrink() const
 
 int32_t Guest::HasEmptyContainerStandardFlag() const
 {
-    return item_standard_flags
+    return ItemStandardFlags
         & (PEEP_ITEM_EMPTY_CAN | PEEP_ITEM_EMPTY_BURGER_BOX | PEEP_ITEM_EMPTY_CUP | PEEP_ITEM_RUBBISH | PEEP_ITEM_EMPTY_BOX
            | PEEP_ITEM_EMPTY_BOTTLE);
 }
@@ -1481,7 +1481,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
 
     bool hasVoucher = false;
 
-    if ((item_standard_flags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
+    if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
         && (voucher_arguments == shopItem))
     {
         hasVoucher = true;
@@ -1650,7 +1650,7 @@ loc_69B221:
     if (shopItem >= 32)
         item_extra_flags |= (1u << (shopItem - 32));
     else
-        item_standard_flags |= (1u << shopItem);
+        ItemStandardFlags |= (1u << shopItem);
 
     if (shopItem == SHOP_ITEM_TSHIRT)
         tshirt_colour = ride->track_colour[0].main;
@@ -1726,7 +1726,7 @@ loc_69B221:
     expenditure = static_cast<ExpenditureType>(static_cast<int32_t>(expenditure) - 1);
     if (hasVoucher)
     {
-        item_standard_flags &= ~PEEP_ITEM_VOUCHER;
+        ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;
         window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
     }
     else if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -1869,7 +1869,7 @@ void Guest::PickRideToGoOn()
         window_invalidate_flags |= PEEP_INVALIDATE_PEEP_ACTION;
 
         // Make peep look at their map if they have one
-        if (item_standard_flags & PEEP_ITEM_MAP)
+        if (ItemStandardFlags & PEEP_ITEM_MAP)
         {
             ReadMap();
         }
@@ -1907,7 +1907,7 @@ std::bitset<MAX_RIDES> Guest::FindRidesToGoOn()
     // FIX  Originally checked for a toy, likely a mistake and should be a map,
     //      but then again this seems to only allow the peep to go on
     //      rides they haven't been on before.
-    if (item_standard_flags & PEEP_ITEM_MAP)
+    if (ItemStandardFlags & PEEP_ITEM_MAP)
     {
         // Consider rides that peep hasn't been on yet
         for (auto& ride : GetRideManager())
@@ -2413,7 +2413,7 @@ void Guest::ReadMap()
 
 static bool peep_has_voucher_for_free_ride(Peep* peep, Ride* ride)
 {
-    return peep->item_standard_flags & PEEP_ITEM_VOUCHER && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
+    return peep->ItemStandardFlags & PEEP_ITEM_VOUCHER && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
         && peep->voucher_arguments == ride->id;
 }
 
@@ -2634,7 +2634,7 @@ static void peep_update_ride_at_entrance_try_leave(Guest* peep)
 
 static bool peep_check_ride_price_at_entrance(Guest* peep, Ride* ride, money32 ridePrice)
 {
-    if ((peep->item_standard_flags & PEEP_ITEM_VOUCHER) && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
+    if ((peep->ItemStandardFlags & PEEP_ITEM_VOUCHER) && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
         && peep->voucher_arguments == peep->current_ride)
         return true;
 
@@ -3160,7 +3160,7 @@ template<typename T> static void peep_head_for_nearest_ride(Guest* peep, bool co
     }
 
     std::bitset<MAX_RIDES> rideConsideration;
-    if (!considerOnlyCloseRides && (peep->item_standard_flags & PEEP_ITEM_MAP))
+    if (!considerOnlyCloseRides && (peep->ItemStandardFlags & PEEP_ITEM_MAP))
     {
         // Consider all rides in the park
         for (const auto& ride : GetRideManager())
@@ -3857,10 +3857,10 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride* ride)
     money16 ridePrice = ride_get_price(ride);
     if (ridePrice != 0)
     {
-        if ((item_standard_flags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_RIDE_FREE)
+        if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_RIDE_FREE)
             && (voucher_arguments == current_ride))
         {
-            item_standard_flags &= ~PEEP_ITEM_VOUCHER;
+            ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;
             window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
         }
         else
@@ -5337,7 +5337,7 @@ void Guest::UpdateWalking()
 
             if (pos_stnd != 32)
             {
-                item_standard_flags &= ~(1u << pos_stnd);
+                ItemStandardFlags &= ~(1u << pos_stnd);
                 litterType = item_standard_litter[pos_stnd];
             }
             else
@@ -5916,7 +5916,7 @@ void Guest::UpdateUsingBin()
                     // switched to scenario_rand as it is more reliable
                     if ((scenario_rand() & 7) == 0)
                         space_left_in_bin--;
-                    item_standard_flags &= ~(1 << cur_container);
+                    ItemStandardFlags &= ~(1 << cur_container);
                     window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
                     UpdateSpriteType();
                     continue;
@@ -5927,7 +5927,7 @@ void Guest::UpdateUsingBin()
                 int32_t litterY = y + (scenario_rand() & 7) - 3;
 
                 litter_create(litterX, litterY, z, scenario_rand() & 3, litterType);
-                item_standard_flags &= ~(1 << cur_container);
+                ItemStandardFlags &= ~(1 << cur_container);
                 window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
 
                 UpdateSpriteType();
@@ -6855,11 +6855,11 @@ void Guest::UpdateSpriteType()
             }
             create_balloon(x, y, z + 9, balloon_colour, isBalloonPopped);
         }
-        item_standard_flags &= ~PEEP_ITEM_BALLOON;
+        ItemStandardFlags &= ~PEEP_ITEM_BALLOON;
         window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
     }
 
-    if (climate_is_raining() && (item_standard_flags & PEEP_ITEM_UMBRELLA) && x != LOCATION_NULL)
+    if (climate_is_raining() && (ItemStandardFlags & PEEP_ITEM_UMBRELLA) && x != LOCATION_NULL)
     {
         CoordsXY loc = { x, y };
         if (map_is_location_valid(loc.ToTileStart()))
@@ -6886,7 +6886,7 @@ void Guest::UpdateSpriteType()
     {
         if (item_pref->type == 0)
         {
-            if (item_standard_flags & item_pref->item)
+            if (ItemStandardFlags & item_pref->item)
             {
                 SetSpriteType(item_pref->sprite_type);
                 return;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1662,7 +1662,7 @@ loc_69B221:
         balloon_colour = ride->track_colour[0].main;
 
     if (shopItem == SHOP_ITEM_UMBRELLA)
-        umbrella_colour = ride->track_colour[0].main;
+        UmbrellaColour = ride->track_colour[0].main;
 
     if (shopItem == SHOP_ITEM_MAP)
         peep_reset_pathfind_goal(this);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -755,10 +755,10 @@ void Guest::Tick128UpdateGuest(int32_t index)
 
         if (state == PEEP_STATE_WALKING || state == PEEP_STATE_SITTING)
         {
-            surroundings_thought_timeout++;
-            if (surroundings_thought_timeout >= 18)
+            SurroundingsThoughtTimeout++;
+            if (SurroundingsThoughtTimeout >= 18)
             {
-                surroundings_thought_timeout = 0;
+                SurroundingsThoughtTimeout = 0;
                 if (x != LOCATION_NULL)
                 {
                     PeepThoughtType thought_type = peep_assess_surroundings(x & 0xFFE0, y & 0xFFE0, z);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1656,7 +1656,7 @@ loc_69B221:
         tshirt_colour = ride->track_colour[0].main;
 
     if (shopItem == SHOP_ITEM_HAT)
-        hat_colour = ride->track_colour[0].main;
+        HatColour = ride->track_colour[0].main;
 
     if (shopItem == SHOP_ITEM_BALLOON)
         balloon_colour = ride->track_colour[0].main;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -3872,7 +3872,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride* ride)
     }
 
     sub_state = PEEP_RIDE_LEAVE_ENTRANCE;
-    uint8_t queueTime = days_in_queue;
+    uint8_t queueTime = DaysInQueue;
     if (queueTime < 253)
         queueTime += 3;
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2713,11 +2713,11 @@ static void peep_update_favourite_ride(Peep* peep, Ride* ride)
 {
     peep->peep_flags &= ~PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
     uint8_t peepRideRating = std::clamp((ride->excitement / 4) + peep->happiness, 0, PEEP_MAX_HAPPINESS);
-    if (peepRideRating >= peep->favourite_ride_rating)
+    if (peepRideRating >= peep->FavouriteRideRating)
     {
         if (peep->happiness >= 160 && peep->happiness_target >= 160)
         {
-            peep->favourite_ride_rating = peepRideRating;
+            peep->FavouriteRideRating = peepRideRating;
             peep->peep_flags |= PEEP_FLAGS_RIDE_SHOULD_BE_MARKED_AS_FAVOURITE;
         }
     }

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1399,10 +1399,10 @@ void Guest::CheckIfLost()
         if (!(peep_flags & PEEP_FLAGS_21))
             return;
 
-        time_lost++;
-        if (time_lost != 254)
+        TimeLost++;
+        if (TimeLost != 254)
             return;
-        time_lost = 230;
+        TimeLost = 230;
     }
     InsertNewThought(PEEP_THOUGHT_TYPE_LOST, PEEP_THOUGHT_ITEM_NONE);
 
@@ -3245,7 +3245,7 @@ template<typename T> static void peep_head_for_nearest_ride(Guest* peep, bool co
         peep->peep_is_lost_countdown = 200;
         peep_reset_pathfind_goal(peep);
         peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_ACTION;
-        peep->time_lost = 0;
+        peep->TimeLost = 0;
     }
 }
 

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -455,7 +455,7 @@ static uint8_t peep_pathfind_get_max_number_junctions(Peep* peep)
         return 8;
     }
 
-    if (peep->item_standard_flags & PEEP_ITEM_MAP)
+    if (peep->ItemStandardFlags & PEEP_ITEM_MAP)
         return 7;
 
     if (peep->peep_flags & PEEP_FLAGS_LEAVING_PARK)
@@ -2024,7 +2024,7 @@ int32_t guest_path_finding(Guest* peep)
     /* If there are still multiple directions to choose from,
      * peeps with maps will randomly read the map: probability of doing so
      * is much higher when heading for a ride or the park exit. */
-    if (peep->item_standard_flags & PEEP_ITEM_MAP)
+    if (peep->ItemStandardFlags & PEEP_ITEM_MAP)
     {
         // If at least 2 directions consult map
         if (bitcount(edges) >= 2)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1774,7 +1774,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->no_of_souvenirs = 0;
     peep->surroundings_thought_timeout = 0;
     peep->angriness = 0;
-    peep->time_lost = 0;
+    peep->TimeLost = 0;
 
     uint8_t tshirtColour = static_cast<uint8_t>(scenario_rand() % std::size(tshirt_colours));
     peep->tshirt_colour = tshirt_colours[tshirtColour];
@@ -2410,7 +2410,7 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
             return;
         }
 
-        peep->time_lost = 0;
+        peep->TimeLost = 0;
         auto stationNum = tile_element->AsEntrance()->GetStationIndex();
         // Guest walks up to the ride for the first time since entering
         // the path tile or since considering another ride attached to
@@ -2839,7 +2839,7 @@ static void peep_interact_with_path(Peep* peep, int16_t x, int16_t y, TileElemen
         else
         {
             // Peep is not queuing.
-            peep->time_lost = 0;
+            peep->TimeLost = 0;
             auto stationNum = tile_element->AsPath()->GetStationIndex();
 
             if ((tile_element->AsPath()->HasQueueBanner())
@@ -2929,7 +2929,7 @@ static bool peep_interact_with_shop(Peep* peep, int16_t x, int16_t y, TileElemen
         return true;
     }
 
-    peep->time_lost = 0;
+    peep->TimeLost = 0;
 
     if (ride->status != RIDE_STATUS_OPEN)
     {
@@ -2951,7 +2951,7 @@ static bool peep_interact_with_shop(Peep* peep, int16_t x, int16_t y, TileElemen
 
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_PEEP_SHOULD_GO_INSIDE_FACILITY))
     {
-        peep->time_lost = 0;
+        peep->TimeLost = 0;
         if (!guest->ShouldGoOnRide(ride, 0, false, false))
         {
             peep_return_to_centre_of_tile(peep);

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1772,7 +1772,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->no_of_food = 0;
     peep->no_of_drinks = 0;
     peep->no_of_souvenirs = 0;
-    peep->surroundings_thought_timeout = 0;
+    peep->SurroundingsThoughtTimeout = 0;
     peep->Angriness = 0;
     peep->TimeLost = 0;
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1482,9 +1482,9 @@ void peep_update_days_in_queue()
     {
         if (peep->outside_of_park == 0 && peep->state == PEEP_STATE_QUEUING)
         {
-            if (peep->days_in_queue < 255)
+            if (peep->DaysInQueue < 255)
             {
-                peep->days_in_queue += 1;
+                peep->DaysInQueue += 1;
             }
         }
     }
@@ -2435,7 +2435,7 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
 
         peep->current_ride = rideIndex;
         peep->current_ride_station = stationNum;
-        peep->days_in_queue = 0;
+        peep->DaysInQueue = 0;
         peep->SetState(PEEP_STATE_QUEUING);
         peep->sub_state = 11;
         peep->time_in_queue = 0;
@@ -2865,7 +2865,7 @@ static void peep_interact_with_path(Peep* peep, int16_t x, int16_t y, TileElemen
                     peep->current_ride = rideIndex;
                     peep->current_ride_station = stationNum;
                     peep->state = PEEP_STATE_QUEUING;
-                    peep->days_in_queue = 0;
+                    peep->DaysInQueue = 0;
                     peep_window_state_update(peep);
 
                     peep->sub_state = 10;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1635,7 +1635,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->action_sprite_type = PEEP_ACTION_SPRITE_TYPE_NONE;
     peep->peep_flags = 0;
     peep->favourite_ride = RIDE_ID_NULL;
-    peep->favourite_ride_rating = 0;
+    peep->FavouriteRideRating = 0;
 
     const rct_sprite_bounds* spriteBounds = g_peep_animation_entries[peep->sprite_type].sprite_bounds;
     peep->sprite_width = spriteBounds[peep->action_sprite_type].sprite_width;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1758,7 +1758,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->pathfind_goal.y = 0xFF;
     peep->pathfind_goal.z = 0xFF;
     peep->pathfind_goal.direction = INVALID_DIRECTION;
-    peep->item_standard_flags = 0;
+    peep->ItemStandardFlags = 0;
     peep->item_extra_flags = 0;
     peep->guest_heading_to_ride_id = RIDE_ID_NULL;
     peep->litter_count = 0;
@@ -2601,18 +2601,18 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
         money16 entranceFee = park_get_entrance_fee();
         if (entranceFee != 0)
         {
-            if (peep->item_standard_flags & PEEP_ITEM_VOUCHER)
+            if (peep->ItemStandardFlags & PEEP_ITEM_VOUCHER)
             {
                 if (peep->voucher_type == VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE)
                 {
                     entranceFee /= 2;
-                    peep->item_standard_flags &= ~PEEP_ITEM_VOUCHER;
+                    peep->ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;
                     peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
                 }
                 else if (peep->voucher_type == VOUCHER_TYPE_PARK_ENTRY_FREE)
                 {
                     entranceFee = 0;
-                    peep->item_standard_flags &= ~PEEP_ITEM_VOUCHER;
+                    peep->ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;
                     peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
                 }
             }
@@ -3392,9 +3392,9 @@ void decrement_guests_heading_for_park()
 
 static void peep_release_balloon(Guest* peep, int16_t spawn_height)
 {
-    if (peep->item_standard_flags & PEEP_ITEM_BALLOON)
+    if (peep->ItemStandardFlags & PEEP_ITEM_BALLOON)
     {
-        peep->item_standard_flags &= ~PEEP_ITEM_BALLOON;
+        peep->ItemStandardFlags &= ~PEEP_ITEM_BALLOON;
 
         if (peep->sprite_type == PEEP_SPRITE_TYPE_BALLOON && peep->x != LOCATION_NULL)
         {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -3398,7 +3398,7 @@ static void peep_release_balloon(Guest* peep, int16_t spawn_height)
 
         if (peep->sprite_type == PEEP_SPRITE_TYPE_BALLOON && peep->x != LOCATION_NULL)
         {
-            create_balloon(peep->x, peep->y, spawn_height, peep->balloon_colour, false);
+            create_balloon(peep->x, peep->y, spawn_height, peep->BalloonColour, false);
             peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
             peep->UpdateSpriteType();
         }

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1773,7 +1773,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->no_of_drinks = 0;
     peep->no_of_souvenirs = 0;
     peep->surroundings_thought_timeout = 0;
-    peep->angriness = 0;
+    peep->Angriness = 0;
     peep->TimeLost = 0;
 
     uint8_t tshirtColour = static_cast<uint8_t>(scenario_rand() % std::size(tshirt_colours));
@@ -2172,7 +2172,7 @@ static constexpr const int32_t face_sprite_large[] = {
 static int32_t get_face_sprite_offset(Peep* peep)
 {
     // ANGRY
-    if (peep->angriness > 0)
+    if (peep->Angriness > 0)
         return PEEP_FACE_OFFSET_ANGRY;
 
     // VERY_VERY_SICK

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1634,7 +1634,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->no_action_frame_num = 0;
     peep->action_sprite_type = PEEP_ACTION_SPRITE_TYPE_NONE;
     peep->peep_flags = 0;
-    peep->favourite_ride = RIDE_ID_NULL;
+    peep->FavouriteRide = RIDE_ID_NULL;
     peep->FavouriteRideRating = 0;
 
     const rct_sprite_bounds* spriteBounds = g_peep_animation_entries[peep->sprite_type].sprite_bounds;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -743,7 +743,7 @@ struct Peep : SpriteBase
     uint8_t time_lost; // the time the peep has been lost when it reaches 254 generates the lost thought
     uint8_t days_in_queue;
     uint8_t balloon_colour;
-    uint8_t umbrella_colour;
+    uint8_t UmbrellaColour;
     uint8_t HatColour;
     uint8_t FavouriteRide;
     uint8_t FavouriteRideRating;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -745,7 +745,7 @@ struct Peep : SpriteBase
     uint8_t balloon_colour;
     uint8_t umbrella_colour;
     uint8_t hat_colour;
-    uint8_t favourite_ride;
+    uint8_t FavouriteRide;
     uint8_t FavouriteRideRating;
     uint32_t ItemStandardFlags;
 

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -403,7 +403,7 @@ enum PeepNauseaTolerance
 
 enum PeepItem
 {
-    // item_standard_flags
+    // ItemStandardFlags
     PEEP_ITEM_BALLOON = (1 << 0),
     PEEP_ITEM_TOY = (1 << 1),
     PEEP_ITEM_MAP = (1 << 2),
@@ -747,7 +747,7 @@ struct Peep : SpriteBase
     uint8_t hat_colour;
     uint8_t favourite_ride;
     uint8_t favourite_ride_rating;
-    uint32_t item_standard_flags;
+    uint32_t ItemStandardFlags;
 
 public: // Peep
     Guest* AsGuest();

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -744,7 +744,7 @@ struct Peep : SpriteBase
     uint8_t days_in_queue;
     uint8_t balloon_colour;
     uint8_t umbrella_colour;
-    uint8_t hat_colour;
+    uint8_t HatColour;
     uint8_t FavouriteRide;
     uint8_t FavouriteRideRating;
     uint32_t ItemStandardFlags;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -740,7 +740,7 @@ struct Peep : SpriteBase
     uint8_t voucher_arguments; // ride_id or string_offset_id
     uint8_t surroundings_thought_timeout;
     uint8_t angriness;
-    uint8_t time_lost; // the time the peep has been lost when it reaches 254 generates the lost thought
+    uint8_t TimeLost; // the time the peep has been lost when it reaches 254 generates the lost thought
     uint8_t DaysInQueue;
     uint8_t BalloonColour;
     uint8_t UmbrellaColour;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -742,7 +742,7 @@ struct Peep : SpriteBase
     uint8_t angriness;
     uint8_t time_lost; // the time the peep has been lost when it reaches 254 generates the lost thought
     uint8_t days_in_queue;
-    uint8_t balloon_colour;
+    uint8_t BalloonColour;
     uint8_t UmbrellaColour;
     uint8_t HatColour;
     uint8_t FavouriteRide;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -738,7 +738,7 @@ struct Peep : SpriteBase
     uint8_t vandalism_seen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
     uint8_t voucher_type;
     uint8_t voucher_arguments; // ride_id or string_offset_id
-    uint8_t surroundings_thought_timeout;
+    uint8_t SurroundingsThoughtTimeout;
     uint8_t Angriness;
     uint8_t TimeLost; // the time the peep has been lost when it reaches 254 generates the lost thought
     uint8_t DaysInQueue;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -741,7 +741,7 @@ struct Peep : SpriteBase
     uint8_t surroundings_thought_timeout;
     uint8_t angriness;
     uint8_t time_lost; // the time the peep has been lost when it reaches 254 generates the lost thought
-    uint8_t days_in_queue;
+    uint8_t DaysInQueue;
     uint8_t BalloonColour;
     uint8_t UmbrellaColour;
     uint8_t HatColour;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -746,7 +746,7 @@ struct Peep : SpriteBase
     uint8_t umbrella_colour;
     uint8_t hat_colour;
     uint8_t favourite_ride;
-    uint8_t favourite_ride_rating;
+    uint8_t FavouriteRideRating;
     uint32_t ItemStandardFlags;
 
 public: // Peep

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -739,7 +739,7 @@ struct Peep : SpriteBase
     uint8_t voucher_type;
     uint8_t voucher_arguments; // ride_id or string_offset_id
     uint8_t surroundings_thought_timeout;
-    uint8_t angriness;
+    uint8_t Angriness;
     uint8_t TimeLost; // the time the peep has been lost when it reaches 254 generates the lost thought
     uint8_t DaysInQueue;
     uint8_t BalloonColour;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1498,7 +1498,7 @@ private:
         dst->voucher_type = src->voucher_type;
 
         dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
-        dst->angriness = src->angriness;
+        dst->Angriness = src->angriness;
         dst->TimeLost = src->time_lost;
 
         for (size_t i = 0; i < 32; i++)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1430,7 +1430,7 @@ private:
 
         dst->tshirt_colour = RCT1::GetColour(src->tshirt_colour);
         dst->trousers_colour = RCT1::GetColour(src->trousers_colour);
-        dst->umbrella_colour = RCT1::GetColour(src->umbrella_colour);
+        dst->UmbrellaColour = RCT1::GetColour(src->umbrella_colour);
         dst->HatColour = RCT1::GetColour(src->hat_colour);
 
         // Balloons were always blue in RCT1 without AA/LL

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1436,11 +1436,11 @@ private:
         // Balloons were always blue in RCT1 without AA/LL
         if (_gameVersion == FILE_VERSION_RCT1)
         {
-            dst->balloon_colour = COLOUR_LIGHT_BLUE;
+            dst->BalloonColour = COLOUR_LIGHT_BLUE;
         }
         else
         {
-            dst->balloon_colour = RCT1::GetColour(src->balloon_colour);
+            dst->BalloonColour = RCT1::GetColour(src->balloon_colour);
         }
 
         dst->destination_x = src->destination_x;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1499,7 +1499,7 @@ private:
 
         dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
         dst->angriness = src->angriness;
-        dst->time_lost = src->time_lost;
+        dst->TimeLost = src->time_lost;
 
         for (size_t i = 0; i < 32; i++)
         {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1472,7 +1472,7 @@ private:
         dst->current_car = src->current_car;
         dst->current_seat = src->current_seat;
         dst->time_on_ride = src->time_on_ride;
-        dst->days_in_queue = src->days_in_queue;
+        dst->DaysInQueue = src->days_in_queue;
 
         dst->interaction_ride_index = src->interaction_ride_index;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1551,7 +1551,7 @@ private:
             dst->favourite_ride_rating = 0;
         }
 
-        dst->item_standard_flags = src->item_standard_flags;
+        dst->ItemStandardFlags = src->item_standard_flags;
 
         if (dst->type == PEEP_TYPE_GUEST)
         {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1543,12 +1543,12 @@ private:
         if (_gameVersion == FILE_VERSION_RCT1_LL)
         {
             dst->favourite_ride = src->favourite_ride;
-            dst->favourite_ride_rating = src->favourite_ride_rating;
+            dst->FavouriteRideRating = src->favourite_ride_rating;
         }
         else
         {
             dst->favourite_ride = RIDE_ID_NULL;
-            dst->favourite_ride_rating = 0;
+            dst->FavouriteRideRating = 0;
         }
 
         dst->ItemStandardFlags = src->item_standard_flags;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1497,7 +1497,7 @@ private:
         dst->voucher_arguments = src->voucher_arguments;
         dst->voucher_type = src->voucher_type;
 
-        dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
+        dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
         dst->Angriness = src->angriness;
         dst->TimeLost = src->time_lost;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1431,7 +1431,7 @@ private:
         dst->tshirt_colour = RCT1::GetColour(src->tshirt_colour);
         dst->trousers_colour = RCT1::GetColour(src->trousers_colour);
         dst->umbrella_colour = RCT1::GetColour(src->umbrella_colour);
-        dst->hat_colour = RCT1::GetColour(src->hat_colour);
+        dst->HatColour = RCT1::GetColour(src->hat_colour);
 
         // Balloons were always blue in RCT1 without AA/LL
         if (_gameVersion == FILE_VERSION_RCT1)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1542,12 +1542,12 @@ private:
         // Set it to N/A if the save comes from the original or AA.
         if (_gameVersion == FILE_VERSION_RCT1_LL)
         {
-            dst->favourite_ride = src->favourite_ride;
+            dst->FavouriteRide = src->favourite_ride;
             dst->FavouriteRideRating = src->favourite_ride_rating;
         }
         else
         {
-            dst->favourite_ride = RIDE_ID_NULL;
+            dst->FavouriteRide = RIDE_ID_NULL;
             dst->FavouriteRideRating = 0;
         }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1231,7 +1231,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->vandalism_seen = src->vandalism_seen;
     dst->voucher_type = src->voucher_type;
     dst->voucher_arguments = src->voucher_arguments;
-    dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
+    dst->surroundings_thought_timeout = src->SurroundingsThoughtTimeout;
     dst->angriness = src->Angriness;
     dst->time_lost = src->TimeLost;
     dst->days_in_queue = src->DaysInQueue;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1233,7 +1233,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->voucher_arguments = src->voucher_arguments;
     dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
     dst->angriness = src->angriness;
-    dst->time_lost = src->time_lost;
+    dst->time_lost = src->TimeLost;
     dst->days_in_queue = src->DaysInQueue;
     dst->balloon_colour = src->BalloonColour;
     dst->umbrella_colour = src->UmbrellaColour;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1235,7 +1235,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->angriness = src->angriness;
     dst->time_lost = src->time_lost;
     dst->days_in_queue = src->days_in_queue;
-    dst->balloon_colour = src->balloon_colour;
+    dst->balloon_colour = src->BalloonColour;
     dst->umbrella_colour = src->UmbrellaColour;
     dst->hat_colour = src->HatColour;
     dst->favourite_ride = src->FavouriteRide;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1239,7 +1239,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->umbrella_colour = src->umbrella_colour;
     dst->hat_colour = src->hat_colour;
     dst->favourite_ride = src->favourite_ride;
-    dst->favourite_ride_rating = src->favourite_ride_rating;
+    dst->favourite_ride_rating = src->FavouriteRideRating;
     dst->item_standard_flags = src->ItemStandardFlags;
 }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1232,7 +1232,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->voucher_type = src->voucher_type;
     dst->voucher_arguments = src->voucher_arguments;
     dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
-    dst->angriness = src->angriness;
+    dst->angriness = src->Angriness;
     dst->time_lost = src->TimeLost;
     dst->days_in_queue = src->DaysInQueue;
     dst->balloon_colour = src->BalloonColour;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1234,7 +1234,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
     dst->angriness = src->angriness;
     dst->time_lost = src->time_lost;
-    dst->days_in_queue = src->days_in_queue;
+    dst->days_in_queue = src->DaysInQueue;
     dst->balloon_colour = src->BalloonColour;
     dst->umbrella_colour = src->UmbrellaColour;
     dst->hat_colour = src->HatColour;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1238,7 +1238,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->balloon_colour = src->balloon_colour;
     dst->umbrella_colour = src->umbrella_colour;
     dst->hat_colour = src->hat_colour;
-    dst->favourite_ride = src->favourite_ride;
+    dst->favourite_ride = src->FavouriteRide;
     dst->favourite_ride_rating = src->FavouriteRideRating;
     dst->item_standard_flags = src->ItemStandardFlags;
 }

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1237,7 +1237,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->days_in_queue = src->days_in_queue;
     dst->balloon_colour = src->balloon_colour;
     dst->umbrella_colour = src->umbrella_colour;
-    dst->hat_colour = src->hat_colour;
+    dst->hat_colour = src->HatColour;
     dst->favourite_ride = src->FavouriteRide;
     dst->favourite_ride_rating = src->FavouriteRideRating;
     dst->item_standard_flags = src->ItemStandardFlags;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1240,7 +1240,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->hat_colour = src->hat_colour;
     dst->favourite_ride = src->favourite_ride;
     dst->favourite_ride_rating = src->favourite_ride_rating;
-    dst->item_standard_flags = src->item_standard_flags;
+    dst->item_standard_flags = src->ItemStandardFlags;
 }
 
 void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1236,7 +1236,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->time_lost = src->time_lost;
     dst->days_in_queue = src->days_in_queue;
     dst->balloon_colour = src->balloon_colour;
-    dst->umbrella_colour = src->umbrella_colour;
+    dst->umbrella_colour = src->UmbrellaColour;
     dst->hat_colour = src->HatColour;
     dst->favourite_ride = src->FavouriteRide;
     dst->favourite_ride_rating = src->FavouriteRideRating;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1502,7 +1502,7 @@ public:
         dst->days_in_queue = src->days_in_queue;
         dst->balloon_colour = src->balloon_colour;
         dst->umbrella_colour = src->umbrella_colour;
-        dst->hat_colour = src->hat_colour;
+        dst->HatColour = src->hat_colour;
         dst->FavouriteRide = src->favourite_ride;
         dst->FavouriteRideRating = src->favourite_ride_rating;
         dst->ItemStandardFlags = src->item_standard_flags;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1504,7 +1504,7 @@ public:
         dst->umbrella_colour = src->umbrella_colour;
         dst->hat_colour = src->hat_colour;
         dst->favourite_ride = src->favourite_ride;
-        dst->favourite_ride_rating = src->favourite_ride_rating;
+        dst->FavouriteRideRating = src->favourite_ride_rating;
         dst->ItemStandardFlags = src->item_standard_flags;
     }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1496,7 +1496,7 @@ public:
         dst->vandalism_seen = src->vandalism_seen;
         dst->voucher_type = src->voucher_type;
         dst->voucher_arguments = src->voucher_arguments;
-        dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
+        dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
         dst->Angriness = src->angriness;
         dst->TimeLost = src->time_lost;
         dst->DaysInQueue = src->days_in_queue;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1503,7 +1503,7 @@ public:
         dst->balloon_colour = src->balloon_colour;
         dst->umbrella_colour = src->umbrella_colour;
         dst->hat_colour = src->hat_colour;
-        dst->favourite_ride = src->favourite_ride;
+        dst->FavouriteRide = src->favourite_ride;
         dst->FavouriteRideRating = src->favourite_ride_rating;
         dst->ItemStandardFlags = src->item_standard_flags;
     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1501,7 +1501,7 @@ public:
         dst->time_lost = src->time_lost;
         dst->days_in_queue = src->days_in_queue;
         dst->balloon_colour = src->balloon_colour;
-        dst->umbrella_colour = src->umbrella_colour;
+        dst->UmbrellaColour = src->umbrella_colour;
         dst->HatColour = src->hat_colour;
         dst->FavouriteRide = src->favourite_ride;
         dst->FavouriteRideRating = src->favourite_ride_rating;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1500,7 +1500,7 @@ public:
         dst->angriness = src->angriness;
         dst->time_lost = src->time_lost;
         dst->days_in_queue = src->days_in_queue;
-        dst->balloon_colour = src->balloon_colour;
+        dst->BalloonColour = src->balloon_colour;
         dst->UmbrellaColour = src->umbrella_colour;
         dst->HatColour = src->hat_colour;
         dst->FavouriteRide = src->favourite_ride;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1499,7 +1499,7 @@ public:
         dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
         dst->angriness = src->angriness;
         dst->time_lost = src->time_lost;
-        dst->days_in_queue = src->days_in_queue;
+        dst->DaysInQueue = src->days_in_queue;
         dst->BalloonColour = src->balloon_colour;
         dst->UmbrellaColour = src->umbrella_colour;
         dst->HatColour = src->hat_colour;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1497,7 +1497,7 @@ public:
         dst->voucher_type = src->voucher_type;
         dst->voucher_arguments = src->voucher_arguments;
         dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
-        dst->angriness = src->angriness;
+        dst->Angriness = src->angriness;
         dst->TimeLost = src->time_lost;
         dst->DaysInQueue = src->days_in_queue;
         dst->BalloonColour = src->balloon_colour;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1498,7 +1498,7 @@ public:
         dst->voucher_arguments = src->voucher_arguments;
         dst->surroundings_thought_timeout = src->surroundings_thought_timeout;
         dst->angriness = src->angriness;
-        dst->time_lost = src->time_lost;
+        dst->TimeLost = src->time_lost;
         dst->DaysInQueue = src->days_in_queue;
         dst->BalloonColour = src->balloon_colour;
         dst->UmbrellaColour = src->umbrella_colour;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1505,7 +1505,7 @@ public:
         dst->hat_colour = src->hat_colour;
         dst->favourite_ride = src->favourite_ride;
         dst->favourite_ride_rating = src->favourite_ride_rating;
-        dst->item_standard_flags = src->item_standard_flags;
+        dst->ItemStandardFlags = src->item_standard_flags;
     }
 
     void ImportSpriteMisc(SpriteBase* cdst, const RCT12SpriteBase* csrc)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -324,9 +324,9 @@ void ride_update_favourited_stat()
 
     FOR_ALL_GUESTS (spriteIndex, peep)
     {
-        if (peep->favourite_ride != RIDE_ID_NULL)
+        if (peep->FavouriteRide != RIDE_ID_NULL)
         {
-            auto ride = get_ride(peep->favourite_ride);
+            auto ride = get_ride(peep->FavouriteRide);
             if (ride != nullptr)
             {
                 ride->guests_favourite++;

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -264,7 +264,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(balloon_colour);
     COMPARE_FIELD(umbrella_colour);
     COMPARE_FIELD(hat_colour);
-    COMPARE_FIELD(favourite_ride);
+    COMPARE_FIELD(FavouriteRide);
     COMPARE_FIELD(FavouriteRideRating);
     COMPARE_FIELD(ItemStandardFlags);
 }

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -258,7 +258,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(voucher_type);
     COMPARE_FIELD(voucher_arguments);
     COMPARE_FIELD(surroundings_thought_timeout);
-    COMPARE_FIELD(angriness);
+    COMPARE_FIELD(Angriness);
     COMPARE_FIELD(TimeLost);
     COMPARE_FIELD(DaysInQueue);
     COMPARE_FIELD(BalloonColour);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -263,7 +263,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(days_in_queue);
     COMPARE_FIELD(balloon_colour);
     COMPARE_FIELD(umbrella_colour);
-    COMPARE_FIELD(hat_colour);
+    COMPARE_FIELD(HatColour);
     COMPARE_FIELD(FavouriteRide);
     COMPARE_FIELD(FavouriteRideRating);
     COMPARE_FIELD(ItemStandardFlags);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -260,7 +260,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(surroundings_thought_timeout);
     COMPARE_FIELD(angriness);
     COMPARE_FIELD(time_lost);
-    COMPARE_FIELD(days_in_queue);
+    COMPARE_FIELD(DaysInQueue);
     COMPARE_FIELD(BalloonColour);
     COMPARE_FIELD(UmbrellaColour);
     COMPARE_FIELD(HatColour);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -261,7 +261,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(angriness);
     COMPARE_FIELD(time_lost);
     COMPARE_FIELD(days_in_queue);
-    COMPARE_FIELD(balloon_colour);
+    COMPARE_FIELD(BalloonColour);
     COMPARE_FIELD(UmbrellaColour);
     COMPARE_FIELD(HatColour);
     COMPARE_FIELD(FavouriteRide);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -257,7 +257,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(vandalism_seen);
     COMPARE_FIELD(voucher_type);
     COMPARE_FIELD(voucher_arguments);
-    COMPARE_FIELD(surroundings_thought_timeout);
+    COMPARE_FIELD(SurroundingsThoughtTimeout);
     COMPARE_FIELD(Angriness);
     COMPARE_FIELD(TimeLost);
     COMPARE_FIELD(DaysInQueue);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -266,7 +266,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(hat_colour);
     COMPARE_FIELD(favourite_ride);
     COMPARE_FIELD(favourite_ride_rating);
-    COMPARE_FIELD(item_standard_flags);
+    COMPARE_FIELD(ItemStandardFlags);
 }
 
 static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -265,7 +265,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(umbrella_colour);
     COMPARE_FIELD(hat_colour);
     COMPARE_FIELD(favourite_ride);
-    COMPARE_FIELD(favourite_ride_rating);
+    COMPARE_FIELD(FavouriteRideRating);
     COMPARE_FIELD(ItemStandardFlags);
 }
 

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -259,7 +259,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(voucher_arguments);
     COMPARE_FIELD(surroundings_thought_timeout);
     COMPARE_FIELD(angriness);
-    COMPARE_FIELD(time_lost);
+    COMPARE_FIELD(TimeLost);
     COMPARE_FIELD(DaysInQueue);
     COMPARE_FIELD(BalloonColour);
     COMPARE_FIELD(UmbrellaColour);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -262,7 +262,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(time_lost);
     COMPARE_FIELD(days_in_queue);
     COMPARE_FIELD(balloon_colour);
-    COMPARE_FIELD(umbrella_colour);
+    COMPARE_FIELD(UmbrellaColour);
     COMPARE_FIELD(HatColour);
     COMPARE_FIELD(FavouriteRide);
     COMPARE_FIELD(FavouriteRideRating);


### PR DESCRIPTION
Continues #10653

It might be easier to review on a commit by commit basis