### PR TITLE
Close #12087: Use ScreenCoordsXY on gfx_filter_pixel

### DIFF
--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -203,10 +203,10 @@ static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_filter_rect(dpi, left + 2, top + 0, right - 2, top + 0, PALETTE_DARKEN_3);
 
     // Corners
-    gfx_filter_pixel(dpi, ScreenCoordsXY{ left + 1, top + 1 }, PALETTE_DARKEN_3);
-    gfx_filter_pixel(dpi, ScreenCoordsXY{ right - 1, top + 1 }, PALETTE_DARKEN_3);
-    gfx_filter_pixel(dpi, ScreenCoordsXY{ left + 1, bottom - 1 }, PALETTE_DARKEN_3);
-    gfx_filter_pixel(dpi, ScreenCoordsXY{ right - 1, bottom - 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, { left + 1, top + 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, { right - 1, top + 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, { left + 1, bottom - 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, { right - 1, bottom - 1 }, PALETTE_DARKEN_3);
 
     // Text
     left = w->windowPos.x + ((w->width + 1) / 2) - 1;

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -203,10 +203,10 @@ static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_filter_rect(dpi, left + 2, top + 0, right - 2, top + 0, PALETTE_DARKEN_3);
 
     // Corners
-    gfx_filter_pixel(dpi, left + 1, top + 1, PALETTE_DARKEN_3);
-    gfx_filter_pixel(dpi, right - 1, top + 1, PALETTE_DARKEN_3);
-    gfx_filter_pixel(dpi, left + 1, bottom - 1, PALETTE_DARKEN_3);
-    gfx_filter_pixel(dpi, right - 1, bottom - 1, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, ScreenCoordsXY{ left + 1, top + 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, ScreenCoordsXY{ right - 1, top + 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, ScreenCoordsXY{ left + 1, bottom - 1 }, PALETTE_DARKEN_3);
+    gfx_filter_pixel(dpi, ScreenCoordsXY{ right - 1, bottom - 1 }, PALETTE_DARKEN_3);
 
     // Text
     left = w->windowPos.x + ((w->width + 1) / 2) - 1;

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -583,13 +583,7 @@ void gfx_draw_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t colour
     gfx_fill_rect(dpi, x, y, x, y, colour);
 }
 
-void gfx_filter_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, FILTER_PALETTE_ID palette)
-{
-    ScreenCoordsXY coords = ScreenCoordsXY(x, y); 
-    gfx_filter_pixel(dpi, coords, palette);       
-}
-
-void gfx_filter_pixel(rct_drawpixelinfo* dpi, ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)
+void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)
 {
     gfx_filter_rect(dpi, coords.x, coords.y, coords.x, coords.y, palette);
 }

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -585,7 +585,13 @@ void gfx_draw_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t colour
 
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, FILTER_PALETTE_ID palette)
 {
-    gfx_filter_rect(dpi, x, y, x, y, palette);
+    ScreenCoordsXY coords = ScreenCoordsXY(x, y); 
+    gfx_filter_pixel(dpi, coords, palette);       
+}
+
+void gfx_filter_pixel(rct_drawpixelinfo* dpi, ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)
+{
+    gfx_filter_rect(dpi, coords.x, coords.y, coords.x, coords.y, palette);
 }
 
 /**

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -594,6 +594,7 @@ void load_palette();
 void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex);
 void gfx_draw_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t colour);
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, FILTER_PALETTE_ID palette);
+void gfx_filter_pixel(rct_drawpixelinfo* dpi, ScreenCoordsXY& coords, FILTER_PALETTE_ID palette);
 void gfx_invalidate_pickedup_peep();
 void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -593,8 +593,7 @@ void load_palette();
 // other
 void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex);
 void gfx_draw_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t colour);
-void gfx_filter_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, FILTER_PALETTE_ID palette);
-void gfx_filter_pixel(rct_drawpixelinfo* dpi, ScreenCoordsXY& coords, FILTER_PALETTE_ID palette);
+void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette);
 void gfx_invalidate_pickedup_peep();
 void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 


### PR DESCRIPTION
This is my first pull request, so my apologies for any errors. 

Modified `gfx_filter_pixel` to now use `const ScreenCoordsXY&`, and changed calls to the old function to reference the new one (there are only 4 calls to the function).