### PR TITLE
Move calls to set_format_arg to Formatter::Common()

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1017,8 +1017,9 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
             totalSelectable = 4;
 
-        set_format_arg(0, uint16_t, numSelected);
-        set_format_arg(2, uint16_t, totalSelectable);
+        auto ft = Formatter::Common();
+        ft.Add<uint16_t>(numSelected);
+        ft.Add<uint16_t>(totalSelectable);
         gfx_draw_string_left(dpi, STR_OBJECT_SELECTION_SELECTION_SIZE, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
 
@@ -1065,16 +1066,18 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     x = w->windowPos.x + (widget->left + widget->right) / 2 + 1;
     y = w->windowPos.y + widget->bottom + 3;
     width = w->width - w->widgets[WIDX_LIST].right - 6;
-    set_format_arg(0, rct_string_id, STR_STRING);
-    set_format_arg(2, const char*, listItem->repositoryItem->Name.c_str());
+    auto ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_STRING);
+    ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
     gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
 
     // Draw description of object
     auto description = object_get_description(_loadedObject);
     if (!description.empty())
     {
-        set_format_arg(0, rct_string_id, STR_STRING);
-        set_format_arg(2, const char*, description.c_str());
+        ft = Formatter::Common();
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(description.c_str());
 
         x = w->windowPos.x + w->widgets[WIDX_LIST].right + 4;
         y += 15;
@@ -1101,8 +1104,9 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
 
     // Draw object dat name
     const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
-    set_format_arg(0, rct_string_id, STR_STRING);
-    set_format_arg(2, const char*, path);
+    ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_STRING);
+    ft.Add<const char*>(path);
     gfx_draw_string_right(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + w->width - 5, y);
 }
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -653,7 +653,9 @@ static void window_finances_summary_invalidate(rct_window* w)
         window_finances_summary_invertscroll(w);
 
     window_finances_set_pressed_tab(w);
