### PR TITLE
Close #12098: Use ScreenRect on gfx_filter_rect

### DIFF
--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -193,14 +193,14 @@ static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t bottom = w->windowPos.y + w->height - 1;
 
     // Background
-    gfx_filter_rect(dpi, { left + 1, top + 1, right - 1, bottom - 1 }, PALETTE_45);
-    gfx_filter_rect(dpi, { left + 1, top + 1, right - 1, bottom - 1 }, PALETTE_GLASS_LIGHT_ORANGE);
+    gfx_filter_rect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, PALETTE_45);
+    gfx_filter_rect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, PALETTE_GLASS_LIGHT_ORANGE);
 
     // Sides
-    gfx_filter_rect(dpi, { left + 0, top + 2, left + 0, bottom - 2 }, PALETTE_DARKEN_3);
-    gfx_filter_rect(dpi, { right + 0, top + 2, right + 0, bottom - 2 }, PALETTE_DARKEN_3);
-    gfx_filter_rect(dpi, { left + 2, bottom + 0, right - 2, bottom + 0 }, PALETTE_DARKEN_3);
-    gfx_filter_rect(dpi, { left + 2, top + 0, right - 2, top + 0 }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { { left + 0, top + 2 }, { left + 0, bottom - 2 } }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { { right + 0, top + 2 }, { right + 0, bottom - 2 } }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { { left + 2, bottom + 0 }, { right - 2, bottom + 0 } }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { { left + 2, top + 0 }, { right - 2, top + 0 } }, PALETTE_DARKEN_3);
 
     // Corners
     gfx_filter_pixel(dpi, { left + 1, top + 1 }, PALETTE_DARKEN_3);

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -193,14 +193,14 @@ static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t bottom = w->windowPos.y + w->height - 1;
 
     // Background
-    gfx_filter_rect(dpi, left + 1, top + 1, right - 1, bottom - 1, PALETTE_45);
-    gfx_filter_rect(dpi, left + 1, top + 1, right - 1, bottom - 1, PALETTE_GLASS_LIGHT_ORANGE);
+    gfx_filter_rect(dpi, { left + 1, top + 1, right - 1, bottom - 1 }, PALETTE_45);
+    gfx_filter_rect(dpi, { left + 1, top + 1, right - 1, bottom - 1 }, PALETTE_GLASS_LIGHT_ORANGE);
 
     // Sides
