### PR TITLE
Fix #12062: Add chain lift to Flying Coaster pieces when inverted

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -39,6 +39,7 @@
 - Fix: [#11676] Spiral Roller Coaster has regular lift hill available.
 - Fix: [#11695] Mechanics walk to tile 0, 0 at entrance only stations when trying to fix them.
 - Fix: [#11953] Incorrect banner text shade colour on wall text.
+- Fix: [#12062] Inconsistent lift hill sprites on Flying Coaster while inverted (original bug).
 - Fix: [#12068] Incorrect Entrance/Exit location on track design preview. Incorrect track design previews with track that contain diagonal track elements.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -196,24 +196,57 @@ static void flying_rc_track_25_deg_up(
 {
     if (!tileElement->AsTrack()->IsInverted())
     {
-        switch (direction)
+        if (tileElement->AsTrack()->HasChain())
         {
-            case 0:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17204, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 1:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17205, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 2:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17206, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 3:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17207, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17498, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 1:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17499, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 2:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17500, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17501, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+            }
+        }
+        else
+        {
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17204, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 1:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17205, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 2:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17206, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17207, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+            }
         }
         if (track_paint_util_should_paint_supports(session->MapPosition))
         {
@@ -413,24 +446,57 @@ static void flying_rc_track_flat_to_25_deg_up(
 {
     if (!tileElement->AsTrack()->IsInverted())
     {
-        switch (direction)
+        if (tileElement->AsTrack()->HasChain())
         {
-            case 0:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17196, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 1:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17197, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 2:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17198, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 3:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17199, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17490, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 1:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17491, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 2:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17492, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17493, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+            }
+        }
+        else
+        {
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17196, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 1:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17197, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 2:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17198, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17199, 0, 0, 32, 20, 3, height, 0, 6,
+                        height);
+                    break;
+            }
         }
         if (track_paint_util_should_paint_supports(session->MapPosition))
         {
@@ -756,24 +822,49 @@ static void flying_rc_track_25_deg_up_to_flat(
 {
     if (!tileElement->AsTrack()->IsInverted())
     {
-        switch (direction)
+        if (tileElement->AsTrack()->HasChain())
         {
-            case 0:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17200, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 1:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17201, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 2:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17202, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
-            case 3:
-                sub_98197C_rotated(
-                    session, direction, session->TrackColours[SCHEME_TRACK] | 17203, 0, 0, 32, 20, 3, height, 0, 6, height);
-                break;
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17494, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+                case 1:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17495, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+                case 2:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17496, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17497, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+            }
+        }
+        else
+        {
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17200, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+                case 1:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17201, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+                case 2:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17202, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17203, 0, 0, 32, 20, 3, height, 0, 6, height);
+                    break;
+            }
         }
         if (track_paint_util_should_paint_supports(session->MapPosition))
         {

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -202,23 +202,19 @@ static void flying_rc_track_25_deg_up(
             {
                 case 0:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17498, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17498, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 1:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17499, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17499, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 2:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17500, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17500, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 3:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17501, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17501, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
         }
@@ -228,23 +224,19 @@ static void flying_rc_track_25_deg_up(
             {
                 case 0:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17204, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17204, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 1:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17205, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17205, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 2:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17206, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17206, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 3:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17207, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17207, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
         }
@@ -452,23 +444,19 @@ static void flying_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17490, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17490, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 1:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17491, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17491, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 2:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17492, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17492, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 3:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17493, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17493, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
         }
@@ -478,23 +466,19 @@ static void flying_rc_track_flat_to_25_deg_up(
             {
                 case 0:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17196, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17196, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 1:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17197, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17197, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 2:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17198, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17198, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
                 case 3:
                     sub_98197C_rotated(
-                        session, direction, session->TrackColours[SCHEME_TRACK] | 17199, 0, 0, 32, 20, 3, height, 0, 6,
-                        height);
+                        session, direction, session->TrackColours[SCHEME_TRACK] | 17199, 0, 0, 32, 20, 3, height, 0, 6, height);
                     break;
             }
         }


### PR DESCRIPTION
Fix #12062 by checking for chain lifts on 3 inverted Flying Coaster pieces: 25 deg up, flat-to-25, and 25-to-flat. This makes Flying Coasters draw chain lifts in a fashion consistent with Lay-Down Coasters.