-    set_format_arg(6, money32, gBankLoan);
+    auto ft = Formatter::Common();
+    ft.Increment(6);
+    ft.Add<money32>(gBankLoan);
 }
 
 /**

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -692,7 +692,8 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Loan and interest rate
     gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_LOAN, nullptr, COLOUR_BLACK, w->windowPos.x + 8, w->windowPos.y + 279);
-    set_format_arg(0, uint16_t, gBankLoanInterestRate);
+    auto ft = Formatter::Common();
+    ft.Add<uint16_t>(gBankLoanInterestRate);
     gfx_draw_string_left(
         dpi, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + 167, w->windowPos.y + 279);
 
@@ -704,7 +705,8 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (gScenarioObjectiveType == OBJECTIVE_MONTHLY_FOOD_INCOME)
     {
         money32 lastMonthProfit = finance_get_last_month_shop_profit();
-        set_format_arg(0, money32, lastMonthProfit);
+        ft = Formatter::Common();
+        ft.Add<money32>(lastMonthProfit);
         gfx_draw_string_left(
             dpi, STR_LAST_MONTH_PROFIT_FROM_FOOD_DRINK_MERCHANDISE_SALES_LABEL, gCommonFormatArgs, COLOUR_BLACK,
             w->windowPos.x + 280, w->windowPos.y + 279);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1958,7 +1958,7 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
     switch (item)
     {
         case SHOP_ITEM_BALLOON:
-            ft.Increment(-ft.NumBytes());
+            ft.Rewind();
             ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->BalloonColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_PHOTO:
@@ -1967,14 +1967,15 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                 ride->FormatNameTo(gCommonFormatArgs + 6);
             break;
         case SHOP_ITEM_UMBRELLA:
-            ft.Increment(-ft.NumBytes());
+            ft.Rewind();
             ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_VOUCHER:
             switch (peep->VoucherType)
             {
                 case VOUCHER_TYPE_PARK_ENTRY_FREE:
-                    ft.Increment(-ft.NumBytes() + 6);
+                    ft.Rewind();
+                    ft.Increment(6);
                     ft.Add<rct_string_id>(STR_PEEP_INVENTORY_VOUCHER_PARK_ENTRY_FREE);
                     ft.Add<rct_string_id>(STR_STRING);
                     ft.Add<const char*>(parkName);
@@ -1983,30 +1984,33 @@ static rct_string_id window_guest_inventory_format_item(Peep* peep, int32_t item
                     ride = get_ride(peep->VoucherArguments);
                     if (ride != nullptr)
                     {
-                        ft.Increment(-ft.NumBytes() + 6);
+                        ft.Rewind();
+                        ft.Increment(6);
                         ft.Add<rct_string_id>(STR_PEEP_INVENTORY_VOUCHER_RIDE_FREE);
                         ride->FormatNameTo(gCommonFormatArgs + 8);
                     }
                     break;
                 case VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE:
-                    ft.Increment(-ft.NumBytes() + 6);
+                    ft.Rewind();
+                    ft.Increment(6);
                     ft.Add<rct_string_id>(STR_PEEP_INVENTORY_VOUCHER_PARK_ENTRY_HALF_PRICE);
                     ft.Add<rct_string_id>(STR_STRING);
                     ft.Add<const char*>(parkName);
                     break;
                 case VOUCHER_TYPE_FOOD_OR_DRINK_FREE:
-                    ft.Increment(-ft.NumBytes() + 6);
+                    ft.Rewind();
+                    ft.Increment(6);
                     ft.Add<rct_string_id>(STR_PEEP_INVENTORY_VOUCHER_FOOD_OR_DRINK_FREE);
                     ft.Add<rct_string_id>(ShopItems[peep->VoucherArguments].Naming.Singular);
                     break;
             }
             break;
         case SHOP_ITEM_HAT:
-            ft.Increment(-ft.NumBytes());
+            ft.Rewind();
             ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->HatColour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_TSHIRT:
-            ft.Increment(-ft.NumBytes());
+            ft.Rewind();
             ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->tshirt_colour) | ShopItems[item].Image);
             break;
         case SHOP_ITEM_PHOTO2:

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1558,7 +1558,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     };
     y += LIST_ROW_HEIGHT;
     int32_t nausea_tolerance = peep->nausea_tolerance & 0x3;
-    auto ft = Formatter::Common();
+    ft = Formatter::Common();
     ft.Add<rct_string_id>(nauseaTolerances[nausea_tolerance]);
     gfx_draw_string_left(dpi, STR_GUEST_STAT_NAUSEA_TOLERANCE, gCommonFormatArgs, COLOUR_BLACK, x, y);
 }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1558,6 +1558,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     };
     y += LIST_ROW_HEIGHT;
     int32_t nausea_tolerance = peep->nausea_tolerance & 0x3;
+    auto ft = Formatter::Common();
     ft.Add<rct_string_id>(nauseaTolerances[nausea_tolerance]);
     gfx_draw_string_left(dpi, STR_GUEST_STAT_NAUSEA_TOLERANCE, gCommonFormatArgs, COLOUR_BLACK, x, y);
 }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1697,7 +1697,8 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
-    set_format_arg(0, rct_string_id, STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
+    auto ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
     if (peep->FavouriteRide != RIDE_ID_NULL)
     {
         auto ride = get_ride(peep->FavouriteRide);
@@ -1778,25 +1779,29 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t y = w->windowPos.y + window_guest_finance_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
     // Cash in pocket
-    set_format_arg(0, money32, peep->cash_in_pocket);
+    auto ft = Formatter::Common();
+    ft.Add<money32>(peep->cash_in_pocket);
     gfx_draw_string_left(dpi, STR_GUEST_STAT_CASH_IN_POCKET, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     // Cash spent
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->cash_spent);
+    ft = Formatter::Common();
+    ft.Add<money32>(peep->cash_spent);
     gfx_draw_string_left(dpi, STR_GUEST_STAT_CASH_SPENT, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     y += LIST_ROW_HEIGHT * 2;
     gfx_fill_rect_inset(dpi, x, y - 6, x + 179, y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
 
     // Paid to enter
-    set_format_arg(0, money32, peep->PaidToEnter);
+    ft = Formatter::Common();
+    ft.Add<money32>(peep->PaidToEnter);
     gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_ENTRANCE_FEE, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     // Paid on rides
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->PaidOnRides);
-    set_format_arg(4, uint16_t, peep->no_of_rides);
+    ft = Formatter::Common();
+    ft.Add<money32>(peep->PaidOnRides);
+    ft.Add<uint16_t>(peep->no_of_rides);
     if (peep->no_of_rides != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_RIDE_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -1808,8 +1813,9 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Paid on food
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->PaidOnFood);
-    set_format_arg(4, uint16_t, peep->AmountOfFood);
+    ft = Formatter::Common();
+    ft.Add<money32>(peep->PaidOnFood);
+    ft.Add<uint16_t>(peep->AmountOfFood);
     if (peep->AmountOfFood != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_FOOD_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -1821,8 +1827,9 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Paid on drinks
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->paid_on_drink);
-    set_format_arg(4, uint16_t, peep->AmountOfDrinks);
+    ft = Formatter::Common();
+    ft.Add<money32>(peep->paid_on_drink);
+    ft.Add<uint16_t>(peep->AmountOfDrinks);
     if (peep->AmountOfDrinks != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_DRINK_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -1834,8 +1841,9 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Paid on souvenirs
     y += LIST_ROW_HEIGHT;
-    set_format_arg(0, money32, peep->PaidOnSouvenirs);
-    set_format_arg(4, uint16_t, peep->AmountOfSouvenirs);
+    ft = Formatter::Common();
+    ft.Add<money32>(peep->PaidOnSouvenirs);
+    ft.Add<uint16_t>(peep->AmountOfSouvenirs);
     if (peep->AmountOfSouvenirs != 1)
     {
         gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -2083,7 +2091,8 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto screenCoords = ScreenCoordsXY{ w->windowPos.x + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].left + 4,
                                         w->windowPos.y + window_guest_debug_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
     {
-        set_format_arg(0, uint32_t, peep->sprite_index);
+        auto ft = Formatter::Common();
+        ft.Add<uint32_t>(peep->sprite_index);
         gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);
     }
     screenCoords.y += LIST_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -659,7 +659,9 @@ static void window_guest_list_invalidate(rct_window* w)
     {
         window_guest_list_widgets[WIDX_PAGE_DROPDOWN].type = WWT_DROPDOWN;
         window_guest_list_widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WWT_BUTTON;
-        set_format_arg(4, uint16_t, _window_guest_list_selected_page + 1);
+        auto ft = Formatter::Common();
+        ft.Increment(4);
+        ft.Add<uint16_t>(_window_guest_list_selected_page + 1);
     }
     else
     {

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -725,7 +725,8 @@ static void window_guest_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         x = w->windowPos.x + 4;
         y = w->windowPos.y + window_guest_list_widgets[WIDX_GUEST_LIST].bottom + 2;
-        set_format_arg(0, int32_t, static_cast<int32_t>(GuestList.size()));
+        auto ft = Formatter::Common();
+        ft.Add<int32_t>(static_cast<int32_t>(GuestList.size()));
         gfx_draw_string_left(
             dpi, (GuestList.size() == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL), gCommonFormatArgs,
             COLOUR_BLACK, x, y);
@@ -846,8 +847,9 @@ static void window_guest_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
                     gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, { 0, y }, 414);
 
                     // Draw guest count
-                    set_format_arg(0, rct_string_id, STR_GUESTS_COUNT_COMMA_SEP);
-                    set_format_arg(2, uint32_t, numGuests);
+                    auto ft = Formatter::Common();
+                    ft.Add<rct_string_id>(STR_GUESTS_COUNT_COMMA_SEP);
+                    ft.Add<uint32_t>(numGuests);
                     gfx_draw_string_right(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 326, y);
                 }
                 y += SUMMARISED_GUEST_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -320,8 +320,9 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         }
 
         // Ride length
-        set_format_arg(0, rct_string_id, STR_RIDE_LENGTH_ENTRY);
-        set_format_arg(2, uint16_t, td6->ride_length);
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
+        ft.Add<uint16_t>(td6->ride_length);
         gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, { x, y }, 214);
         y += LIST_ROW_HEIGHT;
     }
@@ -379,15 +380,17 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (td6->space_required_x != 0xFF)
     {
         // Space required
-        set_format_arg(0, uint16_t, td6->space_required_x);
-        set_format_arg(2, uint16_t, td6->space_required_y);
+        auto ft = Formatter::Common();
+        ft.Add<uint16_t>(td6->space_required_x);
+        ft.Add<uint16_t>(td6->space_required_y);
         gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, x, y);
         y += LIST_ROW_HEIGHT;
     }
 
     if (td6->cost != 0)
     {
-        set_format_arg(0, uint32_t, td6->cost);
+        auto ft = Formatter::Common();
+        ft.Add<uint32_t>(td6->cost);
         gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
 }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -773,25 +773,30 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         // display a marker next to the currently loaded game file
         if (_listItems[i].loaded)
         {
-            set_format_arg(0, rct_string_id, STR_RIGHTGUILLEMET);
+            auto ft = Formatter::Common();
+            ft.Add<rct_string_id>(STR_RIGHTGUILLEMET);
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, 0, y);
         }
 
         // Print filename
-        set_format_arg(0, rct_string_id, STR_STRING);
-        set_format_arg(2, char*, _listItems[i].name.c_str());
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<char*>(_listItems[i].name.c_str());
         int32_t max_file_width = w->widgets[WIDX_SORT_NAME].right - w->widgets[WIDX_SORT_NAME].left - 10;
         gfx_draw_string_left_clipped(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, { 10, y }, max_file_width);
 
         // Print formatted modified date, if this is a file
         if (_listItems[i].type == TYPE_FILE)
         {
-            set_format_arg(0, rct_string_id, STR_STRING);
-            set_format_arg(2, char*, _listItems[i].date_formatted.c_str());
+            ft = Formatter::Common();
+            ft.Add<rct_string_id>(STR_STRING);
+            ft.Add<char*>(_listItems[i].date_formatted.c_str());
             gfx_draw_string_right_clipped(
                 dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, { dateAnchor - DATE_TIME_GAP, y }, maxDateWidth);
 
-            set_format_arg(2, char*, _listItems[i].time_formatted.c_str());
+            ft = Formatter::Common();
+            ft.Add<rct_string_id>(STR_STRING);
+            ft.Add<char*>(_listItems[i].time_formatted.c_str());
             gfx_draw_string_left_clipped(
                 dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, { dateAnchor + DATE_TIME_GAP, y }, maxTimeWidth);
         }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -716,7 +716,8 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
     safe_strcpy(ch, _shortenedDirectory, sizeof(buffer) - (ch - buffer));
 
     // Draw path text
-    set_format_arg(0, uintptr_t, Platform::StrDecompToPrecomp(buffer));
+    auto ft = Formatter::Common();
+    ft.Add<uintptr_t>(Platform::StrDecompToPrecomp(buffer));
     gfx_draw_string_left_clipped(
         dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + 4, w->windowPos.y + 20 }, w->width - 8);
 
@@ -1236,8 +1237,9 @@ static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    set_format_arg(0, rct_string_id, STR_STRING);
-    set_format_arg(2, char*, _window_overwrite_prompt_name);
+    auto ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_STRING);
+    ft.Add<char*>(_window_overwrite_prompt_name);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + w->width / 2, w->windowPos.y + (w->height / 2) - 3);
     gfx_draw_string_centred_wrapped(

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -979,7 +979,9 @@ static void window_map_show_default_scenario_editor_buttons(rct_window* w)
     if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
         w->widgets[WIDX_MAP_GENERATOR].type = WWT_BUTTON;
 
-    set_format_arg(2, uint16_t, gMapSize - 2);
+    auto ft = Formatter::Common();
+    ft.Increment(2);
+    ft.Add<uint16_t>(gMapSize - 2);
 }
 
 static void window_map_inputsize_land(rct_window* w)

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -432,7 +432,9 @@ static void window_maze_construction_invalidate(rct_window* w)
     }
     else
     {
-        set_format_arg(4, rct_string_id, STR_NONE);
+        auto ft = Formatter::Common();
+        ft.Increment(4);
+        ft.Add<rct_string_id>(STR_NONE);
     }
 }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -696,10 +696,14 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
 
             // Draw last action
             int32_t action = network_get_player_last_action(i, 2000);
-            set_format_arg(0, rct_string_id, STR_ACTION_NA);
+            auto ft = Formatter::Common();
             if (action != -999)
             {
-                set_format_arg(0, rct_string_id, network_get_action_name_string_id(action));
+                ft.Add<rct_string_id>(network_get_action_name_string_id(action));
+            }
+            else
+            {
+                ft.Add<rct_string_id>(STR_ACTION_NA);
             }
             gfx_draw_string_left_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { 256, screenCoords.y }, 100);
 
@@ -910,7 +914,8 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         lineCh = buffer;
         lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
         safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
-        set_format_arg(0, const char*, buffer);
+        auto ft = Formatter::Common();
+        ft.Add<const char*>(buffer);
         gfx_draw_string_centred_clipped(
             dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
             w->windowPos.y + widget->top, widget->right - widget->left - 8);
@@ -934,7 +939,8 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         lineCh = buffer;
         lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
         safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
-        set_format_arg(0, const char*, buffer);
+        auto ft = Formatter::Common();
+        ft.Add<const char*>(buffer);
         gfx_draw_string_centred_clipped(
             dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
             w->windowPos.y + widget->top, widget->right - widget->left - 8);
@@ -975,7 +981,8 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
             }
 
             // Draw action name
-            set_format_arg(0, uint16_t, network_get_action_name_string_id(i));
+            auto ft = Formatter::Common();
+            ft.Add<uint16_t>(network_get_action_name_string_id(i));
             gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, 10, screenCoords.y);
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -284,8 +284,9 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
             dpi, -1, y, 383, y + itemHeight - 1, w->colours[1], (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_GREY));
 
         // Date text
-        set_format_arg(0, rct_string_id, DateDayNames[newsItem->Day - 1]);
-        set_format_arg(2, rct_string_id, DateGameMonthNames[date_get_month(newsItem->MonthYear)]);
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(DateDayNames[newsItem->Day - 1]);
+        ft.Add<rct_string_id>(DateGameMonthNames[date_get_month(newsItem->MonthYear)]);
         gfx_draw_string_left(dpi, STR_NEWS_DATE_FORMAT, gCommonFormatArgs, COLOUR_WHITE, 2, y);
 
         // Item text

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -558,13 +558,15 @@ static void window_object_load_error_paint(rct_window* w, rct_drawpixelinfo* dpi
     window_draw_widgets(w, dpi);
 
     // Draw explanatory message
-    set_format_arg(0, rct_string_id, STR_OBJECT_ERROR_WINDOW_EXPLANATION);
+    auto ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_OBJECT_ERROR_WINDOW_EXPLANATION);
     gfx_draw_string_left_wrapped(
         dpi, gCommonFormatArgs, { w->windowPos.x + 5, w->windowPos.y + 18 }, WW - 10, STR_BLACK_STRING, COLOUR_BLACK);
 
     // Draw file name
-    set_format_arg(0, rct_string_id, STR_OBJECT_ERROR_WINDOW_FILE);
-    set_format_arg(2, utf8*, file_path.c_str());
+    ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_OBJECT_ERROR_WINDOW_FILE);
+    ft.Add<utf8*>(file_path.c_str());
     gfx_draw_string_left_clipped(
         dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + 5, w->windowPos.y + 43 }, WW - 5);
 }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1605,8 +1605,10 @@ static void window_options_invalidate(rct_window* w)
         case WINDOW_OPTIONS_PAGE_DISPLAY:
         {
             // Resolution dropdown caption.
-            set_format_arg(16, uint16_t, static_cast<uint16_t>(gConfigGeneral.fullscreen_width));
-            set_format_arg(18, uint16_t, static_cast<uint16_t>(gConfigGeneral.fullscreen_height));
+            auto ft = Formatter::Common();
+            ft.Increment(16);
+            ft.Add<uint16_t>(static_cast<uint16_t>(gConfigGeneral.fullscreen_width));
+            ft.Add<uint16_t>(static_cast<uint16_t>(gConfigGeneral.fullscreen_height));
 
             // Disable resolution dropdown on "Windowed" and "Fullscreen (desktop)"
             if (gConfigGeneral.fullscreen_mode != static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::FULLSCREEN))
@@ -1729,8 +1731,10 @@ static void window_options_invalidate(rct_window* w)
         }
 
         case WINDOW_OPTIONS_PAGE_CULTURE:
+        {
             // Language
-            set_format_arg(0, char*, LanguagesDescriptors[LocalisationService_GetCurrentLanguage()].native_name);
+            auto ft = Formatter::Common();
+            ft.Add<char*>(LanguagesDescriptors[LocalisationService_GetCurrentLanguage()].native_name);
 
             // Currency: pounds, dollars, etc. (10 total)
             window_options_culture_widgets[WIDX_CURRENCY].text = CurrencyDescriptors[gConfigGeneral.currency_format].stringId;
@@ -1767,7 +1771,7 @@ static void window_options_invalidate(rct_window* w)
                                                                                                           : STR_REAL_VALUES;
 
             break;
-
+        }
         case WINDOW_OPTIONS_PAGE_AUDIO:
         {
             // Sound device
@@ -1793,7 +1797,8 @@ static void window_options_invalidate(rct_window* w)
             }
 
             window_options_audio_widgets[WIDX_SOUND].text = audioDeviceStringId;
-            set_format_arg(0, char*, audioDeviceName);
+            auto ft = Formatter::Common();
+            ft.Add<char*>(audioDeviceName);
 
             window_options_audio_widgets[WIDX_TITLE_MUSIC].text = window_options_title_music_names[gConfigSound.title_music];
 
@@ -1830,7 +1835,8 @@ static void window_options_invalidate(rct_window* w)
 
             size_t activeAvailableThemeIndex = theme_manager_get_active_available_theme_index();
             const utf8* activeThemeName = theme_manager_get_available_theme_name(activeAvailableThemeIndex);
-            set_format_arg(0, uintptr_t, reinterpret_cast<uintptr_t>(activeThemeName));
+            auto ft = Formatter::Common();
+            ft.Add<uintptr_t>(reinterpret_cast<uintptr_t>(activeThemeName));
 
             break;
         }
@@ -1838,7 +1844,8 @@ static void window_options_invalidate(rct_window* w)
         case WINDOW_OPTIONS_PAGE_MISC:
         {
             const utf8* name = title_sequence_manager_get_name(title_get_config_sequence());
-            set_format_arg(0, uintptr_t, reinterpret_cast<uintptr_t>(name));
+            auto ft = Formatter::Common();
+            ft.Add<uintptr_t>(reinterpret_cast<uintptr_t>(name));
 
             // The real name setting of clients is fixed to that of the server
             // and the server cannot change the setting during gameplay to prevent desyncs

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2069,7 +2069,8 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 w->windowPos.x + w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1,
                 w->windowPos.y + w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1);
 
-            set_format_arg(0, uintptr_t, Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));
+            auto ft = Formatter::Common();
+            ft.Add<uintptr_t>(Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));
 
             rct_widget pathWidget = window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON];
 
@@ -2118,7 +2119,8 @@ static void window_options_tooltip(rct_window* w, rct_widgetindex widgetIndex, r
         }
         else
         {
-            set_format_arg(0, uintptr_t, reinterpret_cast<uintptr_t>(gConfigGeneral.rct1_path));
+            auto ft = Formatter::Common();
+            ft.Add<uintptr_t>(reinterpret_cast<uintptr_t>(gConfigGeneral.rct1_path));
         }
     }
 }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1627,7 +1627,8 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
         else
         {
             // Objective completed
-            set_format_arg(0, money32, gScenarioCompletedCompanyValue);
+            ft = Formatter::Common();
+            ft.Add<money32>(gScenarioCompletedCompanyValue);
             gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, { x, y }, 222, STR_OBJECTIVE_ACHIEVED, COLOUR_BLACK);
         }
     }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1429,14 +1429,16 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         stringIndex = STR_PARK_SIZE_IMPERIAL_LABEL;
         parkSize = squaredmetres_to_squaredfeet(parkSize);
     }
-    set_format_arg(0, uint32_t, parkSize);
+    auto ft = Formatter::Common();
+    ft.Add<uint32_t>(parkSize);
     gfx_draw_string_left(dpi, stringIndex, gCommonFormatArgs, COLOUR_BLACK, x, y);
     y += LIST_ROW_HEIGHT;
 
     // Draw number of rides / attractions
     if (w->list_information_type != 0xFFFF)
     {
-        set_format_arg(0, uint32_t, w->list_information_type);
+        ft = Formatter::Common();
+        ft.Add<uint32_t>(w->list_information_type);
         gfx_draw_string_left(dpi, STR_NUMBER_OF_RIDES_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
     y += LIST_ROW_HEIGHT;
@@ -1444,7 +1446,8 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw number of staff
     if (w->numberOfStaff != -1)
     {
-        set_format_arg(0, uint32_t, w->numberOfStaff);
+        ft = Formatter::Common();
+        ft.Add<uint32_t>(w->numberOfStaff);
         gfx_draw_string_left(dpi, STR_STAFF_LABEL, gCommonFormatArgs, COLOUR_BLACK, x, y);
     }
     y += LIST_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -374,7 +374,8 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         lineCh = buffer;
         lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
         safe_strcpy(lineCh, network_get_group_name(groupindex), sizeof(buffer) - (lineCh - buffer));
-        set_format_arg(0, const char*, buffer);
+        auto ft = Formatter::Common();
+        ft.Add<const char*>(buffer);
 
         gfx_draw_string_centred_clipped(
             dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
@@ -384,7 +385,8 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw ping
     auto screenCoords = ScreenCoordsXY{ w->windowPos.x + 90, w->windowPos.y + 24 };
 
-    set_format_arg(0, rct_string_id, STR_PING);
+    auto ft = Formatter::Common();
+    ft.Add<rct_string_id>(STR_PING);
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, 0, screenCoords.x, screenCoords.y);
     char ping[64];
     snprintf(ping, 64, "%d ms", network_get_player_ping(player));
@@ -394,10 +396,14 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenCoords = { w->windowPos.x + (w->width / 2), w->windowPos.y + w->height - 13 };
     int32_t width = w->width - 8;
     int32_t lastaction = network_get_player_last_action(player, 0);
-    set_format_arg(0, rct_string_id, STR_ACTION_NA);
+    ft = Formatter::Common();
     if (lastaction != -999)
     {
-        set_format_arg(0, rct_string_id, network_get_action_name_string_id(lastaction));
+        ft.Add<rct_string_id>(network_get_action_name_string_id(lastaction));
+    }
+    else
+    {
+        ft.Add<rct_string_id>(STR_ACTION_NA);
     }
     gfx_draw_string_centred_clipped(
         dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords.x, screenCoords.y, width);
@@ -546,12 +552,14 @@ void window_player_statistics_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t x = w->windowPos.x + window_player_overview_widgets[WIDX_PAGE_BACKGROUND].left + 4;
     int32_t y = w->windowPos.y + window_player_overview_widgets[WIDX_PAGE_BACKGROUND].top + 4;
 
-    set_format_arg(0, uint32_t, network_get_player_commands_ran(player));
+    auto ft = Formatter::Common();
+    ft.Add<uint32_t>(network_get_player_commands_ran(player));
     gfx_draw_string_left(dpi, STR_COMMANDS_RAN, gCommonFormatArgs, COLOUR_BLACK, x, y);
 
     y += LIST_ROW_HEIGHT;
 
-    set_format_arg(0, uint32_t, network_get_player_money_spent(player));
+    ft = Formatter::Common();
+    ft.Add<uint32_t>(network_get_player_money_spent(player));
     gfx_draw_string_left(dpi, STR_MONEY_SPENT, gCommonFormatArgs, COLOUR_BLACK, x, y);
 }
 
@@ -682,13 +690,14 @@ static void window_player_update_viewport(rct_window* w, bool scroll)
 
 static void window_player_update_title(rct_window* w)
 {
+    auto ft = Formatter::Common();
     int32_t player = network_get_player_index(static_cast<uint8_t>(w->number));
     if (player != -1)
     {
-        set_format_arg(0, const char*, network_get_player_name(player)); // set title caption to player name
+        ft.Add<const char*>(network_get_player_name(player)); // set title caption to player name
     }
     else
     {
-        set_format_arg(0, const char*, "");
+        ft.Add<const char*>("");
     }
 }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3797,21 +3797,24 @@ static void window_ride_operating_invalidate(rct_window* w)
         case RIDE_MODE_POWERED_LAUNCH:
         case RIDE_MODE_UPWARD_LAUNCH:
         case RIDE_MODE_POWERED_LAUNCH_BLOCK_SECTIONED:
-            ft.Increment(-ft.NumBytes() + 18);
+            ft.Rewind();
+            ft.Increment(18);
             ft.Add<uint16_t>((ride->launch_speed * 9) / 4);
             format = STR_RIDE_MODE_SPEED_VALUE;
             caption = STR_LAUNCH_SPEED;
             tooltip = STR_LAUNCH_SPEED_TIP;
             break;
         case RIDE_MODE_STATION_TO_STATION:
-            ft.Increment(-ft.NumBytes() + 18);
+            ft.Rewind();
+            ft.Increment(18);
             ft.Add<uint16_t>((ride->speed * 9) / 4);
             format = STR_RIDE_MODE_SPEED_VALUE;
             caption = STR_SPEED;
             tooltip = STR_SPEED_TIP;
             break;
         case RIDE_MODE_RACE:
-            ft.Increment(-ft.NumBytes() + 18);
+            ft.Rewind();
+            ft.Increment(18);
             ft.Add<uint16_t>(ride->num_laps);
             format = STR_NUMBER_OF_LAPS_VALUE;
             caption = STR_NUMBER_OF_LAPS;
@@ -5844,10 +5847,12 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     {
                         // sadly, STR_RIDE_TIME_ENTRY_WITH_SEPARATOR are defined with the separator AFTER an entry
                         // therefore we set the last entry to use the no-separator format now, post-format
-                        ft.Increment(-ft.NumBytes() + ((numTimes - 1) * 4));
+                        ft.Rewind();
+                        ft.Increment((numTimes - 1) * 4);
                         ft.Add<uint16_t>(STR_RIDE_TIME_ENTRY);
                     }
-                    ft.Increment(-ft.NumBytes() + (numTimes * 4));
+                    ft.Rewind();
+                    ft.Increment(numTimes * 4);
                     ft.Add<uint16_t>(0);
                     ft.Add<uint16_t>(0);
                     ft.Add<uint16_t>(0);
@@ -5880,10 +5885,12 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                 {
                     // sadly, STR_RIDE_LENGTH_ENTRY_WITH_SEPARATOR are defined with the separator AFTER an entry
                     // therefore we set the last entry to use the no-separator format now, post-format
-                    ft.Increment(-ft.NumBytes() + ((numLengths - 1) * 4));
+                    ft.Rewind();
+                    ft.Increment((numLengths - 1) * 4);
                     ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
                 }
-                ft.Increment(-ft.NumBytes() + (numLengths * 4));
+                ft.Rewind();
+                ft.Increment(numLengths * 4);
                 ft.Add<uint16_t>(0);
                 ft.Add<uint16_t>(0);
                 ft.Add<uint16_t>(0);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2884,7 +2884,6 @@ static rct_string_id window_ride_get_status(rct_window* w, void* arguments)
 static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     rct_widget* widget;
-    rct_string_id stringId;
 
     window_draw_widgets(w, dpi);
     window_ride_draw_tab_images(dpi, w);
@@ -2902,21 +2901,24 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride == nullptr)
         return;
 
-    stringId = STR_OVERALL_VIEW;
+    auto ft = Formatter::Common();
     if (w->ride.view != 0)
     {
-        stringId = RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].number;
         if (w->ride.view > ride->num_vehicles)
         {
-            set_format_arg(2, uint16_t, w->ride.view - ride->num_vehicles);
-            stringId = RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.station].number;
+            ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.station].number);
+            ft.Add<uint16_t>(w->ride.view - ride->num_vehicles);
         }
         else
         {
-            set_format_arg(2, uint16_t, w->ride.view);
+            ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].number);
+            ft.Add<uint16_t>(w->ride.view);
         }
     }
-    set_format_arg(0, uint16_t, stringId);
+    else
+    {
+        ft.Add<rct_string_id>(STR_OVERALL_VIEW);
+    }
 
     widget = &window_ride_main_widgets[WIDX_VIEW];
     gfx_draw_string_centred(
@@ -3105,33 +3107,33 @@ static void window_ride_vehicle_invalidate(rct_window* w)
         window_ride_vehicle_widgets[WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE].type = WWT_EMPTY;
     }
 
-    set_format_arg(6, uint16_t, carsPerTrain);
+    auto ft = Formatter::Common();
+    ft.Increment(6);
+    ft.Add<uint16_t>(carsPerTrain);
     RIDE_COMPONENT_TYPE vehicleType = RideTypeDescriptors[ride->type].NameConvention.vehicle;
     stringId = RideComponentNames[vehicleType].count;
     if (ride->num_vehicles > 1)
     {
         stringId = RideComponentNames[vehicleType].count_plural;
     }
-    set_format_arg(8, rct_string_id, stringId);
-    set_format_arg(10, uint16_t, ride->num_vehicles);
+    ft.Add<rct_string_id>(stringId);
+    ft.Add<uint16_t>(ride->num_vehicles);
 
     stringId = RideComponentNames[vehicleType].count;
     if (ride->max_trains > 1)
     {
         stringId = RideComponentNames[vehicleType].count_plural;
     }
-    set_format_arg(12, rct_string_id, stringId);
-    set_format_arg(14, uint16_t, ride->max_trains);
-
-    set_format_arg(16, uint16_t, std::max(1, ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars);
+    ft.Add<rct_string_id>(stringId);
+    ft.Add<uint16_t>(ride->max_trains);
+    ft.Add<uint16_t>(std::max(1, ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars);
 
     stringId = RideComponentNames[RIDE_COMPONENT_TYPE_CAR].singular;
     if ((ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars > 1)
     {
         stringId = RideComponentNames[RIDE_COMPONENT_TYPE_CAR].plural;
     }
-
-    set_format_arg(18, rct_string_id, stringId);
+    ft.Add<rct_string_id>(stringId);
 
     window_ride_anchor_border_widgets(w);
     window_align_tabs(w, WIDX_TAB_1, WIDX_TAB_10);
@@ -3664,7 +3666,9 @@ static void window_ride_operating_invalidate(rct_window* w)
         window_ride_operating_widgets[WIDX_LIFT_HILL_SPEED].type = WWT_SPINNER;
         window_ride_operating_widgets[WIDX_LIFT_HILL_SPEED_INCREASE].type = WWT_BUTTON;
         window_ride_operating_widgets[WIDX_LIFT_HILL_SPEED_DECREASE].type = WWT_BUTTON;
-        set_format_arg(20, uint16_t, ride->lift_hill_speed);
+        auto ft = Formatter::Common();
+        ft.Increment(20);
+        ft.Add<uint16_t>(ride->lift_hill_speed);
     }
     else
     {
@@ -3681,7 +3685,9 @@ static void window_ride_operating_invalidate(rct_window* w)
         window_ride_operating_widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].type = WWT_SPINNER;
         window_ride_operating_widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].type = WWT_BUTTON;
         window_ride_operating_widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].type = WWT_BUTTON;
-        set_format_arg(22, uint16_t, ride->num_circuits);
+        auto ft = Formatter::Common();
+        ft.Increment(22);
+        ft.Add<uint16_t>(ride->num_circuits);
     }
     else
     {
@@ -3745,10 +3751,12 @@ static void window_ride_operating_invalidate(rct_window* w)
         window_ride_operating_widgets[WIDX_MAXIMUM_LENGTH_INCREASE].type = WWT_BUTTON;
         window_ride_operating_widgets[WIDX_MAXIMUM_LENGTH_DECREASE].type = WWT_BUTTON;
 
-        set_format_arg(10, rct_string_id, STR_FORMAT_SECONDS);
-        set_format_arg(12, uint16_t, ride->min_waiting_time);
-        set_format_arg(14, rct_string_id, STR_FORMAT_SECONDS);
-        set_format_arg(16, uint16_t, ride->max_waiting_time);
+        auto ft = Formatter::Common();
+        ft.Increment(10);
+        ft.Add<rct_string_id>(STR_FORMAT_SECONDS);
+        ft.Add<uint16_t>(ride->min_waiting_time);
+        ft.Add<rct_string_id>(STR_FORMAT_SECONDS);
+        ft.Add<uint16_t>(ride->max_waiting_time);
 
         if (ride->depart_flags & RIDE_DEPART_WAIT_FOR_LOAD)
             w->pressed_widgets |= (1 << WIDX_LOAD_CHECKBOX);
@@ -3780,26 +3788,31 @@ static void window_ride_operating_invalidate(rct_window* w)
         w->pressed_widgets |= (1 << WIDX_MAXIMUM_LENGTH_CHECKBOX);
 
     // Mode specific functionality
-    set_format_arg(18, uint16_t, ride->operation_option);
+    auto ft = Formatter::Common();
+    ft.Increment(18);
+    ft.Add<uint16_t>(ride->operation_option);
     switch (ride->mode)
     {
         case RIDE_MODE_POWERED_LAUNCH_PASSTROUGH:
         case RIDE_MODE_POWERED_LAUNCH:
         case RIDE_MODE_UPWARD_LAUNCH:
         case RIDE_MODE_POWERED_LAUNCH_BLOCK_SECTIONED:
-            set_format_arg(18, uint16_t, (ride->launch_speed * 9) / 4);
+            ft.Increment(-ft.NumBytes() + 18);
+            ft.Add<uint16_t>((ride->launch_speed * 9) / 4);
             format = STR_RIDE_MODE_SPEED_VALUE;
             caption = STR_LAUNCH_SPEED;
             tooltip = STR_LAUNCH_SPEED_TIP;
             break;
         case RIDE_MODE_STATION_TO_STATION:
-            set_format_arg(18, uint16_t, (ride->speed * 9) / 4);
+            ft.Increment(-ft.NumBytes() + 18);
+            ft.Add<uint16_t>((ride->speed * 9) / 4);
             format = STR_RIDE_MODE_SPEED_VALUE;
             caption = STR_SPEED;
             tooltip = STR_SPEED_TIP;
             break;
         case RIDE_MODE_RACE:
-            set_format_arg(18, uint16_t, ride->num_laps);
+            ft.Increment(-ft.NumBytes() + 18);
+            ft.Add<uint16_t>(ride->num_laps);
             format = STR_NUMBER_OF_LAPS_VALUE;
             caption = STR_NUMBER_OF_LAPS;
             tooltip = STR_NUMBER_OF_LAPS_TIP;
@@ -3836,7 +3849,9 @@ static void window_ride_operating_invalidate(rct_window* w)
         {
             uint16_t arg;
             std::memcpy(&arg, gCommonFormatArgs + 18, sizeof(uint16_t));
-            set_format_arg(18, uint16_t, arg * 3);
+            ft = Formatter::Common();
+            ft.Increment(18);
+            ft.Add<uint16_t>(arg * 3);
         }
 
         window_ride_operating_widgets[WIDX_MODE_TWEAK_LABEL].type = WWT_LABEL;
@@ -5750,8 +5765,9 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
         {
             // Excitement
             rct_string_id ratingName = get_rating_name(ride->excitement);
-            set_format_arg(0, uint32_t, ride->excitement);
-            set_format_arg(4, rct_string_id, ratingName);
+            auto ft = Formatter::Common();
+            ft.Add<uint32_t>(ride->excitement);
+            ft.Add<rct_string_id>(ratingName);
             rct_string_id stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE
                                                                                : STR_EXCITEMENT_RATING;
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, x, y);
@@ -5759,8 +5775,9 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
 
             // Intensity
             ratingName = get_rating_name(ride->intensity);
-            set_format_arg(0, uint32_t, ride->intensity);
-            set_format_arg(4, rct_string_id, ratingName);
+            ft = Formatter::Common();
+            ft.Add<uint32_t>(ride->intensity);
+            ft.Add<rct_string_id>(ratingName);
 
             stringId = STR_INTENSITY_RATING;
             if (ride->excitement == RIDE_RATING_UNDEFINED)
@@ -5773,8 +5790,9 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
 
             // Nausea
             ratingName = get_rating_name(ride->nausea);
-            set_format_arg(0, uint32_t, ride->nausea);
-            set_format_arg(4, rct_string_id, ratingName);
+            ft = Formatter::Common();
+            ft.Add<uint32_t>(ride->nausea);
+            ft.Add<rct_string_id>(ratingName);
             stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
             gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, x, y);
             y += 2 * LIST_ROW_HEIGHT;
@@ -5804,38 +5822,42 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     y += LIST_ROW_HEIGHT;
 
                     // Ride time
+                    ft = Formatter::Common();
                     int32_t numTimes = 0;
                     for (int32_t i = 0; i < ride->num_stations; i++)
                     {
                         time = ride->stations[numTimes].SegmentTime;
                         if (time != 0)
                         {
-                            set_format_arg(0 + (numTimes * 4), uint16_t, STR_RIDE_TIME_ENTRY_WITH_SEPARATOR);
-                            set_format_arg(2 + (numTimes * 4), uint16_t, time);
+                            ft.Add<uint16_t>(STR_RIDE_TIME_ENTRY_WITH_SEPARATOR);
+                            ft.Add<uint16_t>(time);
                             numTimes++;
                         }
                     }
                     if (numTimes == 0)
                     {
-                        set_format_arg(0, rct_string_id, STR_RIDE_TIME_ENTRY);
-                        set_format_arg(2, uint16_t, 0);
+                        ft.Add<uint16_t>(STR_RIDE_TIME_ENTRY);
+                        ft.Add<uint16_t>(0);
                         numTimes++;
                     }
                     else
                     {
                         // sadly, STR_RIDE_TIME_ENTRY_WITH_SEPARATOR are defined with the separator AFTER an entry
                         // therefore we set the last entry to use the no-separator format now, post-format
-                        set_format_arg(0 + ((numTimes - 1) * 4), uint16_t, STR_RIDE_TIME_ENTRY);
+                        ft.Increment(-ft.NumBytes() + ((numTimes - 1) * 4));
+                        ft.Add<uint16_t>(STR_RIDE_TIME_ENTRY);
                     }
-                    set_format_arg(0 + (numTimes * 4), uint16_t, 0);
-                    set_format_arg(2 + (numTimes * 4), uint16_t, 0);
-                    set_format_arg(4 + (numTimes * 4), uint16_t, 0);
-                    set_format_arg(6 + (numTimes * 4), uint16_t, 0);
+                    ft.Increment(-ft.NumBytes() + (numTimes * 4));
+                    ft.Add<uint16_t>(0);
+                    ft.Add<uint16_t>(0);
+                    ft.Add<uint16_t>(0);
+                    ft.Add<uint16_t>(0);
                     gfx_draw_string_left_clipped(dpi, STR_RIDE_TIME, gCommonFormatArgs, COLOUR_BLACK, { x, y }, 308);
                     y += LIST_ROW_HEIGHT;
                 }
 
                 // Ride length
+                ft = Formatter::Common();
                 int32_t numLengths = 0;
                 for (int32_t i = 0; i < ride->num_stations; i++)
                 {
@@ -5843,27 +5865,29 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     if (length != 0)
                     {
                         length >>= 16;
-                        set_format_arg(0 + (numLengths * 4), uint16_t, STR_RIDE_LENGTH_ENTRY_WITH_SEPARATOR);
-                        set_format_arg(2 + (numLengths * 4), uint16_t, (length & 0xFFFF));
+                        ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY_WITH_SEPARATOR);
+                        ft.Add<uint16_t>(length & 0xFFFF);
                         numLengths++;
                     }
                 }
                 if (numLengths == 0)
                 {
-                    set_format_arg(0, rct_string_id, STR_RIDE_LENGTH_ENTRY);
-                    set_format_arg(2, uint16_t, 0);
+                    ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
+                    ft.Add<uint16_t>(0);
                     numLengths++;
                 }
                 else
                 {
                     // sadly, STR_RIDE_LENGTH_ENTRY_WITH_SEPARATOR are defined with the separator AFTER an entry
                     // therefore we set the last entry to use the no-separator format now, post-format
-                    set_format_arg(0 + ((numLengths - 1) * 4), rct_string_id, STR_RIDE_LENGTH_ENTRY);
+                    ft.Increment(-ft.NumBytes() + ((numLengths - 1) * 4));
+                    ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
                 }
-                set_format_arg(0 + (numLengths * 4), uint16_t, 0);
-                set_format_arg(2 + (numLengths * 4), uint16_t, 0);
-                set_format_arg(4 + (numLengths * 4), uint16_t, 0);
-                set_format_arg(6 + (numLengths * 4), uint16_t, 0);
+                ft.Increment(-ft.NumBytes() + (numLengths * 4));
+                ft.Add<uint16_t>(0);
+                ft.Add<uint16_t>(0);
+                ft.Add<uint16_t>(0);
+                ft.Add<uint16_t>(0);
                 gfx_draw_string_left_clipped(dpi, STR_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, { x, y }, 308);
                 y += LIST_ROW_HEIGHT;
 
@@ -6708,7 +6732,9 @@ static void window_ride_income_invalidate(rct_window* w)
 
     window_ride_income_widgets[WIDX_PRIMARY_PRICE].text = STR_ARG_6_CURRENCY2DP;
     money16 ridePrimaryPrice = ride_get_price(ride);
-    set_format_arg(6, money32, ridePrimaryPrice);
+    auto ft = Formatter::Common();
+    ft.Increment(6);
+    ft.Add<money32>(ridePrimaryPrice);
     if (ridePrimaryPrice == 0)
         window_ride_income_widgets[WIDX_PRIMARY_PRICE].text = STR_FREE;
 
@@ -6758,7 +6784,7 @@ static void window_ride_income_invalidate(rct_window* w)
 
         // Set secondary item price
         window_ride_income_widgets[WIDX_SECONDARY_PRICE].text = STR_RIDE_SECONDARY_PRICE_VALUE;
-        set_format_arg(10, money32, ride->price[1]);
+        ft.Add<money32>(ride->price[1]);
         if (ride->price[1] == 0)
             window_ride_income_widgets[WIDX_SECONDARY_PRICE].text = STR_FREE;
     }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4954,11 +4954,13 @@ static void window_ride_colour_invalidate(rct_window* w)
             window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME].type = WWT_EMPTY;
             window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WWT_EMPTY;
         }
-        set_format_arg(6, rct_string_id, VehicleColourSchemeNames[vehicleColourSchemeType]);
-        set_format_arg(8, rct_string_id, RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].singular);
-        set_format_arg(
-            10, rct_string_id, RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].capitalised);
-        set_format_arg(12, uint16_t, w->vehicleIndex + 1);
+        auto ft = Formatter::Common();
+        ft.Increment(6);
+        ft.Add<rct_string_id>(VehicleColourSchemeNames[vehicleColourSchemeType]);
+        ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].singular);
+        ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].capitalised);
+        ft.Add<uint16_t>(w->vehicleIndex + 1);
+
         // Vehicle index
         if (vehicleColourSchemeType != 0)
         {
@@ -4986,7 +4988,9 @@ static void window_ride_colour_invalidate(rct_window* w)
         window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_2].type = WWT_EMPTY;
     }
 
-    set_format_arg(14, rct_string_id, ColourSchemeNames[colourScheme]);
+    auto ft = Formatter::Common();
+    ft.Increment(14);
+    ft.Add<rct_string_id>(ColourSchemeNames[colourScheme]);
 
     window_ride_anchor_border_widgets(w);
     window_align_tabs(w, WIDX_TAB_1, WIDX_TAB_10);
@@ -6090,9 +6094,10 @@ static void window_ride_graphs_tooltip(rct_window* w, rct_widgetindex widgetInde
             auto [measurement, message] = ride_get_measurement(ride);
             if (measurement != nullptr && (measurement->flags & RIDE_MEASUREMENT_FLAG_RUNNING))
             {
-                set_format_arg(4, uint16_t, measurement->vehicle_index + 1);
-                set_format_arg(
-                    2, rct_string_id, RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].count);
+                auto ft = Formatter::Common();
+                ft.Increment(2);
+                ft.Add<rct_string_id>(RideComponentNames[RideTypeDescriptors[ride->type].NameConvention.vehicle].count);
+                ft.Add<uint16_t>(measurement->vehicle_index + 1);
             }
             else
             {
@@ -7048,8 +7053,9 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     shopItem = ride->GetRideEntry()->shop_item[0];
     if (shopItem != SHOP_ITEM_NONE)
     {
-        set_format_arg(0, rct_string_id, ShopItems[shopItem].Naming.Plural);
-        set_format_arg(2, uint32_t, ride->no_primary_items_sold);
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(ShopItems[shopItem].Naming.Plural);
+        ft.Add<uint32_t>(ride->no_primary_items_sold);
         gfx_draw_string_left(dpi, STR_ITEMS_SOLD, gCommonFormatArgs, COLOUR_BLACK, x, y);
         y += LIST_ROW_HEIGHT;
     }
@@ -7059,8 +7065,9 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                                                       : ride->GetRideEntry()->shop_item[1];
     if (shopItem != SHOP_ITEM_NONE)
     {
-        set_format_arg(0, rct_string_id, ShopItems[shopItem].Naming.Plural);
-        set_format_arg(2, uint32_t, ride->no_secondary_items_sold);
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(ShopItems[shopItem].Naming.Plural);
+        ft.Add<uint32_t>(ride->no_secondary_items_sold);
         gfx_draw_string_left(dpi, STR_ITEMS_SOLD, gCommonFormatArgs, COLOUR_BLACK, x, y);
         y += LIST_ROW_HEIGHT;
     }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -609,6 +609,8 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, { 0, y - 1 }, 159);
 
         // Ride information
+        auto ft = Formatter::Common();
+        ft.Increment(2);
         auto formatSecondaryEnabled = true;
         rct_string_id formatSecondary = 0;
         switch (_window_ride_list_information_type)
@@ -628,7 +630,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 if (ride->popularity != 255)
                 {
                     formatSecondary = STR_POPULARITY_LABEL;
-                    set_format_arg(2, uint16_t, ride->popularity * 4);
+                    ft.Add<uint16_t>(ride->popularity * 4);
                 }
                 break;
             case INFORMATION_TYPE_SATISFACTION:
@@ -636,7 +638,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 if (ride->satisfaction != 255)
                 {
                     formatSecondary = STR_SATISFACTION_LABEL;
-                    set_format_arg(2, uint16_t, ride->satisfaction * 5);
+                    ft.Add<uint16_t>(ride->satisfaction * 5);
                 }
                 break;
             case INFORMATION_TYPE_PROFIT:
@@ -644,24 +646,24 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 if (ride->profit != MONEY32_UNDEFINED)
                 {
                     formatSecondary = STR_PROFIT_LABEL;
-                    set_format_arg(2, int32_t, ride->profit);
+                    ft.Add<int32_t>(ride->profit);
                 }
                 break;
             case INFORMATION_TYPE_TOTAL_CUSTOMERS:
                 formatSecondary = STR_RIDE_LIST_TOTAL_CUSTOMERS_LABEL;
-                set_format_arg(2, uint32_t, ride->total_customers);
+                ft.Add<uint32_t>(ride->total_customers);
                 break;
             case INFORMATION_TYPE_TOTAL_PROFIT:
                 formatSecondary = 0;
                 if (ride->total_profit != MONEY32_UNDEFINED)
                 {
                     formatSecondary = STR_RIDE_LIST_TOTAL_PROFIT_LABEL;
-                    set_format_arg(2, int32_t, ride->total_profit);
+                    ft.Add<int32_t>(ride->total_profit);
                 }
                 break;
             case INFORMATION_TYPE_CUSTOMERS:
                 formatSecondary = STR_RIDE_LIST_CUSTOMERS_PER_HOUR_LABEL;
-                set_format_arg(2, uint32_t, ride_customers_per_hour(ride));
+                ft.Add<uint32_t>(ride_customers_per_hour(ride));
                 break;
             case INFORMATION_TYPE_AGE:
             {
@@ -678,7 +680,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                         formatSecondary = STR_RIDE_LIST_BUILT_X_YEARS_AGO_LABEL;
                         break;
                 }
-                set_format_arg(2, int16_t, age);
+                ft.Add<int16_t>(age);
                 break;
             }
             case INFORMATION_TYPE_INCOME:
@@ -686,7 +688,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 if (ride->income_per_hour != MONEY32_UNDEFINED)
                 {
                     formatSecondary = STR_RIDE_LIST_INCOME_LABEL;
-                    set_format_arg(2, int32_t, ride->income_per_hour);
+                    ft.Add<int32_t>(ride->income_per_hour);
                 }
                 break;
             case INFORMATION_TYPE_RUNNING_COST:
@@ -694,11 +696,11 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 if (ride->upkeep_cost != MONEY16_UNDEFINED)
                 {
                     formatSecondary = STR_RIDE_LIST_RUNNING_COST_LABEL;
-                    set_format_arg(2, int32_t, ride->upkeep_cost * 16);
+                    ft.Add<int32_t>(ride->upkeep_cost * 16);
                 }
                 break;
             case INFORMATION_TYPE_QUEUE_LENGTH:
-                set_format_arg(2, uint16_t, ride->GetTotalQueueLength());
+                ft.Add<uint16_t>(ride->GetTotalQueueLength());
                 formatSecondary = STR_QUEUE_EMPTY;
                 {
                     uint16_t arg;
@@ -711,7 +713,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 }
                 break;
             case INFORMATION_TYPE_QUEUE_TIME:
-                set_format_arg(2, uint16_t, ride->GetMaxQueueTime());
+                ft.Add<uint16_t>(ride->GetMaxQueueTime());
                 formatSecondary = STR_QUEUE_TIME_LABEL;
                 {
                     uint16_t arg;
@@ -722,18 +724,18 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 }
                 break;
             case INFORMATION_TYPE_RELIABILITY:
-                set_format_arg(2, uint16_t, ride->reliability_percentage);
+                ft.Add<uint16_t>(ride->reliability_percentage);
                 formatSecondary = STR_RELIABILITY_LABEL;
                 break;
             case INFORMATION_TYPE_DOWN_TIME:
-                set_format_arg(2, uint16_t, ride->downtime);
+                ft.Add<uint16_t>(ride->downtime);
                 formatSecondary = STR_DOWN_TIME_LABEL;
                 break;
             case INFORMATION_TYPE_GUESTS_FAVOURITE:
                 formatSecondary = 0;
                 if (ride->IsRide())
                 {
-                    set_format_arg(2, uint16_t, ride->guests_favourite);
+                    ft.Add<uint16_t>(ride->guests_favourite);
                     formatSecondary = ride->guests_favourite == 1 ? STR_GUESTS_FAVOURITE_LABEL
                                                                   : STR_GUESTS_FAVOURITE_PLURAL_LABEL;
                 }
@@ -742,7 +744,8 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
 
         if (formatSecondaryEnabled)
         {
-            set_format_arg(0, rct_string_id, formatSecondary);
+            ft.Increment(-ft.NumBytes());
+            ft.Add<rct_string_id>(formatSecondary);
         }
         gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, { 160, y - 1 }, 157);
         y += SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -744,7 +744,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
 
         if (formatSecondaryEnabled)
         {
-            ft.Increment(-ft.NumBytes());
+            ft.Rewind();
             ft.Add<rct_string_id>(formatSecondary);
         }
         gfx_draw_string_left_clipped(dpi, format, gCommonFormatArgs, COLOUR_BLACK, { 160, y - 1 }, 157);

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -897,7 +897,8 @@ static void window_title_editor_scrollpaint_saves(rct_window* w, rct_drawpixelin
         }
 
         char buffer[256];
-        set_format_arg(0, uintptr_t, _editingTitleSequence->Saves[i]);
+        auto ft = Formatter::Common();
+        ft.Add<const char*>(_editingTitleSequence->Saves[i]);
         if (selected || hover)
         {
             format_string(buffer, 256, STR_STRING, gCommonFormatArgs);
@@ -907,7 +908,8 @@ static void window_title_editor_scrollpaint_saves(rct_window* w, rct_drawpixelin
             format_string(buffer + 1, 255, STR_STRING, gCommonFormatArgs);
             buffer[0] = static_cast<utf8>(static_cast<uint8_t>(FORMAT_BLACK));
         }
-        set_format_arg(0, uintptr_t, &buffer);
+        ft = Formatter::Common();
+        ft.Add<const char*>(&buffer);
         gfx_draw_string_left(dpi, STR_STRING, gCommonFormatArgs, w->colours[1], x + 5, y);
     }
 }
@@ -946,6 +948,7 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
                 ColourMapA[w->colours[1]].lighter | 0x1000000);
         }
 
+        auto ft = Formatter::Common();
         rct_string_id commandName = STR_NONE;
         switch (command->Type)
         {
@@ -958,25 +961,25 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
                 }
                 else
                 {
-                    set_format_arg(0, uintptr_t, _editingTitleSequence->Saves[command->SaveIndex]);
+                    ft.Add<const char*>(_editingTitleSequence->Saves[command->SaveIndex]);
                 }
                 break;
             case TITLE_SCRIPT_LOCATION:
                 commandName = STR_TITLE_EDITOR_COMMAND_LOCATION;
-                set_format_arg(0, uint16_t, command->X);
-                set_format_arg(2, uint16_t, command->Y);
+                ft.Add<uint16_t>(command->X);
+                ft.Add<uint16_t>(command->Y);
                 break;
             case TITLE_SCRIPT_ROTATE:
                 commandName = STR_TITLE_EDITOR_COMMAND_ROTATE;
-                set_format_arg(0, uint16_t, command->Rotations);
+                ft.Add<uint16_t>(command->Rotations);
                 break;
             case TITLE_SCRIPT_ZOOM:
                 commandName = STR_TITLE_EDITOR_COMMAND_ZOOM;
-                set_format_arg(0, uint16_t, command->Zoom);
+                ft.Add<uint16_t>(command->Zoom);
                 break;
             case TITLE_SCRIPT_SPEED:
                 commandName = STR_TITLE_EDITOR_COMMAND_SPEED;
-                set_format_arg(0, rct_string_id, SpeedNames[command->Speed - 1]);
+                ft.Add<rct_string_id>(SpeedNames[command->Speed - 1]);
                 break;
             case TITLE_SCRIPT_FOLLOW:
                 commandName = STR_TITLE_EDITOR_COMMAND_FOLLOW;
@@ -986,12 +989,12 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
                 }
                 else
                 {
-                    set_format_arg(0, uintptr_t, reinterpret_cast<uintptr_t>(command->SpriteName));
+                    ft.Add<uintptr_t>(reinterpret_cast<uintptr_t>(command->SpriteName));
                 }
                 break;
             case TITLE_SCRIPT_WAIT:
                 commandName = STR_TITLE_EDITOR_COMMAND_WAIT;
-                set_format_arg(0, uint16_t, command->Milliseconds);
+                ft.Add<uint16_t>(command->Milliseconds);
                 break;
             case TITLE_SCRIPT_RESTART:
                 commandName = STR_TITLE_EDITOR_RESTART;
@@ -1016,7 +1019,7 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
                 {
                     commandName = STR_TITLE_EDITOR_COMMAND_LOAD_MISSING_SCENARIO;
                 }
-                set_format_arg(0, uintptr_t, name);
+                ft.Add<const char*>(name);
                 break;
             }
             default:
@@ -1033,7 +1036,8 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
             format_string(buffer + 1, 255, commandName, gCommonFormatArgs);
             buffer[0] = static_cast<utf8>(error ? ((selected || hover) ? FORMAT_LIGHTPINK : FORMAT_RED) : FORMAT_BLACK);
         }
-        set_format_arg(0, uintptr_t, &buffer);
+        ft = Formatter::Common();
+        ft.Add<const char*>(&buffer);
         gfx_draw_string_left(dpi, STR_STRING, gCommonFormatArgs, w->colours[1], x + 5, y);
     }
 }

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -832,7 +832,9 @@ static void window_title_editor_paint(rct_window* w, rct_drawpixelinfo* dpi)
     switch (w->selected_tab)
     {
         case WINDOW_TITLE_EDITOR_TAB_PRESETS:
-            set_format_arg(0, uintptr_t, _sequenceName);
+        {
+            auto ft = Formatter::Common();
+            ft.Add<const char*>(_sequenceName);
             gfx_draw_string_left(
                 dpi, STR_TITLE_SEQUENCE, nullptr, w->colours[1], w->windowPos.x + 10,
                 w->windowPos.y + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top + 1);
@@ -843,6 +845,7 @@ static void window_title_editor_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 w->windowPos.x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS_DROPDOWN].left
                     - window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].left - 4);
             break;
+        }
         case WINDOW_TITLE_EDITOR_TAB_SAVES:
             break;
         case WINDOW_TITLE_EDITOR_TAB_SCRIPT:

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -112,9 +112,14 @@ public:
         return CurrentBuf;
     }
 
-    void Increment(std::size_t count)
+    void Increment(size_t count)
     {
         CurrentBuf += count;
+    }
+
+    void Rewind()
+    {
+        CurrentBuf -= NumBytes();
     }
 
     std::size_t NumBytes() const

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -85,19 +85,6 @@ extern const rct_string_id DateGameShortMonthNames[MONTH_COUNT];
     std::memcpy(args + offset, &value, size);
 }
 
-template<typename T> void constexpr set_format_arg(uint8_t* args, size_t offset, uintptr_t value)
-{
-    static_assert(sizeof(T) <= sizeof(uintptr_t), "Type too large");
-    set_format_arg_body(args, offset, value, sizeof(T));
-}
-
-#define set_format_arg(offset, type, value)                                                                                    \
-    do                                                                                                                         \
-    {                                                                                                                          \
-        static_assert(sizeof(type) <= sizeof(uintptr_t), "Type too large");                                                    \
-        set_format_arg_body(gCommonFormatArgs, offset, (uintptr_t)(value), sizeof(type));                                      \
-    } while (false)
-
 class Formatter
 {
     const uint8_t* StartBuf;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1254,10 +1254,13 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActionResult& 
             }
             break;
         case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+        {
             sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
-            set_format_arg<rct_string_id>(res.ErrorMessageArgs.data(), 0, sceneryEntry->name);
+            auto ft = Formatter(res.ErrorMessageArgs.data());
+            ft.Add<rct_string_id>(sceneryEntry->name);
             break;
+        }
         case TILE_ELEMENT_TYPE_ENTRANCE:
             switch (tileElement->AsEntrance()->GetEntranceType())
             {
@@ -1273,15 +1276,21 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActionResult& 
             }
             break;
         case TILE_ELEMENT_TYPE_WALL:
+        {
             sceneryEntry = tileElement->AsWall()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
-            set_format_arg<rct_string_id>(res.ErrorMessageArgs.data(), 0, sceneryEntry->name);
+            auto ft = Formatter(res.ErrorMessageArgs.data());
+            ft.Add<rct_string_id>(sceneryEntry->name);
             break;
+        }
         case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        {
             sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
-            set_format_arg<rct_string_id>(res.ErrorMessageArgs.data(), 0, sceneryEntry->name);
+            auto ft = Formatter(res.ErrorMessageArgs.data());
+            ft.Add<rct_string_id>(sceneryEntry->name);
             break;
+        }
     }
 }
 


### PR DESCRIPTION
This moves all remaining calls to set_format_arg() to use Formatter::Common(). This also means cleaning up many indirect usages of a C-style cast.