### PR TITLE
Refactor BMP and RLE drawing routines to use a single argument block

### DIFF
--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -227,9 +227,10 @@ static bool sprite_file_export(rct_g1_element* spriteHeader, const char* outPath
     }
     else
     {
-        gfx_bmp_sprite_to_buffer(
-            PaletteMap::GetDefault(), spriteHeader->offset, pixels, spriteHeader, &dpi, spriteHeader->height,
-            spriteHeader->width, ImageId());
+        DrawSpriteArgs args(
+            &dpi, ImageId(), PaletteMap::GetDefault(), *spriteHeader, spriteHeader->width, spriteHeader->height,
+            spriteHeader->offset, pixels);
+        gfx_bmp_sprite_to_buffer(args);
     }
 
     auto const pixels8 = dpi.bits;

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -219,19 +219,9 @@ static bool sprite_file_export(rct_g1_element* spriteHeader, const char* outPath
     dpi.pitch = 0;
     dpi.zoom_level = 0;
 
-    if (spriteHeader->flags & G1_FLAG_RLE_COMPRESSION)
-    {
-        gfx_rle_sprite_to_buffer(
-            spriteHeader->offset, pixels, PaletteMap::GetDefault(), &dpi, ImageId(), 0, spriteHeader->height, 0,
-            spriteHeader->width);
-    }
-    else
-    {
-        DrawSpriteArgs args(
-            &dpi, ImageId(), PaletteMap::GetDefault(), *spriteHeader, spriteHeader->width, spriteHeader->height,
-            spriteHeader->offset, pixels);
-        gfx_bmp_sprite_to_buffer(args);
-    }
+    DrawSpriteArgs args(
+        &dpi, ImageId(), PaletteMap::GetDefault(), *spriteHeader, 0, 0, spriteHeader->width, spriteHeader->height, pixels);
+    gfx_sprite_to_buffer(args);
 
     auto const pixels8 = dpi.bits;
     auto const pixelsLen = (dpi.width + dpi.pitch) * dpi.height;

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2019 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -13,19 +13,22 @@
 
 #include <cstring>
 
-template<int32_t image_type, int32_t zoom_level>
-static void FASTCALL DrawRLESprite2_Magnify(
-    const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const PaletteMap& RESTRICT paletteMap,
-    const rct_drawpixelinfo* RESTRICT dpi, int32_t source_y_start, int32_t height, int32_t source_x_start, int32_t width)
+template<int32_t image_type, int32_t zoom_level> static void FASTCALL DrawRLESpriteMagnify(DrawSpriteArgs& args)
 {
     // TODO
 }
 
-template<int32_t image_type, int32_t zoom_level>
-static void FASTCALL DrawRLESprite2(
-    const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const PaletteMap& RESTRICT paletteMap,
-    const rct_drawpixelinfo* RESTRICT dpi, int32_t source_y_start, int32_t height, int32_t source_x_start, int32_t width)
+template<DrawBlendOp TBlendOp, int32_t zoom_level> static void FASTCALL DrawRLESpriteMinify(DrawSpriteArgs& args)
 {
+    auto dpi = args.DPI;
+    auto source_bits_pointer = args.SourceImage.offset;
+    auto dest_bits_pointer = args.DestinationBits;
+    auto source_x_start = args.SrcX;
+    auto source_y_start = args.SrcY;
+    auto width = args.Width;
+    auto height = args.Height;
+    [[maybe_unused]] auto& paletteMap = args.PalMap;
+
     // The distance between two samples in the source image.
     // We draw the image at 1 / (2^zoom_level) scale.
     int32_t zoom_amount = 1 << zoom_level;
@@ -103,11 +106,11 @@ static void FASTCALL DrawRLESprite2(
 
             // Finally after all those checks, copy the image onto the drawing surface
             // If the image type is not a basic one we require to mix the pixels
-            if (image_type & IMAGE_TYPE_REMAP) // palette controlled images
+            if constexpr ((TBlendOp & BLEND_SRC) != 0) // palette controlled images
             {
                 for (int j = 0; j < numPixels; j += zoom_amount, copySrc += zoom_amount, copyDest++)
                 {
-                    if (image_type & IMAGE_TYPE_TRANSPARENT)
+                    if ((TBlendOp & BLEND_DST) != 0)
                     {
                         *copyDest = paletteMap.Blend(*copySrc, *copyDest);
                     }
@@ -117,13 +120,11 @@ static void FASTCALL DrawRLESprite2(
                     }
                 }
             }
-            else if (image_type & IMAGE_TYPE_TRANSPARENT) // single alpha blended color (used for glass)
+            else if constexpr ((TBlendOp & BLEND_DST) != 0) // single alpha blended color (used for glass)
             {
                 for (int j = 0; j < numPixels; j += zoom_amount, copyDest++)
                 {
-                    uint8_t pixel = *copyDest;
-                    pixel = paletteMap[pixel];
-                    *copyDest = pixel;
+                    *copyDest = paletteMap[*copyDest];
                 }
             }
             else // standard opaque image
@@ -144,39 +145,28 @@ static void FASTCALL DrawRLESprite2(
     }
 }
 
-#define DrawRLESpriteHelper2_Magnify(image_type, zoom_level)                                                                   \
-    DrawRLESprite2_Magnify<image_type, zoom_level>(                                                                            \
-        source_bits_pointer, dest_bits_pointer, paletteMap, dpi, source_y_start, height, source_x_start, width)
-
-#define DrawRLESpriteHelper2(image_type, zoom_level)                                                                           \
-    DrawRLESprite2<image_type, zoom_level>(                                                                                    \
-        source_bits_pointer, dest_bits_pointer, paletteMap, dpi, source_y_start, height, source_x_start, width)
-
-template<int32_t image_type>
-static void FASTCALL DrawRLESprite1(
-    const uint8_t* source_bits_pointer, uint8_t* dest_bits_pointer, const PaletteMap& paletteMap, const rct_drawpixelinfo* dpi,
-    int32_t source_y_start, int32_t height, int32_t source_x_start, int32_t width)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(DrawSpriteArgs& args)
 {
-    auto zoom_level = static_cast<int8_t>(dpi->zoom_level);
+    auto zoom_level = static_cast<int8_t>(args.DPI->zoom_level);
     switch (zoom_level)
     {
         case -2:
-            DrawRLESpriteHelper2_Magnify(image_type, 2);
+            DrawRLESpriteMagnify<TBlendOp, 2>(args);
             break;
         case -1:
-            DrawRLESpriteHelper2_Magnify(image_type, 1);
+            DrawRLESpriteMagnify<TBlendOp, 1>(args);
             break;
         case 0:
-            DrawRLESpriteHelper2(image_type, 0);
+            DrawRLESpriteMinify<TBlendOp, 0>(args);
             break;
         case 1:
-            DrawRLESpriteHelper2(image_type, 1);
+            DrawRLESpriteMinify<TBlendOp, 1>(args);
             break;
         case 2:
-            DrawRLESpriteHelper2(image_type, 2);
+            DrawRLESpriteMinify<TBlendOp, 2>(args);
             break;
         case 3:
-            DrawRLESpriteHelper2(image_type, 3);
+            DrawRLESpriteMinify<TBlendOp, 3>(args);
             break;
         default:
             assert(false);
@@ -184,38 +174,31 @@ static void FASTCALL DrawRLESprite1(
     }
 }
 
-#define DrawRLESpriteHelper1(image_type)                                                                                       \
-    DrawRLESprite1<image_type>(                                                                                                \
-        source_bits_pointer, dest_bits_pointer, paletteMap, dpi, source_y_start, height, source_x_start, width)
-
 /**
  * Transfers readied images onto buffers
  * This function copies the sprite data onto the screen
  *  rct2: 0x0067AA18
  * @param imageId Only flags are used.
  */
-void FASTCALL gfx_rle_sprite_to_buffer(
-    const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const PaletteMap& RESTRICT paletteMap,
-    const rct_drawpixelinfo* RESTRICT dpi, ImageId imageId, int32_t source_y_start, int32_t height, int32_t source_x_start,
-    int32_t width)
+void FASTCALL gfx_rle_sprite_to_buffer(DrawSpriteArgs& args)
 {
-    if (imageId.HasPrimary())
+    if (args.Image.HasPrimary())
     {
-        if (imageId.IsBlended())
+        if (args.Image.IsBlended())
         {
-            DrawRLESpriteHelper1(IMAGE_TYPE_REMAP | IMAGE_TYPE_TRANSPARENT);
+            DrawRLESprite<BLEND_TRANSPARENT | BLEND_SRC | BLEND_DST>(args);
         }
         else
         {
-            DrawRLESpriteHelper1(IMAGE_TYPE_REMAP);
+            DrawRLESprite<BLEND_TRANSPARENT | BLEND_SRC>(args);
         }
     }
-    else if (imageId.IsBlended())
+    else if (args.Image.IsBlended())
     {
-        DrawRLESpriteHelper1(IMAGE_TYPE_TRANSPARENT);
+        DrawRLESprite<BLEND_TRANSPARENT | BLEND_DST>(args);
     }
     else
     {
-        DrawRLESpriteHelper1(IMAGE_TYPE_DEFAULT);
+        DrawRLESprite<BLEND_TRANSPARENT>(args);
     }
 }

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -568,19 +568,8 @@ void FASTCALL gfx_draw_sprite_palette_set_software(
     // Move the pointer to the start point of the destination
     dest_pointer += ((dpi->width / zoom_level) + dpi->pitch) * dest_start_y + dest_start_x;
 
-    if (g1->flags & G1_FLAG_RLE_COMPRESSION)
-    {
-        // We have to use a different method to move the source pointer for
-        // rle encoded sprites so that will be handled within this function
-        DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
-        gfx_rle_sprite_to_buffer(args);
-        return;
-    }
-    else if (!(g1->flags & G1_FLAG_1))
-    {
-        DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
-        gfx_bmp_sprite_to_buffer(args);
-    }
+    DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
+    gfx_sprite_to_buffer(args);
 }
 
 void FASTCALL gfx_sprite_to_buffer(DrawSpriteArgs& args)

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -572,16 +572,25 @@ void FASTCALL gfx_draw_sprite_palette_set_software(
     {
         // We have to use a different method to move the source pointer for
         // rle encoded sprites so that will be handled within this function
-        gfx_rle_sprite_to_buffer(
-            g1->offset, dest_pointer, paletteMap, dpi, imageId, source_start_y, height, source_start_x, width);
+        DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
+        gfx_rle_sprite_to_buffer(args);
         return;
     }
     else if (!(g1->flags & G1_FLAG_1))
     {
-        // Move the pointer to the start point of the source
-        auto source_pointer = g1->offset + ((static_cast<size_t>(g1->width) * source_start_y) + source_start_x);
+        DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
+        gfx_bmp_sprite_to_buffer(args);
+    }
+}
 
-        DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, width, height, source_pointer, dest_pointer);
+void FASTCALL gfx_sprite_to_buffer(DrawSpriteArgs& args)
+{
+    if (args.SourceImage.flags & G1_FLAG_RLE_COMPRESSION)
+    {
+        gfx_rle_sprite_to_buffer(args);
+    }
+    else if (!(args.SourceImage.flags & G1_FLAG_1))
+    {
         gfx_bmp_sprite_to_buffer(args);
     }
 }

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -580,7 +580,9 @@ void FASTCALL gfx_draw_sprite_palette_set_software(
     {
         // Move the pointer to the start point of the source
         auto source_pointer = g1->offset + ((static_cast<size_t>(g1->width) * source_start_y) + source_start_x);
-        gfx_bmp_sprite_to_buffer(paletteMap, source_pointer, dest_pointer, g1, dpi, height, width, imageId);
+
+        DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, width, height, source_pointer, dest_pointer);
+        gfx_bmp_sprite_to_buffer(args);
     }
 }
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -520,21 +520,23 @@ struct DrawSpriteArgs
     ImageId Image;
     const PaletteMap& PalMap;
     const rct_g1_element& SourceImage;
+    int32_t SrcX;
+    int32_t SrcY;
     int32_t Width;
     int32_t Height;
-    const uint8_t* SourceBits;
     uint8_t* DestinationBits;
 
     DrawSpriteArgs(
-        rct_drawpixelinfo* dpi, ImageId image, const PaletteMap& palMap, const rct_g1_element& sourceImage, int32_t width,
-        int32_t height, const uint8_t* sourceBits, uint8_t* destinationBits)
+        rct_drawpixelinfo* dpi, ImageId image, const PaletteMap& palMap, const rct_g1_element& sourceImage, int32_t srcX,
+        int32_t srcY, int32_t width, int32_t height, uint8_t* destinationBits)
         : DPI(dpi)
         , Image(image)
         , PalMap(palMap)
         , SourceImage(sourceImage)
