### PR TITLE
Part of #12096: Use ScreenRect on gfx_fill_rect in libopenrct2

### DIFF
--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -179,8 +179,10 @@ void intro_draw(rct_drawpixelinfo* dpi)
 
             // Draw a white rectangle for the logo background (gives a bit of white margin)
             gfx_fill_rect(
-                dpi, (screenWidth / 2) - 320 + 50, _introStateCounter + 50, (screenWidth / 2) - 320 + 50 + 540,
-                _introStateCounter + 50 + 425, BORDER_COLOUR_PUBLISHER);
+                dpi,
+                { { (screenWidth / 2) - 320 + 50, _introStateCounter + 50 },
+                  { (screenWidth / 2) - 320 + 50 + 540, _introStateCounter + 50 + 425 } },
+                BORDER_COLOUR_PUBLISHER);
 
             // Draw Infogrames logo
             gfx_draw_sprite(dpi, SPR_INTRO_INFOGRAMES_00, { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 }, 0);

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -580,7 +580,7 @@ void mask_init()
 
 void gfx_draw_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t colour)
 {
-    gfx_fill_rect(dpi, coords.x, coords.y, coords.x, coords.y, colour);
+    gfx_fill_rect(dpi, { coords, coords }, colour);
 }
 
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -16,7 +16,6 @@
 
 #include <optional>
 #include <vector>
-struct ScreenCoordsXY;
 
 struct ScreenCoordsXY;
 struct ScreenLine;
