### PR TITLE
Fix peeps leaving shop at upward slope.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.14/objects.zip")
 set(OBJECTS_SHA1 "31a0ed0047b4bdb1428071044130192b3c0a30fa")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.12/replays.zip")
-set(REPLAYS_SHA1 "E85C23FB63AD6C7344AA80779C6CE03FAC2A7100")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.13/replays.zip")
+set(REPLAYS_SHA1 "75598ff319fa18da782e38feb69b65d6d69d1458")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#5451] Guests scream on every descent, no matter how small.
 - Fix: [#6119] Advertising campaign for ride window not updated properly (original bug).
 - Fix: [#7006] Submarine Ride is in the wrong research group.
+- Fix: [#10634] Guests are unable to use uphill paths out of toilets.
 - Fix: [#10876] When removing a path, its guest entry point is not removed.
 - Fix: [#10876] There can be multiple peep spawns on the same location.
 - Fix: [#11002] Rides list shows both red and green light activated.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.14/objects.zip</ObjectsUrl>
     <ObjectsSha1>31a0ed0047b4bdb1428071044130192b3c0a30fa</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.12/replays.zip</ReplaysUrl>
-    <ReplaysSha1>E85C23FB63AD6C7344AA80779C6CE03FAC2A7100</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.13/replays.zip</ReplaysUrl>
+    <ReplaysSha1>75598ff319fa18da782e38feb69b65d6d69d1458</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5113,7 +5113,7 @@ void Guest::UpdateRideShopLeave()
             return;
     }
 
-    SetState(PEEP_STATE_WALKING);
+    SetState(PEEP_STATE_FALLING);
 
     auto ride = get_ride(current_ride);
     if (ride != nullptr)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5113,7 +5113,7 @@ void Guest::UpdateRideShopLeave()
             return;
     }
 
-    // Previously SetState(PEEP_STATE_WALKING) caused Peeps to double-back to exit point of shop
+    //#11758 Previously SetState(PEEP_STATE_WALKING) caused Peeps to double-back to exit point of shop
     SetState(PEEP_STATE_FALLING);
 
     auto ride = get_ride(current_ride);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5113,6 +5113,7 @@ void Guest::UpdateRideShopLeave()
             return;
     }
 
+    // Previously SetState(PEEP_STATE_WALKING) caused Peeps to double-back to exit point of shop
     SetState(PEEP_STATE_FALLING);
 
     auto ride = get_ride(current_ride);


### PR DESCRIPTION
Fix: https://github.com/OpenRCT2/OpenRCT2/issues/10634#event-3273204131

Fix follows logic for peeps exiting rides in UpdateRideLeaveExit().

Originally Peeps, once exiting the shop, would double-back towards the shop before resuming walking. In RCT Classic, Peeps still double-back, but find the sloped path. Not able to verify if issue exists in Vanilla where Peeps get stuck instead of finding path. Either way, this fix prevents Peeps from doubling-back towards the shop.

Included test file. Tests Toilets, First Aid, and Information Kiosk using both slope directions and flat. Use Cheats with Large Tram to fill park. Then execute Max Toilets, Nausea, or Rain. 
[Test_Shop.sv6.zip](https://github.com/OpenRCT2/OpenRCT2/files/4638456/Test_Shop.sv6.zip)
