### PR TITLE
Use ScreenCoordsXY for gfx_draw_string_right

### DIFF
--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -650,13 +650,13 @@ void CustomListView::PaintHeading(
     {
         auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_UP);
-        gfx_draw_string_right(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, pos.x + size.width - 1, pos.y);
+        gfx_draw_string_right(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { pos.x + size.width - 1, pos.y });
     }
     else if (sortOrder == ColumnSortOrder::Descending)
     {
         auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_DOWN);
-        gfx_draw_string_right(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, pos.x + size.width - 1, pos.y);
+        gfx_draw_string_right(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { pos.x + size.width - 1, pos.y });
     }
 }
 

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -650,13 +650,15 @@ void CustomListView::PaintHeading(
     {
         auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_UP);
-        gfx_draw_string_right(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { pos.x + size.width - 1, pos.y });
+        gfx_draw_string_right(
+            dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, pos + ScreenCoordsXY{ size.width - 1, 0 });
     }
     else if (sortOrder == ColumnSortOrder::Descending)
     {
         auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_DOWN);
-        gfx_draw_string_right(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { pos.x + size.width - 1, pos.y });
+        gfx_draw_string_right(
+            dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, pos + ScreenCoordsXY{ size.width - 1, 0 });
     }
 }
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -1216,14 +1216,14 @@ static void window_cheats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         gfx_draw_string_left(
             dpi, STR_DAY, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(9) + TXTO);
         gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &_yearSpinnerValue, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
-            w->windowPos.y + YPL(7) + TXTO);
+            dpi, STR_FORMAT_INTEGER, &_yearSpinnerValue, w->colours[1],
+            { w->windowPos.x + WPL(1) - 34 - TXTO, w->windowPos.y + YPL(7) + TXTO });
         gfx_draw_string_right(
-            dpi, STR_FORMAT_MONTH, &actual_month, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
-            w->windowPos.y + YPL(8) + TXTO);
+            dpi, STR_FORMAT_MONTH, &actual_month, w->colours[1],
+            { w->windowPos.x + WPL(1) - 34 - TXTO, w->windowPos.y + YPL(8) + TXTO });
         gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &_daySpinnerValue, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
-            w->windowPos.y + YPL(9) + TXTO);
+            dpi, STR_FORMAT_INTEGER, &_daySpinnerValue, w->colours[1],
+            { w->windowPos.x + WPL(1) - 34 - TXTO, w->windowPos.y + YPL(9) + TXTO });
     }
     else if (w->page == WINDOW_CHEATS_PAGE_MISC)
     {
@@ -1232,8 +1232,8 @@ static void window_cheats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         gfx_draw_string_left(
             dpi, STR_FORCE_WEATHER, nullptr, COLOUR_BLACK, w->windowPos.x + XPL(0) + TXTO, w->windowPos.y + YPL(10) + TXTO);
         gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &_parkRatingSpinnerValue, w->colours[1], w->windowPos.x + WPL(1) - 34 - TXTO,
-            w->windowPos.y + YPL(5) + TXTO);
+            dpi, STR_FORMAT_INTEGER, &_parkRatingSpinnerValue, w->colours[1],
+            { w->windowPos.x + WPL(1) - 34 - TXTO, w->windowPos.y + YPL(5) + TXTO });
     }
     else if (w->page == WINDOW_CHEATS_PAGE_GUESTS)
     {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -952,22 +952,22 @@ static void window_editor_object_selection_invalidate(rct_window* w)
  */
 static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t x, y, width;
+    int32_t width;
     rct_widget* widget;
     rct_string_id stringId;
 
     window_draw_widgets(w, dpi);
 
     // Draw tabs
+    ScreenCoordsXY screenPos{};
     for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
     {
         widget = &w->widgets[WIDX_TAB_1 + i];
         if (widget->type != WWT_EMPTY)
         {
             auto image = ObjectSelectionPages[i].Image;
-            x = w->windowPos.x + widget->left;
-            y = w->windowPos.y + widget->top;
-            gfx_draw_sprite(dpi, image, x, y, 0);
+            screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+            gfx_draw_sprite(dpi, image, screenPos.x, screenPos.y, 0);
         }
     }
 
@@ -994,9 +994,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
             }
             spriteIndex += (i == 4 ? ThrillRidesTabAnimationSequence[frame] : frame);
 
-            x = w->windowPos.x + widget->left;
-            y = w->windowPos.y + widget->top;
-            gfx_draw_sprite(dpi, spriteIndex | (w->colours[1] << 19), x, y, 0);
+            screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+            gfx_draw_sprite(dpi, spriteIndex | (w->colours[1] << 19), screenPos.x, screenPos.y, 0);
         }
     }
 
@@ -1009,8 +1008,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     // Draw number of selected items
     if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
