### PR TITLE
Clarify CoordsRange-derived interface methods

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -401,10 +401,10 @@ template<> struct DataSerializerTraits<MapRange>
 {
     static void encode(IStream* stream, const MapRange& v)
     {
-        stream->WriteValue(ByteSwapBE(v.LeftTop.x));
-        stream->WriteValue(ByteSwapBE(v.LeftTop.y));
-        stream->WriteValue(ByteSwapBE(v.RightBottom.x));
-        stream->WriteValue(ByteSwapBE(v.RightBottom.y));
+        stream->WriteValue(ByteSwapBE(v.GetLeft()));
+        stream->WriteValue(ByteSwapBE(v.GetTop()));
+        stream->WriteValue(ByteSwapBE(v.GetRight()));
+        stream->WriteValue(ByteSwapBE(v.GetBottom()));
     }
     static void decode(IStream* stream, MapRange& v)
     {
@@ -418,8 +418,8 @@ template<> struct DataSerializerTraits<MapRange>
     {
         char coords[128] = {};
         snprintf(
-            coords, sizeof(coords), "MapRange(l = %d, t = %d, r = %d, b = %d)", v.LeftTop.x, v.LeftTop.y, v.RightBottom.x,
-            v.RightBottom.y);
+            coords, sizeof(coords), "MapRange(l = %d, t = %d, r = %d, b = %d)", v.GetLeft(), v.GetTop(), v.GetRight(),
+            v.GetBottom());
 
         stream->Write(coords, strlen(coords));
     }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -222,23 +222,23 @@ void gfx_draw_dashed_line(
         constexpr int32_t precisionFactor = 1000;
 
         const int32_t dashedLineLength = std::hypot(
-            screenLine.GetRight() - screenLine.GetLeft(), screenLine.GetBottom() - screenLine.GetTop());
+            screenLine.GetXTwo() - screenLine.GetXOne(), screenLine.GetYTwo() - screenLine.GetYOne());
         const int32_t lineSegmentCount = dashedLineLength / dashedLineSegmentLength / 2;
         if (lineSegmentCount == 0)
         {
             return;
         }
 
-        const int32_t lineXDist = std::abs(screenLine.GetRight() - screenLine.GetLeft());
-        const int32_t lineYDist = std::abs(screenLine.GetBottom() - screenLine.GetTop());
+        const int32_t lineXDist = std::abs(screenLine.GetXTwo() - screenLine.GetXOne());
+        const int32_t lineYDist = std::abs(screenLine.GetYTwo() - screenLine.GetYOne());
         const int32_t dxPrecise = precisionFactor * lineXDist / lineSegmentCount / 2;
         const int32_t dyPrecise = precisionFactor * lineYDist / lineSegmentCount / 2;
         IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
 
         for (int32_t i = 0, x, y; i < lineSegmentCount; ++i)
         {
-            x = screenLine.GetLeft() + dxPrecise * i * 2 / precisionFactor;
-            y = screenLine.GetTop() + dyPrecise * i * 2 / precisionFactor;
+            x = screenLine.GetXOne() + dxPrecise * i * 2 / precisionFactor;
+            y = screenLine.GetYOne() + dyPrecise * i * 2 / precisionFactor;
             dc->DrawLine(color, x, y, x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor);
         }
     }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -222,23 +222,23 @@ void gfx_draw_dashed_line(
         constexpr int32_t precisionFactor = 1000;
 
         const int32_t dashedLineLength = std::hypot(
-            screenLine.GetXTwo() - screenLine.GetXOne(), screenLine.GetYTwo() - screenLine.GetYOne());
+            screenLine.GetX2() - screenLine.GetX1(), screenLine.GetY2() - screenLine.GetY1());
         const int32_t lineSegmentCount = dashedLineLength / dashedLineSegmentLength / 2;
         if (lineSegmentCount == 0)
         {
             return;
         }
 
-        const int32_t lineXDist = std::abs(screenLine.GetXTwo() - screenLine.GetXOne());
-        const int32_t lineYDist = std::abs(screenLine.GetYTwo() - screenLine.GetYOne());
+        const int32_t lineXDist = std::abs(screenLine.GetX2() - screenLine.GetX1());
+        const int32_t lineYDist = std::abs(screenLine.GetY2() - screenLine.GetY1());
         const int32_t dxPrecise = precisionFactor * lineXDist / lineSegmentCount / 2;
         const int32_t dyPrecise = precisionFactor * lineYDist / lineSegmentCount / 2;
         IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
 
         for (int32_t i = 0, x, y; i < lineSegmentCount; ++i)
         {
-            x = screenLine.GetXOne() + dxPrecise * i * 2 / precisionFactor;
-            y = screenLine.GetYOne() + dyPrecise * i * 2 / precisionFactor;
+            x = screenLine.GetX1() + dxPrecise * i * 2 / precisionFactor;
+            y = screenLine.GetY1() + dyPrecise * i * 2 / precisionFactor;
             dc->DrawLine(color, x, y, x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor);
         }
     }

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -614,24 +614,24 @@ struct TileCoordsXYZD : public TileCoordsXYZ
  */
 template<class T> struct CoordsRange
 {
-    T PointOne{ 0, 0 };
-    T PointTwo{ 0, 0 };
+    T Point1{ 0, 0 };
+    T Point2{ 0, 0 };
 
-    int32_t GetXOne() const
+    int32_t GetX1() const
     {
-        return PointOne.x;
+        return Point1.x;
     }
-    int32_t GetYOne() const
+    int32_t GetY1() const
     {
-        return PointOne.y;
+        return Point1.y;
     }
-    int32_t GetXTwo() const
+    int32_t GetX2() const
     {
-        return PointTwo.x;
+        return Point2.x;
     }
-    int32_t GetYTwo() const
+    int32_t GetY2() const
     {
-        return PointTwo.y;
+        return Point2.y;
     }
 
     CoordsRange() = default;
@@ -641,8 +641,8 @@ template<class T> struct CoordsRange
     }
 
     CoordsRange(const T& pointOne, const T& pointTwo)
