### PR TITLE
Fix #12095: Use ScreenRect on gfx_set_dirty_blocks

### DIFF
--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -223,7 +223,7 @@ void InGameConsole::WriteLine(const std::string& input, uint32_t colourFormat)
 
 void InGameConsole::Invalidate() const
 {
-    gfx_set_dirty_blocks(_consoleLeft, _consoleTop, _consoleRight, _consoleBottom);
+    gfx_set_dirty_blocks({ { _consoleLeft, _consoleTop }, { _consoleRight, _consoleBottom } });
 }
 
 void InGameConsole::Update()

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -664,7 +664,7 @@ static void window_invalidate_pressed_image_buttons(rct_window* w)
             continue;
 
         if (widget_is_pressed(w, widgetIndex) || widget_is_active_tool(w, widgetIndex))
-            gfx_set_dirty_blocks(w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width, w->windowPos.y + w->height);
+            gfx_set_dirty_blocks({ w->windowPos, w->windowPos + ScreenCoordsXY{ w->width, w->height } });
     }
 }
 

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -783,8 +783,8 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
         }
 
         gfx_set_dirty_blocks(
-            w->windowPos.x + w->widgets[WIDX_VIEWPORT].left, w->windowPos.y + w->widgets[WIDX_VIEWPORT].top,
-            w->windowPos.x + w->widgets[WIDX_VIEWPORT].right, w->windowPos.y + w->widgets[WIDX_VIEWPORT].bottom);
+            { { w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_VIEWPORT].left, w->widgets[WIDX_VIEWPORT].top } },
+              { w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_VIEWPORT].right, w->widgets[WIDX_VIEWPORT].bottom } } });
         gfx_draw_string_left_clipped(
             dpi, spriteString, gCommonFormatArgs, colour,
             { w->windowPos.x + w->widgets[WIDX_VIEWPORT].left + 2, w->windowPos.y + w->widgets[WIDX_VIEWPORT].top + 1 },

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -663,7 +663,7 @@ void load_palette()
  */
 void gfx_invalidate_screen()
 {
-    gfx_set_dirty_blocks(0, 0, context_get_width(), context_get_height());
+    gfx_set_dirty_blocks({ { 0, 0 }, { context_get_width(), context_get_height() } });
 }
 
 /*
@@ -737,7 +737,7 @@ void gfx_invalidate_pickedup_peep()
             int32_t top = gPickupPeepY + g1->y_offset;
             int32_t right = left + g1->width;
             int32_t bottom = top + g1->height;
-            gfx_set_dirty_blocks(left, top, right, bottom);
+            gfx_set_dirty_blocks({ { left, top }, { right, bottom } });
         }
     }
 }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -584,7 +584,7 @@ extern rct_drawpixelinfo gWindowDPI;
 
 bool clip_drawpixelinfo(
     rct_drawpixelinfo* dst, rct_drawpixelinfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
-void gfx_set_dirty_blocks(int16_t left, int16_t top, int16_t right, int16_t bottom);
+void gfx_set_dirty_blocks(const ScreenRect& rect);
 void gfx_draw_all_dirty_blocks();
 void gfx_invalidate_screen();
 

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -16,6 +16,7 @@
 #include "../localisation/StringIds.h"
 #include "../paint/Painter.h"
 #include "../ui/UiContext.h"
+#include "../world/Location.hpp"
 #include "IDrawingContext.h"
 #include "IDrawingEngine.h"
 
@@ -157,12 +158,12 @@ void drawing_engine_set_vsync(bool vsync)
     }
 }
 
-void gfx_set_dirty_blocks(int16_t left, int16_t top, int16_t right, int16_t bottom)
+void gfx_set_dirty_blocks(const ScreenRect& rect)
 {
     auto drawingEngine = GetDrawingEngine();
     if (drawingEngine != nullptr)
     {
-        drawingEngine->Invalidate(left, top, right, bottom);
+        drawingEngine->Invalidate(rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -131,7 +131,7 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
             _chatHeight = 150;
         }
 
-        gfx_set_dirty_blocks(_chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5); // Background area + Textbox
+        gfx_set_dirty_blocks({ { _chatLeft, _chatTop - 5 }, { _chatRight, _chatBottom + 5 } }); // Background area + Textbox
         gfx_filter_rect(
             dpi, { { _chatLeft, _chatTop - 5 }, { _chatRight, _chatBottom + 5 } }, PALETTE_51); // Opaque gray background
         gfx_fill_rect_inset(
@@ -159,7 +159,8 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
         safe_strcpy(lineBuffer, chat_history_get(i), sizeof(lineBuffer));
 
         stringHeight = chat_history_draw_string(dpi, static_cast<void*>(&lineCh), screenCoords, _chatWidth - 10) + 5;
-        gfx_set_dirty_blocks(screenCoords.x, screenCoords.y - stringHeight, screenCoords.x + _chatWidth, screenCoords.y + 20);
+        gfx_set_dirty_blocks(
+            { { screenCoords - ScreenCoordsXY{ 0, stringHeight } }, { screenCoords + ScreenCoordsXY{ _chatWidth, 20 } } });
 
         if ((screenCoords.y - stringHeight) < 50)
         {
@@ -180,8 +181,7 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
         inputLineHeight = gfx_draw_string_left_wrapped(
             dpi, static_cast<void*>(&lineCh), screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING,
             TEXT_COLOUR_255);
-        gfx_set_dirty_blocks(
-            screenCoords.x, screenCoords.y, screenCoords.x + _chatWidth, screenCoords.y + inputLineHeight + 15);
+        gfx_set_dirty_blocks({ screenCoords, { screenCoords + ScreenCoordsXY{ _chatWidth, inputLineHeight + 15 } } });
 
         // TODO: Show caret if the input text has multiple lines
         if (_chatCaretTicks < 15 && gfx_get_string_width(lineBuffer) < (_chatWidth - 10))

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1738,7 +1738,8 @@ void viewport_invalidate(rct_viewport* viewport, int32_t left, int32_t top, int3
         top += viewport->pos.y;
         right += viewport->pos.x;
         bottom += viewport->pos.y;
-        gfx_set_dirty_blocks(left, top, right, bottom);
+
+        gfx_set_dirty_blocks({ { left, top }, { right, bottom } });
     }
 }
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -523,9 +523,8 @@ void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex)
     if (widget->left == -2)
         return;
 
-    gfx_set_dirty_blocks(
-        w->windowPos.x + widget->left, w->windowPos.y + widget->top, w->windowPos.x + widget->right + 1,
-        w->windowPos.y + widget->bottom + 1);
+    gfx_set_dirty_blocks({ { w->windowPos + ScreenCoordsXY{ widget->left, widget->top } },
+                           { w->windowPos + ScreenCoordsXY{ widget->right + 1, widget->bottom + 1 } } });
 }
 
 template<typename _TPred> static void widget_invalidate_by_condition(_TPred pred)

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -42,5 +42,5 @@ void rct_window::ScrollToViewport()
 
 void rct_window::Invalidate()
 {
-    gfx_set_dirty_blocks(windowPos.x, windowPos.y, windowPos.x + width, windowPos.y + height);
+    gfx_set_dirty_blocks({ windowPos, windowPos + ScreenCoordsXY{ width, height } });
 }

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -99,7 +99,7 @@ void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
         gfx_draw_string(dpi, buffer, COLOUR_SATURATED_RED, screenCoords);
 
     // Make area dirty so the text doesn't get drawn over the last
-    gfx_set_dirty_blocks(screenCoords.x, screenCoords.y, screenCoords.x + stringWidth, screenCoords.y + 16);
+    gfx_set_dirty_blocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
 }
 
 void Painter::PaintFPS(rct_drawpixelinfo* dpi)
@@ -124,7 +124,7 @@ void Painter::PaintFPS(rct_drawpixelinfo* dpi)
     gfx_draw_string(dpi, buffer, 0, screenCoords);
 
     // Make area dirty so the text doesn't get drawn over the last
-    gfx_set_dirty_blocks(screenCoords.x - 16, screenCoords.y - 4, gLastDrawStringX + 16, 16);
+    gfx_set_dirty_blocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { gLastDrawStringX + 16, 16 } });
 }
 
 void Painter::MeasureFPS()

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -444,8 +444,7 @@ void DrawOpenRCT2(rct_drawpixelinfo* dpi, const ScreenCoordsXY& screenCoords)
     // Invalidate screen area
     int16_t width = static_cast<int16_t>(gfx_get_string_width(buffer));
     gfx_set_dirty_blocks(
-        screenCoords.x, screenCoords.y, screenCoords.x + width,
-        screenCoords.y + 30); // 30 is an arbitrary height to catch both strings
+        { screenCoords, screenCoords + ScreenCoordsXY{ width, 30 } }); // 30 is an arbitrary height to catch both strings
 
     // Write platform information
     snprintf(ch, 256 - (ch - buffer), "%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);


### PR DESCRIPTION
I had to comment the two assertions in the ScreenRect class as there are many occurences in the code where the width or height of the rectangle is equal to zero.