### PR TITLE
Extend the game action result properties

### DIFF
--- a/src/openrct2/actions/LandRaiseAction.hpp
+++ b/src/openrct2/actions/LandRaiseAction.hpp
@@ -26,7 +26,22 @@
 #include "../world/Surface.h"
 #include "GameAction.h"
 
-DEFINE_GAME_ACTION(LandRaiseAction, GAME_COMMAND_RAISE_LAND, GameActionResult)
+class LandRaiseGameActionResult final : public GameActionResult
+{
+public:
+    LandRaiseGameActionResult()
+        : GameActionResult(GA_ERROR::OK, STR_NONE)
+    {
+    }
+    LandRaiseGameActionResult(GA_ERROR error, rct_string_id message)
+        : GameActionResult(error, STR_CANT_RAISE_LAND_HERE, message)
+    {
+    }
+
+    MapRange Range;
+};
+
+DEFINE_GAME_ACTION(LandRaiseAction, GAME_COMMAND_RAISE_LAND, LandRaiseGameActionResult)
 {
 private:
     CoordsXY _coords;
@@ -42,6 +57,11 @@ public:
         , _range(range)
         , _selectionType(selectionType)
     {
+    }
+
+    const MapRange& GetMapRange() const
+    {
+        return _range;
     }
 
     uint16_t GetActionFlags() const override
@@ -85,6 +105,7 @@ private:
         MapRange validRange = MapRange{ aX, aY, bX, bY };
 
         res->Position = { _coords.x, _coords.y, tile_element_height(_coords) };
+        res->Range = _range;
         res->Expenditure = ExpenditureType::Landscaping;
 
         if (isExecuting)

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -15,6 +15,7 @@
 #    include "../actions/CustomAction.hpp"
 #    include "../actions/GameAction.h"
 #    include "../actions/RideCreateAction.hpp"
+#    include "../actions/LandRaiseAction.hpp"
 #    include "../config/Config.h"
 #    include "../core/File.h"
 #    include "../core/FileScanner.h"
@@ -854,6 +855,25 @@ DukValue ScriptEngine::GameActionResultToDuk(const GameAction& action, const std
         {
             obj.Set("ride", rideCreateResult.rideIndex);
         }
+    }
+
+    if (action.GetType() == GAME_COMMAND_RAISE_LAND)
+    {
+        auto& raiseLandResult = static_cast<LandRaiseGameActionResult&>(*result.get());
+        const MapRange& mapRange = raiseLandResult.Range;
+
+        DukObject range(_context);
+        DukObject leftTop(_context);
+        leftTop.Set("x", mapRange.GetLeft());
+        leftTop.Set("y", mapRange.GetTop());
+        range.Set("leftTop", leftTop.Take());
+
+        DukObject rightBottom(_context);
+        rightBottom.Set("x", mapRange.GetRight());
+        rightBottom.Set("y", mapRange.GetBottom());
+        range.Set("rightBottom", rightBottom.Take());
+
+        obj.Set("range", range.Take());
     }
 
     return obj.Take();


### PR DESCRIPTION
So I've encountered some limitations while developing the territory rights plugin so I am attempting to fill the missing hooks:

- [x] Expose the map range of a raise land action result
