### PR TITLE
Refactor/ride type misc

### DIFF
--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -48,6 +48,7 @@ constexpr const uint8_t RCT2_MAX_SCENERY_GROUP_OBJECTS = 19;
 constexpr const uint8_t RCT2_MAX_PARK_ENTRANCE_OBJECTS = 1;
 constexpr const uint8_t RCT2_MAX_WATER_OBJECTS = 1;
 constexpr const uint8_t RCT2_MAX_SCENARIO_TEXT_OBJECTS = 1;
+constexpr const uint8_t RCT2_RIDE_TYPE_COUNT = 91;
 
 // clang-format off
 constexpr const uint16_t RCT2_OBJECT_ENTRY_COUNT =

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -852,7 +852,7 @@ void S6Exporter::ExportResearchedRideTypes()
 {
     std::fill(std::begin(_s6.researched_ride_types), std::end(_s6.researched_ride_types), false);
 
-    for (int32_t rideType = 0; rideType < RIDE_TYPE_COUNT; rideType++)
+    for (int32_t rideType = 0; rideType < RCT2_RIDE_TYPE_COUNT; rideType++)
     {
         if (ride_type_is_invented(rideType))
         {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -852,7 +852,7 @@ public:
     {
         set_every_ride_type_not_invented();
 
-        for (int32_t rideType = 0; rideType < RIDE_TYPE_COUNT; rideType++)
+        for (int32_t rideType = 0; rideType < RCT2_RIDE_TYPE_COUNT; rideType++)
         {
             int32_t quadIndex = rideType >> 5;
             int32_t bitIndex = rideType & 0x1F;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7441,13 +7441,6 @@ uint8_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry)
     return RIDE_TYPE_NULL;
 }
 
-bool ride_type_supports_boosters(uint8_t rideType)
-{
-    return rideType == RIDE_TYPE_LOOPING_ROLLER_COASTER || rideType == RIDE_TYPE_CORKSCREW_ROLLER_COASTER
-        || rideType == RIDE_TYPE_TWISTER_ROLLER_COASTER || rideType == RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER
-        || rideType == RIDE_TYPE_GIGA_COASTER || rideType == RIDE_TYPE_JUNIOR_ROLLER_COASTER;
-}
-
 int32_t get_booster_speed(uint8_t rideType, int32_t rawSpeed)
 {
     int8_t shiftFactor = RideTypeDescriptors[rideType].OperatingSettings.BoosterSpeedFactor;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1211,7 +1211,6 @@ bool ride_has_ratings(const Ride* ride);
 const char* ride_type_get_enum_name(int32_t rideType);
 
 uint8_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry);
-bool ride_type_supports_boosters(uint8_t rideType);
 int32_t get_booster_speed(uint8_t rideType, int32_t rawSpeed);
 void fix_invalid_vehicle_sprite_sizes();
 bool ride_entry_has_category(const rct_ride_entry* rideEntry, uint8_t category);

--- a/test/testpaint/Data.cpp
+++ b/test/testpaint/Data.cpp
@@ -10,7 +10,7 @@
 #include <openrct2/common.h>
 #include <openrct2/ride/Ride.h>
 
-const_utf8string RideNames[RIDE_TYPE_COUNT] = {
+const_utf8string RideNames[RCT2_RIDE_TYPE_COUNT] = {
     "SpiralRollerCoaster",
     "StandUpRollerCoaster",
     "SuspendedSwingingCoaster",
@@ -883,7 +883,7 @@ const_utf8string TrackElemNames[] = {
     "TRACK_ELEM_255",
 };
 
-const_utf8string RideCodeNames[RIDE_TYPE_COUNT] = {
+const_utf8string RideCodeNames[RCT2_RIDE_TYPE_COUNT] = {
     "spiral_rc",
     "stand_up_rc",
     "suspended_swinging_rc",

--- a/test/testpaint/Data.h
+++ b/test/testpaint/Data.h
@@ -13,12 +13,12 @@
 #include <openrct2/common.h>
 #include <openrct2/ride/Ride.h>
 
-extern const utf8string RideNames[RIDE_TYPE_COUNT];
+extern const utf8string RideNames[RCT2_RIDE_TYPE_COUNT];
 extern const utf8string TrackNames[256];
 extern const utf8string FlatTrackNames[256];
 extern const utf8string TrackElemNames[256];
-extern const utf8string RideCodeNames[RIDE_TYPE_COUNT];
+extern const utf8string RideCodeNames[RCT2_RIDE_TYPE_COUNT];
 extern const utf8string TrackCodeNames[256];
-extern const uint32_t* RideTypeTrackPaintFunctionsOld[RIDE_TYPE_COUNT];
+extern const uint32_t* RideTypeTrackPaintFunctionsOld[RCT2_RIDE_TYPE_COUNT];
 
 #endif // #endif _TEST_PAINT_DATA_H_

--- a/test/testpaint/TrackDataOld.cpp
+++ b/test/testpaint/TrackDataOld.cpp
@@ -19262,7 +19262,7 @@ static constexpr const uint32_t _OldLimLaunchedRollerCoasterTrackPaintFunctions[
 
 static constexpr const uint32_t _null[256] = {0};
 
-const uint32_t * RideTypeTrackPaintFunctionsOld[RIDE_TYPE_COUNT] = {
+const uint32_t * RideTypeTrackPaintFunctionsOld[RCT2_RIDE_TYPE_COUNT] = {
     _OldSpiralRollerCoasterTrackPaintFunctions,             // RIDE_TYPE_SPIRAL_ROLLER_COASTER
     _OldStandUpRollerCoasterTrackPaintFunctions,            // RIDE_TYPE_STAND_UP_ROLLER_COASTER
     _OldSuspendedSwingingCoasterTrackPaintFunctions,        // RIDE_TYPE_SUSPENDED_SWINGING_COASTER

--- a/test/testpaint/main.cpp
+++ b/test/testpaint/main.cpp
@@ -398,7 +398,7 @@ static bool openrct2_setup_rct2_segment()
 
 static void PrintRideTypes()
 {
-    for (uint8_t rideType = 0; rideType < RIDE_TYPE_COUNT; rideType++)
+    for (uint8_t rideType = 0; rideType < RCT2_RIDE_TYPE_COUNT; rideType++)
     {
         CLIColour colour = CLIColour::DEFAULT;
         bool implemented = Utils::rideIsImplemented(rideType);
@@ -505,7 +505,7 @@ int main(int argc, char* argv[])
         return generatePaintCode(specificRideType);
     }
 
-    for (uint8_t rideType = 0; rideType < RIDE_TYPE_COUNT; rideType++)
+    for (uint8_t rideType = 0; rideType < RCT2_RIDE_TYPE_COUNT; rideType++)
     {
         if (specificRideType != RIDE_TYPE_NULL && rideType != specificRideType)
         {


### PR DESCRIPTION
The first commit introduces `RCT2_RIDE_TYPE_COUNT`, so that we can increase the value of `RIDE_TYPE_COUNT`.

The second commit removes an unused function, which also cleans up some direct references to ride types (which have to go when we turn ride types into objects).