-        x = w->windowPos.x + 3;
-        y = w->windowPos.y + w->height - 13;
+        screenPos = w->windowPos + ScreenCoordsXY{ 3, w->height - 13 };
 
         int32_t numSelected = _numSelectedObjectsForType[get_selected_object_type(w)];
         int32_t totalSelectable = object_entry_group_counts[get_selected_object_type(w)];
@@ -1020,7 +1018,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         auto ft = Formatter::Common();
         ft.Add<uint16_t>(numSelected);
         ft.Add<uint16_t>(totalSelectable);
-        gfx_draw_string_left(dpi, STR_OBJECT_SELECTION_SELECTION_SIZE, gCommonFormatArgs, COLOUR_BLACK, x, y);
+        gfx_draw_string_left(
+            dpi, STR_OBJECT_SELECTION_SELECTION_SIZE, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y);
     }
 
     // Draw sort button text
@@ -1029,18 +1028,18 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     {
         stringId = _listSortType == RIDE_SORT_TYPE ? static_cast<rct_string_id>(_listSortDescending ? STR_DOWN : STR_UP)
                                                    : STR_NONE;
-        ScreenCoordsXY screenCoords = { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 };
+        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         gfx_draw_string_left_clipped(
-            dpi, STR_OBJECTS_SORT_TYPE, &stringId, w->colours[1], screenCoords, widget->right - widget->left);
+            dpi, STR_OBJECTS_SORT_TYPE, &stringId, w->colours[1], screenPos, widget->right - widget->left);
     }
     widget = &w->widgets[WIDX_LIST_SORT_RIDE];
     if (widget->type != WWT_EMPTY)
     {
         stringId = _listSortType == RIDE_SORT_RIDE ? static_cast<rct_string_id>(_listSortDescending ? STR_DOWN : STR_UP)
                                                    : STR_NONE;
-        ScreenCoordsXY screenCoord = { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 };
+        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         gfx_draw_string_left_clipped(
-            dpi, STR_OBJECTS_SORT_RIDE, &stringId, w->colours[1], screenCoord, widget->right - widget->left);
+            dpi, STR_OBJECTS_SORT_RIDE, &stringId, w->colours[1], screenPos, widget->right - widget->left);
     }
 
     if (w->selected_list_item == -1 || _loadedObject == nullptr)
@@ -1052,24 +1051,23 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     widget = &w->widgets[WIDX_PREVIEW];
     {
         rct_drawpixelinfo clipDPI;
-        x = w->windowPos.x + widget->left + 1;
-        y = w->windowPos.y + widget->top + 1;
+        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         width = widget->right - widget->left - 1;
         int32_t height = widget->bottom - widget->top - 1;
-        if (clip_drawpixelinfo(&clipDPI, dpi, x, y, width, height))
+        if (clip_drawpixelinfo(&clipDPI, dpi, screenPos.x, screenPos.y, width, height))
         {
             object_draw_preview(_loadedObject, &clipDPI, width, height);
         }
     }
 
     // Draw name of object
-    x = w->windowPos.x + (widget->left + widget->right) / 2 + 1;
-    y = w->windowPos.y + widget->bottom + 3;
+    screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2 + 1, widget->bottom + 3 };
     width = w->width - w->widgets[WIDX_LIST].right - 6;
     auto ft = Formatter::Common();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
-    gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    gfx_draw_string_centred_clipped(
+        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y, width);
 
     // Draw description of object
     auto description = object_get_description(_loadedObject);
@@ -1079,28 +1077,28 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(description.c_str());
 
-        x = w->windowPos.x + w->widgets[WIDX_LIST].right + 4;
-        y += 15;
-        width = w->windowPos.x + w->width - x - 4;
+        screenPos = { w->windowPos.x + w->widgets[WIDX_LIST].right + 4, screenPos.y + 15 };
+        width = w->windowPos.x + w->width - screenPos.x - 4;
 
-        gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y + 5, width, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_BLACK);
+        gfx_draw_string_left_wrapped(
+            dpi, gCommonFormatArgs, screenPos.x, screenPos.y + 5, width, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_BLACK);
     }
 
-    y = w->windowPos.y + w->height - (12 * 4);
+    screenPos.y = w->windowPos.y + w->height - (12 * 4);
 
     // Draw ride type.
     if (get_selected_object_type(w) == OBJECT_TYPE_RIDE)
     {
         stringId = get_ride_type_string_id(listItem->repositoryItem);
-        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, y });
+        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, screenPos.y });
     }
 
-    y += 12;
+    screenPos.y += 12;
 
     // Draw object source
     stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
-    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, y });
-    y += 12;
+    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, screenPos.y });
+    screenPos.y += 12;
 
     // Draw object dat name
     const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
@@ -1108,7 +1106,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(path);
     gfx_draw_string_right(
-        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, y });
+        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, screenPos.y });
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1092,14 +1092,14 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     if (get_selected_object_type(w) == OBJECT_TYPE_RIDE)
     {
         stringId = get_ride_type_string_id(listItem->repositoryItem);
-        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->windowPos.x + w->width - 5, y);
+        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, y });
     }
 
     y += 12;
 
     // Draw object source
     stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
