### PR TITLE
Fix #11816: Text overflowing boundary box

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -413,7 +413,7 @@ static void widget_text(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex w
         stringId = STR_STRING;
         formatArgs = &widget->string;
     }
-    gfx_draw_string_left_clipped(dpi, stringId, formatArgs, colour, { l + 1, t }, r - 1);
+    gfx_draw_string_left_clipped(dpi, stringId, formatArgs, colour, { l + 1, t }, r - l);
 }
 
 /**


### PR DESCRIPTION
Fabulous `l` becoming `1` . Damn fonts :X