### PR TITLE
Close #12086: Use ScreenCoordsXY on gfx_draw_pixel

### DIFF
--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -578,9 +578,9 @@ void mask_init()
     }
 }
 
-void gfx_draw_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t colour)
+void gfx_draw_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t colour)
 {
-    gfx_fill_rect(dpi, x, y, x, y, colour);
+    gfx_fill_rect(dpi, coords.x, coords.y, coords.x, coords.y, colour);
 }
 
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -592,7 +592,7 @@ void load_palette();
 
 // other
 void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex);
-void gfx_draw_pixel(rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t colour);
+void gfx_draw_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t colour);
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette);
 void gfx_invalidate_pickedup_peep();
 void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);


### PR DESCRIPTION
Refactored `gfx_draw_pixel` to use `const ScreenCoordsXY&`, though I wasn't able to find any other references to the function aside from the two I modified. Is the function being used?