-    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, w->windowPos.x + w->width - 5, y);
+    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, y });
     y += 12;
 
     // Draw object dat name
@@ -1107,7 +1107,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     ft = Formatter::Common();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(path);
-    gfx_draw_string_right(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + w->width - 5, y);
+    gfx_draw_string_right(
+        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, y });
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -959,14 +959,13 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     window_draw_widgets(w, dpi);
 
     // Draw tabs
-    ScreenCoordsXY screenPos{};
     for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
     {
         widget = &w->widgets[WIDX_TAB_1 + i];
         if (widget->type != WWT_EMPTY)
         {
             auto image = ObjectSelectionPages[i].Image;
-            screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+            auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
             gfx_draw_sprite(dpi, image, screenPos.x, screenPos.y, 0);
         }
     }
@@ -994,7 +993,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
             }
             spriteIndex += (i == 4 ? ThrillRidesTabAnimationSequence[frame] : frame);
 
-            screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+            auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
             gfx_draw_sprite(dpi, spriteIndex | (w->colours[1] << 19), screenPos.x, screenPos.y, 0);
         }
     }
@@ -1008,7 +1007,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     // Draw number of selected items
     if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
-        screenPos = w->windowPos + ScreenCoordsXY{ 3, w->height - 13 };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ 3, w->height - 13 };
 
         int32_t numSelected = _numSelectedObjectsForType[get_selected_object_type(w)];
         int32_t totalSelectable = object_entry_group_counts[get_selected_object_type(w)];
@@ -1028,7 +1027,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     {
         stringId = _listSortType == RIDE_SORT_TYPE ? static_cast<rct_string_id>(_listSortDescending ? STR_DOWN : STR_UP)
                                                    : STR_NONE;
-        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         gfx_draw_string_left_clipped(
             dpi, STR_OBJECTS_SORT_TYPE, &stringId, w->colours[1], screenPos, widget->right - widget->left);
     }
@@ -1037,7 +1036,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     {
         stringId = _listSortType == RIDE_SORT_RIDE ? static_cast<rct_string_id>(_listSortDescending ? STR_DOWN : STR_UP)
                                                    : STR_NONE;
-        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         gfx_draw_string_left_clipped(
             dpi, STR_OBJECTS_SORT_RIDE, &stringId, w->colours[1], screenPos, widget->right - widget->left);
     }
@@ -1051,7 +1050,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     widget = &w->widgets[WIDX_PREVIEW];
     {
         rct_drawpixelinfo clipDPI;
-        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         width = widget->right - widget->left - 1;
         int32_t height = widget->bottom - widget->top - 1;
         if (clip_drawpixelinfo(&clipDPI, dpi, screenPos.x, screenPos.y, width, height))
@@ -1061,48 +1060,50 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     }
 
     // Draw name of object
-    screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2 + 1, widget->bottom + 3 };
-    width = w->width - w->widgets[WIDX_LIST].right - 6;
-    auto ft = Formatter::Common();
-    ft.Add<rct_string_id>(STR_STRING);
-    ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
-    gfx_draw_string_centred_clipped(
-        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y, width);
+    {
+        auto screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2 + 1, widget->bottom + 3 };
+        width = w->width - w->widgets[WIDX_LIST].right - 6;
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
+        gfx_draw_string_centred_clipped(
+            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y, width);
+    }
 
     // Draw description of object
     auto description = object_get_description(_loadedObject);
     if (!description.empty())
     {
-        ft = Formatter::Common();
+        auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(description.c_str());
 
-        screenPos = { w->windowPos.x + w->widgets[WIDX_LIST].right + 4, screenPos.y + 15 };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LIST].right + 4, widget->bottom + 18 };
         width = w->windowPos.x + w->width - screenPos.x - 4;
 
         gfx_draw_string_left_wrapped(
             dpi, gCommonFormatArgs, screenPos.x, screenPos.y + 5, width, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_BLACK);
     }
 
-    screenPos.y = w->windowPos.y + w->height - (12 * 4);
+    auto screenPos = w->windowPos + ScreenCoordsXY{ w->width - 5, w->height - (12 * 4) };
 
     // Draw ride type.
     if (get_selected_object_type(w) == OBJECT_TYPE_RIDE)
     {
         stringId = get_ride_type_string_id(listItem->repositoryItem);
-        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, screenPos.y });
+        gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, screenPos);
     }
 
     screenPos.y += 12;
 
     // Draw object source
     stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
-    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, { w->windowPos.x + w->width - 5, screenPos.y });
+    gfx_draw_string_right(dpi, stringId, nullptr, COLOUR_WHITE, screenPos);
     screenPos.y += 12;
 
     // Draw object dat name
     const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
