### PR TITLE
Part of #10960: Pause and setting game speed enabled in multiplayer

### DIFF
--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -98,6 +98,7 @@ enum GAME_COMMAND
     GAME_COMMAND_REMOVE_FOOTPATH_SCENERY,      // GA
     GAME_COMMAND_GUEST_SET_FLAGS,              // GA
     GAME_COMMAND_SET_DATE,                     // GA
+    GAME_COMMAND_SET_SIMULATION_SPEED,         // GA
     GAME_COMMAND_CUSTOM,                       // GA
     GAME_COMMAND_COUNT,
 };

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -159,6 +159,12 @@ void GameState::Update()
         }
     }
 
+    isPaused = game_is_paused();
+    if (isPaused)
+    {
+        numUpdates = 0;
+    }
+
     // Update the game one or more times
     for (uint32_t i = 0; i < numUpdates; i++)
     {

--- a/src/openrct2/actions/GameActionRegistration.cpp
+++ b/src/openrct2/actions/GameActionRegistration.cpp
@@ -22,6 +22,7 @@
 #include "FootpathSceneryPlaceAction.hpp"
 #include "FootpathSceneryRemoveAction.hpp"
 #include "GameAction.h"
+#include "GameSetSimulationSpeed.hpp"
 #include "GuestSetFlagsAction.hpp"
 #include "GuestSetNameAction.hpp"
 #include "LandBuyRightsAction.hpp"
@@ -172,6 +173,7 @@ namespace GameActions
         Register<GuestSetFlagsAction>();
         Register<ParkSetDateAction>();
         Register<SetCheatAction>();
+        Register<GameSetSimulationSpeedAction>();
 #ifdef ENABLE_SCRIPTING
         Register<CustomAction>();
 #endif

--- a/src/openrct2/actions/GameSetSimulationSpeed.hpp
+++ b/src/openrct2/actions/GameSetSimulationSpeed.hpp
@@ -1,0 +1,55 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2019 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "GameAction.h"
+
+// Clang format is broken for small game actions
+// clang-format off
+DEFINE_GAME_ACTION(GameSetSimulationSpeedAction, GAME_COMMAND_SET_SIMULATION_SPEED, GameActionResult)
+{
+private:
+    uint32_t _simSpeed;
+public:
+    GameSetSimulationSpeedAction(int32_t simSpeed = 1): _simSpeed(simSpeed){};
+
+    uint16_t GetActionFlags() const override
+    {
+        return GameAction::GetActionFlags() | GA_FLAGS::ALLOW_WHILE_PAUSED;
+    }
+
+    GameActionResult::Ptr Query() const override
+    {
+        return std::make_unique<GameActionResult>();
+    }
+
+    uint32_t GetSimulationSpeed() const
+    {
+        return _simSpeed;
+    }
+
+     void Serialise(DataSerialiser & stream) override
+    {
+        GameAction::Serialise(stream);
+
+        stream << DS_TAG(_simSpeed);
+    }
+
+    GameActionResult::Ptr Execute() const override
+    {
+        if (gGamePaused) {
+            pause_toggle();
+        }
+        gGameSpeed = _simSpeed;
+        window_invalidate_by_class(WC_TOP_TOOLBAR);
+        return std::make_unique<GameActionResult>();
+    }
+};
+// clang-format on

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -78,9 +78,7 @@ const std::array<NetworkAction, NETWORK_PERMISSION_COUNT> NetworkActions::Action
     NetworkAction{
         STR_ACTION_TOGGLE_PAUSE,
         "PERMISSION_TOGGLE_PAUSE",
-        {
-            GAME_COMMAND_TOGGLE_PAUSE,
-        },
+        { GAME_COMMAND_TOGGLE_PAUSE, GAME_COMMAND_SET_SIMULATION_SPEED },
     },
     NetworkAction{
         STR_ACTION_CREATE_RIDE,


### PR DESCRIPTION
- [x] Enable pause actions for the users in group with toggle pause permission
- [x] Enable set game simulation speed for the users in group with toggle pause permission
- [x] Disable pause on client's side when he is not allowed to pause the game on the server side
- [x] Disable setting game speed on client's side when he is not allowed to set game speed on the server side
- [x] Invalidate the pause and fast forward buttons when receiving a TogglePause and SetSimulationSpeed action
- [ ] Rename toggle pause permission to set game simulation speed permission
- [x] Hide pause and fast forward buttons when the client has not the permissions. Seems to work partially as it doesn't redraw the top toolbar when permissions change
- [x] When client joins the server, make sure that the server is correctly sending the pause status and simulation speed
- [ ] When client joins the server when paused, force a redraw of all sprites
- [x] When sever pauses game, force the client to call toggle_pause to stop audio
- [x] When server pauses game when gameSpeed != 1, stop the audio
- [ ] When server is paused, changing togglePause permissions for the user do not invalidate the top toolbar