### PR TITLE
Implement Sprite Is As functions

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -170,7 +170,7 @@ int32_t viewport_interaction_left_click(const ScreenCoordsXY& screenCoords)
                         {
                             case SPRITE_MISC_BALLOON:
                             {
-                                auto balloonPress = BalloonPressAction(info.sprite->AsBalloon()->sprite_index);
+                                auto balloonPress = BalloonPressAction(info.sprite->generic.sprite_index);
                                 GameActions::Execute(&balloonPress);
                             }
                             break;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -612,7 +612,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
             if (sprite == nullptr)
                 break;
 
-            auto peep = sprite->AsPeep();
+            auto peep = sprite->generic.As<Peep>();
             if (peep == nullptr)
                 return;
 

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -327,7 +327,7 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
                     if (sprite == nullptr)
                         break;
 
-                    auto peep = sprite->AsPeep();
+                    auto peep = sprite->generic.As<Peep>();
                     if (peep == nullptr)
                         break;
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1214,7 +1214,7 @@ void window_staff_overview_tool_down(rct_window* w, rct_widgetindex widgetIndex,
             return;
 
         rct_sprite* sprite = try_get_sprite(w->number);
-        if (sprite == nullptr || !sprite->IsPeep())
+        if (sprite == nullptr || !sprite->generic.Is<Peep>())
             return;
 
         Peep& peep = sprite->peep;
@@ -1255,7 +1255,7 @@ void window_staff_overview_tool_drag(rct_window* w, rct_widgetindex widgetIndex,
         return;
 
     rct_sprite* sprite = try_get_sprite(w->number);
-    if (sprite == nullptr || !sprite->IsPeep())
+    if (sprite == nullptr || !sprite->generic.Is<Peep>())
         return;
 
     Peep& peep = sprite->peep;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -657,7 +657,7 @@ static void window_title_command_editor_tool_down(
         }
         else if (spriteIdentifier == SPRITE_IDENTIFIER_MISC)
         {
-            if (info.sprite->IsBalloon())
+            if (info.sprite->generic.Is<Balloon>())
             {
                 validSprite = true;
                 format_string(command.SpriteName, USER_STRING_MAX_LENGTH, STR_SHOP_ITEM_SINGULAR_BALLOON, nullptr);

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -662,7 +662,7 @@ static void window_title_command_editor_tool_down(
                 validSprite = true;
                 format_string(command.SpriteName, USER_STRING_MAX_LENGTH, STR_SHOP_ITEM_SINGULAR_BALLOON, nullptr);
             }
-            else if (info.sprite->IsDuck())
+            else if (info.sprite->generic.Is<Duck>())
             {
                 validSprite = true;
                 format_string(command.SpriteName, USER_STRING_MAX_LENGTH, STR_DUCK, nullptr);

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -620,7 +620,7 @@ static void window_title_command_editor_tool_down(
         uint16_t spriteIndex = info.sprite->generic.sprite_index;
         uint16_t spriteIdentifier = info.sprite->generic.sprite_identifier;
         bool validSprite = false;
-        if (info.sprite->IsPeep())
+        if (info.sprite->generic.Is<Peep>())
         {
             validSprite = true;
             auto peep = GET_PEEP(spriteIndex);

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -309,7 +309,7 @@ namespace Editor
         //
         for (int32_t i = 0; i < MAX_SPRITES; i++)
         {
-            auto peep = get_sprite(i)->AsPeep();
+            auto peep = get_sprite(i)->generic.As<Peep>();
             if (peep != nullptr)
             {
                 peep->SetName({});

--- a/src/openrct2/actions/BalloonPressAction.hpp
+++ b/src/openrct2/actions/BalloonPressAction.hpp
@@ -37,7 +37,7 @@ public:
     GameActionResult::Ptr Query() const override
     {
         rct_sprite* sprite = try_get_sprite(_spriteIndex);
-        if (sprite == nullptr || !sprite->IsBalloon())
+        if (sprite == nullptr || !sprite->generic.Is<Balloon>())
         {
             log_error("Tried getting invalid sprite for balloon: %u", _spriteIndex);
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
@@ -48,7 +48,7 @@ public:
     GameActionResult::Ptr Execute() const override
     {
         rct_sprite* sprite = try_get_sprite(_spriteIndex);
-        if (sprite == nullptr || !sprite->IsBalloon())
+        if (sprite == nullptr || !sprite->generic.Is<Balloon>())
         {
             log_error("Tried getting invalid sprite for balloon: %u", _spriteIndex);
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_NONE);

--- a/src/openrct2/actions/BalloonPressAction.hpp
+++ b/src/openrct2/actions/BalloonPressAction.hpp
@@ -54,7 +54,7 @@ public:
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
         }
 
-        sprite->AsBalloon()->Press();
+        sprite->generic.As<Balloon>()->Press();
 
         return MakeResult();
     }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1574,7 +1574,7 @@ static int32_t cc_mp_desync(InteractiveConsole& console, const arguments_t& argv
         if (sprite->generic.sprite_identifier == SPRITE_IDENTIFIER_NULL)
             continue;
 
-        auto peep = sprite->AsPeep();
+        auto peep = sprite->generic.As<Peep>();
         if (peep != nullptr)
             peeps.push_back(peep);
     }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -274,7 +274,7 @@ std::optional<CoordsXYZ> news_item_get_subject_location(int32_t type, int32_t su
             if (sprite == nullptr)
                 break;
 
-            auto peep = sprite->AsPeep();
+            auto peep = sprite->generic.As<Peep>();
             if (peep == nullptr)
                 break;
 
@@ -314,7 +314,7 @@ std::optional<CoordsXYZ> news_item_get_subject_location(int32_t type, int32_t su
             auto sprite = try_get_sprite(subject);
             if (sprite != nullptr)
             {
-                auto peep = sprite->AsPeep();
+                auto peep = sprite->generic.As<Peep>();
                 if (peep != nullptr)
                 {
                     subjectLoc = CoordsXYZ{ peep->x, peep->y, peep->z };
@@ -410,7 +410,7 @@ void news_item_open_subject(int32_t type, int32_t subject)
             auto sprite = try_get_sprite(subject);
             if (sprite != nullptr)
             {
-                auto peep = sprite->AsPeep();
+                auto peep = sprite->generic.As<Peep>();
                 if (peep != nullptr)
                 {
                     auto intent = Intent(WC_PEEP);

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -56,7 +56,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
 
         if (highlightPathIssues)
         {
-            if (spr->IsPeep())
+            if (spr->generic.Is<Peep>())
             {
                 Peep* peep = (Peep*)spr;
                 if (!(peep->type == PEEP_TYPE_STAFF && peep->staff_type == STAFF_TYPE_HANDYMAN))

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5483,7 +5483,7 @@ void Guest::UpdateWalking()
     {
         sprite = get_sprite(sprite_id);
 
-        if (!sprite->IsPeep())
+        if (!sprite->generic.Is<Peep>())
             continue;
 
         if (sprite->peep.state != PEEP_STATE_WATCHING)
@@ -6069,7 +6069,7 @@ bool Guest::UpdateWalkingFindBench()
     {
         sprite = get_sprite(sprite_id);
 
-        if (!sprite->IsPeep())
+        if (!sprite->generic.Is<Peep>())
             continue;
 
         if (sprite->peep.state != PEEP_STATE_SITTING)
@@ -6263,7 +6263,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
     {
         sprite = get_sprite(sprite_id);
 
-        if (!sprite->IsPeep() || (sprite->peep.state != PEEP_STATE_SITTING) || (peep->z != sprite->peep.z))
+        if (!sprite->generic.Is<Peep>() || (sprite->peep.state != PEEP_STATE_SITTING) || (peep->z != sprite->peep.z))
         {
             continue;
         }

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -328,16 +328,6 @@ template<> bool SpriteBase::Is<Peep>() const
     return sprite_identifier == SPRITE_IDENTIFIER_PEEP;
 }
 
-Peep* rct_sprite::AsPeep()
-{
-    Peep* result = nullptr;
-    if (generic.Is<Peep>())
-    {
-        return reinterpret_cast<Peep*>(this);
-    }
-    return result;
-}
-
 Guest* Peep::AsGuest()
 {
     return type == PEEP_TYPE_GUEST ? static_cast<Guest*>(this) : nullptr;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -328,15 +328,10 @@ template<> bool SpriteBase::Is<Peep>() const
     return sprite_identifier == SPRITE_IDENTIFIER_PEEP;
 }
 
-bool rct_sprite::IsPeep() const
-{
-    return peep.sprite_identifier == SPRITE_IDENTIFIER_PEEP;
-}
-
 Peep* rct_sprite::AsPeep()
 {
     Peep* result = nullptr;
-    if (IsPeep())
+    if (generic.Is<Peep>())
     {
         return reinterpret_cast<Peep*>(this);
     }
@@ -392,7 +387,7 @@ Peep* try_get_guest(uint16_t spriteIndex)
     rct_sprite* sprite = try_get_sprite(spriteIndex);
     if (sprite == nullptr)
         return nullptr;
-    if (!sprite->IsPeep())
+    if (!sprite->generic.Is<Peep>())
         return nullptr;
     if (sprite->peep.type != PEEP_TYPE_GUEST)
         return nullptr;
@@ -2697,7 +2692,7 @@ static void peep_footpath_move_forward(Peep* peep, int16_t x, int16_t y, TileEle
     for (rct_sprite* sprite; sprite_id != SPRITE_INDEX_NULL; sprite_id = sprite->generic.next_in_quadrant)
     {
         sprite = get_sprite(sprite_id);
-        if (sprite->IsPeep())
+        if (sprite->generic.Is<Peep>())
         {
             Peep* other_peep = reinterpret_cast<Peep*>(sprite);
             if (other_peep->state != PEEP_STATE_WALKING)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -323,6 +323,11 @@ const bool gSpriteTypeToSlowWalkMap[] = {
 
 // clang-format on
 
+template<> bool SpriteBase::Is<Peep>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_PEEP;
+}
+
 bool rct_sprite::IsPeep() const
 {
     return peep.sprite_identifier == SPRITE_IDENTIFIER_PEEP;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -832,7 +832,7 @@ size_t Ride::FormatStatusTo(void* argsV) const
         && race_winner != SPRITE_INDEX_NULL)
     {
         auto sprite = get_sprite(race_winner);
-        if (sprite != nullptr && sprite->IsPeep())
+        if (sprite != nullptr && sprite->generic.Is<Peep>())
         {
             auto peep = sprite->AsPeep();
             ft.Add<rct_string_id>(STR_RACE_WON_BY);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -834,7 +834,7 @@ size_t Ride::FormatStatusTo(void* argsV) const
         auto sprite = get_sprite(race_winner);
         if (sprite != nullptr && sprite->generic.Is<Peep>())
         {
-            auto peep = sprite->AsPeep();
+            auto peep = sprite->generic.As<Peep>();
             ft.Add<rct_string_id>(STR_RACE_WON_BY);
             peep->FormatNameTo(ft);
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -726,6 +726,11 @@ static const struct
 
 // clang-format on
 
+template<> bool SpriteBase::Is<Vehicle>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_VEHICLE;
+}
+
 static bool vehicle_move_info_valid(int32_t trackSubposition, int32_t typeAndDirection, int32_t offset)
 {
     if (trackSubposition >= static_cast<int32_t>(std::size(gTrackVehicleInfo)))

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -333,7 +333,7 @@ namespace OpenRCT2::Scripting
     protected:
         Peep* GetPeep() const
         {
-            return get_sprite(_id)->AsPeep();
+            return get_sprite(_id)->generic.As<Peep>();
         }
     };
 

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -19,16 +19,6 @@ template<> bool SpriteBase::Is<Balloon>() const
     return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_BALLOON;
 }
 
-Balloon* rct_sprite::AsBalloon()
-{
-    Balloon* result = nullptr;
-    if (generic.Is<Balloon>())
-    {
-        result = reinterpret_cast<Balloon*>(this);
-    }
-    return result;
-}
-
 void Balloon::Update()
 {
     invalidate_sprite_2(this);

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -14,11 +14,6 @@
 #include "../util/Util.h"
 #include "Sprite.h"
 
-bool rct_sprite::IsBalloon()
-{
-    return this->balloon.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->balloon.type == SPRITE_MISC_BALLOON;
-}
-
 template<> bool SpriteBase::Is<Balloon>() const
 {
     return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_BALLOON;
@@ -27,7 +22,7 @@ template<> bool SpriteBase::Is<Balloon>() const
 Balloon* rct_sprite::AsBalloon()
 {
     Balloon* result = nullptr;
-    if (IsBalloon())
+    if (generic.Is<Balloon>())
     {
         result = reinterpret_cast<Balloon*>(this);
     }

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -19,6 +19,11 @@ bool rct_sprite::IsBalloon()
     return this->balloon.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->balloon.type == SPRITE_MISC_BALLOON;
 }
 
+template<> bool SpriteBase::Is<Balloon>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_BALLOON;
+}
+
 Balloon* rct_sprite::AsBalloon()
 {
     Balloon* result = nullptr;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -79,15 +79,10 @@ template<> bool SpriteBase::Is<Duck>() const
     return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_DUCK;
 }
 
-bool rct_sprite::IsDuck()
-{
-    return this->duck.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->duck.type == SPRITE_MISC_DUCK;
-}
-
 Duck* rct_sprite::AsDuck()
 {
     Duck* result = nullptr;
-    if (IsDuck())
+    if (generic.Is<Duck>())
     {
         return reinterpret_cast<Duck*>(this);
     }

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -74,6 +74,11 @@ static constexpr const uint8_t * DuckAnimations[] =
 };
 // clang-format on
 
+template<> bool SpriteBase::Is<Duck>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_DUCK;
+}
+
 bool rct_sprite::IsDuck()
 {
     return this->duck.sprite_identifier == SPRITE_IDENTIFIER_MISC && this->duck.type == SPRITE_MISC_DUCK;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -79,16 +79,6 @@ template<> bool SpriteBase::Is<Duck>() const
     return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_DUCK;
 }
 
-Duck* rct_sprite::AsDuck()
-{
-    Duck* result = nullptr;
-    if (generic.Is<Duck>())
-    {
-        return reinterpret_cast<Duck*>(this);
-    }
-    return result;
-}
-
 void Duck::Invalidate()
 {
     invalidate_sprite_1(this);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -419,7 +419,7 @@ void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
     {
         auto* entity = get_sprite(spriteIndex);
         uint16_t nextSpriteIndex = entity->generic.next_in_quadrant;
-        if (entity->IsPeep())
+        if (entity->generic.Is<Peep>())
         {
             Peep* peep = &entity->peep;
             if (peep->state == PEEP_STATE_SITTING || peep->state == PEEP_STATE_WATCHING)

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -80,6 +80,12 @@ const uint8_t _fountainPatternFlags[] = {
     FOUNTAIN_FLAG::FAST                                                    // FAST_RANDOM_CHASERS
 };
 
+template<> bool SpriteBase::Is<JumpingFountain>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC
+        && (type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW || type == SPRITE_MISC_JUMPING_FOUNTAIN_WATER);
+}
+
 void JumpingFountain::StartAnimation(const int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement)
 {
     int32_t randomIndex;

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -202,7 +202,7 @@ static bool map_animation_invalidate_small_scenery(const CoordsXYZ& loc)
                 for (; spriteIdx != SPRITE_INDEX_NULL; spriteIdx = sprite->generic.next_in_quadrant)
                 {
                     sprite = get_sprite(spriteIdx);
-                    if (!sprite->IsPeep())
+                    if (!sprite->generic.Is<Peep>())
                         continue;
 
                     peep = &sprite->peep;

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -23,16 +23,10 @@ template<> bool SpriteBase::Is<MoneyEffect>() const
     return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_MONEY_EFFECT;
 }
 
-bool rct_sprite::IsMoneyEffect()
-{
-    return this->money_effect.sprite_identifier == SPRITE_IDENTIFIER_MISC
-        && this->money_effect.type == SPRITE_MISC_MONEY_EFFECT;
-}
-
 MoneyEffect* rct_sprite::AsMoneyEffect()
 {
     MoneyEffect* result = nullptr;
-    if (IsMoneyEffect())
+    if (generic.Is<MoneyEffect>())
     {
         result = reinterpret_cast<MoneyEffect*>(this);
     }

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -18,6 +18,11 @@
 
 static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }, { -1, 1 }, { -1, -1 } };
 
+template<> bool SpriteBase::Is<MoneyEffect>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_MONEY_EFFECT;
+}
+
 bool rct_sprite::IsMoneyEffect()
 {
     return this->money_effect.sprite_identifier == SPRITE_IDENTIFIER_MISC

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -23,16 +23,6 @@ template<> bool SpriteBase::Is<MoneyEffect>() const
     return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_MONEY_EFFECT;
 }
 
-MoneyEffect* rct_sprite::AsMoneyEffect()
-{
-    MoneyEffect* result = nullptr;
-    if (generic.Is<MoneyEffect>())
-    {
-        result = reinterpret_cast<MoneyEffect*>(this);
-    }
-    return result;
-}
-
 /**
  *
  *  rct2: 0x0067351F

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -14,6 +14,15 @@
 
 #include <iterator>
 
+template<> bool SpriteBase::Is<VehicleCrashParticle>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_CRASHED_VEHICLE_PARTICLE;
+}
+
+template<> bool SpriteBase::Is<CrashSplashParticle>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_CRASH_SPLASH;
+}
 /**
  *
  *  rct2: 0x006735A1

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -288,7 +288,7 @@ rct_sprite_checksum sprite_checksum()
                         break;
                 }
 
-                if (copy.IsPeep())
+                if (copy.generic.Is<Peep>())
                 {
                     // Name is pointer and will not be the same across clients
                     copy.peep.name = {};

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -888,7 +888,7 @@ uint16_t remove_floating_sprites()
         }
         else if (rctSprite->generic.Is<Duck>())
         {
-            if (rctSprite->AsDuck()->IsFlying())
+            if (rctSprite->generic.As<Duck>()->IsFlying())
             {
                 rctSprite->duck.Remove();
                 sprite_misc_update(rctSprite);

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -880,7 +880,7 @@ uint16_t remove_floating_sprites()
     for (uint16_t i = 0; i < MAX_SPRITES; i++)
     {
         rct_sprite* rctSprite = get_sprite(i);
-        if (rctSprite->IsBalloon())
+        if (rctSprite->generic.Is<Balloon>())
         {
             sprite_remove(rctSprite->AsBalloon());
             sprite_misc_update(rctSprite);

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -886,7 +886,7 @@ uint16_t remove_floating_sprites()
             sprite_misc_update(rctSprite);
             removed++;
         }
-        else if (rctSprite->IsDuck())
+        else if (rctSprite->generic.Is<Duck>())
         {
             if (rctSprite->AsDuck()->IsFlying())
             {

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -745,7 +745,7 @@ void sprite_set_coordinates(int16_t x, int16_t y, int16_t z, SpriteBase* sprite)
  */
 void sprite_remove(SpriteBase* sprite)
 {
-    auto peep = (reinterpret_cast<rct_sprite*>(sprite))->AsPeep();
+    auto peep = sprite->As<Peep>();
     if (peep != nullptr)
     {
         peep->SetName({});

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -882,7 +882,7 @@ uint16_t remove_floating_sprites()
         rct_sprite* rctSprite = get_sprite(i);
         if (rctSprite->generic.Is<Balloon>())
         {
-            sprite_remove(rctSprite->AsBalloon());
+            sprite_remove(&rctSprite->generic);
             sprite_misc_update(rctSprite);
             removed++;
         }
@@ -897,7 +897,7 @@ uint16_t remove_floating_sprites()
         }
         else if (rctSprite->generic.Is<MoneyEffect>())
         {
-            sprite_remove(rctSprite->AsMoneyEffect());
+            sprite_remove(&rctSprite->generic);
             sprite_misc_update(rctSprite);
             removed++;
         }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -895,7 +895,7 @@ uint16_t remove_floating_sprites()
                 removed++;
             }
         }
-        else if (rctSprite->IsMoneyEffect())
+        else if (rctSprite->generic.Is<MoneyEffect>())
         {
             sprite_remove(rctSprite->AsMoneyEffect());
             sprite_misc_update(rctSprite);

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -52,6 +52,26 @@ static CoordsXYZ _spritelocations2[MAX_SPRITES];
 static size_t GetSpatialIndexOffset(int32_t x, int32_t y);
 static void move_sprite_to_list(SpriteBase* sprite, SPRITE_LIST newListIndex);
 
+template<> bool SpriteBase::Is<Litter>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_LITTER;
+}
+
+template<> bool SpriteBase::Is<SteamParticle>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_STEAM_PARTICLE;
+}
+
+template<> bool SpriteBase::Is<ExplosionFlare>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_EXPLOSION_FLARE;
+}
+
+template<> bool SpriteBase::Is<ExplosionCloud>() const
+{
+    return sprite_identifier == SPRITE_IDENTIFIER_MISC && type == SPRITE_MISC_EXPLOSION_CLOUD;
+}
+
 std::string rct_sprite_checksum::ToString() const
 {
     std::string result;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -100,6 +100,14 @@ struct VehicleCrashParticle : SpriteGeneric
     int32_t acceleration_z;
 };
 
+struct ExplosionFlare : SpriteGeneric
+{
+};
+
+struct ExplosionCloud : SpriteGeneric
+{
+};
+
 struct CrashSplashParticle : SpriteGeneric
 {
 };

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    bool IsMoneyEffect();
     bool IsPeep() const;
     Balloon* AsBalloon();
     Duck* AsDuck();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    bool IsPeep() const;
     Balloon* AsBalloon();
     Duck* AsDuck();
     MoneyEffect* AsMoneyEffect();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    Peep* AsPeep();
     // Default constructor to prevent non trivial construction issues
     rct_sprite()
         : pad_00()

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    Balloon* AsBalloon();
     Duck* AsDuck();
     MoneyEffect* AsMoneyEffect();
     Peep* AsPeep();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    MoneyEffect* AsMoneyEffect();
     Peep* AsPeep();
     // Default constructor to prevent non trivial construction issues
     rct_sprite()

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    bool IsBalloon();
     bool IsDuck();
     bool IsMoneyEffect();
     bool IsPeep() const;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    bool IsDuck();
     bool IsMoneyEffect();
     bool IsPeep() const;
     Balloon* AsBalloon();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -137,7 +137,6 @@ union rct_sprite
     CrashSplashParticle crash_splash;
     SteamParticle steam_particle;
 
-    Duck* AsDuck();
     MoneyEffect* AsMoneyEffect();
     Peep* AsPeep();
     // Default constructor to prevent non trivial construction issues

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -36,12 +36,11 @@ struct SpriteBase
     template<typename T> bool Is() const;
     template<typename T> T* As()
     {
-        T* result = nullptr;
-        if (Is<T>())
-        {
-            result = reinterpret_cast<T*>(this);
-        }
-        return result;
+        return Is<T>() ? reinterpret_cast<T*>(this) : nullptr;
+    }
+    template<typename T> const T* As() const
+    {
+        return Is<T>() ? reinterpret_cast<const T*>(this) : nullptr;
     }
 };
 

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -33,6 +33,16 @@ struct SpriteBase
     uint8_t sprite_direction;
 
     void MoveTo(const CoordsXYZ& newLocation);
+    template<typename T> bool Is() const;
+    template<typename T> T* As()
+    {
+        T* result = nullptr;
+        if (Is<T>())
+        {
+            result = reinterpret_cast<T*>(this);
+        }
+        return result;
+    }
 };
 
 struct SpriteGeneric : SpriteBase


### PR DESCRIPTION
Okay think this might be the 3rd attempt at doing this. This time taking it in nice easy chunks.

Yes all this `->generic.Is` / `->generic.As` is horrible but it will be removed as the functions use the `SpriteBase` instead of `rct_sprite`. I've already started another branch that converts get_sprite to return a specific type or a SpriteBase.