-    ft = Formatter::Common();
+    auto ft = Formatter::Common();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(path);
     gfx_draw_string_right(

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1050,7 +1050,7 @@ static void window_finances_profit_graph_invalidate(rct_window* w)
  */
 static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t i, x, y, graphLeft, graphTop, graphRight, graphBottom;
+    int32_t i, graphLeft, graphTop, graphRight, graphBottom;
 
     window_draw_widgets(w, dpi);
     window_finances_draw_tab_images(dpi, w);
@@ -1088,21 +1088,22 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     }
 
     // Y axis labels
-    x = graphLeft + 18;
-    y = graphTop + 14;
+    auto screenPos = ScreenCoordsXY{ graphLeft + 18, graphTop + 14 };
     money32 axisBase;
     for (axisBase = MONEY(12, 00); axisBase >= MONEY(-12, 00); axisBase -= MONEY(6, 00))
     {
         money32 axisValue = axisBase << yAxisScale;
-        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, { x + 70, y });
-        gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
-        y += 39;
+        gfx_draw_string_right(
+            dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 70, 0 });
+        gfx_fill_rect_inset(
+            dpi, screenPos.x + 70, screenPos.y + 5, graphLeft + 482, screenPos.y + 5, w->colours[2],
+            INSET_RECT_FLAG_BORDER_INSET);
+        screenPos.y += 39;
     }
 
     // X axis labels and values
-    x = graphLeft + 98;
-    y = graphTop + 17;
-    graph_draw_money32(dpi, gWeeklyProfitHistory, 64, x, y, yAxisScale, 128);
+    screenPos = { graphLeft + 98, graphTop + 17 };
+    graph_draw_money32(dpi, gWeeklyProfitHistory, 64, screenPos.x, screenPos.y, yAxisScale, 128);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -887,7 +887,7 @@ static void window_finances_financial_graph_paint(rct_window* w, rct_drawpixelin
     for (axisBase = MONEY(12, 00); axisBase >= MONEY(-12, 00); axisBase -= MONEY(6, 00))
     {
         money32 axisValue = axisBase << yAxisScale;
-        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
+        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, { x + 70, y });
         gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
@@ -990,7 +990,7 @@ static void window_finances_park_value_graph_paint(rct_window* w, rct_drawpixeli
     for (axisBase = MONEY(24, 00); axisBase >= MONEY(0, 00); axisBase -= MONEY(6, 00))
     {
         money32 axisValue = axisBase << yAxisScale;
-        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
+        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, { x + 70, y });
         gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
@@ -1094,7 +1094,7 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
     for (axisBase = MONEY(12, 00); axisBase >= MONEY(-12, 00); axisBase -= MONEY(6, 00))
     {
         money32 axisValue = axisBase << yAxisScale;
-        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, x + 70, y);
+        gfx_draw_string_right(dpi, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, &axisValue, COLOUR_BLACK, { x + 70, y });
         gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -852,7 +852,7 @@ static void window_guest_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
                     auto ft = Formatter::Common();
                     ft.Add<rct_string_id>(STR_GUESTS_COUNT_COMMA_SEP);
                     ft.Add<uint32_t>(numGuests);
-                    gfx_draw_string_right(dpi, format, gCommonFormatArgs, COLOUR_BLACK, 326, y);
+                    gfx_draw_string_right(dpi, format, gCommonFormatArgs, COLOUR_BLACK, { 326, y });
                 }
                 y += SUMMARISED_GUEST_ROW_HEIGHT;
             }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -266,7 +266,7 @@ static void window_new_ride_set_page(rct_window* w, int32_t page);
 static void window_new_ride_refresh_widget_sizing(rct_window* w);
 static RideSelection window_new_ride_scroll_get_ride_list_item_at(rct_window* w, const ScreenCoordsXY& screenCoords);
 static void window_new_ride_paint_ride_information(
-    rct_window* w, rct_drawpixelinfo* dpi, RideSelection item, int32_t x, int32_t y, int32_t width);
+    rct_window* w, rct_drawpixelinfo* dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t width);
 static void window_new_ride_select(rct_window* w);
 static RideSelection* window_new_ride_iterate_over_ride_group(
     uint8_t rideType, uint8_t rideGroupIndex, RideSelection* nextListItem);
