### PR TITLE
Fix Action Location for SurfaceSetStyle

### DIFF
--- a/src/openrct2/actions/LandSmoothAction.hpp
+++ b/src/openrct2/actions/LandSmoothAction.hpp
@@ -113,7 +113,7 @@ private:
         money32 totalCost = 0;
 
         // check if we need to start at all
-        if (!map_is_location_valid(loc) || !map_is_location_valid({ loc.x + stepX, loc.y + stepY }))
+        if (!LocationValid(loc) || !LocationValid({ loc.x + stepX, loc.y + stepY }))
         {
             return 0;
         }
@@ -149,7 +149,7 @@ private:
             nextLoc.y += stepY;
             // check if we need to continue after raising the current tile
             // this needs to be checked before the tile is changed
-            if (!map_is_location_valid({ nextLoc.x + stepX, nextLoc.y + stepY }))
+            if (!LocationValid({ nextLoc.x + stepX, nextLoc.y + stepY }))
             {
                 shouldContinue &= ~0x3;
             }
@@ -265,7 +265,7 @@ private:
         }
 
         // check if we need to start at all
-        if (!map_is_location_valid(loc) || !map_is_location_valid({ loc.x + stepX, loc.y + stepY }))
+        if (!LocationValid(loc) || !LocationValid({ loc.x + stepX, loc.y + stepY }))
         {
             return 0;
         }
@@ -292,7 +292,7 @@ private:
             nextLoc.y += stepY;
             // check if we need to continue after raising the current tile
             // this needs to be checked before the tile is changed
-            if (!map_is_location_valid({ nextLoc.x + stepX, nextLoc.y + stepY }))
+            if (!LocationValid({ nextLoc.x + stepX, nextLoc.y + stepY }))
             {
                 shouldContinue = false;
             }

--- a/src/openrct2/actions/SurfaceSetStyleAction.hpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.hpp
@@ -194,6 +194,9 @@ public:
         {
             for (coords.y = validRange.GetTop(); coords.y <= validRange.GetBottom(); coords.y += COORDS_XY_STEP)
             {
+                if (!LocationValid(coords))
+                    continue;
+
                 if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
                 {
                     if (!map_is_location_in_park(coords))


### PR DESCRIPTION
Also noticed that the LocationValid function was not being called in LandSmoothAction. This did not cause issues as the nested call to land set height would check for valid locations.