+        , SrcX(srcX)
+        , SrcY(srcY)
         , Width(width)
         , Height(height)
-        , SourceBits(sourceBits)
         , DestinationBits(destinationBits)
     {
     }
@@ -624,11 +626,9 @@ void gfx_object_free_images(uint32_t baseImageId, uint32_t count);
 void gfx_object_check_all_images_freed();
 size_t ImageListGetUsedCount();
 size_t ImageListGetMaximum();
+void FASTCALL gfx_sprite_to_buffer(DrawSpriteArgs& args);
 void FASTCALL gfx_bmp_sprite_to_buffer(DrawSpriteArgs& args);
-void FASTCALL gfx_rle_sprite_to_buffer(
-    const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const PaletteMap& RESTRICT paletteMap,
-    const rct_drawpixelinfo* RESTRICT dpi, ImageId imageId, int32_t source_y_start, int32_t height, int32_t source_x_start,
-    int32_t width);
+void FASTCALL gfx_rle_sprite_to_buffer(DrawSpriteArgs& args);
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, int32_t image_id, int32_t x, int32_t y, uint32_t tertiary_colour);
 void FASTCALL gfx_draw_glyph(rct_drawpixelinfo* dpi, int32_t image_id, int32_t x, int32_t y, const PaletteMap& paletteMap);
 void FASTCALL gfx_draw_sprite_raw_masked(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t maskImage, int32_t colourImage);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -142,6 +142,28 @@ enum : uint32_t
     // REMAP_2_PLUS = REMAP 3
 };
 
