### PR TITLE
Close #11614: Require plugins to specify their license

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -108,6 +108,7 @@ declare global {
         version: string;
         authors: string | string[];
         type: PluginType;
+        licence: string;
         minApiVersion?: number;
         main: () => void;
     }

--- a/distribution/scripting.md
+++ b/distribution/scripting.md
@@ -18,7 +18,7 @@ Local scripts can **not** alter the game state. This allows each player to enabl
 
 Remote scripts on the other hand can alter the game state in certain contexts, thus must be enabled for every player in a multiplayer game. Players **cannot** enable or disable remote scripts for multiplayer servers they join. Instead the server will upload any remote scripts that have been enabled on the server to each player. This allows servers to enable scripts without players needing to manually download or enable the same script on their end.
 
-The authors should also define a licence for the plugin, making it clear to the community whether that plugin can be altered, copied, etc. A good reference material is listed on [ChooseALlicense](https://choosealicense.com/appendix/), try to pick one of them and use its corresponding identifier, as listed on [SPDX](https://spdx.org/licenses/).
+The authors must also define a licence for the plug-in, making it clear to the community whether that plug-in can be altered, copied, etc. A good reference material is listed on [ChooseALlicense](https://choosealicense.com/appendix/), try to pick one of them and use its corresponding identifier, as listed on [SPDX](https://spdx.org/licenses/).
 
 ## Writing Scripts
 

--- a/distribution/scripting.md
+++ b/distribution/scripting.md
@@ -18,6 +18,8 @@ Local scripts can **not** alter the game state. This allows each player to enabl
 
 Remote scripts on the other hand can alter the game state in certain contexts, thus must be enabled for every player in a multiplayer game. Players **cannot** enable or disable remote scripts for multiplayer servers they join. Instead the server will upload any remote scripts that have been enabled on the server to each player. This allows servers to enable scripts without players needing to manually download or enable the same script on their end.
 
+The authors should also define a licence for the plugin, making it clear to the community whether that plugin can be altered, copied, etc. A good reference material is listed on [ChooseALlicense](https://choosealicense.com/appendix/), try to pick one of them and use its corresponding identifier, as listed on [SPDX](https://spdx.org/licenses/).
+
 ## Writing Scripts
 
 Scripts are written in ECMAScript 5 compatible JavaScript. OpenRCT2 currently uses the [duktape](https://duktape.org) library to execute scripts. This however does not mean you need to write your plug-in in JavaScript, there are many transpilers that allow you to write in a language of your choice and then compile it to JavaScript allowing it to be executed by OpenRCT2. JavaScript or [TypeScript](https://www.typescriptlang.org) is recommended however, as that will allow you to utilise the type definition file we supply (`openrct2.d.ts`). If you would like to use ECMAScript 6 or later which contain features such as the `let` keyword or classes, then you will need to use a transpiler such as [Babel](https://babeljs.io) or [TypeScript](https://www.typescriptlang.org).
@@ -38,6 +40,7 @@ registerPlugin({
     version: '1.0',
     authors: ['Your Name'],
     type: 'remote',
+    licence: 'MIT',
     main: main
 });
 ```

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -11,6 +11,7 @@
 
 #    include "Plugin.h"
 
+#    include "../Diagnostic.h"
 #    include "../OpenRCT2.h"
 #    include "Duktape.hpp"
 
@@ -127,6 +128,7 @@ PluginMetadata Plugin::GetMetadata(const DukValue& dukMetadata)
         metadata.Name = TryGetString(dukMetadata["name"], "Plugin name not specified.");
         metadata.Version = TryGetString(dukMetadata["version"], "Plugin version not specified.");
         metadata.Type = ParsePluginType(TryGetString(dukMetadata["type"], "Plugin type not specified."));
+        CheckForLicence(dukMetadata["licence"], metadata.Name);
 
         auto dukMinApiVersion = dukMetadata["minApiVersion"];
         if (dukMinApiVersion.type() == DukValue::Type::NUMBER)
@@ -159,6 +161,12 @@ PluginType Plugin::ParsePluginType(const std::string_view& type)
     if (type == "remote")
         return PluginType::Remote;
     throw std::invalid_argument("Unknown plugin type.");
+}
+
+void Plugin::CheckForLicence(const DukValue& dukLicence, const std::string_view& pluginName)
+{
+    if (dukLicence.type() != DukValue::Type::STRING || dukLicence.as_string().empty())
+        log_error("Plugin %s does not specify a licence", pluginName.data());
 }
 
 #endif

--- a/src/openrct2/scripting/Plugin.h
+++ b/src/openrct2/scripting/Plugin.h
@@ -95,6 +95,7 @@ namespace OpenRCT2::Scripting
 
         static PluginMetadata GetMetadata(const DukValue& dukMetadata);
         static PluginType ParsePluginType(const std::string_view& type);
+        static void CheckForLicence(const DukValue& dukLicence, const std::string_view& pluginName);
     };
 } // namespace OpenRCT2::Scripting
 


### PR DESCRIPTION
I might have been greedy about the number of licenses, but I think that [ChooseALicense](https://choosealicense.com/) is the official GitHub guide, so why not support all of the ones listed there?

I didn't save the license when parsing it, because we actually don't need it, we just want to make sure that people specify it.