### PR TITLE
Part of #11389: Remove FormatTexto that take void* in banner struct

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -2110,7 +2110,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     if (banner != nullptr && !banner->IsNull())
                     {
                         uint8_t args[32]{};
-                        banner->FormatTextTo(args);
+                        Formatter ft(args);
+                        banner->FormatTextTo(ft);
                         gfx_draw_string_left(
                             dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, args, COLOUR_WHITE,
                             screenCoords + ScreenCoordsXY{ 0, 11 });
@@ -2176,7 +2177,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     if (banner != nullptr && !banner->IsNull())
                     {
                         uint8_t args[32]{};
-                        banner->FormatTextTo(args);
+                        Formatter ft(args);
+                        banner->FormatTextTo(ft);
                         gfx_draw_string_left(
                             dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, args, COLOUR_WHITE,
                             screenCoords + ScreenCoordsXY{ 0, 22 });
@@ -2209,7 +2211,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 if (banner != nullptr && !banner->IsNull())
                 {
                     uint8_t args[32]{};
-                    banner->FormatTextTo(args);
+                    Formatter ft(args);
+                    banner->FormatTextTo(ft);
                     gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, args, COLOUR_WHITE, screenCoords);
                 }
 

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -101,7 +101,8 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
 
     scrollingMode += direction;
 
-    banner->FormatTextTo(gCommonFormatArgs, /*addColour*/ true);
+    auto ft = Formatter::Common();
+    banner->FormatTextTo(ft, /*addColour*/ true);
 
     if (gConfigGeneral.upper_case_banners)
     {

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -434,7 +434,8 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     auto banner = tile_element->AsWall()->GetBanner();
     if (banner != nullptr && !banner->IsNull())
     {
-        banner->FormatTextTo(gCommonFormatArgs);
+        auto ft = Formatter::Common();
+        banner->FormatTextTo(ft);
         utf8 signString[256];
         if (gConfigGeneral.upper_case_banners)
         {

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -60,59 +60,46 @@ static constexpr CodePointToUtf8<FORMAT_COLOUR_CODE_START, FORMAT_COLOUR_CODE_EN
 std::string Banner::GetText() const
 {
     uint8_t args[32]{};
-    FormatTextTo(args);
+    Formatter ft(args);
+    FormatTextTo(ft);
     return format_string(STR_STRINGID, args);
 }
 
 void Banner::FormatTextTo(Formatter& ft, bool addColour) const
 {
-    ft.Increment(FormatTextTo(ft.Buf(), addColour));
-}
-
-size_t Banner::FormatTextTo(void* argsV, bool addColour) const
-{
-    Formatter ft(static_cast<uint8_t*>(argsV));
-
     if (addColour)
     {
         ft.Add<rct_string_id>(STR_STRING_STRINGID).Add<const char*>(colourToUtf8(text_colour));
     }
 
-    return ft.NumBytes() + FormatTextTo(ft.Buf());
+    FormatTextTo(ft);
 }
 
 void Banner::FormatTextTo(Formatter& ft) const
 {
-    ft.Increment(FormatTextTo(ft.Buf()));
-}
-
-size_t Banner::FormatTextTo(void* argsV) const
-{
-    Formatter ft(static_cast<uint8_t*>(argsV));
-
     if (flags & BANNER_FLAG_NO_ENTRY)
     {
-        return ft.Add<rct_string_id>(STR_NO_ENTRY).NumBytes();
+        ft.Add<rct_string_id>(STR_NO_ENTRY).NumBytes();
     }
     else if (flags & BANNER_FLAG_LINKED_TO_RIDE)
     {
         auto ride = get_ride(ride_index);
         if (ride != nullptr)
         {
-            return ride->FormatNameTo(ft.Buf());
+            ride->FormatNameTo(ft);
         }
         else
         {
-            return ft.Add<rct_string_id>(STR_DEFAULT_SIGN).NumBytes();
+            ft.Add<rct_string_id>(STR_DEFAULT_SIGN).NumBytes();
         }
     }
     else if (text.empty())
     {
-        return ft.Add<rct_string_id>(STR_DEFAULT_SIGN).NumBytes();
+        ft.Add<rct_string_id>(STR_DEFAULT_SIGN).NumBytes();
     }
     else
     {
-        return ft.Add<rct_string_id>(STR_STRING).Add<const char*>(text.c_str()).NumBytes();
+        ft.Add<rct_string_id>(STR_STRING).Add<const char*>(text.c_str()).NumBytes();
     }
 }
 

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -45,8 +45,6 @@ struct Banner
     std::string GetText() const;
     void FormatTextTo(Formatter&, bool addColour) const;
     void FormatTextTo(Formatter&) const;
-    size_t FormatTextTo(void* args, bool addColour) const;
-    size_t FormatTextTo(void* args) const;
 };
 
 enum BANNER_FLAGS


### PR DESCRIPTION
Banner struct now uses only FormatTextTo(Formatte&, bool addColour) and FormatTexTo(Formatter&).