### PR TITLE
Renames some Peep member variables to prevent shadowing

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1834,7 +1834,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Paid on souvenirs
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->paid_on_souvenirs);
+    set_format_arg(0, money32, peep->PaidOnSouvenirs);
     set_format_arg(4, uint16_t, peep->NoOfSouvenirs);
     if (peep->NoOfSouvenirs != 1)
     {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1808,7 +1808,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Paid on food
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->paid_on_food);
+    set_format_arg(0, money32, peep->PaidOnFood);
     set_format_arg(4, uint16_t, peep->NoOfFood);
     if (peep->NoOfFood != 1)
     {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1955,7 +1955,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
             set_format_arg(0, uint32_t, SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_VOUCHER:
-            switch (peep->voucher_type)
+            switch (peep->VoucherType)
             {
                 case VOUCHER_TYPE_PARK_ENTRY_FREE:
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_PARK_ENTRY_FREE);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1835,8 +1835,8 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Paid on souvenirs
     y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_souvenirs);
-    set_format_arg(4, uint16_t, peep->no_of_souvenirs);
-    if (peep->no_of_souvenirs != 1)
+    set_format_arg(4, uint16_t, peep->NoOfSouvenirs);
+    if (peep->NoOfSouvenirs != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1809,8 +1809,8 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Paid on food
     y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_food);
-    set_format_arg(4, uint16_t, peep->no_of_food);
-    if (peep->no_of_food != 1)
+    set_format_arg(4, uint16_t, peep->NoOfFood);
+    if (peep->NoOfFood != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_FOOD_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1822,8 +1822,8 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Paid on drinks
     y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_drink);
-    set_format_arg(4, uint16_t, peep->no_of_drinks);
-    if (peep->no_of_drinks != 1)
+    set_format_arg(4, uint16_t, peep->NoOfDrinks);
+    if (peep->NoOfDrinks != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_DRINK_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1809,8 +1809,8 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Paid on food
     y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->PaidOnFood);
-    set_format_arg(4, uint16_t, peep->NoOfFood);
-    if (peep->NoOfFood != 1)
+    set_format_arg(4, uint16_t, peep->AmountOfFood);
+    if (peep->AmountOfFood != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_FOOD_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
@@ -1822,8 +1822,8 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Paid on drinks
     y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->paid_on_drink);
-    set_format_arg(4, uint16_t, peep->NoOfDrinks);
-    if (peep->NoOfDrinks != 1)
+    set_format_arg(4, uint16_t, peep->AmountOfDrinks);
+    if (peep->AmountOfDrinks != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_DRINK_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
@@ -1835,8 +1835,8 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Paid on souvenirs
     y += LIST_ROW_HEIGHT;
     set_format_arg(0, money32, peep->PaidOnSouvenirs);
-    set_format_arg(4, uint16_t, peep->NoOfSouvenirs);
-    if (peep->NoOfSouvenirs != 1)
+    set_format_arg(4, uint16_t, peep->AmountOfSouvenirs);
+    if (peep->AmountOfSouvenirs != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1963,7 +1963,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                     set_format_arg(10, const char*, parkName);
                     break;
                 case VOUCHER_TYPE_RIDE_FREE:
-                    ride = get_ride(peep->voucher_arguments);
+                    ride = get_ride(peep->VoucherArguments);
                     if (ride != nullptr)
                     {
                         set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_RIDE_FREE);
@@ -1977,7 +1977,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                     break;
                 case VOUCHER_TYPE_FOOD_OR_DRINK_FREE:
                     set_format_arg(6, rct_string_id, STR_PEEP_INVENTORY_VOUCHER_FOOD_OR_DRINK_FREE);
-                    set_format_arg(8, rct_string_id, ShopItems[peep->voucher_arguments].Naming.Singular);
+                    set_format_arg(8, rct_string_id, ShopItems[peep->VoucherArguments].Naming.Singular);
                     break;
             }
             break;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1795,7 +1795,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Paid on rides
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->paid_on_rides);
+    set_format_arg(0, money32, peep->PaidOnRides);
     set_format_arg(4, uint16_t, peep->no_of_rides);
     if (peep->no_of_rides != 1)
     {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1790,7 +1790,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_fill_rect_inset(dpi, x, y - 6, x + 179, y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
 
     // Paid to enter
-    set_format_arg(0, money32, peep->paid_to_enter);
+    set_format_arg(0, money32, peep->PaidToEnter);
     gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_ENTRANCE_FEE, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     // Paid on rides

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1110,8 +1110,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     switch (peep->staff_type)
     {
         case STAFF_TYPE_HANDYMAN:
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_LAWNS_MOWN, static_cast<void*>(&peep->staff_lawns_mown), COLOUR_BLACK, x, y);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_LAWNS_MOWN, static_cast<void*>(&peep->StaffLawnsMown), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_GARDENS_WATERED, static_cast<void*>(&peep->StaffGardensWatered), COLOUR_BLACK, x, y);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1117,7 +1117,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, STR_STAFF_STAT_GARDENS_WATERED, static_cast<void*>(&peep->staff_gardens_watered), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_LITTER_SWEPT, static_cast<void*>(&peep->staff_litter_swept), COLOUR_BLACK, x, y);
+                dpi, STR_STAFF_STAT_LITTER_SWEPT, static_cast<void*>(&peep->StaffLitterSwept), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_BINS_EMPTIED, static_cast<void*>(&peep->StaffBinsEmptied), COLOUR_BLACK, x, y);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1124,7 +1124,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
             break;
         case STAFF_TYPE_MECHANIC:
             gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_RIDES_INSPECTED, static_cast<void*>(&peep->staff_rides_inspected), COLOUR_BLACK, x, y);
+                dpi, STR_STAFF_STAT_RIDES_INSPECTED, static_cast<void*>(&peep->StaffRidesInspected), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_RIDES_FIXED, static_cast<void*>(&peep->staff_rides_fixed), COLOUR_BLACK, x, y);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1127,7 +1127,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, STR_STAFF_STAT_RIDES_INSPECTED, static_cast<void*>(&peep->StaffRidesInspected), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_RIDES_FIXED, static_cast<void*>(&peep->staff_rides_fixed), COLOUR_BLACK, x, y);
+                dpi, STR_STAFF_STAT_RIDES_FIXED, static_cast<void*>(&peep->StaffRidesFixed), COLOUR_BLACK, x, y);
             break;
     }
 }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1120,7 +1120,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, STR_STAFF_STAT_LITTER_SWEPT, static_cast<void*>(&peep->staff_litter_swept), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_BINS_EMPTIED, static_cast<void*>(&peep->staff_bins_emptied), COLOUR_BLACK, x, y);
+                dpi, STR_STAFF_STAT_BINS_EMPTIED, static_cast<void*>(&peep->StaffBinsEmptied), COLOUR_BLACK, x, y);
             break;
         case STAFF_TYPE_MECHANIC:
             gfx_draw_string_left(

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1114,7 +1114,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, STR_STAFF_STAT_LAWNS_MOWN, static_cast<void*>(&peep->staff_lawns_mown), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_GARDENS_WATERED, static_cast<void*>(&peep->staff_gardens_watered), COLOUR_BLACK, x, y);
+                dpi, STR_STAFF_STAT_GARDENS_WATERED, static_cast<void*>(&peep->StaffGardensWatered), COLOUR_BLACK, x, y);
             y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_LITTER_SWEPT, static_cast<void*>(&peep->StaffLitterSwept), COLOUR_BLACK, x, y);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -299,7 +299,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, paid_on_food);
         COMPARE_FIELD(Peep, paid_on_souvenirs);
         COMPARE_FIELD(Peep, no_of_food);
-        COMPARE_FIELD(Peep, no_of_drinks);
+        COMPARE_FIELD(Peep, NoOfDrinks);
         COMPARE_FIELD(Peep, NoOfSouvenirs);
         COMPARE_FIELD(Peep, VandalismSeen);
         COMPARE_FIELD(Peep, VoucherType);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -297,7 +297,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, paid_to_enter);
         COMPARE_FIELD(Peep, paid_on_rides);
         COMPARE_FIELD(Peep, paid_on_food);