@@ -842,7 +842,7 @@ static void window_new_ride_paint(rct_window* w, rct_drawpixelinfo* dpi)
         item = w->new_ride.HighlightedRide;
         if (item.Type != RIDE_TYPE_NULL || item.EntryIndex != RIDE_ENTRY_INDEX_NULL)
             window_new_ride_paint_ride_information(
-                w, dpi, item, w->windowPos.x + 3, w->windowPos.y + w->height - 64, w->width - 6);
+                w, dpi, item, w->windowPos + ScreenCoordsXY{ 3, w->height - 64 }, w->width - 6);
     }
     else
     {
@@ -963,7 +963,7 @@ static int32_t get_num_track_designs(RideSelection item)
  *  rct2: 0x006B701C
  */
 static void window_new_ride_paint_ride_information(
-    rct_window* w, rct_drawpixelinfo* dpi, RideSelection item, int32_t x, int32_t y, int32_t width)
+    rct_window* w, rct_drawpixelinfo* dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t width)
 {
     rct_ride_entry* rideEntry = get_ride_entry(item.EntryIndex);
     rct_ride_name rideNaming;
@@ -973,7 +973,7 @@ static void window_new_ride_paint_ride_information(
     auto ft = Formatter::Common();
     ft.Add<rct_string_id>(rideNaming.name);
     ft.Add<rct_string_id>(rideNaming.description);
-    gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, { x, y }, width, STR_NEW_RIDE_NAME_AND_DESCRIPTION, COLOUR_BLACK);
+    gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, screenPos, width, STR_NEW_RIDE_NAME_AND_DESCRIPTION, COLOUR_BLACK);
 
     char availabilityString[AVAILABILITY_STRING_SIZE];
     window_new_ride_list_vehicles_for(item.Type, rideEntry, availabilityString, sizeof(availabilityString));
@@ -981,7 +981,8 @@ static void window_new_ride_paint_ride_information(
     if (availabilityString[0] != 0)
     {
         const char* drawString = availabilityString;
-        gfx_draw_string_left_clipped(dpi, STR_AVAILABLE_VEHICLES, &drawString, COLOUR_BLACK, { x, y + 39 }, WW - 2);
+        gfx_draw_string_left_clipped(
+            dpi, STR_AVAILABLE_VEHICLES, &drawString, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 0, 39 }, WW - 2);
     }
 
     if (item.Type != _lastTrackDesignCountRideType.Type || item.EntryIndex != _lastTrackDesignCountRideType.EntryIndex)
@@ -1004,7 +1005,7 @@ static void window_new_ride_paint_ride_information(
             break;
     }
 
-    gfx_draw_string_left(dpi, designCountStringId, &_lastTrackDesignCount, COLOUR_BLACK, x, y + 51);
+    gfx_draw_string_left(dpi, designCountStringId, &_lastTrackDesignCount, COLOUR_BLACK, screenPos.x, screenPos.y + 51);
 
     // Price
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -1027,7 +1028,7 @@ static void window_new_ride_paint_ride_information(
         if (!ride_type_has_flag(item.Type, RIDE_TYPE_FLAG_HAS_NO_TRACK))
             stringId = STR_NEW_RIDE_COST_FROM;
 
-        gfx_draw_string_right(dpi, stringId, &price, COLOUR_BLACK, { x + width, y + 51 });
+        gfx_draw_string_right(dpi, stringId, &price, COLOUR_BLACK, screenPos + ScreenCoordsXY{ width, 51 });
     }
 }
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -1027,7 +1027,7 @@ static void window_new_ride_paint_ride_information(
         if (!ride_type_has_flag(item.Type, RIDE_TYPE_FLAG_HAS_NO_TRACK))
             stringId = STR_NEW_RIDE_COST_FROM;
 
-        gfx_draw_string_right(dpi, stringId, &price, COLOUR_BLACK, x + width, y + 51);
+        gfx_draw_string_right(dpi, stringId, &price, COLOUR_BLACK, { x + width, y + 51 });
     }
 }
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1064,7 +1064,7 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     for (int i = 5; i >= 0; i--)
     {
         uint32_t axisValue = i * 200;
-        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, x + 10, y);
+        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, { x + 10, y });
         gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 32, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 20;
     }
@@ -1195,7 +1195,7 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
     for (int i = 5; i >= 0; i--)
     {
         uint32_t axisValue = i * 1000;
-        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, x + 10, y);
+        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, { x + 10, y });
         gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 32, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 20;
     }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1046,34 +1046,34 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    int32_t x = w->windowPos.x;
-    int32_t y = w->windowPos.y;
+    auto screenPos = ScreenCoordsXY{ w->windowPos.x, w->windowPos.y };
     rct_widget* widget = &window_park_rating_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
-    gfx_draw_string_left(dpi, STR_PARK_RATING_LABEL, &gParkRating, COLOUR_BLACK, x + widget->left + 3, y + widget->top + 2);
+    gfx_draw_string_left(
+        dpi, STR_PARK_RATING_LABEL, &gParkRating, COLOUR_BLACK, screenPos.x + widget->left + 3, screenPos.y + widget->top + 2);
 
     // Graph border
     gfx_fill_rect_inset(
-        dpi, x + widget->left + 4, y + widget->top + 15, x + widget->right - 4, y + widget->bottom - 4, w->colours[1],
-        INSET_RECT_F_30);
+        dpi, screenPos.x + widget->left + 4, screenPos.y + widget->top + 15, screenPos.x + widget->right - 4,
+        screenPos.y + widget->bottom - 4, w->colours[1], INSET_RECT_F_30);
 
     // Y axis labels
