### PR TITLE
Patch unused variables

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -2981,8 +2981,6 @@
 				F76C840C1EC4E7CC00FA49E2 /* ServerList.h */,
 				F76C840D1EC4E7CC00FA49E2 /* Socket.cpp */,
 				F76C840E1EC4E7CC00FA49E2 /* Socket.h */,
-				F76C840F1EC4E7CC00FA49E2 /* Twitch.cpp */,
-				F76C84101EC4E7CC00FA49E2 /* Twitch.h */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -4278,7 +4276,6 @@
 				F76C865C1EC4E88300FA49E2 /* Socket.cpp in Sources */,
 				C688784B202899B90084B384 /* Intro.cpp in Sources */,
 				C68878FD20289B9B0084B384 /* MiniRollerCoaster.cpp in Sources */,
-				2A1F4FE0221FF4B0003CA045 /* Twitch.cpp in Sources */,
 				93F76EF520BFF76E00D4512C /* Paint.Peep.cpp in Sources */,
 				C6887857202899FD0084B384 /* Park.cpp in Sources */,
 				F76C86601EC4E88300FA49E2 /* BannerObject.cpp in Sources */,

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -33,7 +33,6 @@
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRINGID;
 static constexpr const int32_t WH = 224;
-static constexpr const int32_t WW = 230;
 
 // clang-format off
 enum WINDOW_PARK_PAGE {

--- a/src/openrct2/core/FileWatcher.h
+++ b/src/openrct2/core/FileWatcher.h
@@ -59,7 +59,9 @@ public:
     ~FileWatcher();
 
 private:
+#if defined(_WIN32) || defined(__linux__)
     bool _finished{};
+#endif
 
     void WatchDirectory();
 };


### PR DESCRIPTION
Fix compilation failure due to unused vars. (Compilation only fails due to warnings-turned-errors.)

As a bonus, remove references to Twitch source files from Xcode project.