### PR TITLE
Fix #7324: Research window shows vehicle name instead of ride name

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3670,6 +3670,8 @@ STR_6372    :The specified path contains a RollerCoaster Tycoon 1 installation, 
 STR_6373    :Toggle clearance checks
 STR_6374    :C
 STR_6375    :Unknown Ride
+STR_6376    :{WINDOW_COLOUR_2}Ride vehicle:{NEWLINE}{BLACK}{STRINGID} for {STRINGID}
+STR_6377    :{WINDOW_COLOUR_2}Type: {BLACK}{STRINGID} for {STRINGID}
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#5451] Guests scream on every descent, no matter how small.
 - Fix: [#6119] Advertising campaign for ride window not updated properly (original bug).
 - Fix: [#7006] Submarine Ride is in the wrong research group.
+- Fix: [#7324] Research window shows vehicle name instead of ride name.
 - Fix: [#10634] Guests are unable to use uphill paths out of toilets.
 - Fix: [#10876] When removing a path, its guest entry point is not removed.
 - Fix: [#10876] There can be multiple peep spawns on the same location.

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/management/Finance.h>
 #include <openrct2/management/NewsItem.h>
 #include <openrct2/management/Research.h>
+#include <openrct2/ride/RideData.h>
 #include <openrct2/sprites.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
@@ -362,16 +363,33 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
     else
     {
         // Research type
-        stringId = STR_RESEARCH_UNKNOWN;
+        rct_string_id strings[2] = { STR_RESEARCH_UNKNOWN, 0 };
+        rct_string_id label = STR_RESEARCH_TYPE_LABEL;
         if (gResearchProgressStage != RESEARCH_STAGE_INITIAL_RESEARCH)
         {
-            stringId = ResearchCategoryNames[gResearchNextItem->category];
+            strings[0] = ResearchCategoryNames[gResearchNextItem->category];
             if (gResearchProgressStage != RESEARCH_STAGE_DESIGNING)
             {
-                stringId = gResearchNextItem->GetName();
+                strings[0] = gResearchNextItem->GetName();
+                if (gResearchNextItem->type == RESEARCH_ENTRY_TYPE_RIDE)
+                {
+                    auto rtd = RideTypeDescriptors[gResearchNextItem->baseRideType];
+                    if (!rtd.HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
+                    {
+                        if (gResearchNextItem->flags & RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE)
+                        {
+                            strings[0] = rtd.Naming.Name;
+                        }
+                        else
+                        {
+                            strings[1] = rtd.Naming.Name;
+                            label = STR_RESEARCH_TYPE_LABEL_VEHICLE;
+                        }
+                    }
+                }
             }
         }
-        gfx_draw_string_left_wrapped(dpi, &stringId, x, y, 296, STR_RESEARCH_TYPE_LABEL, COLOUR_BLACK);
+        gfx_draw_string_left_wrapped(dpi, &strings, x, y, 296, label, COLOUR_BLACK);
         y += 25;
 
         // Progress
@@ -402,11 +420,31 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
     rct_string_id lastDevelopmentFormat;
     if (gResearchLastItem.has_value())
     {
-        stringId = gResearchLastItem->GetName();
+        rct_string_id strings[2] = { gResearchLastItem->GetName(), 0 };
         uint8_t type = gResearchLastItem->type;
-        lastDevelopmentFormat = (type == RESEARCH_ENTRY_TYPE_RIDE) ? STR_RESEARCH_RIDE_LABEL : STR_RESEARCH_SCENERY_LABEL;
+        if (type == RESEARCH_ENTRY_TYPE_SCENERY)
+        {
+            lastDevelopmentFormat = STR_RESEARCH_SCENERY_LABEL;
+        }
+        else
+        {
+            lastDevelopmentFormat = STR_RESEARCH_RIDE_LABEL;
+            auto rtd = RideTypeDescriptors[gResearchLastItem->baseRideType];
+            if (!rtd.HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
+            {
+                if (gResearchLastItem->flags & RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE)
+                {
+                    strings[0] = rtd.Naming.Name;
+                }
+                else
+                {
+                    strings[1] = rtd.Naming.Name;
+                    lastDevelopmentFormat = STR_RESEARCH_VEHICLE_LABEL;
+                }
+            }
+        }
 
-        gfx_draw_string_left_wrapped(dpi, &stringId, x, y, 266, lastDevelopmentFormat, COLOUR_BLACK);
+        gfx_draw_string_left_wrapped(dpi, &strings, x, y, 266, lastDevelopmentFormat, COLOUR_BLACK);
     }
 }
 

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -363,7 +363,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
     else
     {
         // Research type
-        rct_string_id strings[2] = { STR_RESEARCH_UNKNOWN, 0 };
+        std::array<rct_string_id, 2> strings = { STR_RESEARCH_UNKNOWN, 0 };
         rct_string_id label = STR_RESEARCH_TYPE_LABEL;
         if (gResearchProgressStage != RESEARCH_STAGE_INITIAL_RESEARCH)
         {
@@ -417,10 +417,10 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
     x = w->windowPos.x + 10;
     y = w->windowPos.y + w->widgets[WIDX_LAST_DEVELOPMENT_GROUP + baseWidgetIndex].top + 12;
 
-    rct_string_id lastDevelopmentFormat;
     if (gResearchLastItem.has_value())
     {
-        rct_string_id strings[2] = { gResearchLastItem->GetName(), 0 };
+        rct_string_id lastDevelopmentFormat = STR_EMPTY;
+        std::array<rct_string_id, 2> strings = { gResearchLastItem->GetName(), 0 };
         uint8_t type = gResearchLastItem->type;
         if (type == RESEARCH_ENTRY_TYPE_SCENERY)
         {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3911,6 +3911,9 @@ enum
 
     STR_UNKNOWN_RIDE = 6375,
 
+    STR_RESEARCH_VEHICLE_LABEL = 6376,
+    STR_RESEARCH_TYPE_LABEL_VEHICLE = 6377,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -17,6 +17,19 @@
 
 struct rct_ride_entry;
 
+enum
+{
+    RESEARCH_ENTRY_TYPE_SCENERY = 0,
+    RESEARCH_ENTRY_TYPE_RIDE = 1,
+};
+
+enum
+{
+    RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE = (1 << 0),
+    RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED = (1 << 5),
+    RESEARCH_ENTRY_FLAG_RIDE_ALWAYS_RESEARCHED = (1 << 6),
+};
+
 struct ResearchItem
 {
     union
@@ -67,7 +80,7 @@ struct ResearchItem
             retItem.entryIndex = OpenRCT2EntryIndexToRCTEntryIndex(entryIndex);
             retItem.baseRideType = baseRideType;
             retItem.type = type;
-            retItem.flags = flags;
+            retItem.flags = (flags & ~RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE);
             retItem.category = category;
         }
 
@@ -93,18 +106,6 @@ struct ResearchItem
             category = oldResearchItem.category;
         }
     }
-};
-
-enum
-{
-    RESEARCH_ENTRY_TYPE_SCENERY = 0,
-    RESEARCH_ENTRY_TYPE_RIDE = 1,
-};
-
-enum
-{
-    RESEARCH_ENTRY_FLAG_SCENERY_SET_ALWAYS_RESEARCHED = (1 << 5),
-    RESEARCH_ENTRY_FLAG_RIDE_ALWAYS_RESEARCHED = (1 << 6),
 };
 
 // Only used to mark as null nowadays. Deprecated. TODO: remove.
@@ -192,3 +193,8 @@ void research_fix();
 void research_items_make_all_unresearched();
 void research_items_make_all_researched();
 void research_items_shuffle();
+/**
+ * Determines if a newly invented ride entry should be listed as a new ride
+ * or as a new vehicle for a pre-existing ride.
+ */
+void research_determine_first_of_type();

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -399,31 +399,7 @@ void RideObject::SetRepositoryItem(ObjectRepositoryItem* item) const
     }
 
     item->RideInfo.RideFlags = 0;
-
-    // Determines the ride group. Will fall back to 0 if there is none found.
-    uint8_t rideGroupIndex = 0;
-
-    const RideGroup* rideGroup = RideGroupManager::GetRideGroup(firstRideType, &_legacyType);
-
-    // If the ride group is nullptr, the track type does not have ride groups.
-    if (rideGroup != nullptr)
-    {
-        for (uint8_t i = rideGroupIndex + 1; i < MAX_RIDE_GROUPS_PER_RIDE_TYPE; i++)
-        {
-            const RideGroup* irg = RideGroupManager::RideGroupFind(firstRideType, i);
-
-            if (irg != nullptr)
-            {
-                if (irg->Equals(rideGroup))
-                {
-                    rideGroupIndex = i;
-                    break;
-                }
-            }
-        }
-    }
-
-    item->RideInfo.RideGroupIndex = rideGroupIndex;
+    item->RideInfo.RideGroupIndex = RideGroupManager::GetRideGroupIndex(firstRideType, &_legacyType);
 }
 
 void RideObject::ReadLegacyVehicle(

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -210,6 +210,7 @@ public:
 
         game_convert_news_items_to_utf8();
         map_count_remaining_land_rights();
+        research_determine_first_of_type();
     }
 
     bool GetDetails(scenario_index_entry* dst) override

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -487,6 +487,8 @@ public:
                 OWNERSHIP_OWNED);
             // clang-format on
         }
+
+        research_determine_first_of_type();
     }
 
     void ImportRides()

--- a/src/openrct2/ride/RideGroupManager.cpp
+++ b/src/openrct2/ride/RideGroupManager.cpp
@@ -245,3 +245,30 @@ const RideGroup* RideGroupManager::RideGroupFind(const uint8_t rideType, const u
             return nullptr;
     }
 }
+
+uint8_t RideGroupManager::GetRideGroupIndex(const uint8_t rideType, const rct_ride_entry* rideEntry)
+{
+    uint8_t rideGroupIndex = 0;
+
+    const RideGroup* rideGroup = RideGroupManager::GetRideGroup(rideType, rideEntry);
+
+    // If the ride group is nullptr, the track type does not have ride groups.
+    if (rideGroup != nullptr)
+    {
+        for (uint8_t i = rideGroupIndex + 1; i < MAX_RIDE_GROUPS_PER_RIDE_TYPE; i++)
+        {
+            const RideGroup* irg = RideGroupManager::RideGroupFind(rideType, i);
+
+            if (irg != nullptr)
+            {
+                if (irg->Equals(rideGroup))
+                {
+                    rideGroupIndex = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    return rideGroupIndex;
+}

--- a/src/openrct2/ride/RideGroupManager.h
+++ b/src/openrct2/ride/RideGroupManager.h
@@ -32,6 +32,8 @@ class RideGroupManager
 {
 public:
     static const RideGroup* GetRideGroup(const uint8_t trackType, const rct_ride_entry* rideEntry);
+    /** Will fall back to 0 if there is none found. */
+    static uint8_t GetRideGroupIndex(const uint8_t trackType, const rct_ride_entry* rideEntry);
     static const RideGroup* RideGroupFind(const uint8_t rideType, const uint8_t index);
 };
 


### PR DESCRIPTION
This iterates over the research list upon loading a save and determines whether a vehicle is the first to be invented for its type. If so, it sets a flag.

![Six Flags Great Adventure 2020-06-17 16-50-02](https://user-images.githubusercontent.com/1478678/84918436-e1fec100-b0c0-11ea-95c8-0412336c5fd0.png)
