### PR TITLE
Generic coords structs for reusability

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -189,41 +189,6 @@ struct FinancialTooltipInfo
     const money32 money{};
 };
 
-struct ScreenRect
-{
-    const ScreenCoordsXY LeftTop;
-    const ScreenCoordsXY RightBottom;
-
-    int32_t GetLeft() const
-    {
-        return LeftTop.x;
-    }
-    int32_t GetTop() const
-    {
-        return LeftTop.y;
-    }
-    int32_t GetRight() const
-    {
-        return RightBottom.x;
-    }
-    int32_t GetBottom() const
-    {
-        return RightBottom.y;
-    }
-    int32_t GetWidth() const
-    {
-        return RightBottom.x - LeftTop.x;
-    }
-    int32_t GetHeight() const
-    {
-        return RightBottom.y - LeftTop.y;
-    }
-    bool Contains(const ScreenCoordsXY& coords) const
-    {
-        return coords.x >= GetLeft() && coords.x <= GetRight() && coords.y >= GetTop() && coords.y <= GetBottom();
-    }
-};
-
 static constexpr auto CHART_MAX_DATA_COUNT = 64;
 static constexpr auto CHART_MAX_INDEX = CHART_MAX_DATA_COUNT - 1;
 static constexpr auto CHART_DATA_WIDTH = 6;

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -689,3 +689,31 @@ struct ScreenLine : public CoordsRange<ScreenCoordsXY>
         assert((std::abs(GetLeft() - GetRight()) > 0) || (std::abs(GetTop() - GetBottom()) > 0));
     }
 };
+
+/**
+ * Represents a rectangular range on the screen
+ */
+
+struct ScreenRect : public CoordsRange<ScreenCoordsXY>
+{
+    ScreenRect(const ScreenCoordsXY& leftTop, const ScreenCoordsXY& rightBottom)
+        : CoordsRange<ScreenCoordsXY>(leftTop, rightBottom)
+    {
+        // Make sure it's a rectangle
+        assert(std::abs(GetLeft() - GetRight()) > 0);
+        assert(std::abs(GetTop() - GetBottom()) > 0);
+    }
+    
+    int32_t GetWidth() const
+    {
+        return RightBottom.x - LeftTop.x;
+    }
+    int32_t GetHeight() const
+    {
+        return RightBottom.y - LeftTop.y;
+    }
+    bool Contains(const ScreenCoordsXY& coords) const
+    {
+        return coords.x >= GetLeft() && coords.x <= GetRight() && coords.y >= GetTop() && coords.y <= GetBottom();
+    }
+};

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -666,12 +666,26 @@ struct MapRange : public CoordsRange<CoordsXY>
         assert(std::abs(GetLeft() - GetRight()) > 0);
         assert(std::abs(GetTop() - GetBottom()) > 0);
     }
-    
+
     MapRange Normalise() const
     {
         auto result = MapRange(
             std::min(GetLeft(), GetRight()), std::min(GetTop(), GetBottom()), std::max(GetLeft(), GetRight()),
             std::max(GetTop(), GetBottom()));
         return result;
+    }
+};
+
+/**
+ * Represents a line on the screen
+ */
+
+struct ScreenLine : public CoordsRange<ScreenCoordsXY>
+{
+    ScreenLine(const ScreenCoordsXY& leftTop, const ScreenCoordsXY& rightBottom)
+        : CoordsRange<ScreenCoordsXY>(leftTop, rightBottom)
+    {
+        // Make sure one of the point coords change
+        assert((std::abs(GetLeft() - GetRight()) > 0) || (std::abs(GetTop() - GetBottom()) > 0));
     }
 };

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -647,25 +647,31 @@ template<class T> struct CoordsRange
     }
 };
 
+template<class T> struct RectRange : public CoordsRange<T>
+{
+    using CoordsRange<T>::CoordsRange;
+
+    RectRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
+        : RectRange({ left, top }, { right, bottom })
+    {
+    }
+
+    RectRange(const T& leftTop, const T& rightBottom)
+        : CoordsRange<T>(leftTop, rightBottom)
+    {
+        // Make sure it's a rectangle
+        assert(std::abs(CoordsRange<T>::GetLeft() - CoordsRange<T>::GetRight()) > 0);
+        assert(std::abs(CoordsRange<T>::GetTop() - CoordsRange<T>::GetBottom()) > 0);
+    }
+};
+
 /**
  * Represents a rectangular range of the map using regular coordinates (32 per tile).
  */
 