-    gfx_filter_rect(dpi, left + 0, top + 2, left + 0, bottom - 2, PALETTE_DARKEN_3);
-    gfx_filter_rect(dpi, right + 0, top + 2, right + 0, bottom - 2, PALETTE_DARKEN_3);
-    gfx_filter_rect(dpi, left + 2, bottom + 0, right - 2, bottom + 0, PALETTE_DARKEN_3);
-    gfx_filter_rect(dpi, left + 2, top + 0, right - 2, top + 0, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { left + 0, top + 2, left + 0, bottom - 2 }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { right + 0, top + 2, right + 0, bottom - 2 }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { left + 2, bottom + 0, right - 2, bottom + 0 }, PALETTE_DARKEN_3);
+    gfx_filter_rect(dpi, { left + 2, top + 0, right - 2, top + 0 }, PALETTE_DARKEN_3);
 
     // Corners
     gfx_filter_pixel(dpi, { left + 1, top + 1 }, PALETTE_DARKEN_3);

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -585,7 +585,7 @@ void gfx_draw_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_
 
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)
 {
-    gfx_filter_rect(dpi, { coords.x, coords.y, coords.x, coords.y }, palette);
+    gfx_filter_rect(dpi, { coords, coords }, palette);
 }
 
 /**

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -585,7 +585,7 @@ void gfx_draw_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_
 
 void gfx_filter_pixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FILTER_PALETTE_ID palette)
 {
-    gfx_filter_rect(dpi, coords.x, coords.y, coords.x, coords.y, palette);
+    gfx_filter_rect(dpi, { coords.x, coords.y, coords.x, coords.y }, palette);
 }
 
 /**

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -611,8 +611,7 @@ void gfx_fill_rect_inset(
     rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t right, int16_t bottom, int32_t colour, uint8_t flags);
 void gfx_filter_rect(
     rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette);
-void gfx_filter_rect(
-    rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette);
+void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette);
 
 // sprite
 bool gfx_load_g1(const OpenRCT2::IPlatformEnvironment& env);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -20,6 +20,7 @@ struct ScreenCoordsXY;
 
 struct ScreenCoordsXY;
 struct ScreenLine;
+struct ScreenRect;
 namespace OpenRCT2
 {
     interface IPlatformEnvironment;
@@ -610,6 +611,8 @@ void gfx_fill_rect_inset(
     rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t right, int16_t bottom, int32_t colour, uint8_t flags);
 void gfx_filter_rect(
     rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette);
+void gfx_filter_rect(
+    rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette);
 
 // sprite
 bool gfx_load_g1(const OpenRCT2::IPlatformEnvironment& env);

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -180,8 +180,7 @@ void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
     }
 }
 
-void gfx_fill_rect(
-    rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
+void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -201,13 +200,13 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t ri
     }
 }
 
-void gfx_filter_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
+void gfx_filter_rect(
+    rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
 {
     gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
 }
 
-void gfx_filter_rect(
-    rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
+void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -190,14 +190,29 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t ri
     }
 }
 
-void gfx_filter_rect(
-    rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
+
+void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-        dc->FilterRect(palette, left, top, right, bottom);
+        dc->FillRect(colour, left, top, right, bottom);
+    }
+}
+
+void gfx_filter_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
+{
+    gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
+}
+
+void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
+{
+    auto drawingEngine = dpi->DrawingEngine;
+    if (drawingEngine != nullptr)
+    {
+        IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
+        dc->FilterRect(palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -190,16 +190,6 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t ri
     }
 }
 
-void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
-{
-    auto drawingEngine = dpi->DrawingEngine;
-    if (drawingEngine != nullptr)
-    {
-        IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-        dc->FillRect(colour, left, top, right, bottom);
-    }
-}
-
 void gfx_filter_rect(
     rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
 {

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -180,7 +180,8 @@ void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
     }
 }
 
-void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
+void gfx_fill_rect(
+    rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -189,7 +190,6 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t ri
         dc->FillRect(colour, left, top, right, bottom);
     }
 }
-
 
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
 {
@@ -206,7 +206,8 @@ void gfx_filter_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t 
     gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
 }
 
-void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
+void gfx_filter_rect(
+    rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -130,7 +130,7 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
             _chatHeight = 150;
         }
 
-        gfx_set_dirty_blocks(_chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5);             // Background area + Textbox
+        gfx_set_dirty_blocks(_chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5); // Background area + Textbox
         gfx_filter_rect(
             dpi, { { _chatLeft, _chatTop - 5 }, { _chatRight, _chatBottom + 5 } }, PALETTE_51); // Opaque gray background
         gfx_fill_rect_inset(

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -131,7 +131,7 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
         }
 
         gfx_set_dirty_blocks(_chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5);             // Background area + Textbox
-        gfx_filter_rect(dpi, _chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5, PALETTE_51); // Opaque gray background
+        gfx_filter_rect(dpi, { _chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5 }, PALETTE_51); // Opaque gray background
         gfx_fill_rect_inset(
             dpi, _chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5, chatBackgroundColor, INSET_RECT_FLAG_FILL_NONE);
         gfx_fill_rect_inset(

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -131,7 +131,8 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
         }
 
         gfx_set_dirty_blocks(_chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5);             // Background area + Textbox
-        gfx_filter_rect(dpi, { _chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5 }, PALETTE_51); // Opaque gray background
+        gfx_filter_rect(
+            dpi, { { _chatLeft, _chatTop - 5 }, { _chatRight, _chatBottom + 5 } }, PALETTE_51); // Opaque gray background
         gfx_fill_rect_inset(
             dpi, _chatLeft, _chatTop - 5, _chatRight, _chatBottom + 5, chatBackgroundColor, INSET_RECT_FLAG_FILL_NONE);
         gfx_fill_rect_inset(


### PR DESCRIPTION
Refactored `gfx_filter_rect` to use `const ScreenRect&` and modified calls to the old function to make them point at the new one.