### PR TITLE
Fix JSON object walls with only remap colours 2 and 3

### DIFF
--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -142,6 +142,7 @@ void WallObject::ReadJson(IReadObjectContext* context, const json_t* root)
         if ((_legacyType.wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
             || (_legacyType.wall.flags & WALL_SCENERY_HAS_TERNARY_COLOUR))
         {
+            _legacyType.wall.flags |= WALL_SCENERY_HAS_PRIMARY_COLOUR;
             _legacyType.wall.flags2 |= WALL_SCENERY_2_NO_SELECT_PRIMARY_COLOUR;
         }
     }


### PR DESCRIPTION
This fixes the hack, allowing JSON files laid out in the described manner to actually work properly.
The objects themselves will also need to be updated, but that can be done separately.