-    x = x + widget->left + 27;
-    y = y + widget->top + 23;
+    screenPos = screenPos + ScreenCoordsXY{ widget->left + 27, widget->top + 23 };
     for (int i = 5; i >= 0; i--)
     {
         uint32_t axisValue = i * 200;
-        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, { x + 10, y });
-        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 32, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
-        y += 20;
+        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 10, 0 });
+        gfx_fill_rect_inset(
+            dpi, screenPos.x + 15, screenPos.y + 5, screenPos.x + w->width - 32, screenPos.y + 5, w->colours[2],
+            INSET_RECT_FLAG_BORDER_INSET);
+        screenPos.y += 20;
     }
 
     // Graph
-    x = w->windowPos.x + widget->left + 47;
-    y = w->windowPos.y + widget->top + 26;
+    screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 47, widget->top + 26 };
 
-    graph_draw_uint8_t(dpi, gParkRatingHistory, 32, x, y);
+    graph_draw_uint8_t(dpi, gParkRatingHistory, 32, screenPos.x, screenPos.y);
 }
 
 #pragma endregion
@@ -1176,35 +1176,35 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    int32_t x = w->windowPos.x;
-    int32_t y = w->windowPos.y;
+    auto screenPos = ScreenCoordsXY{ w->windowPos.x, w->windowPos.y };
     rct_widget* widget = &window_park_guests_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
     gfx_draw_string_left(
-        dpi, STR_GUESTS_IN_PARK_LABEL, &gNumGuestsInPark, COLOUR_BLACK, x + widget->left + 3, y + widget->top + 2);
+        dpi, STR_GUESTS_IN_PARK_LABEL, &gNumGuestsInPark, COLOUR_BLACK, screenPos.x + widget->left + 3,
+        screenPos.y + widget->top + 2);
 
     // Graph border
     gfx_fill_rect_inset(
-        dpi, x + widget->left + 4, y + widget->top + 15, x + widget->right - 4, y + widget->bottom - 4, w->colours[1],
-        INSET_RECT_F_30);
+        dpi, screenPos.x + widget->left + 4, screenPos.y + widget->top + 15, screenPos.x + widget->right - 4,
+        screenPos.y + widget->bottom - 4, w->colours[1], INSET_RECT_F_30);
 
     // Y axis labels
-    x = x + widget->left + 27;
-    y = y + widget->top + 23;
+    screenPos = screenPos + ScreenCoordsXY{ widget->left + 27, widget->top + 23 };
     for (int i = 5; i >= 0; i--)
     {
         uint32_t axisValue = i * 1000;
-        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, { x + 10, y });
-        gfx_fill_rect_inset(dpi, x + 15, y + 5, x + w->width - 32, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
-        y += 20;
+        gfx_draw_string_right(dpi, STR_GRAPH_AXIS_LABEL, &axisValue, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 10, 0 });
+        gfx_fill_rect_inset(
+            dpi, screenPos.x + 15, screenPos.y + 5, screenPos.x + w->width - 32, screenPos.y + 5, w->colours[2],
+            INSET_RECT_FLAG_BORDER_INSET);
+        screenPos.y += 20;
     }
 
     // Graph
-    x = w->windowPos.x + widget->left + 47;
-    y = w->windowPos.y + widget->top + 26;
+    screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 47, widget->top + 26 };
 
-    graph_draw_uint8_t(dpi, gGuestsInParkHistory, 32, x, y);
+    graph_draw_uint8_t(dpi, gGuestsInParkHistory, 32, screenPos.x, screenPos.y);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1046,7 +1046,7 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
     window_park_draw_tab_images(dpi, w);
 
