### PR TITLE
Part of #12098: Use ScreenRect on gfx_filter_rect

### DIFF
--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -290,10 +290,10 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
     Invalidate();
 
     // Give console area a translucent effect.
-    gfx_filter_rect(dpi, _consoleLeft, _consoleTop, _consoleRight, _consoleBottom, PALETTE_51);
+    gfx_filter_rect(dpi, { _consoleLeft, _consoleTop, _consoleRight, _consoleBottom }, PALETTE_51);
 
     // Make input area more opaque.
-    gfx_filter_rect(dpi, _consoleLeft, _consoleBottom - lineHeight - 10, _consoleRight, _consoleBottom - 1, PALETTE_51);
+    gfx_filter_rect(dpi, { _consoleLeft, _consoleBottom - lineHeight - 10, _consoleRight, _consoleBottom - 1 }, PALETTE_51);
 
     // Paint background colour.
     uint8_t backgroundColour = theme_get_colour(WC_CONSOLE, 0);

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -290,10 +290,11 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
     Invalidate();
 
     // Give console area a translucent effect.
-    gfx_filter_rect(dpi, { _consoleLeft, _consoleTop, _consoleRight, _consoleBottom }, PALETTE_51);
+    gfx_filter_rect(dpi, { { _consoleLeft, _consoleTop }, { _consoleRight, _consoleBottom } }, PALETTE_51);
 
     // Make input area more opaque.
-    gfx_filter_rect(dpi, { _consoleLeft, _consoleBottom - lineHeight - 10, _consoleRight, _consoleBottom - 1 }, PALETTE_51);
+    gfx_filter_rect(
+        dpi, { { _consoleLeft, _consoleBottom - lineHeight - 10 }, { _consoleRight, _consoleBottom - 1 } }, PALETTE_51);
 
     // Paint background colour.
     uint8_t backgroundColour = theme_get_colour(WC_CONSOLE, 0);

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -532,7 +532,8 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         gfx_fill_rect(
             dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, ColourMapA[colour].dark);
     else
-        gfx_filter_rect(dpi, { { topLeft.x + 1, topLeft.y + 1 }, { bottomRight.x - 1, bottomRight.y - 1 } }, PALETTE_DARKEN_3);
+        gfx_filter_rect(
+            dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, PALETTE_DARKEN_3);
 
     // Draw text
     if (widget->text == STR_NONE)

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -532,7 +532,7 @@ static void widget_caption_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widge
         gfx_fill_rect(
             dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, ColourMapA[colour].dark);
     else
-        gfx_filter_rect(dpi, topLeft.x + 1, topLeft.y + 1, bottomRight.x - 1, bottomRight.y - 1, PALETTE_DARKEN_3);
+        gfx_filter_rect(dpi, { { topLeft.x + 1, topLeft.y + 1 }, { bottomRight.x - 1, bottomRight.y - 1 } }, PALETTE_DARKEN_3);
 
     // Draw text
     if (widget->text == STR_NONE)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -587,7 +587,8 @@ void window_draw_widgets(rct_window* w, rct_drawpixelinfo* dpi)
 
     if ((w->flags & WF_TRANSPARENT) && !(w->flags & WF_NO_BACKGROUND))
         gfx_filter_rect(
-            dpi, w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width - 1, w->windowPos.y + w->height - 1, PALETTE_51);
+            dpi, { { w->windowPos.x, w->windowPos.y }, { w->windowPos.x + w->width - 1, w->windowPos.y + w->height - 1 } },
+            PALETTE_51);
 
     // todo: some code missing here? Between 006EB18C and 006EB260
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -587,8 +587,7 @@ void window_draw_widgets(rct_window* w, rct_drawpixelinfo* dpi)
 
     if ((w->flags & WF_TRANSPARENT) && !(w->flags & WF_NO_BACKGROUND))
         gfx_filter_rect(
-            dpi, { { w->windowPos.x, w->windowPos.y }, { w->windowPos.x + w->width - 1, w->windowPos.y + w->height - 1 } },
-            PALETTE_51);
+            dpi, { w->windowPos, w->windowPos + ScreenCoordsXY{ w->width - 1, w->windowPos.y + w->height - 1 } }, PALETTE_51);
 
     // todo: some code missing here? Between 006EB18C and 006EB260
 

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -557,11 +557,11 @@ void CustomListView::Paint(rct_window* w, rct_drawpixelinfo* dpi, const rct_scro
             auto isSelected = (SelectedCell && itemIndex == SelectedCell->Row);
             if (isSelected)
             {
-                gfx_filter_rect(dpi, dpi->x, y, dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1), PALETTE_DARKEN_2);
+                gfx_filter_rect(dpi, { { dpi->x, y }, {dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } }, PALETTE_DARKEN_2);
             }
             else if (isHighlighted)
             {
-                gfx_filter_rect(dpi, dpi->x, y, dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1), PALETTE_DARKEN_1);
+                gfx_filter_rect(dpi, { { dpi->x, y }, { dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } }, PALETTE_DARKEN_1);
             }
             else if (isStriped)
             {

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -557,7 +557,7 @@ void CustomListView::Paint(rct_window* w, rct_drawpixelinfo* dpi, const rct_scro
             auto isSelected = (SelectedCell && itemIndex == SelectedCell->Row);
             if (isSelected)
             {
-                gfx_filter_rect(dpi, { { dpi->x, y }, {dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } }, PALETTE_DARKEN_2);
+                gfx_filter_rect(dpi, { { dpi->x, y }, { dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } }, PALETTE_DARKEN_2);
             }
             else if (isHighlighted)
             {

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -202,7 +202,8 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t ri
     }
 }
 
-void gfx_filter_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
+void gfx_filter_rect(
+    rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
 {
     gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
 }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -192,16 +192,6 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colou
     }
 }
 
-void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
-{
-    auto drawingEngine = dpi->DrawingEngine;
-    if (drawingEngine != nullptr)
-    {
-        IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-        dc->FillRect(colour, left, top, right, bottom);
-    }
-}
-
 void gfx_filter_rect(
     rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
 {

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -191,8 +191,23 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colou
     }
 }
 
-void gfx_filter_rect(
-    rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
+
+void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
+{
+    auto drawingEngine = dpi->DrawingEngine;
+    if (drawingEngine != nullptr)
+    {
+        IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
+        dc->FillRect(colour, left, top, right, bottom);
+    }
+}
+
+void gfx_filter_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
+{
+    gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
+}
+
+void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
 {
     gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
 }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -181,7 +181,6 @@ void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
     }
 }
 
-
 void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -181,6 +181,7 @@ void gfx_clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
     }
 }
 
+
 void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
@@ -190,7 +191,6 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colou
         dc->FillRect(colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
-
 
 void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t colour)
 {
@@ -203,11 +203,6 @@ void gfx_fill_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t ri
 }
 
 void gfx_filter_rect(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom, FILTER_PALETTE_ID palette)
-{
-    gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
-}
-
-void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALETTE_ID palette)
 {
     gfx_filter_rect(dpi, { left, top, right, bottom }, palette);
 }


### PR DESCRIPTION
Changed another reference to the old `gfx_filter_rect` function. I also found that the remaining references to the old function are located in the `gfx_fill_rect_inset`. 

When I attempt to change them, I receive an error stating `no instance of overloaded function gfx_filter_rect matches the argument list`. My guess is that once issue #12097 is completed, we'll be able to get those taken care of. 