-struct MapRange : public CoordsRange<CoordsXY>
+struct MapRange : public RectRange<CoordsXY>
 {
-    using CoordsRange::CoordsRange;
-    MapRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
-        : MapRange({ left, top }, { right, bottom })
-    {
-    }
-
-    MapRange(const CoordsXY& leftTop, const CoordsXY& rightBottom)
-        : CoordsRange<CoordsXY>(leftTop, rightBottom)
-    {
-        // Make sure it's a rectangle
-        assert(std::abs(GetLeft() - GetRight()) > 0);
-        assert(std::abs(GetTop() - GetBottom()) > 0);
-    }
+    using RectRange::RectRange;
 
     MapRange Normalise() const
     {
@@ -694,16 +700,10 @@ struct ScreenLine : public CoordsRange<ScreenCoordsXY>
  * Represents a rectangular range on the screen
  */
 
-struct ScreenRect : public CoordsRange<ScreenCoordsXY>
+struct ScreenRect : public RectRange<ScreenCoordsXY>
 {
-    ScreenRect(const ScreenCoordsXY& leftTop, const ScreenCoordsXY& rightBottom)
-        : CoordsRange<ScreenCoordsXY>(leftTop, rightBottom)
-    {
-        // Make sure it's a rectangle
-        assert(std::abs(GetLeft() - GetRight()) > 0);
-        assert(std::abs(GetTop() - GetBottom()) > 0);
-    }
-    
+    using RectRange::RectRange;
+
     int32_t GetWidth() const
     {
         return RightBottom.x - LeftTop.x;

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -610,12 +610,12 @@ struct TileCoordsXYZD : public TileCoordsXYZ
 };
 
 /**
- * Represents a rectangular range of the map using regular coordinates (32 per tile).
+ * Represents a range of the map using regular coordinates.
  */
-struct MapRange
+template<class T> struct CoordsRange
 {
-    CoordsXY LeftTop;
-    CoordsXY RightBottom;
+    T LeftTop{ 0, 0 };
+    T RightBottom{ 0, 0 };
 
     int32_t GetLeft() const
     {
@@ -634,16 +634,29 @@ struct MapRange
         return RightBottom.y;
     }
 
-    MapRange()
-        : MapRange(0, 0, 0, 0)
-    {
-    }
-    MapRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
+    CoordsRange() = default;
+    CoordsRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
         : LeftTop(left, top)
         , RightBottom(right, bottom)
     {
     }
+};
 
+/**
+ * Represents a rectangular range of the map using regular coordinates (32 per tile).
+ */
+
+struct MapRange : public CoordsRange<CoordsXY>
+{
+    using CoordsRange::CoordsRange;
+    MapRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
+        : CoordsRange<CoordsXY>(left, top, right, bottom)
+    {
+        // Make sure it's a rectangle
+        assert(std::abs(GetLeft() - GetRight()) > 0);
+        assert(std::abs(GetTop() - GetBottom()) > 0);
+    }
+    
     MapRange Normalise() const
     {
         auto result = MapRange(

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -636,8 +636,13 @@ template<class T> struct CoordsRange
 
     CoordsRange() = default;
     CoordsRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
-        : LeftTop(left, top)
-        , RightBottom(right, bottom)
+        : CoordsRange({ left, top }, { right, bottom })
+    {
+    }
+
+    CoordsRange(const T& leftTop, const T& rightBottom)
+        : LeftTop(leftTop)
+        , RightBottom(rightBottom)
     {
     }
 };
@@ -650,7 +655,12 @@ struct MapRange : public CoordsRange<CoordsXY>
 {
     using CoordsRange::CoordsRange;
     MapRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
-        : CoordsRange<CoordsXY>(left, top, right, bottom)
+        : MapRange({ left, top }, { right, bottom })
+    {
+    }
+
+    MapRange(const CoordsXY& leftTop, const CoordsXY& rightBottom)
+        : CoordsRange<CoordsXY>(leftTop, rightBottom)
     {
         // Make sure it's a rectangle
         assert(std::abs(GetLeft() - GetRight()) > 0);


### PR DESCRIPTION
This is just making `MapRange` more useful by allowing multiple combinations of ranges.

It is strict with regards to each of its inheritors, such as `ScreenRect`, `MapRange`, `ScreenLine`

This will make it possible to convert functions like:
```c++
void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour);
```

into

```c++
void gfx_draw_line(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour);
void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour);
```
