### PR TITLE
Remember sort mode in ride list window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Change: [#11449] Remove complete circuit requirement from Air Powered Vertical Coaster (for RCT1 parity).
 - Change: [#11898] The `openrct-data-path` command-line argument has been renamed to `openrct2-data-path`.
+- Change: [#11944] The ride list sort mode is now remembered for the duration of the game.
 - Fix: [#1013] Negative length displayed in Ride window.
 - Fix: [#1148] Research funding dropdown not shown in finances window.
 - Fix: [#5451] Guests scream on every descent, no matter how small.

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -185,7 +185,7 @@ static constexpr const rct_string_id page_names[] = {
 };
 // clang-format on
 
-static int32_t _window_ride_list_information_type;
+static int32_t _window_ride_list_information_type = INFORMATION_TYPE_STATUS;
 
 static void window_ride_list_draw_tab_images(rct_drawpixelinfo* dpi, rct_window* w);
 static void window_ride_list_close_all(rct_window* w);
@@ -223,7 +223,7 @@ rct_window* window_ride_list_open()
         window->max_height = 700;
         window_ride_list_refresh_list(window);
     }
-    _window_ride_list_information_type = INFORMATION_TYPE_STATUS;
+
     window->list_information_type = 0;
     _quickDemolishMode = false;
 


### PR DESCRIPTION
This PR changes the ride list window to only statically initialise the sort mode to 'status' by default, instead of doing so every time the window is opened. The net effect is that the sort mode is remembered as long as OpenRCT2 remains open.

Change requested in #11944.