-        COMPARE_FIELD(Peep, paid_on_souvenirs);
+        COMPARE_FIELD(Peep, PaidOnSouvenirs);
         COMPARE_FIELD(Peep, NoOfFood);
         COMPARE_FIELD(Peep, NoOfDrinks);
         COMPARE_FIELD(Peep, NoOfSouvenirs);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -300,7 +300,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, paid_on_souvenirs);
         COMPARE_FIELD(Peep, no_of_food);
         COMPARE_FIELD(Peep, no_of_drinks);
-        COMPARE_FIELD(Peep, no_of_souvenirs);
+        COMPARE_FIELD(Peep, NoOfSouvenirs);
         COMPARE_FIELD(Peep, VandalismSeen);
         COMPARE_FIELD(Peep, VoucherType);
         COMPARE_FIELD(Peep, VoucherArguments);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -303,7 +303,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, no_of_souvenirs);
         COMPARE_FIELD(Peep, vandalism_seen);
         COMPARE_FIELD(Peep, voucher_type);
-        COMPARE_FIELD(Peep, voucher_arguments);
+        COMPARE_FIELD(Peep, VoucherArguments);
         COMPARE_FIELD(Peep, SurroundingsThoughtTimeout);
         COMPARE_FIELD(Peep, Angriness);
         COMPARE_FIELD(Peep, TimeLost);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -298,9 +298,9 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, PaidOnRides);
         COMPARE_FIELD(Peep, PaidOnFood);
         COMPARE_FIELD(Peep, PaidOnSouvenirs);
-        COMPARE_FIELD(Peep, NoOfFood);
-        COMPARE_FIELD(Peep, NoOfDrinks);
-        COMPARE_FIELD(Peep, NoOfSouvenirs);
+        COMPARE_FIELD(Peep, AmountOfFood);
+        COMPARE_FIELD(Peep, AmountOfDrinks);
+        COMPARE_FIELD(Peep, AmountOfSouvenirs);
         COMPARE_FIELD(Peep, VandalismSeen);
         COMPARE_FIELD(Peep, VoucherType);
         COMPARE_FIELD(Peep, VoucherArguments);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -294,7 +294,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, litter_count);
         COMPARE_FIELD(Peep, time_on_ride);
         COMPARE_FIELD(Peep, disgusting_count);
-        COMPARE_FIELD(Peep, paid_to_enter);
+        COMPARE_FIELD(Peep, PaidToEnter);
         COMPARE_FIELD(Peep, PaidOnRides);
         COMPARE_FIELD(Peep, PaidOnFood);
         COMPARE_FIELD(Peep, PaidOnSouvenirs);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -298,7 +298,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, paid_on_rides);
         COMPARE_FIELD(Peep, paid_on_food);
         COMPARE_FIELD(Peep, paid_on_souvenirs);
-        COMPARE_FIELD(Peep, no_of_food);
+        COMPARE_FIELD(Peep, NoOfFood);
         COMPARE_FIELD(Peep, NoOfDrinks);
         COMPARE_FIELD(Peep, NoOfSouvenirs);
         COMPARE_FIELD(Peep, VandalismSeen);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -302,7 +302,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, no_of_drinks);
         COMPARE_FIELD(Peep, no_of_souvenirs);
         COMPARE_FIELD(Peep, vandalism_seen);
-        COMPARE_FIELD(Peep, voucher_type);
+        COMPARE_FIELD(Peep, VoucherType);
         COMPARE_FIELD(Peep, VoucherArguments);
         COMPARE_FIELD(Peep, SurroundingsThoughtTimeout);
         COMPARE_FIELD(Peep, Angriness);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -301,7 +301,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, no_of_food);
         COMPARE_FIELD(Peep, no_of_drinks);
         COMPARE_FIELD(Peep, no_of_souvenirs);
-        COMPARE_FIELD(Peep, vandalism_seen);
+        COMPARE_FIELD(Peep, VandalismSeen);
         COMPARE_FIELD(Peep, VoucherType);
         COMPARE_FIELD(Peep, VoucherArguments);
         COMPARE_FIELD(Peep, SurroundingsThoughtTimeout);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -296,7 +296,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, disgusting_count);
         COMPARE_FIELD(Peep, paid_to_enter);
         COMPARE_FIELD(Peep, paid_on_rides);
-        COMPARE_FIELD(Peep, paid_on_food);
+        COMPARE_FIELD(Peep, PaidOnFood);
         COMPARE_FIELD(Peep, PaidOnSouvenirs);
         COMPARE_FIELD(Peep, NoOfFood);
         COMPARE_FIELD(Peep, NoOfDrinks);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -293,7 +293,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, no_action_frame_num);
         COMPARE_FIELD(Peep, litter_count);
         COMPARE_FIELD(Peep, time_on_ride);
-        COMPARE_FIELD(Peep, disgusting_count);
+        COMPARE_FIELD(Peep, DisgustingCount);
         COMPARE_FIELD(Peep, PaidToEnter);
         COMPARE_FIELD(Peep, PaidOnRides);
         COMPARE_FIELD(Peep, PaidOnFood);

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -295,7 +295,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, time_on_ride);
         COMPARE_FIELD(Peep, disgusting_count);
         COMPARE_FIELD(Peep, paid_to_enter);
