### PR TITLE
Use forward declares and reduce header's dependencies on Location.hpp

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -43,6 +43,7 @@
 #include <openrct2/title/TitleSequencePlayer.h>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
+#include <openrct2/world/Location.hpp>
 #include <vector>
 
 using namespace OpenRCT2;

--- a/src/openrct2-ui/input/KeyboardShortcuts.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcuts.cpp
@@ -20,6 +20,7 @@
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/world/Location.hpp>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Input;

--- a/src/openrct2-ui/input/KeyboardShortcuts.h
+++ b/src/openrct2-ui/input/KeyboardShortcuts.h
@@ -11,7 +11,6 @@
 
 #include <memory>
 #include <openrct2/common.h>
-#include <openrct2/world/Location.hpp>
 
 #define SHIFT 0x100
 #define CTRL 0x200
@@ -22,6 +21,8 @@
 #else
 #    define PLATFORM_MODIFIER CTRL
 #endif
+
+struct ScreenCoordsXY;
 
 enum KeyboardShortcut
 {

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -17,6 +17,7 @@
 #include "../network/network.h"
 #include "../platform/platform.h"
 #include "../util/Util.h"
+#include "../world/Location.hpp"
 
 #include <algorithm>
 

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -11,7 +11,6 @@
 #define _CHAT_H_
 
 #include "../common.h"
-#include "../world/Location.hpp"
 
 #define CHAT_HISTORY_SIZE 10
 #define CHAT_INPUT_SIZE 1024
@@ -19,6 +18,7 @@
 #define CHAT_MAX_WINDOW_WIDTH 600
 
 struct rct_drawpixelinfo;
+struct ScreenCoordsXY;
 
 enum CHAT_INPUT
 {

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -21,6 +21,7 @@
 #include "../ride/Ride.h"
 #include "../util/Util.h"
 #include "../windows/Intent.h"
+#include "../world/Location.hpp"
 #include "../world/Sprite.h"
 
 NewsItemQueues gNewsItems;

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 
+#include <algorithm>
 #include <array>
 #include <iterator>
 #include <optional>

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -10,11 +10,12 @@
 #pragma once
 
 #include "../common.h"
-#include "../world/Location.hpp"
 
 #include <array>
 #include <iterator>
 #include <optional>
+
+struct CoordsXYZ;
 
 enum
 {

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "../world/Location.hpp"
 #include "../world/Scenery.h"
 #include "SceneryObject.h"
 

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -15,6 +15,7 @@
 #include "../core/String.hpp"
 #include "../drawing/Drawing.h"
 #include "../localisation/Localisation.h"
+#include "../world/Location.hpp"
 #include "ObjectJsonHelpers.h"
 
 void TerrainSurfaceObject::Load()

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include "../world/Location.hpp"
 #include "Object.h"
+
+struct CoordsXY;
 
 enum TERRAIN_SURFACE_FLAGS
 {

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -14,6 +14,7 @@
 #include "../config/Config.h"
 #include "../interface/Viewport.h"
 #include "../sprites.h"
+#include "../world/Location.hpp"
 #include "../world/Map.h"
 #include "Paint.h"
 #include "VirtualFloor.h"

--- a/src/openrct2/paint/VirtualFloor.h
+++ b/src/openrct2/paint/VirtualFloor.h
@@ -10,7 +10,8 @@
 #pragma once
 
 #include "../common.h"
-#include "../world/Location.hpp"
+
+struct CoordsXY;
 
 enum VirtualFloorStyles
 {

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -13,7 +13,6 @@
 
 #include "../common.h"
 #include "../object/Object.h"
-#include "../world/Location.hpp"
 
 #include <string>
 #include <string_view>

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -14,7 +14,6 @@
 #include "../rct12/RCT12.h"
 #include "../ride/RideRatings.h"
 #include "../ride/Vehicle.h"
-#include "../world/Location.hpp"
 
 constexpr const uint8_t RCT2_MAX_STAFF = 200;
 constexpr const uint8_t RCT2_MAX_BANNERS_IN_PARK = 250;

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -11,6 +11,7 @@
 
 #include "../Game.h"
 #include "../scenario/Scenario.h"
+#include "../world/Location.hpp"
 #include "../world/Sprite.h"
 #include "Track.h"
 

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -10,9 +10,9 @@
 #pragma once
 
 #include "../common.h"
-#include "../world/Location.hpp"
 
 struct Ride;
+struct TileCoordsXYZD;
 
 using StationIndex = uint8_t;
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -12,12 +12,12 @@
 #include "../Context.h"
 #include "../common.h"
 #include "../interface/Cursors.h"
-#include "../world/Location.hpp"
 
 #include <memory>
 #include <string>
 #include <vector>
 
+struct ScreenCoordsXY;
 struct rct_drawpixelinfo;
 interface ITitleSequencePlayer;
 

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -15,6 +15,7 @@
 #include "../ride/Track.h"
 #include "Banner.h"
 #include "LargeScenery.h"
+#include "Location.hpp"
 #include "Scenery.h"
 
 uint8_t TileElementBase::GetType() const

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -14,9 +14,9 @@
 #include "../ride/Station.h"
 #include "Banner.h"
 #include "Footpath.h"
-#include "Location.hpp"
 
 struct Banner;
+struct CoordsXY;
 struct rct_scenery_entry;
 struct rct_footpath_entry;
 using track_type_t = uint16_t;


### PR DESCRIPTION
Prefer forward declaration instead of including the Location.hpp in header files.
Tested it by compiling :)

Closes #12118.