### PR TITLE
Use ScreenCoordsXY for gfx_draw_string_centred_clipped

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -369,7 +369,7 @@ static void widget_text_centred(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         formatArgs = &widget->string;
     }
     gfx_draw_string_centred_clipped(
-        dpi, stringId, formatArgs, colour, (l + r + 1) / 2 - 1, t, widget->right - widget->left - 2);
+        dpi, stringId, formatArgs, colour, { (l + r + 1) / 2 - 1, t }, widget->right - widget->left - 2);
 }
 
 /**
@@ -565,7 +565,7 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
             width -= 10;
     }
     l += width / 2;
-    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, l, t, width);
+    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, { l, t }, width);
 }
 
 /**
@@ -605,7 +605,7 @@ static void widget_closebox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     if (widget_is_disabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
-    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, colour, l, t, widget->right - widget->left - 2);
+    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, colour, { l, t }, widget->right - widget->left - 2);
 }
 
 /**

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -346,20 +346,19 @@ static void widget_text_centred(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    int32_t l = w->windowPos.x + widget->left;
+    auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, 0 };
     int32_t r = w->windowPos.x + widget->right;
-    int32_t t;
 
     if (widget->type == WWT_BUTTON || widget->type == WWT_TABLE_HEADER)
     {
         int32_t height = (widget->bottom - widget->top);
         if (height >= 10)
-            t = w->windowPos.y + std::max<int32_t>(widget->top, widget->top + (height / 2) - 5);
+            topLeft.y += std::max<int32_t>(widget->top, widget->top + (height / 2) - 5);
         else
-            t = w->windowPos.y + widget->top - 1;
+            topLeft.y += widget->top - 1;
     }
     else
-        t = w->windowPos.y + widget->top;
+        topLeft.y += widget->top;
 
     auto stringId = widget->text;
     void* formatArgs = gCommonFormatArgs;
@@ -369,7 +368,7 @@ static void widget_text_centred(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         formatArgs = &widget->string;
     }
     gfx_draw_string_centred_clipped(
-        dpi, stringId, formatArgs, colour, { (l + r + 1) / 2 - 1, t }, widget->right - widget->left - 2);
+        dpi, stringId, formatArgs, colour, { (topLeft.x + r + 1) / 2 - 1, topLeft.y }, widget->right - widget->left - 2);
 }
 
 /**
@@ -531,10 +530,8 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->windowPos.x + widget->left;
-    int32_t t = w->windowPos.y + widget->top;
-    int32_t r = w->windowPos.x + widget->right;
-    int32_t b = w->windowPos.y + widget->bottom;
+    auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    auto bottomRight = w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
 
     // Get the colour
     uint8_t colour = w->colours[widget->colour];
@@ -543,20 +540,19 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
     if (w->flags & WF_10)
         press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
 
-    gfx_fill_rect_inset(dpi, l, t, r, b, colour, press);
+    gfx_fill_rect_inset(dpi, topLeft.x, topLeft.y, bottomRight.x, bottomRight.y, colour, press);
 
     // Black caption bars look slightly green, this fixes that
     if (colour == 0)
-        gfx_fill_rect(dpi, l + 1, t + 1, r - 1, b - 1, ColourMapA[colour].dark);
+        gfx_fill_rect(dpi, topLeft.x + 1, topLeft.y + 1, bottomRight.x - 1, bottomRight.y - 1, ColourMapA[colour].dark);
     else
-        gfx_filter_rect(dpi, l + 1, t + 1, r - 1, b - 1, PALETTE_DARKEN_3);
+        gfx_filter_rect(dpi, topLeft.x + 1, topLeft.y + 1, bottomRight.x - 1, bottomRight.y - 1, PALETTE_DARKEN_3);
 
     // Draw text
     if (widget->text == STR_NONE)
         return;
 
-    l = widget->left + w->windowPos.x + 2;
-    t = widget->top + w->windowPos.y + 1;
+    topLeft = w->windowPos + ScreenCoordsXY{ widget->left + 2, widget->top + 1 };
     int32_t width = widget->right - widget->left - 4;
     if ((widget + 1)->type == WWT_CLOSEBOX)
     {
@@ -564,8 +560,8 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         if ((widget + 2)->type == WWT_CLOSEBOX)
             width -= 10;
     }
-    l += width / 2;
-    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, { l, t }, width);
+    topLeft.x += width / 2;
+    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, COLOUR_WHITE | COLOUR_FLAG_OUTLINE, topLeft, width);
 }
 
 /**
@@ -578,10 +574,8 @@ static void widget_closebox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     rct_widget* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    int32_t l = w->windowPos.x + widget->left;
-    int32_t t = w->windowPos.y + widget->top;
-    int32_t r = w->windowPos.x + widget->right;
-    int32_t b = w->windowPos.y + widget->bottom;
+    auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    auto bottomRight = w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
 
     // Check if the button is pressed down
     uint8_t press = 0;
@@ -594,18 +588,19 @@ static void widget_closebox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     uint8_t colour = w->colours[widget->colour];
 
     // Draw the button
-    gfx_fill_rect_inset(dpi, l, t, r, b, colour, press);
+    gfx_fill_rect_inset(dpi, topLeft.x, topLeft.y, bottomRight.x, bottomRight.y, colour, press);
 
     if (widget->text == STR_NONE)
         return;
 
-    l = w->windowPos.x + (widget->left + widget->right) / 2 - 1;
-    t = w->windowPos.y + std::max<int32_t>(widget->top, (widget->top + widget->bottom) / 2 - 5);
+    topLeft = w->windowPos
+        + ScreenCoordsXY{ (widget->left + widget->right) / 2 - 1,
+                          std::max<int32_t>(widget->top, (widget->top + widget->bottom) / 2 - 5) };
 
     if (widget_is_disabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
-    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, colour, { l, t }, widget->right - widget->left - 2);
+    gfx_draw_string_centred_clipped(dpi, widget->text, gCommonFormatArgs, colour, topLeft, widget->right - widget->left - 2);
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -612,7 +612,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     width = w->width - w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right - 6;
 
     rct_string_id drawString = window_editor_inventions_list_prepare_name(researchItem, false);
-    gfx_draw_string_centred_clipped(dpi, drawString, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    gfx_draw_string_centred_clipped(dpi, drawString, gCommonFormatArgs, COLOUR_BLACK, { x, y }, width);
     y += 15;
 
     // Item category

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -546,24 +546,23 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     rct_widget* widget;
     ResearchItem* researchItem;
     rct_string_id stringId;
-    int32_t x, y, width;
+    int32_t width;
 
     window_draw_widgets(w, dpi);
 
     // Tab image
-    x = w->windowPos.x + w->widgets[WIDX_TAB_1].left;
-    y = w->windowPos.y + w->widgets[WIDX_TAB_1].top;
-    gfx_draw_sprite(dpi, SPR_TAB_FINANCES_RESEARCH_0 + (w->frame_no / 2) % 8, x, y, 0);
+    auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_TAB_1].left, w->widgets[WIDX_TAB_1].top };
+    gfx_draw_sprite(dpi, SPR_TAB_FINANCES_RESEARCH_0 + (w->frame_no / 2) % 8, screenPos.x, screenPos.y, 0);
 
     // Pre-researched items label
-    x = w->windowPos.x + w->widgets[WIDX_PRE_RESEARCHED_SCROLL].left;
-    y = w->windowPos.y + w->widgets[WIDX_PRE_RESEARCHED_SCROLL].top - 11;
-    gfx_draw_string_left(dpi, STR_INVENTION_PREINVENTED_ITEMS, nullptr, COLOUR_BLACK, x, y - 1);
+    screenPos = w->windowPos
+        + ScreenCoordsXY{ w->widgets[WIDX_PRE_RESEARCHED_SCROLL].left, w->widgets[WIDX_PRE_RESEARCHED_SCROLL].top - 11 };
+    gfx_draw_string_left(dpi, STR_INVENTION_PREINVENTED_ITEMS, nullptr, COLOUR_BLACK, screenPos.x, screenPos.y - 1);
 
     // Research order label
-    x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].left;
-    y = w->windowPos.y + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].top - 11;
-    gfx_draw_string_left(dpi, STR_INVENTION_TO_BE_INVENTED_ITEMS, nullptr, COLOUR_BLACK, x, y - 1);
+    screenPos = w->windowPos
+        + ScreenCoordsXY{ w->widgets[WIDX_RESEARCH_ORDER_SCROLL].left, w->widgets[WIDX_RESEARCH_ORDER_SCROLL].top - 11 };
+    gfx_draw_string_left(dpi, STR_INVENTION_TO_BE_INVENTED_ITEMS, nullptr, COLOUR_BLACK, screenPos.x, screenPos.y - 1);
 
     // Preview background
     widget = &w->widgets[WIDX_PREVIEW];
@@ -596,29 +595,27 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     if (object != nullptr)
     {
         rct_drawpixelinfo clipDPI;
-        x = w->windowPos.x + widget->left + 1;
-        y = w->windowPos.y + widget->top + 1;
+        screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         width = widget->right - widget->left - 1;
         int32_t height = widget->bottom - widget->top - 1;
-        if (clip_drawpixelinfo(&clipDPI, dpi, x, y, width, height))
+        if (clip_drawpixelinfo(&clipDPI, dpi, screenPos.x, screenPos.y, width, height))
         {
             object_draw_preview(object, &clipDPI, width, height);
         }
     }
 
     // Item name
-    x = w->windowPos.x + ((widget->left + widget->right) / 2) + 1;
-    y = w->windowPos.y + widget->bottom + 3;
+    screenPos = w->windowPos + ScreenCoordsXY{ ((widget->left + widget->right) / 2) + 1, widget->bottom + 3 };
     width = w->width - w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right - 6;
 
     rct_string_id drawString = window_editor_inventions_list_prepare_name(researchItem, false);
-    gfx_draw_string_centred_clipped(dpi, drawString, gCommonFormatArgs, COLOUR_BLACK, { x, y }, width);
-    y += 15;
+    gfx_draw_string_centred_clipped(dpi, drawString, gCommonFormatArgs, COLOUR_BLACK, screenPos, width);
+    screenPos.y += 15;
 
     // Item category
-    x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
+    screenPos.x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
     stringId = EditorInventionsResearchCategories[researchItem->category];
-    gfx_draw_string_left(dpi, STR_INVENTION_RESEARCH_GROUP, &stringId, COLOUR_BLACK, x, y);
+    gfx_draw_string_left(dpi, STR_INVENTION_RESEARCH_GROUP, &stringId, COLOUR_BLACK, screenPos.x, screenPos.y);
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1066,8 +1066,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
-        gfx_draw_string_centred_clipped(
-            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos, width);
+        gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos, width);
     }
 
     // Draw description of object

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1067,7 +1067,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
         gfx_draw_string_centred_clipped(
-            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y, width);
+            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos, width);
     }
 
     // Draw description of object

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1085,10 +1085,9 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
     peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_ACTION_LBL];
-    int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
-    int32_t y = w->windowPos.y + widget->top - 1;
+    auto screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top - 1 };
     int32_t width = widget->right - widget->left;
-    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { x, y }, width);
+    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, screenPos, width);
 
     // Draw the marquee thought
     widget = &w->widgets[WIDX_MARQUEE];
@@ -1121,9 +1120,9 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    x = widget->right - widget->left - w->list_information_type;
+    screenPos.x = widget->right - widget->left - w->list_information_type;
     peep_thought_set_format_args(&peep->Thoughts[i]);
-    gfx_draw_string_left(&dpi_marquee, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, x, 0);
+    gfx_draw_string_left(&dpi_marquee, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, 0);
 }
 
 /**

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1088,7 +1088,7 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
     int32_t y = w->windowPos.y + widget->top - 1;
     int32_t width = widget->right - widget->left;
-    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { x, y }, width);
 
     // Draw the marquee thought
     widget = &w->widgets[WIDX_MARQUEE];

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -250,7 +250,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             gfx_draw_string_centred_clipped(
-                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, x, y, 368);
+                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, { x, y }, 368);
             y -= LIST_ROW_HEIGHT;
         }
     }

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -225,10 +225,9 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Track preview
     rct_widget* widget = &window_install_track_widgets[WIDX_TRACK_PREVIEW];
-    int32_t x = w->windowPos.x + widget->left + 1;
-    int32_t y = w->windowPos.y + widget->top + 1;
+    auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
     int32_t colour = ColourMapA[w->colours[0]].darkest;
-    gfx_fill_rect(dpi, x, y, x + 369, y + 216, colour);
+    gfx_fill_rect(dpi, screenPos.x, screenPos.y, screenPos.x + 369, screenPos.y + 216, colour);
 
     rct_g1_element g1temp = {};
     g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
@@ -237,10 +236,9 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     g1temp.flags = G1_FLAG_BMP;
     gfx_set_g1_element(SPR_TEMP, &g1temp);
     drawing_engine_invalidate_image(SPR_TEMP);
-    gfx_draw_sprite(dpi, SPR_TEMP, x, y, 0);
+    gfx_draw_sprite(dpi, SPR_TEMP, screenPos.x, screenPos.y, 0);
 
-    x = w->windowPos.x + (widget->left + widget->right) / 2;
-    y = w->windowPos.y + widget->bottom - 12;
+    screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->bottom - 12 };
 
     // Warnings
     const TrackDesign* td6 = _trackDesign.get();
@@ -250,20 +248,19 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             gfx_draw_string_centred_clipped(
-                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, { x, y }, 368);
-            y -= LIST_ROW_HEIGHT;
+                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, screenPos, 368);
+            screenPos.y -= LIST_ROW_HEIGHT;
         }
     }
 
     // Information
-    x = w->windowPos.x + widget->left + 1;
-    y = w->windowPos.y + widget->bottom + 4;
+    screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->bottom + 4 };
     // 0x006D3CF1 -- 0x006d3d71 missing
 
     // Track design name & type
     auto trackName = _trackName.c_str();
-    gfx_draw_string_left(dpi, STR_TRACK_DESIGN_NAME, &trackName, COLOUR_BLACK, x - 1, y);
-    y += LIST_ROW_HEIGHT;
+    gfx_draw_string_left(dpi, STR_TRACK_DESIGN_NAME, &trackName, COLOUR_BLACK, screenPos.x - 1, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT;
 
     rct_ride_name rideName;
     rct_string_id friendlyTrackName;
@@ -281,21 +278,21 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         friendlyTrackName = RideNaming[td6->type].name;
     }
 
-    gfx_draw_string_left(dpi, STR_TRACK_DESIGN_TYPE, &friendlyTrackName, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT + 4;
+    gfx_draw_string_left(dpi, STR_TRACK_DESIGN_TYPE, &friendlyTrackName, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT + 4;
 
     // Stats
     fixed32_2dp rating = td6->excitement * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, &rating, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT;
+    gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, &rating, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT;
 
     rating = td6->intensity * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, &rating, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT;
+    gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, &rating, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT;
 
     rating = td6->nausea * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, &rating, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT + 4;
+    gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, &rating, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT + 4;
 
     if (td6->type != RIDE_TYPE_MAZE)
     {
@@ -303,53 +300,53 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Holes
             uint16_t holes = td6->holes & 0x1F;
-            gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
         }
         else
         {
             // Maximum speed
             uint16_t speed = ((td6->max_speed << 16) * 9) >> 18;
-            gfx_draw_string_left(dpi, STR_MAX_SPEED, &speed, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_MAX_SPEED, &speed, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
 
             // Average speed
             speed = ((td6->average_speed << 16) * 9) >> 18;
-            gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &speed, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &speed, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
         }
 
         // Ride length
         auto ft = Formatter::Common();
         ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
         ft.Add<uint16_t>(td6->ride_length);
-        gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, { x, y }, 214);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, screenPos, 214);
+        screenPos.y += LIST_ROW_HEIGHT;
     }
 
     if (ride_type_has_flag(td6->type, RIDE_TYPE_FLAG_HAS_G_FORCES))
     {
         // Maximum positive vertical Gs
         int32_t gForces = td6->max_positive_vertical_g * 32;
-        gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, &gForces, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
 
         // Maximum negative vertical Gs
         gForces = td6->max_negative_vertical_g * 32;
-        gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, &gForces, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
 
         // Maximum lateral Gs
         gForces = td6->max_lateral_g * 32;
-        gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, &gForces, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, &gForces, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
 
         if (td6->total_air_time != 0)
         {
             // Total air time
             int32_t airTime = td6->total_air_time * 25;
-            gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &airTime, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &airTime, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
         }
     }
 
@@ -357,12 +354,12 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         // Drops
         uint16_t drops = td6->drops & 0x3F;
-        gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
 
         // Drop height is multiplied by 0.75
-        gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &drops, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &drops, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
     }
 
     if (td6->type != RIDE_TYPE_MINI_GOLF)
@@ -371,11 +368,11 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (inversions != 0)
         {
             // Inversions
-            gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
         }
     }
-    y += 4;
+    screenPos.y += 4;
 
     if (td6->space_required_x != 0xFF)
     {
@@ -383,15 +380,15 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter::Common();
         ft.Add<uint16_t>(td6->space_required_x);
         ft.Add<uint16_t>(td6->space_required_y);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
     }
 
     if (td6->cost != 0)
     {
         auto ft = Formatter::Common();
         ft.Add<uint32_t>(td6->cost);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, x, y);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y);
     }
 }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -922,14 +922,16 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
             widget->right - widget->left - 8);
     }
 
-    int32_t x = w->windowPos.x + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4;
-    int32_t y = w->windowPos.y + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].top + 4;
+    auto screenPos = w->windowPos
+        + ScreenCoordsXY{ window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4,
+                          window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].top + 4 };
 
-    gfx_draw_string_left(dpi, STR_DEFAULT_GROUP, nullptr, w->colours[2], x, y);
+    gfx_draw_string_left(dpi, STR_DEFAULT_GROUP, nullptr, w->colours[2], screenPos.x, screenPos.y);
 
-    y += 20;
+    screenPos.y += 20;
 
-    gfx_fill_rect_inset(dpi, x, y - 6, x + 310, y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
+    gfx_fill_rect_inset(
+        dpi, screenPos.x, screenPos.y - 6, screenPos.x + 310, screenPos.y - 5, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
 
     widget = &window_multiplayer_groups_widgets[WIDX_SELECTED_GROUP];
     group = network_get_group_index(_selectedGroup);

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -917,8 +917,9 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         auto ft = Formatter::Common();
         ft.Add<const char*>(buffer);
         gfx_draw_string_centred_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
-            w->windowPos.y + widget->top, widget->right - widget->left - 8);
+            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK,
+            w->windowPos + ScreenCoordsXY{ (widget->left + widget->right - 11) / 2, widget->top },
+            widget->right - widget->left - 8);
     }
 
     int32_t x = w->windowPos.x + window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4;
@@ -942,8 +943,9 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         auto ft = Formatter::Common();
         ft.Add<const char*>(buffer);
         gfx_draw_string_centred_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
-            w->windowPos.y + widget->top, widget->right - widget->left - 8);
+            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK,
+            w->windowPos + ScreenCoordsXY{ (widget->left + widget->right - 11) / 2, widget->top },
+            widget->right - widget->left - 8);
     }
 }
 

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -876,8 +876,9 @@ static void window_park_entrance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     labelWidget = &window_park_entrance_widgets[WIDX_STATUS];
     gfx_draw_string_centred_clipped(
-        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (labelWidget->left + labelWidget->right) / 2,
-        w->windowPos.y + labelWidget->top, labelWidget->right - labelWidget->left);
+        dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK,
+        w->windowPos + ScreenCoordsXY{ (labelWidget->left + labelWidget->right) / 2, labelWidget->top },
+        labelWidget->right - labelWidget->left);
 }
 
 /**

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -378,8 +378,9 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<const char*>(buffer);
 
         gfx_draw_string_centred_clipped(
-            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right - 11) / 2,
-            w->windowPos.y + widget->top, widget->right - widget->left - 8);
+            dpi, STR_STRING, gCommonFormatArgs, COLOUR_BLACK,
+            w->windowPos + ScreenCoordsXY{ (widget->left + widget->right - 11) / 2, widget->top },
+            widget->right - widget->left - 8);
     }
 
     // Draw ping
@@ -405,8 +406,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ft.Add<rct_string_id>(STR_ACTION_NA);
     }
-    gfx_draw_string_centred_clipped(
-        dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords.x, screenCoords.y, width);
+    gfx_draw_string_centred_clipped(dpi, STR_LAST_ACTION_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords, width);
 
     if (w->viewport != nullptr && w->var_492 != -1)
     {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2930,8 +2930,8 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     widget = &window_ride_main_widgets[WIDX_STATUS];
     rct_string_id ride_status = window_ride_get_status(w, gCommonFormatArgs);
     gfx_draw_string_centred_clipped(
-        dpi, ride_status, gCommonFormatArgs, COLOUR_BLACK, w->windowPos.x + (widget->left + widget->right) / 2,
-        w->windowPos.y + widget->top, widget->right - widget->left);
+        dpi, ride_status, gCommonFormatArgs, COLOUR_BLACK,
+        w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->right - widget->left);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -948,10 +948,9 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     Peep* peep = GET_PEEP(w->number);
     peep->FormatActionTo(gCommonFormatArgs);
     rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];
-    int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
-    int32_t y = w->windowPos.y + widget->top;
+    auto screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top };
     int32_t width = widget->right - widget->left;
-    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { x, y }, width);
+    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, screenPos, width);
 }
 
 /**

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -951,7 +951,7 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t x = (widget->left + widget->right) / 2 + w->windowPos.x;
     int32_t y = w->windowPos.y + widget->top;
     int32_t width = widget->right - widget->left;
-    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, x, y, width);
+    gfx_draw_string_centred_clipped(dpi, STR_BLACK_STRING, gCommonFormatArgs, COLOUR_BLACK, { x, y }, width);
 }
 
 /**

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -473,11 +473,13 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (_showLockedInformation)
         {
             // Show locked information
-            int32_t x = w->windowPos.x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
-            int32_t y = w->windowPos.y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
-            gfx_draw_string_centred_clipped(dpi, STR_SCENARIO_LOCKED, nullptr, COLOUR_BLACK, { x + 85, y }, 170);
-            y += 15;
-            y += gfx_draw_string_left_wrapped(dpi, nullptr, x, y, 170, STR_SCENARIO_LOCKED_DESC, COLOUR_BLACK) + 5;
+            auto screenPos = w->windowPos
+                + ScreenCoordsXY{ window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4,
+                                  window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5 };
+            gfx_draw_string_centred_clipped(
+                dpi, STR_SCENARIO_LOCKED, nullptr, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 85, 0 }, 170);
+            gfx_draw_string_left_wrapped(
+                dpi, nullptr, screenPos.x, screenPos.y + 15, 170, STR_SCENARIO_LOCKED_DESC, COLOUR_BLACK);
         }
         return;
     }
@@ -497,19 +499,23 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Scenario name
-    int32_t x = w->windowPos.x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
-    int32_t y = w->windowPos.y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
+    auto screenPos = w->windowPos
+        + ScreenCoordsXY{ window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4,
+                          window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5 };
     auto ft = Formatter::Common();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->name);
-    gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { x + 85, y }, 170);
-    y += 15;
+    gfx_draw_string_centred_clipped(
+        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 85, 0 }, 170);
+    screenPos.y += 15;
 
     // Scenario details
     ft = Formatter::Common();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->details);
-    y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y, 170, STR_BLACK_STRING, COLOUR_BLACK) + 5;
+    screenPos.y += gfx_draw_string_left_wrapped(
+                       dpi, gCommonFormatArgs, screenPos.x, screenPos.y, 170, STR_BLACK_STRING, COLOUR_BLACK)
+        + 5;
 
     // Scenario objective
     ft = Formatter::Common();
@@ -517,7 +523,9 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ft.Add<int16_t>(scenario->objective_arg_3);
     ft.Add<int16_t>(date_get_total_months(MONTH_OCTOBER, scenario->objective_arg_1));
     ft.Add<int32_t>(scenario->objective_arg_2);
-    y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y, 170, STR_OBJECTIVE, COLOUR_BLACK) + 5;
+    screenPos.y += gfx_draw_string_left_wrapped(
+                       dpi, gCommonFormatArgs, screenPos.x, screenPos.y, 170, STR_OBJECTIVE, COLOUR_BLACK)
+        + 5;
 
     // Scenario score
     if (scenario->highscore != nullptr)
@@ -532,7 +540,8 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(completedByName);
         ft.Add<money32>(scenario->highscore->company_value);
-        y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, x, y, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, COLOUR_BLACK);
+        screenPos.y += gfx_draw_string_left_wrapped(
+            dpi, gCommonFormatArgs, screenPos.x, screenPos.y, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, COLOUR_BLACK);
     }
 }
 

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -475,7 +475,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
             // Show locked information
             int32_t x = w->windowPos.x + window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4;
             int32_t y = w->windowPos.y + window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5;
-            gfx_draw_string_centred_clipped(dpi, STR_SCENARIO_LOCKED, nullptr, COLOUR_BLACK, x + 85, y, 170);
+            gfx_draw_string_centred_clipped(dpi, STR_SCENARIO_LOCKED, nullptr, COLOUR_BLACK, { x + 85, y }, 170);
             y += 15;
             y += gfx_draw_string_left_wrapped(dpi, nullptr, x, y, 170, STR_SCENARIO_LOCKED_DESC, COLOUR_BLACK) + 5;
         }
@@ -502,7 +502,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto ft = Formatter::Common();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->name);
-    gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, x + 85, y, 170);
+    gfx_draw_string_centred_clipped(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { x + 85, y }, 170);
     y += 15;
 
     // Scenario details

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -515,12 +515,11 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t trackIndex = _filteredTrackIds[listItemIndex];
 
     // Track preview
-    int32_t x, y, colour;
+    int32_t colour;
     rct_widget* widget = &window_track_list_widgets[WIDX_TRACK_PREVIEW];
-    x = w->windowPos.x + widget->left + 1;
-    y = w->windowPos.y + widget->top + 1;
+    auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
     colour = ColourMapA[w->colours[0]].darkest;
-    gfx_fill_rect(dpi, x, y, x + 369, y + 216, colour);
+    gfx_fill_rect(dpi, screenPos.x, screenPos.y, screenPos.x + 369, screenPos.y + 216, colour);
 
     if (_loadedTrackDesignIndex != trackIndex)
     {
@@ -540,9 +539,8 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    int32_t trackPreviewX = x, trackPreviewY = y;
-    x = w->windowPos.x + (widget->left + widget->right) / 2;
-    y = w->windowPos.y + (widget->top + widget->bottom) / 2;
+    auto trackPreview = screenPos;
+    screenPos = w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, (widget->top + widget->bottom) / 2 };
 
     rct_g1_element g1temp = {};
     g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
@@ -551,17 +549,17 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     g1temp.flags = G1_FLAG_BMP;
     gfx_set_g1_element(SPR_TEMP, &g1temp);
     drawing_engine_invalidate_image(SPR_TEMP);
-    gfx_draw_sprite(dpi, SPR_TEMP, trackPreviewX, trackPreviewY, 0);
+    gfx_draw_sprite(dpi, SPR_TEMP, trackPreview.x, trackPreview.y, 0);
 
-    y = w->windowPos.y + widget->bottom - 12;
+    screenPos.y = w->windowPos.y + widget->bottom - 12;
 
     // Warnings
     if ((_loadedTrackDesign->track_flags & TRACK_DESIGN_FLAG_VEHICLE_UNAVAILABLE)
         && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         // Vehicle design not available
-        gfx_draw_string_centred_clipped(dpi, STR_VEHICLE_DESIGN_UNAVAILABLE, nullptr, COLOUR_BLACK, { x, y }, 368);
-        y -= SCROLLABLE_ROW_HEIGHT;
+        gfx_draw_string_centred_clipped(dpi, STR_VEHICLE_DESIGN_UNAVAILABLE, nullptr, COLOUR_BLACK, screenPos, 368);
+        screenPos.y -= SCROLLABLE_ROW_HEIGHT;
     }
 
     if (_loadedTrackDesign->track_flags & TRACK_DESIGN_FLAG_SCENERY_UNAVAILABLE)
@@ -570,31 +568,30 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             gfx_draw_string_centred_clipped(
-                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, { x, y }, 368);
-            y -= SCROLLABLE_ROW_HEIGHT;
+                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, screenPos, 368);
+            screenPos.y -= SCROLLABLE_ROW_HEIGHT;
         }
     }
 
     // Track design name
     utf8* trackName = _trackDesigns[trackIndex].name;
-    gfx_draw_string_centred_clipped(dpi, STR_TRACK_PREVIEW_NAME_FORMAT, &trackName, COLOUR_BLACK, { x, y }, 368);
+    gfx_draw_string_centred_clipped(dpi, STR_TRACK_PREVIEW_NAME_FORMAT, &trackName, COLOUR_BLACK, screenPos, 368);
 
     // Information
-    x = w->windowPos.x + widget->left + 1;
-    y = w->windowPos.y + widget->bottom + 2;
+    screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->bottom + 2 };
 
     // Stats
     fixed32_2dp rating = _loadedTrackDesign->excitement * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, &rating, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT;
+    gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, &rating, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT;
 
     rating = _loadedTrackDesign->intensity * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, &rating, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT;
+    gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, &rating, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT;
 
     rating = _loadedTrackDesign->nausea * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, &rating, COLOUR_BLACK, x, y);
-    y += LIST_ROW_HEIGHT + 4;
+    gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, &rating, COLOUR_BLACK, screenPos.x, screenPos.y);
+    screenPos.y += LIST_ROW_HEIGHT + 4;
 
     // Information for tracked rides.
     if (ride_type_has_flag(_loadedTrackDesign->type, RIDE_TYPE_FLAG_HAS_TRACK))
@@ -605,53 +602,53 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
             {
                 // Holes
                 uint16_t holes = _loadedTrackDesign->holes & 0x1F;
-                gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, x, y);
-                y += LIST_ROW_HEIGHT;
+                gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, screenPos.x, screenPos.y);
+                screenPos.y += LIST_ROW_HEIGHT;
             }
             else
             {
                 // Maximum speed
                 uint16_t speed = ((_loadedTrackDesign->max_speed << 16) * 9) >> 18;
-                gfx_draw_string_left(dpi, STR_MAX_SPEED, &speed, COLOUR_BLACK, x, y);
-                y += LIST_ROW_HEIGHT;
+                gfx_draw_string_left(dpi, STR_MAX_SPEED, &speed, COLOUR_BLACK, screenPos.x, screenPos.y);
+                screenPos.y += LIST_ROW_HEIGHT;
 
                 // Average speed
                 speed = ((_loadedTrackDesign->average_speed << 16) * 9) >> 18;
-                gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &speed, COLOUR_BLACK, x, y);
-                y += LIST_ROW_HEIGHT;
+                gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &speed, COLOUR_BLACK, screenPos.x, screenPos.y);
+                screenPos.y += LIST_ROW_HEIGHT;
             }
 
             // Ride length
             auto ft = Formatter::Common();
             ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
             ft.Add<uint16_t>(_loadedTrackDesign->ride_length);
-            gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, { x, y }, 214);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left_clipped(dpi, STR_TRACK_LIST_RIDE_LENGTH, gCommonFormatArgs, COLOUR_BLACK, screenPos, 214);
+            screenPos.y += LIST_ROW_HEIGHT;
         }
 
         if (ride_type_has_flag(_loadedTrackDesign->type, RIDE_TYPE_FLAG_HAS_G_FORCES))
         {
             // Maximum positive vertical Gs
             int32_t gForces = _loadedTrackDesign->max_positive_vertical_g * 32;
-            gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, &gForces, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
 
             // Maximum negative vertical Gs
             gForces = _loadedTrackDesign->max_negative_vertical_g * 32;
-            gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, &gForces, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
 
             // Maximum lateral Gs
             gForces = _loadedTrackDesign->max_lateral_g * 32;
-            gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, &gForces, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, &gForces, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
 
             if (_loadedTrackDesign->total_air_time != 0)
             {
                 // Total air time
                 int32_t airTime = _loadedTrackDesign->total_air_time * 25;
-                gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &airTime, COLOUR_BLACK, x, y);
-                y += LIST_ROW_HEIGHT;
+                gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &airTime, COLOUR_BLACK, screenPos.x, screenPos.y);
+                screenPos.y += LIST_ROW_HEIGHT;
             }
         }
 
@@ -659,13 +656,13 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Drops
             uint16_t drops = _loadedTrackDesign->drops & 0x3F;
-            gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
 
             // Drop height is multiplied by 0.75
             uint16_t highestDropHeight = (_loadedTrackDesign->highest_drop_height * 3) / 4;
-            gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight, COLOUR_BLACK, x, y);
-            y += LIST_ROW_HEIGHT;
+            gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight, COLOUR_BLACK, screenPos.x, screenPos.y);
+            screenPos.y += LIST_ROW_HEIGHT;
         }
 
         if (_loadedTrackDesign->type != RIDE_TYPE_MINI_GOLF)
@@ -674,11 +671,11 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
             if (inversions != 0)
             {
                 // Inversions
-                gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, x, y);
-                y += LIST_ROW_HEIGHT;
+                gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, screenPos.x, screenPos.y);
+                screenPos.y += LIST_ROW_HEIGHT;
             }
         }
-        y += 4;
+        screenPos.y += 4;
     }
 
     if (_loadedTrackDesign->space_required_x != 0xFF)
@@ -687,14 +684,14 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter::Common();
         ft.Add<uint16_t>(_loadedTrackDesign->space_required_x);
         ft.Add<uint16_t>(_loadedTrackDesign->space_required_y);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, x, y);
-        y += LIST_ROW_HEIGHT;
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y);
+        screenPos.y += LIST_ROW_HEIGHT;
     }
 
     if (_loadedTrackDesign->cost != 0)
     {
         Formatter::Common().Add<uint32_t>(_loadedTrackDesign->cost);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, x, y);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, screenPos.x, screenPos.y);
     }
 }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -560,7 +560,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         // Vehicle design not available
-        gfx_draw_string_centred_clipped(dpi, STR_VEHICLE_DESIGN_UNAVAILABLE, nullptr, COLOUR_BLACK, x, y, 368);
+        gfx_draw_string_centred_clipped(dpi, STR_VEHICLE_DESIGN_UNAVAILABLE, nullptr, COLOUR_BLACK, { x, y }, 368);
         y -= SCROLLABLE_ROW_HEIGHT;
     }
 
@@ -570,14 +570,14 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             gfx_draw_string_centred_clipped(
-                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, x, y, 368);
+                dpi, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, nullptr, COLOUR_BLACK, { x, y }, 368);
             y -= SCROLLABLE_ROW_HEIGHT;
         }
     }
 
     // Track design name
     utf8* trackName = _trackDesigns[trackIndex].name;
-    gfx_draw_string_centred_clipped(dpi, STR_TRACK_PREVIEW_NAME_FORMAT, &trackName, COLOUR_BLACK, x, y, 368);
+    gfx_draw_string_centred_clipped(dpi, STR_TRACK_PREVIEW_NAME_FORMAT, &trackName, COLOUR_BLACK, { x, y }, 368);
 
     // Information
     x = w->windowPos.x + widget->left + 1;

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -659,7 +659,7 @@ void draw_string_right_underline(
 void gfx_draw_string_left_clipped(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width);
 void gfx_draw_string_centred_clipped(
-    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y, int32_t width);
+    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width);
 void gfx_draw_string_right_clipped(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width);
 

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -194,9 +194,9 @@ void gfx_draw_string_left_clipped(
 }
 
 void gfx_draw_string_centred_clipped(
-    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, int32_t x, int32_t y, int32_t width)
+    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width)
 {
-    DrawTextEllipsisedCompat(dpi, x, y, width, format, args, colour, TextAlignment::CENTRE);
+    DrawTextEllipsisedCompat(dpi, coords.x, coords.y, width, format, args, colour, TextAlignment::CENTRE);
 }
 
 void gfx_draw_string_right_clipped(


### PR DESCRIPTION
Closes #11564

- First commit just stops using the old overload
- Second commit converts local variables to `ScreenCoordsXY`