### PR TITLE
Make handymen not enter queue lines

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -87,6 +87,7 @@ The following people are not part of the development team, but have been contrib
 * Chad Ian Anderson (pizza2004) - Added New Game option, bug fixes, misc.
 * Peter Ryszkiewicz (pRizz) - Added horizontal grid lines to finance charts.
 * Hudson Oliveira (hdpoliveira) - Misc.
+* Jim Verheijde (Jimver) - Prevent handymen from entering queue lines.
 
 ## Bug fixes
 * (halfbro)


### PR DESCRIPTION
Hey I implemented a feature which was requested in #1999. 

It does the following:
- Handymen won't go from a normal path to a queue path if there is a queue banner facing the handymen
- Handymen will still be able to exit queue lines should they somehow end up in one as I check the direction of the queue line banner.

In the picture below the handyman never goes into the queue line, I attached the save file below.
![handyman-queue](https://user-images.githubusercontent.com/7677699/86545309-4f6a7880-bf2e-11ea-98ca-94c8eb8b0135.png).

[sandbox-handyman.zip](https://github.com/OpenRCT2/OpenRCT2/files/4876081/sandbox-handyman.zip)