-        COMPARE_FIELD(Peep, paid_on_rides);
+        COMPARE_FIELD(Peep, PaidOnRides);
         COMPARE_FIELD(Peep, PaidOnFood);
         COMPARE_FIELD(Peep, PaidOnSouvenirs);
         COMPARE_FIELD(Peep, NoOfFood);

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -178,7 +178,7 @@ private:
             // remove any free voucher for this ride from peep
             if (peep->ItemStandardFlags & PEEP_ITEM_VOUCHER)
             {
-                if (peep->voucher_type == VOUCHER_TYPE_RIDE_FREE && peep->VoucherArguments == _rideIndex)
+                if (peep->VoucherType == VOUCHER_TYPE_RIDE_FREE && peep->VoucherArguments == _rideIndex)
                 {
                     peep->ItemStandardFlags &= ~(PEEP_ITEM_VOUCHER);
                 }

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -178,7 +178,7 @@ private:
             // remove any free voucher for this ride from peep
             if (peep->ItemStandardFlags & PEEP_ITEM_VOUCHER)
             {
-                if (peep->voucher_type == VOUCHER_TYPE_RIDE_FREE && peep->voucher_arguments == _rideIndex)
+                if (peep->voucher_type == VOUCHER_TYPE_RIDE_FREE && peep->VoucherArguments == _rideIndex)
                 {
                     peep->ItemStandardFlags &= ~(PEEP_ITEM_VOUCHER);
                 }

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -172,7 +172,7 @@ private:
             newPeep->paid_to_enter = 0;
             newPeep->paid_on_rides = 0;
             newPeep->paid_on_food = 0;
-            newPeep->paid_on_souvenirs = 0;
+            newPeep->PaidOnSouvenirs = 0;
             newPeep->FavouriteRide = RIDE_ID_NULL;
             newPeep->staff_orders = _staffOrders;
 

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -169,7 +169,7 @@ private:
             newPeep->type = PEEP_TYPE_STAFF;
             newPeep->outside_of_park = 0;
             newPeep->peep_flags = 0;
-            newPeep->paid_to_enter = 0;
+            newPeep->PaidToEnter = 0;
             newPeep->PaidOnRides = 0;
             newPeep->PaidOnFood = 0;
             newPeep->PaidOnSouvenirs = 0;

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -170,7 +170,7 @@ private:
             newPeep->outside_of_park = 0;
             newPeep->peep_flags = 0;
             newPeep->paid_to_enter = 0;
-            newPeep->paid_on_rides = 0;
+            newPeep->PaidOnRides = 0;
             newPeep->PaidOnFood = 0;
             newPeep->PaidOnSouvenirs = 0;
             newPeep->FavouriteRide = RIDE_ID_NULL;

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -171,7 +171,7 @@ private:
             newPeep->peep_flags = 0;
             newPeep->paid_to_enter = 0;
             newPeep->paid_on_rides = 0;
-            newPeep->paid_on_food = 0;
+            newPeep->PaidOnFood = 0;
             newPeep->PaidOnSouvenirs = 0;
             newPeep->FavouriteRide = RIDE_ID_NULL;
             newPeep->staff_orders = _staffOrders;

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -136,22 +136,22 @@ void marketing_set_guest_campaign(Peep* peep, int32_t campaignType)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
             peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
-            peep->voucher_type = VOUCHER_TYPE_PARK_ENTRY_FREE;
+            peep->VoucherType = VOUCHER_TYPE_PARK_ENTRY_FREE;
             break;
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
             peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
-            peep->voucher_type = VOUCHER_TYPE_RIDE_FREE;
+            peep->VoucherType = VOUCHER_TYPE_RIDE_FREE;
             peep->VoucherArguments = campaign->RideId;
             peep->guest_heading_to_ride_id = campaign->RideId;
             peep->peep_is_lost_countdown = 240;
             break;
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
             peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
-            peep->voucher_type = VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE;
+            peep->VoucherType = VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE;
             break;
         case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
             peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
-            peep->voucher_type = VOUCHER_TYPE_FOOD_OR_DRINK_FREE;
+            peep->VoucherType = VOUCHER_TYPE_FOOD_OR_DRINK_FREE;
             peep->VoucherArguments = campaign->ShopItemType;
             break;
         case ADVERTISING_CAMPAIGN_PARK:

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -141,7 +141,7 @@ void marketing_set_guest_campaign(Peep* peep, int32_t campaignType)
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
             peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
             peep->voucher_type = VOUCHER_TYPE_RIDE_FREE;
-            peep->voucher_arguments = campaign->RideId;
+            peep->VoucherArguments = campaign->RideId;
             peep->guest_heading_to_ride_id = campaign->RideId;
             peep->peep_is_lost_countdown = 240;
             break;
@@ -152,7 +152,7 @@ void marketing_set_guest_campaign(Peep* peep, int32_t campaignType)
         case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
             peep->ItemStandardFlags |= PEEP_ITEM_VOUCHER;
             peep->voucher_type = VOUCHER_TYPE_FOOD_OR_DRINK_FREE;
-            peep->voucher_arguments = campaign->ShopItemType;
+            peep->VoucherArguments = campaign->ShopItemType;
             break;
         case ADVERTISING_CAMPAIGN_PARK:
             break;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1696,13 +1696,13 @@ loc_69B221:
     }
 
     if (ShopItems[shopItem].IsFood())
-        NoOfFood++;
+        AmountOfFood++;
 
     if (ShopItems[shopItem].IsDrink())
-        NoOfDrinks++;
+        AmountOfDrinks++;
 
     if (ShopItems[shopItem].IsSouvenir())
-        NoOfSouvenirs++;
+        AmountOfSouvenirs++;
 
     money16* expend_type = &PaidOnSouvenirs;
     ExpenditureType expenditure = ExpenditureType::ShopStock;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -3867,7 +3867,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride* ride)
         {
             ride->total_profit += ridePrice;
             ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME;
-            SpendMoney(paid_on_rides, ridePrice, ExpenditureType::ParkRideTickets);
+            SpendMoney(PaidOnRides, ridePrice, ExpenditureType::ParkRideTickets);
         }
     }
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1699,7 +1699,7 @@ loc_69B221:
         no_of_food++;
 
     if (ShopItems[shopItem].IsDrink())
-        no_of_drinks++;
+        NoOfDrinks++;
 
     if (ShopItems[shopItem].IsSouvenir())
         NoOfSouvenirs++;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -6212,7 +6212,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
         if (peep->state != PEEP_STATE_WALKING)
             return;
 
-        if ((peep->litter_count & 0xC0) != 0xC0 && (peep->disgusting_count & 0xC0) != 0xC0)
+        if ((peep->litter_count & 0xC0) != 0xC0 && (peep->DisgustingCount & 0xC0) != 0xC0)
             return;
 
         if ((scenario_rand() & 0xFFFF) > 3276)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1702,7 +1702,7 @@ loc_69B221:
         no_of_drinks++;
 
     if (ShopItems[shopItem].IsSouvenir())
-        no_of_souvenirs++;
+        NoOfSouvenirs++;
 
     money16* expend_type = &paid_on_souvenirs;
     ExpenditureType expenditure = ExpenditureType::ShopStock;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1481,7 +1481,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
 
     bool hasVoucher = false;
 
-    if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
+    if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
         && (VoucherArguments == shopItem))
     {
         hasVoucher = true;
@@ -2413,7 +2413,7 @@ void Guest::ReadMap()
 
 static bool peep_has_voucher_for_free_ride(Peep* peep, Ride* ride)
 {
-    return peep->ItemStandardFlags & PEEP_ITEM_VOUCHER && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
+    return peep->ItemStandardFlags & PEEP_ITEM_VOUCHER && peep->VoucherType == VOUCHER_TYPE_RIDE_FREE
         && peep->VoucherArguments == ride->id;
 }
 
@@ -2634,7 +2634,7 @@ static void peep_update_ride_at_entrance_try_leave(Guest* peep)
 
 static bool peep_check_ride_price_at_entrance(Guest* peep, Ride* ride, money32 ridePrice)
 {
-    if ((peep->ItemStandardFlags & PEEP_ITEM_VOUCHER) && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
+    if ((peep->ItemStandardFlags & PEEP_ITEM_VOUCHER) && peep->VoucherType == VOUCHER_TYPE_RIDE_FREE
         && peep->VoucherArguments == peep->current_ride)
         return true;
 
@@ -3857,7 +3857,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride* ride)
     money16 ridePrice = ride_get_price(ride);
     if (ridePrice != 0)
     {
-        if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_RIDE_FREE)
+        if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (VoucherType == VOUCHER_TYPE_RIDE_FREE)
             && (VoucherArguments == current_ride))
         {
             ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1482,7 +1482,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
     bool hasVoucher = false;
 
     if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
-        && (voucher_arguments == shopItem))
+        && (VoucherArguments == shopItem))
     {
         hasVoucher = true;
     }