+using DrawBlendOp = uint8_t;
+
+constexpr DrawBlendOp BLEND_NONE = 0;
+
+/**
+ * Only supported by BITMAP. RLE images always encode transparency via the encoding.
+ * Pixel value of 0 represents transparent.
+ */
+constexpr DrawBlendOp BLEND_TRANSPARENT = 1 << 0;
+
+/**
+ * Whether to use the pixel value from the source image.
+ * This is usually only unset for glass images where there the src is only a transparency mask.
+ */
+constexpr DrawBlendOp BLEND_SRC = 1 << 1;
+
+/**
+ * Whether to use the pixel value of the destination image for blending.
+ * This is used for any image that filters the target image, e.g. glass or water.
+ */
+constexpr DrawBlendOp BLEND_DST = 2 << 2;
+
 enum
 {
     INSET_RECT_FLAG_FILL_GREY = (1 << 2),         // 0x04
@@ -492,6 +514,32 @@ public:
     void Copy(size_t dstIndex, const PaletteMap& src, size_t srcIndex, size_t length);
 };
 
+struct DrawSpriteArgs
+{
+    rct_drawpixelinfo* DPI;
+    ImageId Image;
+    const PaletteMap& PalMap;
+    const rct_g1_element& SourceImage;
+    int32_t Width;
+    int32_t Height;
+    const uint8_t* SourceBits;
+    uint8_t* DestinationBits;
+
+    DrawSpriteArgs(
+        rct_drawpixelinfo* dpi, ImageId image, const PaletteMap& palMap, const rct_g1_element& sourceImage, int32_t width,
+        int32_t height, const uint8_t* sourceBits, uint8_t* destinationBits)
+        : DPI(dpi)
+        , Image(image)
+        , PalMap(palMap)
+        , SourceImage(sourceImage)
+        , Width(width)
+        , Height(height)
+        , SourceBits(sourceBits)
+        , DestinationBits(destinationBits)
+    {
+    }
+};
+
 #define SPRITE_ID_PALETTE_COLOUR_1(colourId) (IMAGE_TYPE_REMAP | ((colourId) << 19))
 #define SPRITE_ID_PALETTE_COLOUR_2(primaryId, secondaryId)                                                                     \
     (IMAGE_TYPE_REMAP_2_PLUS | IMAGE_TYPE_REMAP | (((primaryId) << 19) | ((secondaryId) << 24)))
