### PR TITLE
Do not try to force dimensions of a rectangle

### DIFF
--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -659,9 +659,6 @@ template<class T> struct RectRange : public CoordsRange<T>
     RectRange(const T& leftTop, const T& rightBottom)
         : CoordsRange<T>(leftTop, rightBottom)
     {
-        // Make sure it's a rectangle
-        assert(std::abs(CoordsRange<T>::GetLeft() - CoordsRange<T>::GetRight()) > 0);
-        assert(std::abs(CoordsRange<T>::GetTop() - CoordsRange<T>::GetBottom()) > 0);
     }
 };
 


### PR DESCRIPTION
Sadly, many pieces of the code create a window with no width or similar first and then alter its size later, so we can't really enforce this for now.

This will help some open PRs by @frutiemax 