### PR TITLE
Fix #12093. Incorrect position and animation of staff tab

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Fix: [#11953] Incorrect banner text shade colour on wall text.
 - Fix: [#12062] Inconsistent lift hill sprites on Flying Coaster while inverted (original bug).
 - Fix: [#12068] Incorrect Entrance/Exit location on track design preview. Incorrect track design previews with track that contain diagonal track elements.
+- Fix: [#12093] Staff window tab animation was no longer updating.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1022,7 +1022,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    screenCoords = ScreenCoordsXY{ 20, 14 };
+    screenCoords = ScreenCoordsXY{ 14, 20 };
 
     Peep* peep = GET_PEEP(w->number);
 
@@ -1035,7 +1035,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (w->page == WINDOW_STAFF_OVERVIEW)
     {
-        eax = w->highlighted_item >> 16;
+        eax = w->var_496;
         eax &= 0xFFFC;
     }
     ebx += eax;

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -80,10 +80,7 @@ struct rct_window
         ResearchItem* research_item;
         rct_object_entry* object_entry;
         const scenario_index_entry* highlighted_scenario;
-        struct
-        {
-            uint16_t var_496;
-        };
+        uint16_t var_496;
     };
     int16_t selected_tab;
     int16_t var_4AE;


### PR DESCRIPTION
Fix #12093. Incorrect position and animation of staff tab.

Mistake made when refactoring transposed two digits. Additional mistake made when removing a variable that was unused that changed the memory layout of the window. This meant that a part of the code that accessed a different variable in a union fetched the wrong memory. This was a mistake ultimately made during implementation.