### PR TITLE
Fix #12065 again. Fixed track design previews with diagonals

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -39,7 +39,7 @@
 - Fix: [#11676] Spiral Roller Coaster has regular lift hill available.
 - Fix: [#11695] Mechanics walk to tile 0, 0 at entrance only stations when trying to fix them.
 - Fix: [#11953] Incorrect banner text shade colour on wall text.
-- Fix: [#12068] Incorrect Entrance/Exit location on track design preview.
+- Fix: [#12068] Incorrect Entrance/Exit location on track design preview. Incorrect track design previews with track that contain diagonal track elements.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.


### PR DESCRIPTION
Fix #12065 again. Fixed track design previews with diagonals
Unsure when mistake was made but there was a variety of issues with this section of code. The rotation of the entrance was meant to be relative to the track design rotation not the last track pieces rotation. This caused issues for tracks that were not complete circuits. In addition there was a mistake for diagonal track pieces where the location of the end piece was not incremented this caused the diagonal piece to act as though it didn't exist breaking the preview.