@@ -576,9 +624,7 @@ void gfx_object_free_images(uint32_t baseImageId, uint32_t count);
 void gfx_object_check_all_images_freed();
 size_t ImageListGetUsedCount();
 size_t ImageListGetMaximum();
-void FASTCALL gfx_bmp_sprite_to_buffer(
-    const PaletteMap& paletteMap, uint8_t* source_pointer, uint8_t* dest_pointer, const rct_g1_element* source_image,
-    rct_drawpixelinfo* dest_dpi, int32_t height, int32_t width, ImageId imageId);
+void FASTCALL gfx_bmp_sprite_to_buffer(DrawSpriteArgs& args);
 void FASTCALL gfx_rle_sprite_to_buffer(
     const uint8_t* RESTRICT source_bits_pointer, uint8_t* RESTRICT dest_bits_pointer, const PaletteMap& RESTRICT paletteMap,
     const rct_drawpixelinfo* RESTRICT dpi, ImageId imageId, int32_t source_y_start, int32_t height, int32_t source_x_start,


### PR DESCRIPTION
This does the following things:
* Properly define the different blend modes when drawing sprites.
* Support all blends modes for BMP sprites
* Unify the signature between BMP and RLE to share one common drawing arg struct.

While not intentional, there appears to be a slight performance boost.
**This PR:**
```
PS .\openrct2.exe benchgfx ..\test\tests\testdata\parks\bpb.sv6 10
Engine: Software
Render Count: 120
Zoom[0] average: 0.089170s, 11 FPS
Zoom[1] average: 0.048053s, 21 FPS
Zoom[2] average: 0.029150s, 34 FPS
Total average: 0.055458s, 18 FPS
Time: 6.65494s
```

**develop:**
```
PS $HOME\OpenRCT2\bin\openrct2.com benchgfx ..\test\tests\testdata\parks\bpb.sv6 10
Engine: Software
Render Count: 120
Zoom[0] average: 0.122068s, 8 FPS
Zoom[1] average: 0.063263s, 16 FPS
Zoom[2] average: 0.036116s, 28 FPS
Total average: 0.073816s, 14 FPS
Time: 8.85787s
```

I investigated converting all of g1.dat to BMP sprites. There was a negative performance to doing this. If AVX2 can be used for all BMP sprites, this may yield better results.

The aim of these changes is to help me write the Magnify functions which currently have TODO placeholder comments.