### PR TITLE
Fix #11298: Unable to advertise server (500): Retry with ipv4 only

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#10572] Cheat to allow building at invalid heights.
 - Feature: [#11155] Guest entry points can now be removed by clicking them again.
 - Feature: [#11231] Change shortcut window list order to be more intuitive, and split it into logical sections.
+- Feature: [#11298] Custom IP address can now be advertised to the master server to work around IPv6 issues.
 - Feature: [#11306] Path additions are now kept when replacing the path.
 - Feature: [#11320] Support for custom JavaScript plugins.
 - Feature: [#11788] Command to extract images from a .DAT file.

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -386,6 +386,7 @@ namespace Config
             model->default_password = reader->GetString("default_password", "");
             model->stay_connected = reader->GetBoolean("stay_connected", true);
             model->advertise = reader->GetBoolean("advertise", true);
+            model->advertise_address = reader->GetString("advertise_address", "");
             model->maxplayers = reader->GetInt32("maxplayers", 16);
             model->server_name = reader->GetString("server_name", "Server");
             model->server_description = reader->GetString("server_description", "");
@@ -412,6 +413,7 @@ namespace Config
         writer->WriteString("default_password", model->default_password);
         writer->WriteBoolean("stay_connected", model->stay_connected);
         writer->WriteBoolean("advertise", model->advertise);
+        writer->WriteString("advertise_address", model->advertise_address);
         writer->WriteInt32("maxplayers", model->maxplayers);
         writer->WriteString("server_name", model->server_name);
         writer->WriteString("server_description", model->server_description);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -136,6 +136,7 @@ struct NetworkConfiguration
     std::string default_password;
     bool stay_connected;
     bool advertise;
+    std::string advertise_address;
     int32_t maxplayers;
     std::string server_name;
     std::string server_description;

--- a/src/openrct2/core/Http.WinHttp.cpp
+++ b/src/openrct2/core/Http.WinHttp.cpp
@@ -177,10 +177,16 @@ namespace Http
             if (hConnect == nullptr)
                 ThrowWin32Exception("WinHttpConnect");
 
+            auto dwFlags = 0;
+            if (lstrcmpiW(std::wstring(url.lpszScheme, url.dwSchemeLength).c_str(), L"https") == 0)
+            {
+                dwFlags = WINHTTP_FLAG_SECURE;
+            }
+
             auto wVerb = GetVerb(req.method);
             auto wQuery = std::wstring(url.lpszUrlPath, url.dwUrlPathLength);
             hRequest = WinHttpOpenRequest(
-                hConnect, wVerb, wQuery.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+                hConnect, wVerb, wQuery.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, dwFlags);
             if (hRequest == nullptr)
                 ThrowWin32Exception("WinHttpOpenRequest");
 

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -175,6 +175,11 @@ private:
         json_t* body = json_object();
         json_object_set_new(body, "key", json_string(_key.c_str()));
         json_object_set_new(body, "port", json_integer(_port));
+
+        if (!gConfigNetwork.advertise_address.empty())
+        {
+            json_object_set_new(body, "address", json_string(gConfigNetwork.advertise_address.c_str()));
+        }
 
         char* bodyDump = json_dumps(body, JSON_COMPACT);
         request.body = bodyDump;


### PR DESCRIPTION
Add new config option to allow any address to be advertised. This then doesn't rely on the master server retrieving the server IP address via the HTTP request which can often be IPv6 by default.

Also fixes WinHTTP not working with non TLS URLs.