### PR TITLE
Fix #7037 : Roller coasters starting with helix can be saved

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1177,7 +1177,7 @@ std::optional<CoordsXYZ> sub_6C683D(
     const CoordsXYZD& location, int32_t type, uint16_t extra_params, TileElement** output_element, uint16_t flags)
 {
     // Find the relevant track piece, prefer sequence 0 (this ensures correct behaviour for diagonal track pieces)
-    auto trackElement = map_get_track_element_at_of_type_seq(location, type, 0);
+    auto trackElement = map_get_track_element_at_of_type_seq(location, type, 0, true);
     if (trackElement == nullptr)
     {
         trackElement = map_get_track_element_at_of_type(location, type);
@@ -1214,7 +1214,13 @@ std::optional<CoordsXYZ> sub_6C683D(
         map_invalidate_tile_full(cur);
 
         trackElement = map_get_track_element_at_of_type_seq(
-            { cur, cur_z, static_cast<Direction>(location.direction) }, type, trackBlock[i].index);
+            { cur, cur_z, static_cast<Direction>(location.direction) }, type, trackBlock[i].index, false);
+        if (trackElement == nullptr)
+        {
+            // try with correct invalid heights
+            trackElement = map_get_track_element_at_of_type_seq(
+                { cur, cur_z, static_cast<Direction>(location.direction) }, type, trackBlock[i].index, true);
+        }
         if (trackElement == nullptr)
         {
             return std::nullopt;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -205,7 +205,6 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
 
     CoordsXYZ startPos = { trackElement.x, trackElement.y, z + trackCoordinates->z_begin };
     _trackPreviewOrigin = startPos;
-
     do
     {
         TrackDesignTrackElement track{};
@@ -317,11 +316,15 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
             z -= _trackPreviewOrigin.z;
             z /= 8;
 
+            // hack : check for invalid height
+            if (z % 2 != 0)
+            {
+                z++;
+            }
             if (z > 127 || z < -126)
             {
                 return STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
             }
-
             entrance.z = z;
 
             // If this is the exit version

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -253,7 +253,8 @@ TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos);
 TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, int32_t trackType);
 TileElement* map_get_track_element_at_of_type_seq(const CoordsXYZ& trackPos, int32_t trackType, int32_t sequence);
 TrackElement* map_get_track_element_at_of_type(const CoordsXYZD& location, int32_t trackType);
-TrackElement* map_get_track_element_at_of_type_seq(const CoordsXYZD& location, int32_t trackType, int32_t sequence);
+TrackElement* map_get_track_element_at_of_type_seq(
+    const CoordsXYZD& location, int32_t trackType, int32_t sequence, bool correctInvalidHeights = false);
 TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPos, int32_t trackType, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_from_ride(const CoordsXYZ& trackPos, ride_id_t rideIndex);
 TileElement* map_get_track_element_at_with_direction_from_ride(const CoordsXYZD& trackPos, ride_id_t rideIndex);


### PR DESCRIPTION
[BuggedRollercoaster3.zip](https://github.com/OpenRCT2/OpenRCT2/files/4808438/BuggedRollercoaster3.zip)

Both the roller coasters couldn't be saved to a track design, now they can. BuggedRollerCoaster2 also couldn't be placed without a z coordinates check on the entrance, exit and stations.