### PR TITLE
ScreenCordsXY refactor gfx_draw_dashed_line

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -248,12 +248,12 @@ static void graph_draw_hovered_value(
     {
         return;
     }
-    gfx_draw_dashed_line(dpi, {{info.coords.x, chartFrame.GetTop()}, info.coords}, DEFAULT_DASHED_LENGTH, 0);
-    gfx_draw_dashed_line(dpi, {{chartFrame.GetLeft() - 10, info.coords.y}, info.coords}, DEFAULT_DASHED_LENGTH, 0);
+    gfx_draw_dashed_line(dpi, { { info.coords.x, chartFrame.GetTop() }, info.coords }, DEFAULT_DASHED_LENGTH, 0);
+    gfx_draw_dashed_line(dpi, { { chartFrame.GetLeft() - 10, info.coords.y }, info.coords }, DEFAULT_DASHED_LENGTH, 0);
 
     if (cursorPosition.y > info.coords.y)
     {
-        gfx_draw_dashed_line(dpi, {info.coords, {info.coords.x, cursorPosition.y}}, DEFAULT_DASHED_LENGTH, 0);
+        gfx_draw_dashed_line(dpi, { info.coords, { info.coords.x, cursorPosition.y } }, DEFAULT_DASHED_LENGTH, 0);
     }
 
     gfx_draw_string_centred(

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -248,12 +248,12 @@ static void graph_draw_hovered_value(
     {
         return;
     }
-    gfx_draw_dashed_line(dpi, ScreenLine(ScreenCoordsXY(info.coords.x, chartFrame.GetTop()), info.coords), DEFAULT_DASHED_LENGTH, 0);
-    gfx_draw_dashed_line(dpi, ScreenLine(ScreenCoordsXY(chartFrame.GetLeft() - 10, info.coords.y), info.coords), DEFAULT_DASHED_LENGTH, 0);
+    gfx_draw_dashed_line(dpi, {{info.coords.x, chartFrame.GetTop()}, info.coords}, DEFAULT_DASHED_LENGTH, 0);
+    gfx_draw_dashed_line(dpi, {{chartFrame.GetLeft() - 10, info.coords.y}, info.coords}, DEFAULT_DASHED_LENGTH, 0);
 
     if (cursorPosition.y > info.coords.y)
     {
-        gfx_draw_dashed_line(dpi, ScreenLine(info.coords, ScreenCoordsXY(info.coords.x, cursorPosition.y), DEFAULT_DASHED_LENGTH, 0);
+        gfx_draw_dashed_line(dpi, {info.coords, {info.coords.x, cursorPosition.y}}, DEFAULT_DASHED_LENGTH, 0);
     }
 
     gfx_draw_string_centred(

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -248,13 +248,12 @@ static void graph_draw_hovered_value(
     {
         return;
     }
-
-    gfx_draw_dashed_line(dpi, info.coords.x, chartFrame.GetTop(), info.coords.x, info.coords.y, DEFAULT_DASHED_LENGTH, 0);
-    gfx_draw_dashed_line(dpi, chartFrame.GetLeft() - 10, info.coords.y, info.coords.x, info.coords.y, DEFAULT_DASHED_LENGTH, 0);
+    gfx_draw_dashed_line(dpi, ScreenLine(ScreenCoordsXY(info.coords.x, chartFrame.GetTop()), info.coords), DEFAULT_DASHED_LENGTH, 0);
+    gfx_draw_dashed_line(dpi, ScreenLine(ScreenCoordsXY(chartFrame.GetLeft() - 10, info.coords.y), info.coords), DEFAULT_DASHED_LENGTH, 0);
 
     if (cursorPosition.y > info.coords.y)
     {
-        gfx_draw_dashed_line(dpi, info.coords.x, info.coords.y, info.coords.x, cursorPosition.y, DEFAULT_DASHED_LENGTH, 0);
+        gfx_draw_dashed_line(dpi, ScreenLine(info.coords, ScreenCoordsXY(info.coords.x, cursorPosition.y), DEFAULT_DASHED_LENGTH, 0);
     }
 
     gfx_draw_string_centred(

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -602,6 +602,8 @@ void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, i
 void gfx_draw_line_software(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_dashed_line(
     rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t dashedLineSegmentLength, int32_t colour);
+void gfx_draw_dashed_line(
+    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLenght, const int32_t color)
 
 // rect
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -601,8 +601,6 @@ void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_line_software(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_dashed_line(
-    rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t dashedLineSegmentLength, int32_t colour);
-void gfx_draw_dashed_line(
     rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLenght, const int32_t color)
 
 // rect

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -601,7 +601,7 @@ void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_line_software(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_dashed_line(
-    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLenght, const int32_t color)
+    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
 
 // rect
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -19,6 +19,7 @@
 struct ScreenCoordsXY;
 
 struct ScreenCoordsXY;
+struct ScreenLine;
 namespace OpenRCT2
 {
     interface IPlatformEnvironment;

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -601,7 +601,7 @@ void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_line_software(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_dashed_line(
-    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
+    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
 
 // rect
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour);

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -212,18 +212,18 @@ void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, i
 }
 
 void gfx_draw_dashed_line(
-    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLenght, const int32_t color)
+    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
 {
-    assert(dashedLineSegmentLenght > 0);
+    assert(dashedLineSegmentLength > 0);
 
     const auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
     {
         constexpr int32_t precisionFactor = 1000;
 
-        const int32_t dashedLineLenght = std::hypot(
-            screenLine.GetRight() - screenLine.GetLeft(), screenLine.GetBottom() - screenLine.GetRight());
-        const int32_t lineSegmentCount = dashedLineLenght / dashedLineSegmentLenght / 2;
+        const int32_t dashedLineLength = std::hypot(
+            screenLine.GetRight() - screenLine.GetLeft(), screenLine.GetBottom() - screenLine.GetTop());
+        const int32_t lineSegmentCount = dashedLineLength / dashedLineSegmentLength / 2;
         if (lineSegmentCount == 0)
         {
             return;

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -212,39 +212,6 @@ void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, i
 }
 
 void gfx_draw_dashed_line(
-    rct_drawpixelinfo* dpi, const int32_t x1, const int32_t y1, const int32_t x2, const int32_t y2,
-    const int32_t dashedLineSegmentLength, const int32_t colour)
-{
-    assert(dashedLineSegmentLength > 0);
-
-    const auto drawingEngine = dpi->DrawingEngine;
-    if (drawingEngine != nullptr)
-    {
-        constexpr int32_t precisionFactor = 1000;
-
-        const int32_t dashedLineLength = std::hypot(x2 - x1, y2 - y1);
-        const int32_t lineSegmentCount = dashedLineLength / dashedLineSegmentLength / 2;
-        if (lineSegmentCount == 0)
-        {
-            return;
-        }
-
-        const int32_t lineXDist = std::abs(x2 - x1);
-        const int32_t lineYDist = std::abs(y2 - y1);
-        const int32_t dxPrecise = precisionFactor * lineXDist / lineSegmentCount / 2;
-        const int32_t dyPrecise = precisionFactor * lineYDist / lineSegmentCount / 2;
-        IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-
-        for (int32_t i = 0, x, y; i < lineSegmentCount; ++i)
-        {
-            x = x1 + dxPrecise * i * 2 / precisionFactor;
-            y = y1 + dyPrecise * i * 2 / precisionFactor;
-            dc->DrawLine(colour, x, y, x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor);
-        }
-    }
-}
-
-void gfx_draw_dashed_line(
     rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLenght, const int32_t color)
 {
     assert(dashedLineSegmentLenght > 0);

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -238,7 +238,7 @@ void gfx_draw_dashed_line(
         for (int32_t i = 0, x, y; i < lineSegmentCount; ++i)
         {
             x = screenLine.GetLeft() + dxPrecise * i * 2 / precisionFactor;
-            y = screenLine.GetTop()  + dyPrecise * i * 2 / precisionFactor;
+            y = screenLine.GetTop() + dyPrecise * i * 2 / precisionFactor;
             dc->DrawLine(color, x, y, x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor);
         }
     }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -244,6 +244,39 @@ void gfx_draw_dashed_line(
     }
 }
 
+void gfx_draw_dashed_line(
+    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLenght, const int32_t color)
+{
+    assert(dashedLineSegmentLenght > 0);
+
+    const auto drawingEngine = dpi->DrawingEngine;
+    if (drawingEngine != nullptr)
+    {
+        constexpr int32_t precisionFactor = 1000;
+
+        const int32_t dashedLineLenght = std::hypot(
+            screenLine.GetRight() - screenLine.GetLeft(), screenLine.GetBottom() - screenLine.GetRight());
+        const int32_t lineSegmentCount = dashedLineLenght / dashedLineSegmentLenght / 2;
+        if (lineSegmentCount == 0)
+        {
+            return;
+        }
+
+        const int32_t lineXDist = std::abs(screenLine.GetRight() - screenLine.GetLeft());
+        const int32_t lineYDist = std::abs(screenLine.GetBottom() - screenLine.GetTop());
+        const int32_t dxPrecise = precisionFactor * lineXDist / lineSegmentCount / 2;
+        const int32_t dyPrecise = precisionFactor * lineYDist / lineSegmentCount / 2;
+        IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
+
+        for (int32_t i = 0, x, y; i < lineSegmentCount; ++i)
+        {
+            x = screenLine.GetLeft() + dxPrecise * i * 2 / precisionFactor;
+            y = screenLine.GetTop()  + dyPrecise * i * 2 / precisionFactor;
+            dc->DrawLine(color, x, y, x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor);
+        }
+    }
+}
+
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, int32_t image, const ScreenCoordsXY& coords, uint32_t tertiary_colour)
 {
     auto drawingEngine = dpi->DrawingEngine;


### PR DESCRIPTION
Lurking on Github for a while I wanted to try my first PR. I looked at the Issues and found some tagged with "Good first issue". So I read the Contributing.md file and tried to follow it as best I can. I selected this #12101 issue and worked on it.

I used 'grep "gfx_draw_dashed_line" *' in the directory src to find all occurrences of the function

For the replacement of calls I am not sure if I should create ScreenLine() inline.
For the include for ScreenLine I am not sure where to place it. I need to include "openrct2/world/Location.hpp" somewhere. I think this needs to be in "openrct2/drawing/Drawing.h" since it other includes delegate to it (Graph.h)