@@ -607,6 +606,7 @@ void gfx_draw_dashed_line(
 
 // rect
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour);
+void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour);
 void gfx_fill_rect_inset(
     rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t right, int16_t bottom, int32_t colour, uint8_t flags);
 void gfx_filter_rect(

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -183,11 +183,16 @@ void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
 
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
 {
+    gfx_fill_rect(dpi, { { left, top }, { right, bottom } }, colour);
+}
+
+void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour)
+{
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-        dc->FillRect(colour, left, top, right, bottom);
+        dc->FillRect(colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -9,6 +9,7 @@
 
 #include "../common.h"
 #include "../interface/Colour.h"
+#include "../world/Location.hpp"
 #include "Drawing.h"
 
 /**
@@ -90,15 +91,15 @@ void gfx_fill_rect_inset(
 
         if (flags & INSET_RECT_FLAG_BORDER_NONE)
         {
-            gfx_fill_rect(dpi, left, top, right, bottom, fill);
+            gfx_fill_rect(dpi, { { left, top }, { right, bottom } }, fill);
         }
         else if (flags & INSET_RECT_FLAG_BORDER_INSET)
         {
             // Draw outline of box
-            gfx_fill_rect(dpi, left, top, left, bottom, shadow);
-            gfx_fill_rect(dpi, left + 1, top, right, top, shadow);
-            gfx_fill_rect(dpi, right, top + 1, right, bottom - 1, hilight);
-            gfx_fill_rect(dpi, left + 1, bottom, right, bottom, hilight);
+            gfx_fill_rect(dpi, { { left, top }, { left, bottom } }, shadow);
+            gfx_fill_rect(dpi, { { left + 1, top }, { right, top } }, shadow);
+            gfx_fill_rect(dpi, { { right, top + 1 }, { right, bottom - 1 } }, hilight);
+            gfx_fill_rect(dpi, { { left + 1, bottom }, { right, bottom } }, hilight);
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
@@ -113,16 +114,16 @@ void gfx_fill_rect_inset(
                         fill = ColourMapA[colour].lighter;
                     }
                 }
-                gfx_fill_rect(dpi, left + 1, top + 1, right - 1, bottom - 1, fill);
+                gfx_fill_rect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, fill);
             }
         }
         else
         {
             // Draw outline of box
-            gfx_fill_rect(dpi, left, top, left, bottom - 1, hilight);
-            gfx_fill_rect(dpi, left + 1, top, right - 1, top, hilight);
-            gfx_fill_rect(dpi, right, top, right, bottom - 1, shadow);
-            gfx_fill_rect(dpi, left, bottom, right, bottom, shadow);
+            gfx_fill_rect(dpi, { { left, top }, { left, bottom - 1 } }, hilight);
+            gfx_fill_rect(dpi, { { left + 1, top }, { right - 1, top } }, hilight);
+            gfx_fill_rect(dpi, { { right, top }, { right, bottom - 1 } }, shadow);
+            gfx_fill_rect(dpi, { { left, bottom }, { right, bottom } }, shadow);
 
             if (!(flags & INSET_RECT_FLAG_FILL_NONE))
             {
@@ -130,7 +131,7 @@ void gfx_fill_rect_inset(
                 {
                     fill = ColourMapA[COLOUR_BLACK].light;
                 }
-                gfx_fill_rect(dpi, left + 1, top + 1, right - 1, bottom - 1, fill);
+                gfx_fill_rect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, fill);
             }
         }
     }

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -98,11 +98,12 @@ static void DrawText(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, TextP
     if (paint->UnderlineText)
     {
         gfx_fill_rect(
-            dpi, alignedCoords.x, alignedCoords.y + 11, alignedCoords.x + width, alignedCoords.y + 11, text_palette[1]);
+            dpi, { { alignedCoords + ScreenCoordsXY{ 0, 11 } }, { alignedCoords + ScreenCoordsXY{ width, 11 } } },
+            text_palette[1]);
         if (text_palette[2] != 0)
         {
             gfx_fill_rect(
-                dpi, alignedCoords.x + 1, alignedCoords.y + 12, alignedCoords.x + width + 1, alignedCoords.y + 12,
+                dpi, { { alignedCoords + ScreenCoordsXY{ 1, 12 } }, { alignedCoords + ScreenCoordsXY{ width + 1, 12 } } },
                 text_palette[2]);
         }
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -191,7 +191,7 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
             int32_t caretX = screenCoords.x + gfx_get_string_width(lineBuffer);
             int32_t caretY = screenCoords.y + 14;
 
-            gfx_fill_rect(dpi, caretX, caretY, caretX + 6, caretY + 1, PALETTE_INDEX_56);
+            gfx_fill_rect(dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PALETTE_INDEX_56);
         }
     }
 }


### PR DESCRIPTION
ScreenRect class is creating some assertion errors as well for this PR:

```
>	openrct2.exe!issue_debug_notification(const wchar_t * const message) Line 28	C++
 	openrct2.exe!__acrt_report_runtime_error(const wchar_t * message) Line 154	C++
 	openrct2.exe!abort() Line 61	C++
 	openrct2.exe!common_assert_to_stderr_direct(const wchar_t * const expression, const wchar_t * const file_name, const unsigned int line_number) Line 161	C++
 	openrct2.exe!common_assert_to_stderr<wchar_t>(const wchar_t * const expression, const wchar_t * const file_name, const unsigned int line_number) Line 179	C++
 	openrct2.exe!common_assert<wchar_t>(const wchar_t * const expression, const wchar_t * const file_name, const unsigned int line_number, void * const return_address) Line 420	C++
 	openrct2.exe!_wassert(const wchar_t * expression, const wchar_t * file_name, unsigned int line_number) Line 444	C++
 	openrct2.exe!RectRange<ScreenCoordsXY>::RectRange<ScreenCoordsXY>(const ScreenCoordsXY & leftTop, const ScreenCoordsXY & rightBottom) Line 663	C++
 	openrct2.exe!RectRange<ScreenCoordsXY>::RectRange<ScreenCoordsXY>(int left, int top, int right, int bottom) Line 657	C++
 	[External Code]	
 	openrct2.exe!gfx_fill_rect_inset(rct_drawpixelinfo * dpi, short left, short top, short right, short bottom, int colour, unsigned char flags) Line 123	C++
 	openrct2.exe!widget_frame_draw(rct_drawpixelinfo * dpi, rct_window * w, short widgetIndex) Line 133	C++
 	openrct2.exe!widget_draw(rct_drawpixelinfo * dpi, rct_window * w, short widgetIndex) Line 56	C++
 	openrct2.exe!window_draw_widgets(rct_window * w, rct_drawpixelinfo * dpi) Line 638	C++
 	openrct2.exe!window_scenarioselect_paint(rct_window * w, rct_drawpixelinfo * dpi) Line 444	C++
 	openrct2.exe!window_event_paint_call(rct_window * w, rct_drawpixelinfo * dpi) Line 1562	C++
 	openrct2.exe!window_draw_single(rct_drawpixelinfo * dpi, rct_window * w, int left, int top, int right, int bottom) Line 1246	C++
 	openrct2.exe!window_draw(rct_drawpixelinfo * dpi, rct_window * w, int left, int top, int right, int bottom) Line 1129	C++
 	openrct2.exe!window_draw_all::__l2::<lambda>(rct_window * w) Line 2042	C++
 	[External Code]	
 	openrct2.exe!window_visit_each(std::function<void __cdecl(rct_window *)> func) Line 104	C++
 	openrct2.exe!window_draw_all(rct_drawpixelinfo * dpi, short left, short top, short right, short bottom) Line 2043	C++
 	openrct2.exe!OpenRCT2::Drawing::X8DrawingEngine::DrawDirtyBlocks(unsigned int x, unsigned int y, unsigned int columns, unsigned int rows) Line 454	C++
 	openrct2.exe!OpenRCT2::Drawing::X8DrawingEngine::DrawAllDirtyBlocks() Line 422	C++
 	openrct2.exe!OpenRCT2::Drawing::X8DrawingEngine::PaintWindows() Line 216	C++
 	openrct2.exe!OpenRCT2::Paint::Painter::Paint(OpenRCT2::Drawing::IDrawingEngine & de) Line 48	C++
 	openrct2.exe!OpenRCT2::Context::RunVariableFrame() Line 985	C++
 	openrct2.exe!OpenRCT2::Context::RunFrame() Line 902	C++
 	openrct2.exe!OpenRCT2::Context::RunGameLoop() Line 877	C++
 	openrct2.exe!OpenRCT2::Context::Launch() Line 849	C++
 	openrct2.exe!OpenRCT2::Context::RunOpenRCT2(int argc, const char * * argv) Line 259	C++
 	openrct2.exe!NormalisedMain(int argc, const char * * argv) Line 62	C++
 	openrct2.exe!wmain(int argc, wchar_t * * argvW, wchar_t * envp) Line 43	C++
 	[External Code]	
```