-        : PointOne(pointOne)
-        , PointTwo(pointTwo)
+        : Point1(pointOne)
+        , Point2(pointTwo)
     {
     }
 };
@@ -653,19 +653,19 @@ template<class T> struct RectRange : public CoordsRange<T>
 
     int32_t GetLeft() const
     {
-        return CoordsRange<T>::GetXOne();
+        return CoordsRange<T>::GetX1();
     }
     int32_t GetTop() const
     {
-        return CoordsRange<T>::GetYOne();
+        return CoordsRange<T>::GetY1();
     }
     int32_t GetRight() const
     {
-        return CoordsRange<T>::GetXTwo();
+        return CoordsRange<T>::GetX2();
     }
     int32_t GetBottom() const
     {
-        return CoordsRange<T>::GetYTwo();
+        return CoordsRange<T>::GetY2();
     }
 
     RectRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
@@ -706,7 +706,7 @@ struct ScreenLine : public CoordsRange<ScreenCoordsXY>
         : CoordsRange<ScreenCoordsXY>(leftTop, rightBottom)
     {
         // Make sure one of the point coords change
-        assert((std::abs(GetXOne() - GetXTwo()) > 0) || (std::abs(GetYOne() - GetYTwo()) > 0));
+        assert((std::abs(GetX1() - GetX2()) > 0) || (std::abs(GetY1() - GetY2()) > 0));
     }
 };
 

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -614,35 +614,35 @@ struct TileCoordsXYZD : public TileCoordsXYZ
  */
 template<class T> struct CoordsRange
 {
-    T LeftTop{ 0, 0 };
-    T RightBottom{ 0, 0 };
+    T PointOne{ 0, 0 };
+    T PointTwo{ 0, 0 };
 
-    int32_t GetLeft() const
+    int32_t GetXOne() const
     {
-        return LeftTop.x;
+        return PointOne.x;
     }
-    int32_t GetTop() const
+    int32_t GetYOne() const
     {
-        return LeftTop.y;
+        return PointOne.y;
     }
-    int32_t GetRight() const
+    int32_t GetXTwo() const
     {
-        return RightBottom.x;
+        return PointTwo.x;
     }
-    int32_t GetBottom() const
+    int32_t GetYTwo() const
     {
-        return RightBottom.y;
+        return PointTwo.y;
     }
 
     CoordsRange() = default;
-    CoordsRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
-        : CoordsRange({ left, top }, { right, bottom })
+    CoordsRange(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+        : CoordsRange({ x1, y1 }, { x2, y2 })
     {
     }
 
-    CoordsRange(const T& leftTop, const T& rightBottom)
-        : LeftTop(leftTop)
-        , RightBottom(rightBottom)
+    CoordsRange(const T& pointOne, const T& pointTwo)
+        : PointOne(pointOne)
+        , PointTwo(pointTwo)
     {
     }
 };
@@ -650,6 +650,23 @@ template<class T> struct CoordsRange
 template<class T> struct RectRange : public CoordsRange<T>
 {
     using CoordsRange<T>::CoordsRange;
+
+    int32_t GetLeft() const
+    {
+        return CoordsRange<T>::GetXOne();
+    }
+    int32_t GetTop() const
+    {
+        return CoordsRange<T>::GetYOne();
+    }
+    int32_t GetRight() const
+    {
+        return CoordsRange<T>::GetXTwo();
+    }
+    int32_t GetBottom() const
+    {
+        return CoordsRange<T>::GetYTwo();
+    }
 
     RectRange(int32_t left, int32_t top, int32_t right, int32_t bottom)
         : RectRange({ left, top }, { right, bottom })
@@ -689,7 +706,7 @@ struct ScreenLine : public CoordsRange<ScreenCoordsXY>
         : CoordsRange<ScreenCoordsXY>(leftTop, rightBottom)
     {
         // Make sure one of the point coords change
-        assert((std::abs(GetLeft() - GetRight()) > 0) || (std::abs(GetTop() - GetBottom()) > 0));
+        assert((std::abs(GetXOne() - GetXTwo()) > 0) || (std::abs(GetYOne() - GetYTwo()) > 0));
     }
 };
 
@@ -703,11 +720,11 @@ struct ScreenRect : public RectRange<ScreenCoordsXY>
 
     int32_t GetWidth() const
     {
-        return RightBottom.x - LeftTop.x;
+        return GetRight() - GetLeft();
     }
     int32_t GetHeight() const
     {
-        return RightBottom.y - LeftTop.y;
+        return GetBottom() - GetTop();
     }
     bool Contains(const ScreenCoordsXY& coords) const
     {


### PR DESCRIPTION
When I  turned `MapRange` into `CoordsRange`, I kept the names `leftTop` and `rightBottom`, but these don't make sense from the `ScreeLine` point of view, as the point don't really need to follow this convention. In this PR:

- `LeftTop` and `RightBottom` are renamed to `PointOne` and `PointTwo` in the base class.
- Base class defines getters for the generic point variables
- `GeLeft()`, `GetRight()`, `GetTop()` and `GetBottom()` are redefined using these new generic getters.

As a side effect of changing the names of the variables, I also had to change `DataSeraliserTraits` to use the getters, which I think is a plus :D