@@ -2414,7 +2414,7 @@ void Guest::ReadMap()
 static bool peep_has_voucher_for_free_ride(Peep* peep, Ride* ride)
 {
     return peep->ItemStandardFlags & PEEP_ITEM_VOUCHER && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
-        && peep->voucher_arguments == ride->id;
+        && peep->VoucherArguments == ride->id;
 }
 
 /**
@@ -2635,7 +2635,7 @@ static void peep_update_ride_at_entrance_try_leave(Guest* peep)
 static bool peep_check_ride_price_at_entrance(Guest* peep, Ride* ride, money32 ridePrice)
 {
     if ((peep->ItemStandardFlags & PEEP_ITEM_VOUCHER) && peep->voucher_type == VOUCHER_TYPE_RIDE_FREE
-        && peep->voucher_arguments == peep->current_ride)
+        && peep->VoucherArguments == peep->current_ride)
         return true;
 
     if (peep->cash_in_pocket <= 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -3858,7 +3858,7 @@ void Guest::UpdateRideFreeVehicleEnterRide(Ride* ride)
     if (ridePrice != 0)
     {
         if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (voucher_type == VOUCHER_TYPE_RIDE_FREE)
-            && (voucher_arguments == current_ride))
+            && (VoucherArguments == current_ride))
         {
             ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;
             window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1704,7 +1704,7 @@ loc_69B221:
     if (ShopItems[shopItem].IsSouvenir())
         NoOfSouvenirs++;
 
-    money16* expend_type = &paid_on_souvenirs;
+    money16* expend_type = &PaidOnSouvenirs;
     ExpenditureType expenditure = ExpenditureType::ShopStock;
 
     if (ShopItems[shopItem].IsFood())

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1709,7 +1709,7 @@ loc_69B221:
 
     if (ShopItems[shopItem].IsFood())
     {
-        expend_type = &paid_on_food;
+        expend_type = &PaidOnFood;
         expenditure = ExpenditureType::FoodDrinkStock;
     }
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1696,7 +1696,7 @@ loc_69B221:
     }
 
     if (ShopItems[shopItem].IsFood())
-        no_of_food++;
+        NoOfFood++;
 
     if (ShopItems[shopItem].IsDrink())
         NoOfDrinks++;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1770,7 +1770,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->paid_on_drink = 0;
     peep->paid_on_souvenirs = 0;
     peep->no_of_food = 0;
-    peep->no_of_drinks = 0;
+    peep->NoOfDrinks = 0;
     peep->NoOfSouvenirs = 0;
     peep->SurroundingsThoughtTimeout = 0;
     peep->Angriness = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1769,7 +1769,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->paid_on_food = 0;
     peep->paid_on_drink = 0;
     peep->paid_on_souvenirs = 0;
-    peep->no_of_food = 0;
+    peep->NoOfFood = 0;
     peep->NoOfDrinks = 0;
     peep->NoOfSouvenirs = 0;
     peep->SurroundingsThoughtTimeout = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1768,7 +1768,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->paid_on_rides = 0;
     peep->paid_on_food = 0;
     peep->paid_on_drink = 0;
-    peep->paid_on_souvenirs = 0;
+    peep->PaidOnSouvenirs = 0;
     peep->NoOfFood = 0;
     peep->NoOfDrinks = 0;
     peep->NoOfSouvenirs = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2603,13 +2603,13 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
         {
             if (peep->ItemStandardFlags & PEEP_ITEM_VOUCHER)
             {
-                if (peep->voucher_type == VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE)
+                if (peep->VoucherType == VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE)
                 {
                     entranceFee /= 2;
                     peep->ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;
                     peep->window_invalidate_flags |= PEEP_INVALIDATE_PEEP_INVENTORY;
                 }
-                else if (peep->voucher_type == VOUCHER_TYPE_PARK_ENTRY_FREE)
+                else if (peep->VoucherType == VOUCHER_TYPE_PARK_ENTRY_FREE)
                 {
                     entranceFee = 0;
                     peep->ItemStandardFlags &= ~PEEP_ITEM_VOUCHER;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1765,7 +1765,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->disgusting_count = 0;
     peep->VandalismSeen = 0;
     peep->paid_to_enter = 0;
-    peep->paid_on_rides = 0;
+    peep->PaidOnRides = 0;
     peep->PaidOnFood = 0;
     peep->paid_on_drink = 0;
     peep->PaidOnSouvenirs = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1764,7 +1764,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->litter_count = 0;
     peep->disgusting_count = 0;
     peep->VandalismSeen = 0;
-    peep->paid_to_enter = 0;
+    peep->PaidToEnter = 0;
     peep->PaidOnRides = 0;
     peep->PaidOnFood = 0;
     peep->paid_on_drink = 0;
@@ -2627,7 +2627,7 @@ static void peep_interact_with_entrance(Peep* peep, int16_t x, int16_t y, TileEl
             }
 
             gTotalIncomeFromAdmissions += entranceFee;
-            guest->SpendMoney(peep->paid_to_enter, entranceFee, ExpenditureType::ParkEntranceTickets);
+            guest->SpendMoney(peep->PaidToEnter, entranceFee, ExpenditureType::ParkEntranceTickets);
             peep->peep_flags |= PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY;
         }
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1766,7 +1766,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->VandalismSeen = 0;
     peep->paid_to_enter = 0;
     peep->paid_on_rides = 0;
-    peep->paid_on_food = 0;
+    peep->PaidOnFood = 0;
     peep->paid_on_drink = 0;
     peep->PaidOnSouvenirs = 0;
     peep->NoOfFood = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1763,7 +1763,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->guest_heading_to_ride_id = RIDE_ID_NULL;
     peep->litter_count = 0;
     peep->disgusting_count = 0;
-    peep->vandalism_seen = 0;
+    peep->VandalismSeen = 0;
     peep->paid_to_enter = 0;
     peep->paid_on_rides = 0;
     peep->paid_on_food = 0;
@@ -2659,9 +2659,9 @@ static void peep_footpath_move_forward(Peep* peep, int16_t x, int16_t y, TileEle
         return;
     }
 
-    uint8_t vandalThoughtTimeout = (peep->vandalism_seen & 0xC0) >> 6;
+    uint8_t vandalThoughtTimeout = (peep->VandalismSeen & 0xC0) >> 6;
     // Advance the vandalised tiles by 1
-    uint8_t vandalisedTiles = (peep->vandalism_seen * 2) & 0x3F;
+    uint8_t vandalisedTiles = (peep->VandalismSeen * 2) & 0x3F;
 
     if (vandalism)
     {
@@ -2684,7 +2684,7 @@ static void peep_footpath_move_forward(Peep* peep, int16_t x, int16_t y, TileEle
         vandalThoughtTimeout--;
     }
 
-    peep->vandalism_seen = (vandalThoughtTimeout << 6) | vandalisedTiles;
+    peep->VandalismSeen = (vandalThoughtTimeout << 6) | vandalisedTiles;
     uint16_t crowded = 0;
     uint8_t litter_count = 0;
     uint8_t sick_count = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1769,9 +1769,9 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->PaidOnFood = 0;
     peep->paid_on_drink = 0;
     peep->PaidOnSouvenirs = 0;
-    peep->NoOfFood = 0;
-    peep->NoOfDrinks = 0;
-    peep->NoOfSouvenirs = 0;
+    peep->AmountOfFood = 0;
+    peep->AmountOfDrinks = 0;
+    peep->AmountOfSouvenirs = 0;
     peep->SurroundingsThoughtTimeout = 0;
     peep->Angriness = 0;
     peep->TimeLost = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1762,7 +1762,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->item_extra_flags = 0;
     peep->guest_heading_to_ride_id = RIDE_ID_NULL;
     peep->litter_count = 0;
-    peep->disgusting_count = 0;
+    peep->DisgustingCount = 0;
     peep->VandalismSeen = 0;
     peep->PaidToEnter = 0;
     peep->PaidOnRides = 0;
@@ -2727,14 +2727,14 @@ static void peep_footpath_move_forward(Peep* peep, int16_t x, int16_t y, TileEle
     litter_count = std::min(static_cast<uint8_t>(3), litter_count);
     sick_count = std::min(static_cast<uint8_t>(3), sick_count);
 
-    uint8_t disgusting_time = peep->disgusting_count & 0xC0;
-    uint8_t disgusting_count = ((peep->disgusting_count & 0xF) << 2) | sick_count;
-    peep->disgusting_count = disgusting_count | disgusting_time;
+    uint8_t disgusting_time = peep->DisgustingCount & 0xC0;
+    uint8_t disgusting_count = ((peep->DisgustingCount & 0xF) << 2) | sick_count;
+    peep->DisgustingCount = disgusting_count | disgusting_time;
 
     if (disgusting_time & 0xC0 && (scenario_rand() & 0xFFFF) <= 4369)
     {
         // Reduce the disgusting time
-        peep->disgusting_count -= 0x40;
+        peep->DisgustingCount -= 0x40;
     }
     else
     {
@@ -2749,7 +2749,7 @@ static void peep_footpath_move_forward(Peep* peep, int16_t x, int16_t y, TileEle
             peep->InsertNewThought(PEEP_THOUGHT_TYPE_PATH_DISGUSTING, PEEP_THOUGHT_ITEM_NONE);
             peep->happiness_target = std::max(0, peep->happiness_target - 17);
             // Reset disgusting time
-            peep->disgusting_count |= 0xC0;
+            peep->DisgustingCount |= 0xC0;
         }
     }
 

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1771,7 +1771,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
     peep->paid_on_souvenirs = 0;
     peep->no_of_food = 0;
     peep->no_of_drinks = 0;
-    peep->no_of_souvenirs = 0;
+    peep->NoOfSouvenirs = 0;
     peep->SurroundingsThoughtTimeout = 0;
     peep->Angriness = 0;
     peep->TimeLost = 0;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -714,7 +714,7 @@ struct Peep : SpriteBase
     {
         money16 paid_to_enter;
         uint16_t staff_lawns_mown;
-        uint16_t staff_rides_fixed;
+        uint16_t StaffRidesFixed;
     };
     union
     {

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -724,7 +724,7 @@ struct Peep : SpriteBase
     };
     union
     {
-        money16 paid_on_food;
+        money16 PaidOnFood;
         uint16_t StaffLitterSwept;
     };
     union

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -732,7 +732,7 @@ struct Peep : SpriteBase
         money16 paid_on_souvenirs;
         uint16_t staff_bins_emptied;
     };
-    uint8_t no_of_food;
+    uint8_t NoOfFood;
     uint8_t NoOfDrinks;
     uint8_t NoOfSouvenirs;
     uint8_t VandalismSeen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -734,7 +734,7 @@ struct Peep : SpriteBase
     };
     uint8_t no_of_food;
     uint8_t no_of_drinks;
-    uint8_t no_of_souvenirs;
+    uint8_t NoOfSouvenirs;
     uint8_t VandalismSeen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
     uint8_t VoucherType;
     uint8_t VoucherArguments; // ride_id or string_offset_id

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -713,7 +713,7 @@ struct Peep : SpriteBase
     union
     {
         money16 paid_to_enter;
-        uint16_t staff_lawns_mown;
+        uint16_t StaffLawnsMown;
         uint16_t StaffRidesFixed;
     };
     union

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -712,7 +712,7 @@ struct Peep : SpriteBase
     uint8_t disgusting_count;
     union
     {
-        money16 paid_to_enter;
+        money16 PaidToEnter;
         uint16_t StaffLawnsMown;
         uint16_t StaffRidesFixed;
     };

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -730,7 +730,7 @@ struct Peep : SpriteBase
     union
     {
         money16 paid_on_souvenirs;
-        uint16_t staff_bins_emptied;
+        uint16_t StaffBinsEmptied;
     };
     uint8_t NoOfFood;
     uint8_t NoOfDrinks;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -720,7 +720,7 @@ struct Peep : SpriteBase
     {
         money16 paid_on_rides;
         uint16_t staff_gardens_watered;
-        uint16_t staff_rides_inspected;
+        uint16_t StaffRidesInspected;
     };
     union
     {

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -725,7 +725,7 @@ struct Peep : SpriteBase
     union
     {
         money16 paid_on_food;
-        uint16_t staff_litter_swept;
+        uint16_t StaffLitterSwept;
     };
     union
     {

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -733,7 +733,7 @@ struct Peep : SpriteBase
         uint16_t staff_bins_emptied;
     };
     uint8_t no_of_food;
-    uint8_t no_of_drinks;
+    uint8_t NoOfDrinks;
     uint8_t NoOfSouvenirs;
     uint8_t VandalismSeen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
     uint8_t VoucherType;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -729,7 +729,7 @@ struct Peep : SpriteBase
     };
     union
     {
-        money16 paid_on_souvenirs;
+        money16 PaidOnSouvenirs;
         uint16_t StaffBinsEmptied;
     };
     uint8_t NoOfFood;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -718,7 +718,7 @@ struct Peep : SpriteBase
     };
     union
     {
-        money16 paid_on_rides;
+        money16 PaidOnRides;
         uint16_t StaffGardensWatered;
         uint16_t StaffRidesInspected;
     };

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -735,7 +735,7 @@ struct Peep : SpriteBase
     uint8_t no_of_food;
     uint8_t no_of_drinks;
     uint8_t no_of_souvenirs;
-    uint8_t vandalism_seen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
+    uint8_t VandalismSeen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
     uint8_t VoucherType;
     uint8_t VoucherArguments; // ride_id or string_offset_id
     uint8_t SurroundingsThoughtTimeout;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -737,7 +737,7 @@ struct Peep : SpriteBase
     uint8_t no_of_souvenirs;
     uint8_t vandalism_seen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
     uint8_t voucher_type;
-    uint8_t voucher_arguments; // ride_id or string_offset_id
+    uint8_t VoucherArguments; // ride_id or string_offset_id
     uint8_t SurroundingsThoughtTimeout;
     uint8_t Angriness;
     uint8_t TimeLost; // the time the peep has been lost when it reaches 254 generates the lost thought

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -709,7 +709,7 @@ struct Peep : SpriteBase
         uint8_t staff_mowing_timeout;
     };
     // 0x3F Sick Count split into lots of 3 with time, 0xC0 Time since last recalc
-    uint8_t disgusting_count;
+    uint8_t DisgustingCount;
     union
     {
         money16 PaidToEnter;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -732,9 +732,9 @@ struct Peep : SpriteBase
         money16 PaidOnSouvenirs;
         uint16_t StaffBinsEmptied;
     };
-    uint8_t NoOfFood;
-    uint8_t NoOfDrinks;
-    uint8_t NoOfSouvenirs;
+    uint8_t AmountOfFood;
+    uint8_t AmountOfDrinks;
+    uint8_t AmountOfSouvenirs;
     uint8_t VandalismSeen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
     uint8_t VoucherType;
     uint8_t VoucherArguments; // ride_id or string_offset_id

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -736,7 +736,7 @@ struct Peep : SpriteBase
     uint8_t no_of_drinks;
     uint8_t no_of_souvenirs;
     uint8_t vandalism_seen; // 0xC0 vandalism thought timeout, 0x3F vandalism tiles seen
-    uint8_t voucher_type;
+    uint8_t VoucherType;
     uint8_t VoucherArguments; // ride_id or string_offset_id
     uint8_t SurroundingsThoughtTimeout;
     uint8_t Angriness;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -719,7 +719,7 @@ struct Peep : SpriteBase
     union
     {
         money16 paid_on_rides;
-        uint16_t staff_gardens_watered;
+        uint16_t StaffGardensWatered;
         uint16_t StaffRidesInspected;
     };
     union

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -372,7 +372,7 @@ void staff_reset_stats()
         peep->staff_gardens_watered = 0;
         peep->staff_rides_inspected = 0;
         peep->staff_litter_swept = 0;
-        peep->staff_bins_emptied = 0;
+        peep->StaffBinsEmptied = 0;
     }
 }
 
@@ -1375,7 +1375,7 @@ void Staff::UpdateEmptyingBin()
         tile_element->AsPath()->SetAdditionStatus(additionStatus);
 
         map_invalidate_tile_zoom0({ NextLoc, tile_element->GetBaseZ(), tile_element->GetClearanceZ() });
-        staff_bins_emptied++;
+        StaffBinsEmptied++;
         window_invalidate_flags |= PEEP_INVALIDATE_STAFF_STATS;
     }
 }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -368,7 +368,7 @@ void staff_reset_stats()
     {
         peep->time_in_park = gDateMonthsElapsed;
         peep->staff_lawns_mown = 0;
-        peep->staff_rides_fixed = 0;
+        peep->StaffRidesFixed = 0;
         peep->StaffGardensWatered = 0;
         peep->StaffRidesInspected = 0;
         peep->StaffLitterSwept = 0;
@@ -2636,7 +2636,7 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride* r
             return true;
         }
 
-        staff_rides_fixed++;
+        StaffRidesFixed++;
         window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
         sprite_direction = direction << 3;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -367,7 +367,7 @@ void staff_reset_stats()
     FOR_ALL_STAFF (spriteIndex, peep)
     {
         peep->time_in_park = gDateMonthsElapsed;
-        peep->staff_lawns_mown = 0;
+        peep->StaffLawnsMown = 0;
         peep->StaffRidesFixed = 0;
         peep->StaffGardensWatered = 0;
         peep->StaffRidesInspected = 0;
@@ -1231,7 +1231,7 @@ void Staff::UpdateMowing()
             surfaceElement->SetGrassLength(GRASS_LENGTH_MOWED);
             map_invalidate_tile_zoom0({ NextLoc, surfaceElement->GetBaseZ(), surfaceElement->GetBaseZ() + 16 });
         }
-        staff_lawns_mown++;
+        StaffLawnsMown++;
         window_invalidate_flags |= PEEP_INVALIDATE_STAFF_STATS;
     }
 }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -371,7 +371,7 @@ void staff_reset_stats()
         peep->staff_rides_fixed = 0;
         peep->staff_gardens_watered = 0;
         peep->staff_rides_inspected = 0;
-        peep->staff_litter_swept = 0;
+        peep->StaffLitterSwept = 0;
         peep->StaffBinsEmptied = 0;
     }
 }
@@ -1394,7 +1394,7 @@ void Staff::UpdateSweeping()
     {
         // Remove sick at this location
         litter_remove_at(x, y, z);
-        staff_litter_swept++;
+        StaffLitterSwept++;
         window_invalidate_flags |= PEEP_INVALIDATE_STAFF_STATS;
     }
     if (auto loc = UpdateAction())

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -370,7 +370,7 @@ void staff_reset_stats()
         peep->staff_lawns_mown = 0;
         peep->staff_rides_fixed = 0;
         peep->staff_gardens_watered = 0;
-        peep->staff_rides_inspected = 0;
+        peep->StaffRidesInspected = 0;
         peep->StaffLitterSwept = 0;
         peep->StaffBinsEmptied = 0;
     }
@@ -2630,7 +2630,7 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride* r
         {
             UpdateRideInspected(current_ride);
 
-            staff_rides_inspected++;
+            StaffRidesInspected++;
             window_invalidate_flags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
             return true;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -369,7 +369,7 @@ void staff_reset_stats()
         peep->time_in_park = gDateMonthsElapsed;
         peep->staff_lawns_mown = 0;
         peep->staff_rides_fixed = 0;
-        peep->staff_gardens_watered = 0;
+        peep->StaffGardensWatered = 0;
         peep->StaffRidesInspected = 0;
         peep->StaffLitterSwept = 0;
         peep->StaffBinsEmptied = 0;
@@ -1291,7 +1291,7 @@ void Staff::UpdateWatering()
 
             tile_element->AsSmallScenery()->SetAge(0);
             map_invalidate_tile_zoom0({ actionLoc, tile_element->GetBaseZ(), tile_element->GetClearanceZ() });
-            staff_gardens_watered++;
+            StaffGardensWatered++;
             window_invalidate_flags |= PEEP_INVALIDATE_STAFF_STATS;
         } while (!(tile_element++)->IsLastForTile());
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1494,7 +1494,7 @@ private:
         dst->paid_on_food = src->paid_on_food;
         dst->paid_on_souvenirs = src->paid_on_souvenirs;
 
-        dst->voucher_arguments = src->voucher_arguments;
+        dst->VoucherArguments = src->voucher_arguments;
         dst->voucher_type = src->voucher_type;
 
         dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1489,7 +1489,7 @@ private:
         dst->NoOfSouvenirs = src->no_of_souvenirs;
 
         dst->paid_to_enter = src->paid_to_enter;
-        dst->paid_on_rides = src->paid_on_rides;
+        dst->PaidOnRides = src->paid_on_rides;
         dst->paid_on_drink = src->paid_on_drink;
         dst->PaidOnFood = src->paid_on_food;
         dst->PaidOnSouvenirs = src->paid_on_souvenirs;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1495,7 +1495,7 @@ private:
         dst->paid_on_souvenirs = src->paid_on_souvenirs;
 
         dst->VoucherArguments = src->voucher_arguments;
-        dst->voucher_type = src->voucher_type;
+        dst->VoucherType = src->voucher_type;
 
         dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
         dst->Angriness = src->angriness;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1491,7 +1491,7 @@ private:
         dst->paid_to_enter = src->paid_to_enter;
         dst->paid_on_rides = src->paid_on_rides;
         dst->paid_on_drink = src->paid_on_drink;
-        dst->paid_on_food = src->paid_on_food;
+        dst->PaidOnFood = src->paid_on_food;
         dst->PaidOnSouvenirs = src->paid_on_souvenirs;
 
         dst->VoucherArguments = src->voucher_arguments;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1484,7 +1484,7 @@ private:
         // This doubles as staff type
         dst->no_of_rides = src->no_of_rides;
 
-        dst->no_of_drinks = src->no_of_drinks;
+        dst->NoOfDrinks = src->no_of_drinks;
         dst->no_of_food = src->no_of_food;
         dst->NoOfSouvenirs = src->no_of_souvenirs;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1485,7 +1485,7 @@ private:
         dst->no_of_rides = src->no_of_rides;
 
         dst->NoOfDrinks = src->no_of_drinks;
-        dst->no_of_food = src->no_of_food;
+        dst->NoOfFood = src->no_of_food;
         dst->NoOfSouvenirs = src->no_of_souvenirs;
 
         dst->paid_to_enter = src->paid_to_enter;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1486,7 +1486,7 @@ private:
 
         dst->no_of_drinks = src->no_of_drinks;
         dst->no_of_food = src->no_of_food;
-        dst->no_of_souvenirs = src->no_of_souvenirs;
+        dst->NoOfSouvenirs = src->no_of_souvenirs;
 
         dst->paid_to_enter = src->paid_to_enter;
         dst->paid_on_rides = src->paid_on_rides;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1492,7 +1492,7 @@ private:
         dst->paid_on_rides = src->paid_on_rides;
         dst->paid_on_drink = src->paid_on_drink;
         dst->paid_on_food = src->paid_on_food;
-        dst->paid_on_souvenirs = src->paid_on_souvenirs;
+        dst->PaidOnSouvenirs = src->paid_on_souvenirs;
 
         dst->VoucherArguments = src->voucher_arguments;
         dst->VoucherType = src->voucher_type;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1484,9 +1484,9 @@ private:
         // This doubles as staff type
         dst->no_of_rides = src->no_of_rides;
 
-        dst->NoOfDrinks = src->no_of_drinks;
-        dst->NoOfFood = src->no_of_food;
-        dst->NoOfSouvenirs = src->no_of_souvenirs;
+        dst->AmountOfDrinks = src->no_of_drinks;
+        dst->AmountOfFood = src->no_of_food;
+        dst->AmountOfSouvenirs = src->no_of_souvenirs;
 
         dst->PaidToEnter = src->paid_to_enter;
         dst->PaidOnRides = src->paid_on_rides;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1488,7 +1488,7 @@ private:
         dst->NoOfFood = src->no_of_food;
         dst->NoOfSouvenirs = src->no_of_souvenirs;
 
-        dst->paid_to_enter = src->paid_to_enter;
+        dst->PaidToEnter = src->paid_to_enter;
         dst->PaidOnRides = src->paid_on_rides;
         dst->paid_on_drink = src->paid_on_drink;
         dst->PaidOnFood = src->paid_on_food;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1460,7 +1460,7 @@ private:
         dst->mass = src->mass;
 
         dst->litter_count = src->litter_count;
-        dst->disgusting_count = src->disgusting_count;
+        dst->DisgustingCount = src->disgusting_count;
 
         dst->intensity = static_cast<IntensityRange>(src->intensity);
         dst->nausea_tolerance = src->nausea_tolerance;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1424,7 +1424,7 @@ private:
         dst->var_37 = src->var_37;
         dst->time_to_consume = src->time_to_consume;
         dst->step_progress = src->step_progress;
-        dst->vandalism_seen = src->vandalism_seen;
+        dst->VandalismSeen = src->vandalism_seen;
 
         dst->type = static_cast<PeepType>(src->type);
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1230,7 +1230,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->no_of_souvenirs = src->no_of_souvenirs;
     dst->vandalism_seen = src->vandalism_seen;
     dst->voucher_type = src->voucher_type;
-    dst->voucher_arguments = src->voucher_arguments;
+    dst->voucher_arguments = src->VoucherArguments;
     dst->surroundings_thought_timeout = src->SurroundingsThoughtTimeout;
     dst->angriness = src->Angriness;
     dst->time_lost = src->TimeLost;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1227,7 +1227,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->paid_on_souvenirs = src->paid_on_souvenirs;
     dst->no_of_food = src->no_of_food;
     dst->no_of_drinks = src->no_of_drinks;
-    dst->no_of_souvenirs = src->no_of_souvenirs;
+    dst->no_of_souvenirs = src->NoOfSouvenirs;
     dst->vandalism_seen = src->VandalismSeen;
     dst->voucher_type = src->VoucherType;
     dst->voucher_arguments = src->VoucherArguments;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1229,7 +1229,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->no_of_drinks = src->no_of_drinks;
     dst->no_of_souvenirs = src->no_of_souvenirs;
     dst->vandalism_seen = src->vandalism_seen;
-    dst->voucher_type = src->voucher_type;
+    dst->voucher_type = src->VoucherType;
     dst->voucher_arguments = src->VoucherArguments;
     dst->surroundings_thought_timeout = src->SurroundingsThoughtTimeout;
     dst->angriness = src->Angriness;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1223,7 +1223,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->disgusting_count = src->disgusting_count;
     dst->paid_to_enter = src->paid_to_enter;
     dst->paid_on_rides = src->paid_on_rides;
-    dst->paid_on_food = src->paid_on_food;
+    dst->paid_on_food = src->PaidOnFood;
     dst->paid_on_souvenirs = src->PaidOnSouvenirs;
     dst->no_of_food = src->NoOfFood;
     dst->no_of_drinks = src->NoOfDrinks;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1220,7 +1220,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->no_action_frame_num = src->no_action_frame_num;
     dst->litter_count = src->litter_count;
     dst->time_on_ride = src->time_on_ride;
-    dst->disgusting_count = src->disgusting_count;
+    dst->disgusting_count = src->DisgustingCount;
     dst->paid_to_enter = src->PaidToEnter;
     dst->paid_on_rides = src->PaidOnRides;
     dst->paid_on_food = src->PaidOnFood;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1222,7 +1222,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->time_on_ride = src->time_on_ride;
     dst->disgusting_count = src->disgusting_count;
     dst->paid_to_enter = src->paid_to_enter;
-    dst->paid_on_rides = src->paid_on_rides;
+    dst->paid_on_rides = src->PaidOnRides;
     dst->paid_on_food = src->PaidOnFood;
     dst->paid_on_souvenirs = src->PaidOnSouvenirs;
     dst->no_of_food = src->NoOfFood;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1224,7 +1224,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->paid_to_enter = src->paid_to_enter;
     dst->paid_on_rides = src->paid_on_rides;
     dst->paid_on_food = src->paid_on_food;
-    dst->paid_on_souvenirs = src->paid_on_souvenirs;
+    dst->paid_on_souvenirs = src->PaidOnSouvenirs;
     dst->no_of_food = src->NoOfFood;
     dst->no_of_drinks = src->NoOfDrinks;
     dst->no_of_souvenirs = src->NoOfSouvenirs;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1225,7 +1225,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->paid_on_rides = src->paid_on_rides;
     dst->paid_on_food = src->paid_on_food;
     dst->paid_on_souvenirs = src->paid_on_souvenirs;
-    dst->no_of_food = src->no_of_food;
+    dst->no_of_food = src->NoOfFood;
     dst->no_of_drinks = src->NoOfDrinks;
     dst->no_of_souvenirs = src->NoOfSouvenirs;
     dst->vandalism_seen = src->VandalismSeen;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1221,7 +1221,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->litter_count = src->litter_count;
     dst->time_on_ride = src->time_on_ride;
     dst->disgusting_count = src->disgusting_count;
-    dst->paid_to_enter = src->paid_to_enter;
+    dst->paid_to_enter = src->PaidToEnter;
     dst->paid_on_rides = src->PaidOnRides;
     dst->paid_on_food = src->PaidOnFood;
     dst->paid_on_souvenirs = src->PaidOnSouvenirs;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1226,7 +1226,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->paid_on_food = src->paid_on_food;
     dst->paid_on_souvenirs = src->paid_on_souvenirs;
     dst->no_of_food = src->no_of_food;
-    dst->no_of_drinks = src->no_of_drinks;
+    dst->no_of_drinks = src->NoOfDrinks;
     dst->no_of_souvenirs = src->NoOfSouvenirs;
     dst->vandalism_seen = src->VandalismSeen;
     dst->voucher_type = src->VoucherType;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1228,7 +1228,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->no_of_food = src->no_of_food;
     dst->no_of_drinks = src->no_of_drinks;
     dst->no_of_souvenirs = src->no_of_souvenirs;
-    dst->vandalism_seen = src->vandalism_seen;
+    dst->vandalism_seen = src->VandalismSeen;
     dst->voucher_type = src->VoucherType;
     dst->voucher_arguments = src->VoucherArguments;
     dst->surroundings_thought_timeout = src->SurroundingsThoughtTimeout;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1225,9 +1225,9 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->paid_on_rides = src->PaidOnRides;
     dst->paid_on_food = src->PaidOnFood;
     dst->paid_on_souvenirs = src->PaidOnSouvenirs;
-    dst->no_of_food = src->NoOfFood;
-    dst->no_of_drinks = src->NoOfDrinks;
-    dst->no_of_souvenirs = src->NoOfSouvenirs;
+    dst->no_of_food = src->AmountOfFood;
+    dst->no_of_drinks = src->AmountOfDrinks;
+    dst->no_of_souvenirs = src->AmountOfSouvenirs;
     dst->vandalism_seen = src->VandalismSeen;
     dst->voucher_type = src->VoucherType;
     dst->voucher_arguments = src->VoucherArguments;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1495,7 +1495,7 @@ public:
         dst->no_of_souvenirs = src->no_of_souvenirs;
         dst->vandalism_seen = src->vandalism_seen;
         dst->voucher_type = src->voucher_type;
-        dst->voucher_arguments = src->voucher_arguments;
+        dst->VoucherArguments = src->voucher_arguments;
         dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
         dst->Angriness = src->angriness;
         dst->TimeLost = src->time_lost;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1492,7 +1492,7 @@ public:
         dst->paid_on_souvenirs = src->paid_on_souvenirs;
         dst->no_of_food = src->no_of_food;
         dst->no_of_drinks = src->no_of_drinks;
-        dst->no_of_souvenirs = src->no_of_souvenirs;
+        dst->NoOfSouvenirs = src->no_of_souvenirs;
         dst->VandalismSeen = src->vandalism_seen;
         dst->VoucherType = src->voucher_type;
         dst->VoucherArguments = src->voucher_arguments;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1490,7 +1490,7 @@ public:
         dst->paid_on_rides = src->paid_on_rides;
         dst->paid_on_food = src->paid_on_food;
         dst->paid_on_souvenirs = src->paid_on_souvenirs;
-        dst->no_of_food = src->no_of_food;
+        dst->NoOfFood = src->no_of_food;
         dst->NoOfDrinks = src->no_of_drinks;
         dst->NoOfSouvenirs = src->no_of_souvenirs;
         dst->VandalismSeen = src->vandalism_seen;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1490,9 +1490,9 @@ public:
         dst->PaidOnRides = src->paid_on_rides;
         dst->PaidOnFood = src->paid_on_food;
         dst->PaidOnSouvenirs = src->paid_on_souvenirs;
-        dst->NoOfFood = src->no_of_food;
-        dst->NoOfDrinks = src->no_of_drinks;
-        dst->NoOfSouvenirs = src->no_of_souvenirs;
+        dst->AmountOfFood = src->no_of_food;
+        dst->AmountOfDrinks = src->no_of_drinks;
+        dst->AmountOfSouvenirs = src->no_of_souvenirs;
         dst->VandalismSeen = src->vandalism_seen;
         dst->VoucherType = src->voucher_type;
         dst->VoucherArguments = src->voucher_arguments;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1491,7 +1491,7 @@ public:
         dst->paid_on_food = src->paid_on_food;
         dst->paid_on_souvenirs = src->paid_on_souvenirs;
         dst->no_of_food = src->no_of_food;
-        dst->no_of_drinks = src->no_of_drinks;
+        dst->NoOfDrinks = src->no_of_drinks;
         dst->NoOfSouvenirs = src->no_of_souvenirs;
         dst->VandalismSeen = src->vandalism_seen;
         dst->VoucherType = src->voucher_type;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1485,7 +1485,7 @@ public:
         dst->no_action_frame_num = src->no_action_frame_num;
         dst->litter_count = src->litter_count;
         dst->time_on_ride = src->time_on_ride;
-        dst->disgusting_count = src->disgusting_count;
+        dst->DisgustingCount = src->disgusting_count;
         dst->PaidToEnter = src->paid_to_enter;
         dst->PaidOnRides = src->paid_on_rides;
         dst->PaidOnFood = src->paid_on_food;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1488,7 +1488,7 @@ public:
         dst->disgusting_count = src->disgusting_count;
         dst->paid_to_enter = src->paid_to_enter;
         dst->paid_on_rides = src->paid_on_rides;
-        dst->paid_on_food = src->paid_on_food;
+        dst->PaidOnFood = src->paid_on_food;
         dst->PaidOnSouvenirs = src->paid_on_souvenirs;
         dst->NoOfFood = src->no_of_food;
         dst->NoOfDrinks = src->no_of_drinks;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1494,7 +1494,7 @@ public:
         dst->no_of_drinks = src->no_of_drinks;
         dst->no_of_souvenirs = src->no_of_souvenirs;
         dst->vandalism_seen = src->vandalism_seen;
-        dst->voucher_type = src->voucher_type;
+        dst->VoucherType = src->voucher_type;
         dst->VoucherArguments = src->voucher_arguments;
         dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
         dst->Angriness = src->angriness;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1486,7 +1486,7 @@ public:
         dst->litter_count = src->litter_count;
         dst->time_on_ride = src->time_on_ride;
         dst->disgusting_count = src->disgusting_count;
-        dst->paid_to_enter = src->paid_to_enter;
+        dst->PaidToEnter = src->paid_to_enter;
         dst->PaidOnRides = src->paid_on_rides;
         dst->PaidOnFood = src->paid_on_food;
         dst->PaidOnSouvenirs = src->paid_on_souvenirs;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1487,7 +1487,7 @@ public:
         dst->time_on_ride = src->time_on_ride;
         dst->disgusting_count = src->disgusting_count;
         dst->paid_to_enter = src->paid_to_enter;
-        dst->paid_on_rides = src->paid_on_rides;
+        dst->PaidOnRides = src->paid_on_rides;
         dst->PaidOnFood = src->paid_on_food;
         dst->PaidOnSouvenirs = src->paid_on_souvenirs;
         dst->NoOfFood = src->no_of_food;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1493,7 +1493,7 @@ public:
         dst->no_of_food = src->no_of_food;
         dst->no_of_drinks = src->no_of_drinks;
         dst->no_of_souvenirs = src->no_of_souvenirs;
-        dst->vandalism_seen = src->vandalism_seen;
+        dst->VandalismSeen = src->vandalism_seen;
         dst->VoucherType = src->voucher_type;
         dst->VoucherArguments = src->voucher_arguments;
         dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1489,7 +1489,7 @@ public:
         dst->paid_to_enter = src->paid_to_enter;
         dst->paid_on_rides = src->paid_on_rides;
         dst->paid_on_food = src->paid_on_food;
-        dst->paid_on_souvenirs = src->paid_on_souvenirs;
+        dst->PaidOnSouvenirs = src->paid_on_souvenirs;
         dst->NoOfFood = src->no_of_food;
         dst->NoOfDrinks = src->no_of_drinks;
         dst->NoOfSouvenirs = src->no_of_souvenirs;

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -252,7 +252,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(paid_on_food);
     COMPARE_FIELD(paid_on_souvenirs);
     COMPARE_FIELD(no_of_food);
-    COMPARE_FIELD(no_of_drinks);
+    COMPARE_FIELD(NoOfDrinks);
     COMPARE_FIELD(NoOfSouvenirs);
     COMPARE_FIELD(VandalismSeen);
     COMPARE_FIELD(VoucherType);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -251,9 +251,9 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(PaidOnRides);
     COMPARE_FIELD(PaidOnFood);
     COMPARE_FIELD(PaidOnSouvenirs);
-    COMPARE_FIELD(NoOfFood);
-    COMPARE_FIELD(NoOfDrinks);
-    COMPARE_FIELD(NoOfSouvenirs);
+    COMPARE_FIELD(AmountOfFood);
+    COMPARE_FIELD(AmountOfDrinks);
+    COMPARE_FIELD(AmountOfSouvenirs);
     COMPARE_FIELD(VandalismSeen);
     COMPARE_FIELD(VoucherType);
     COMPARE_FIELD(VoucherArguments);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -249,7 +249,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(disgusting_count);
     COMPARE_FIELD(paid_to_enter);
     COMPARE_FIELD(paid_on_rides);
-    COMPARE_FIELD(paid_on_food);
+    COMPARE_FIELD(PaidOnFood);
     COMPARE_FIELD(PaidOnSouvenirs);
     COMPARE_FIELD(NoOfFood);
     COMPARE_FIELD(NoOfDrinks);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -255,7 +255,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(no_of_drinks);
     COMPARE_FIELD(no_of_souvenirs);
     COMPARE_FIELD(vandalism_seen);
-    COMPARE_FIELD(voucher_type);
+    COMPARE_FIELD(VoucherType);
     COMPARE_FIELD(VoucherArguments);
     COMPARE_FIELD(SurroundingsThoughtTimeout);
     COMPARE_FIELD(Angriness);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -256,7 +256,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(no_of_souvenirs);
     COMPARE_FIELD(vandalism_seen);
     COMPARE_FIELD(voucher_type);
-    COMPARE_FIELD(voucher_arguments);
+    COMPARE_FIELD(VoucherArguments);
     COMPARE_FIELD(SurroundingsThoughtTimeout);
     COMPARE_FIELD(Angriness);
     COMPARE_FIELD(TimeLost);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -246,7 +246,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(no_action_frame_num);
     COMPARE_FIELD(litter_count);
     COMPARE_FIELD(time_on_ride);
-    COMPARE_FIELD(disgusting_count);
+    COMPARE_FIELD(DisgustingCount);
     COMPARE_FIELD(PaidToEnter);
     COMPARE_FIELD(PaidOnRides);
     COMPARE_FIELD(PaidOnFood);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -251,7 +251,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(paid_on_rides);
     COMPARE_FIELD(paid_on_food);
     COMPARE_FIELD(paid_on_souvenirs);
-    COMPARE_FIELD(no_of_food);
+    COMPARE_FIELD(NoOfFood);
     COMPARE_FIELD(NoOfDrinks);
     COMPARE_FIELD(NoOfSouvenirs);
     COMPARE_FIELD(VandalismSeen);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -250,7 +250,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(paid_to_enter);
     COMPARE_FIELD(paid_on_rides);
     COMPARE_FIELD(paid_on_food);
-    COMPARE_FIELD(paid_on_souvenirs);
+    COMPARE_FIELD(PaidOnSouvenirs);
     COMPARE_FIELD(NoOfFood);
     COMPARE_FIELD(NoOfDrinks);
     COMPARE_FIELD(NoOfSouvenirs);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -247,7 +247,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(litter_count);
     COMPARE_FIELD(time_on_ride);
     COMPARE_FIELD(disgusting_count);
-    COMPARE_FIELD(paid_to_enter);
+    COMPARE_FIELD(PaidToEnter);
     COMPARE_FIELD(PaidOnRides);
     COMPARE_FIELD(PaidOnFood);
     COMPARE_FIELD(PaidOnSouvenirs);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -248,7 +248,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(time_on_ride);
     COMPARE_FIELD(disgusting_count);
     COMPARE_FIELD(paid_to_enter);
-    COMPARE_FIELD(paid_on_rides);
+    COMPARE_FIELD(PaidOnRides);
     COMPARE_FIELD(PaidOnFood);
     COMPARE_FIELD(PaidOnSouvenirs);
     COMPARE_FIELD(NoOfFood);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -253,7 +253,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(paid_on_souvenirs);
     COMPARE_FIELD(no_of_food);
     COMPARE_FIELD(no_of_drinks);
-    COMPARE_FIELD(no_of_souvenirs);
+    COMPARE_FIELD(NoOfSouvenirs);
     COMPARE_FIELD(VandalismSeen);
     COMPARE_FIELD(VoucherType);
     COMPARE_FIELD(VoucherArguments);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -254,7 +254,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(no_of_food);
     COMPARE_FIELD(no_of_drinks);
     COMPARE_FIELD(no_of_souvenirs);
-    COMPARE_FIELD(vandalism_seen);
+    COMPARE_FIELD(VandalismSeen);
     COMPARE_FIELD(VoucherType);
     COMPARE_FIELD(VoucherArguments);
     COMPARE_FIELD(SurroundingsThoughtTimeout);


### PR DESCRIPTION
Continues #10653

It might be easier to review on a commit by commit basis