-    auto screenPos = ScreenCoordsXY{ w->windowPos.x, w->windowPos.y };
+    auto screenPos = w->windowPos;
     rct_widget* widget = &window_park_rating_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1180,8 +1180,8 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         // -14
         gfx_draw_string_right(
-            dpi, STR_COST_LABEL, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + w->width - 0x1A,
-            w->windowPos.y + w->height - 13);
+            dpi, STR_COST_LABEL, gCommonFormatArgs, COLOUR_BLACK,
+            { w->windowPos.x + w->width - 0x1A, w->windowPos.y + w->height - 13 });
     }
 
     auto ft = Formatter::Common();

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1181,7 +1181,7 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
         // -14
         gfx_draw_string_right(
             dpi, STR_COST_LABEL, gCommonFormatArgs, COLOUR_BLACK,
-            { w->windowPos.x + w->width - 0x1A, w->windowPos.y + w->height - 13 });
+            w->windowPos + ScreenCoordsXY{ w->width - 0x1A, w->height - 13 });
     }
 
     auto ft = Formatter::Common();

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1790,8 +1790,10 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (windowTileInspectorTileSelected)
     {
         auto tileCoords = TileCoordsXY{ windowTileInspectorToolMap };
-        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.x, COLOUR_WHITE, w->windowPos.x + 43, w->windowPos.y + 24);
-        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.y, COLOUR_WHITE, w->windowPos.x + 113, w->windowPos.y + 24);
+        gfx_draw_string_right(
+            dpi, STR_FORMAT_INTEGER, &tileCoords.x, COLOUR_WHITE, { w->windowPos.x + 43, w->windowPos.y + 24 });
+            gfx_draw_string_right(
+                dpi, STR_FORMAT_INTEGER, &tileCoords.y, COLOUR_WHITE, { w->windowPos.x + 113, w->windowPos.y + 24 });
     }
     else
     {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1790,10 +1790,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (windowTileInspectorTileSelected)
     {
         auto tileCoords = TileCoordsXY{ windowTileInspectorToolMap };
-        gfx_draw_string_right(
-            dpi, STR_FORMAT_INTEGER, &tileCoords.x, COLOUR_WHITE, { w->windowPos.x + 43, w->windowPos.y + 24 });
-            gfx_draw_string_right(
-                dpi, STR_FORMAT_INTEGER, &tileCoords.y, COLOUR_WHITE, { w->windowPos.x + 113, w->windowPos.y + 24 });
+        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.x, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 43, 24 });
+        gfx_draw_string_right(dpi, STR_FORMAT_INTEGER, &tileCoords.y, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 113, 24 });
     }
     else
     {

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -842,132 +842,134 @@ static void window_top_toolbar_invalidate(rct_window* w)
  */
 static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t x, y, imgId;
+    int32_t imgId;
 
     window_draw_widgets(w, dpi);
 
+    ScreenCoordsXY screenPos{};
     // Draw staff button image (setting masks to the staff colours)
     if (window_top_toolbar_widgets[WIDX_STAFF].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_STAFF].left;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_STAFF].top;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_STAFF].left,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_STAFF].top };
         imgId = SPR_TOOLBAR_STAFF;
         if (widget_is_pressed(w, WIDX_STAFF))
             imgId++;
         imgId |= SPRITE_ID_PALETTE_COLOUR_2(gStaffHandymanColour, gStaffMechanicColour);
-        gfx_draw_sprite(dpi, imgId, x, y, 0);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 0);
     }
 
     // Draw fast forward button
     if (window_top_toolbar_widgets[WIDX_FASTFORWARD].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_FASTFORWARD].left + 0;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_FASTFORWARD].top + 0;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_FASTFORWARD].left + 0,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_FASTFORWARD].top + 0 };
         if (widget_is_pressed(w, WIDX_FASTFORWARD))
-            y++;
+            screenPos.y++;
         imgId = SPR_G2_FASTFORWARD;
-        gfx_draw_sprite(dpi, imgId, x + 6, y + 3, 0);
+        gfx_draw_sprite(dpi, imgId, screenPos.x + 6, screenPos.y + 3, 0);
 
         for (int32_t i = 0; i < gGameSpeed && gGameSpeed <= 4; i++)
         {
-            gfx_draw_sprite(dpi, SPR_G2_SPEED_ARROW, x + 5 + i * 5, y + 15, 0);
+            gfx_draw_sprite(dpi, SPR_G2_SPEED_ARROW, screenPos.x + 5 + i * 5, screenPos.y + 15, 0);
         }
         for (int32_t i = 0; i < 3 && i < gGameSpeed - 4 && gGameSpeed >= 5; i++)
         {
-            gfx_draw_sprite(dpi, SPR_G2_HYPER_ARROW, x + 5 + i * 6, y + 15, 0);
+            gfx_draw_sprite(dpi, SPR_G2_HYPER_ARROW, screenPos.x + 5 + i * 6, screenPos.y + 15, 0);
         }
     }
 
     // Draw cheats button
     if (window_top_toolbar_widgets[WIDX_CHEATS].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_CHEATS].left - 1;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_CHEATS].top - 1;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_CHEATS].left - 1,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_CHEATS].top - 1 };
         if (widget_is_pressed(w, WIDX_CHEATS))
-            y++;
+            screenPos.y++;
         imgId = SPR_G2_SANDBOX;
-        gfx_draw_sprite(dpi, imgId, x, y, 3);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 3);
 
         // Draw an overlay if clearance checks are disabled
         if (gCheatsDisableClearanceChecks)
         {
             gfx_draw_string_right(
                 dpi, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, nullptr, COLOUR_DARK_ORANGE | COLOUR_FLAG_OUTLINE,
-                { x + 26, y + 2 });
+                screenPos + ScreenCoordsXY{ 26, 2 });
         }
     }
 
     // Draw chat button
     if (window_top_toolbar_widgets[WIDX_CHAT].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_CHAT].left;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_CHAT].top - 2;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_CHAT].left,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_CHAT].top - 2 };
         if (widget_is_pressed(w, WIDX_CHAT))
-            y++;
+            screenPos.y++;
         imgId = SPR_G2_CHAT;
-        gfx_draw_sprite(dpi, imgId, x, y, 3);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 3);
     }
 
     // Draw debug button
     if (window_top_toolbar_widgets[WIDX_DEBUG].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_DEBUG].left;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_DEBUG].top - 1;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_DEBUG].left,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_DEBUG].top - 1 };
         if (widget_is_pressed(w, WIDX_DEBUG))
-            y++;
+            screenPos.y++;
         imgId = SPR_TAB_GEARS_0;
-        gfx_draw_sprite(dpi, imgId, x, y, 3);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 3);
     }
 
     // Draw research button
     if (window_top_toolbar_widgets[WIDX_RESEARCH].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_RESEARCH].left - 1;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_RESEARCH].top;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_RESEARCH].left - 1,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_RESEARCH].top };
         if (widget_is_pressed(w, WIDX_RESEARCH))
-            y++;
+            screenPos.y++;
         imgId = SPR_TAB_FINANCES_RESEARCH_0;
-        gfx_draw_sprite(dpi, imgId, x, y, 0);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 0);
     }
 
     // Draw finances button
     if (window_top_toolbar_widgets[WIDX_FINANCES].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_FINANCES].left + 3;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_FINANCES].top + 1;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_FINANCES].left + 3,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_FINANCES].top + 1 };
         if (widget_is_pressed(w, WIDX_FINANCES))
-            y++;
+            screenPos.y++;
         imgId = SPR_FINANCE;
-        gfx_draw_sprite(dpi, imgId, x, y, 0);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 0);
     }
 
     // Draw news button
     if (window_top_toolbar_widgets[WIDX_NEWS].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_NEWS].left + 3;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_NEWS].top + 0;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_NEWS].left + 3,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_NEWS].top + 0 };
         if (widget_is_pressed(w, WIDX_NEWS))
-            y++;
+            screenPos.y++;
         imgId = SPR_G2_TAB_NEWS;
-        gfx_draw_sprite(dpi, imgId, x, y, 0);
+        gfx_draw_sprite(dpi, imgId, screenPos.x, screenPos.y, 0);
     }
 
     // Draw network button
     if (window_top_toolbar_widgets[WIDX_NETWORK].type != WWT_EMPTY)
     {
-        x = w->windowPos.x + window_top_toolbar_widgets[WIDX_NETWORK].left + 3;
-        y = w->windowPos.y + window_top_toolbar_widgets[WIDX_NETWORK].top + 0;
+        screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_NETWORK].left + 3,
+                      w->windowPos.y + window_top_toolbar_widgets[WIDX_NETWORK].top + 0 };
         if (widget_is_pressed(w, WIDX_NETWORK))
-            y++;
+            screenPos.y++;
 
         // Draw (de)sync icon.
         imgId = (network_is_desynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
-        gfx_draw_sprite(dpi, imgId, x + 3, y + 11, 0);
+        gfx_draw_sprite(dpi, imgId, screenPos.x + 3, screenPos.y + 11, 0);
 
         // Draw number of players.
         int32_t player_count = network_get_num_players();
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-        gfx_draw_string_right(dpi, STR_COMMA16, &player_count, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, { x + 23, y + 1 });
+        gfx_draw_string_right(
+            dpi, STR_COMMA16, &player_count, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, screenPos + ScreenCoordsXY{ 23, 1 });
     }
 }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -892,7 +892,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (gCheatsDisableClearanceChecks)
         {
             gfx_draw_string_right(
-                dpi, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, nullptr, COLOUR_DARK_ORANGE | COLOUR_FLAG_OUTLINE, x + 26, y + 2);
+                dpi, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, nullptr, COLOUR_DARK_ORANGE | COLOUR_FLAG_OUTLINE,
+                { x + 26, y + 2 });
         }
     }
 
@@ -966,7 +967,7 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         // Draw number of players.
         int32_t player_count = network_get_num_players();
         gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-        gfx_draw_string_right(dpi, STR_COMMA16, &player_count, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, x + 23, y + 1);
+        gfx_draw_string_right(dpi, STR_COMMA16, &player_count, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, { x + 23, y + 1 });
     }
 }
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -648,7 +648,6 @@ void gfx_draw_string_centred(
     rct_drawpixelinfo* dpi, rct_string_id format, const ScreenCoordsXY& coords, uint8_t colour, const void* args);
 void gfx_draw_string_right(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords);
-void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y);
 
 void draw_string_left_underline(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -162,11 +162,6 @@ void gfx_draw_string_centred(
     DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::CENTRE);
 }
 
-void gfx_draw_string_right(rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y)
-{
-    gfx_draw_string_right(dpi, format, args, colour, { x, y });
-}
-
 void gfx_draw_string_right(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {


### PR DESCRIPTION
Closes #11569

- First commit just stops using the old overload
- Second commit converts local variables to `ScreenCoordsXY`