### PR TITLE
Replace gfx_draw_line to accept a ScreenLine object instead of the coordinates as ints

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -55,8 +55,12 @@ static void graph_draw_line_a_uint8_t(
 
             if (lastX != -1)
             {
-                gfx_draw_line(dpi, lastX + 1, lastY + 1, x + 1, y + 1, PALETTE_INDEX_10);
-                gfx_draw_line(dpi, lastX, lastY + 1, x, y + 1, PALETTE_INDEX_10);
+                auto leftTop1 = ScreenCoordsXY{ lastX + 1, lastY + 1 };
+                auto rightBottom1 = ScreenCoordsXY{ x + 1, y + 1 };
+                auto leftTop2 = ScreenCoordsXY{ lastX, lastY + 1 };
+                auto rightBottom2 = ScreenCoordsXY{ x, y + 1 };
+                gfx_draw_line(dpi, {leftTop1, rightBottom1}, PALETTE_INDEX_10);
+                gfx_draw_line(dpi, {leftTop2, rightBottom2}, PALETTE_INDEX_10);
             }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x, y }, { x + 2, y + 2 } }, PALETTE_INDEX_10);
@@ -83,7 +87,11 @@ static void graph_draw_line_b_uint8_t(
             y = baseY + ((255 - history[i]) * 100) / 256;
 
             if (lastX != -1)
-                gfx_draw_line(dpi, lastX, lastY, x, y, PALETTE_INDEX_21);
+            {
+                auto leftTop = ScreenCoordsXY{ lastX, lastY };
+                auto rightBottom = ScreenCoordsXY{ x, y };
+                gfx_draw_line(dpi, {leftTop, rightBottom}, PALETTE_INDEX_21);
+            }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x - 1, y - 1 }, { x + 1, y + 1 } }, PALETTE_INDEX_21);
 
@@ -143,8 +151,12 @@ static void graph_draw_line_a_money32(
 
             if (lastX != -1)
             {
-                gfx_draw_line(dpi, lastX + 1, lastY + 1, x + 1, y + 1, PALETTE_INDEX_10);
-                gfx_draw_line(dpi, lastX, lastY + 1, x, y + 1, PALETTE_INDEX_10);
+                auto leftTop1 = ScreenCoordsXY{ lastX + 1, lastY + 1 };
+                auto rightBottom1 = ScreenCoordsXY{ x + 1, y + 1 };
+                auto leftTop2 = ScreenCoordsXY{ lastX, lastY + 1 };
+                auto rightBottom2 = ScreenCoordsXY{ x, y + 1 };
+                gfx_draw_line(dpi, {leftTop1, rightBottom1}, PALETTE_INDEX_10);
+                gfx_draw_line(dpi, {leftTop2, rightBottom2}, PALETTE_INDEX_10);
             }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x, y }, { x + 2, y + 2 } }, PALETTE_INDEX_10);
@@ -172,7 +184,11 @@ static void graph_draw_line_b_money32(
             y = baseY + 170 - 6 - ((((history[i] >> modifier) + offset) * 170) / 256);
 
             if (lastX != -1)
-                gfx_draw_line(dpi, lastX, lastY, x, y, PALETTE_INDEX_21);
+            {
+                auto leftTop = ScreenCoordsXY{ lastX, lastY };
+                auto rightBottom = ScreenCoordsXY{ x, y };
+                gfx_draw_line(dpi, {leftTop, rightBottom}, PALETTE_INDEX_21);
+            }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x - 1, y - 1 }, { x + 1, y + 1 } }, PALETTE_INDEX_21);
 

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -59,8 +59,8 @@ static void graph_draw_line_a_uint8_t(
                 auto rightBottom1 = ScreenCoordsXY{ x + 1, y + 1 };
                 auto leftTop2 = ScreenCoordsXY{ lastX, lastY + 1 };
                 auto rightBottom2 = ScreenCoordsXY{ x, y + 1 };
-                gfx_draw_line(dpi, {leftTop1, rightBottom1}, PALETTE_INDEX_10);
-                gfx_draw_line(dpi, {leftTop2, rightBottom2}, PALETTE_INDEX_10);
+                gfx_draw_line(dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
+                gfx_draw_line(dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
             }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x, y }, { x + 2, y + 2 } }, PALETTE_INDEX_10);
@@ -90,7 +90,7 @@ static void graph_draw_line_b_uint8_t(
             {
                 auto leftTop = ScreenCoordsXY{ lastX, lastY };
                 auto rightBottom = ScreenCoordsXY{ x, y };
-                gfx_draw_line(dpi, {leftTop, rightBottom}, PALETTE_INDEX_21);
+                gfx_draw_line(dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
             }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x - 1, y - 1 }, { x + 1, y + 1 } }, PALETTE_INDEX_21);
@@ -155,8 +155,8 @@ static void graph_draw_line_a_money32(
                 auto rightBottom1 = ScreenCoordsXY{ x + 1, y + 1 };
                 auto leftTop2 = ScreenCoordsXY{ lastX, lastY + 1 };
                 auto rightBottom2 = ScreenCoordsXY{ x, y + 1 };
-                gfx_draw_line(dpi, {leftTop1, rightBottom1}, PALETTE_INDEX_10);
-                gfx_draw_line(dpi, {leftTop2, rightBottom2}, PALETTE_INDEX_10);
+                gfx_draw_line(dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
+                gfx_draw_line(dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
             }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x, y }, { x + 2, y + 2 } }, PALETTE_INDEX_10);
@@ -187,7 +187,7 @@ static void graph_draw_line_b_money32(
             {
                 auto leftTop = ScreenCoordsXY{ lastX, lastY };
                 auto rightBottom = ScreenCoordsXY{ x, y };
-                gfx_draw_line(dpi, {leftTop, rightBottom}, PALETTE_INDEX_21);
+                gfx_draw_line(dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
             }
             if (i == 0)
                 gfx_fill_rect(dpi, { { x - 1, y - 1 }, { x + 1, y + 1 } }, PALETTE_INDEX_21);

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -310,11 +310,21 @@ static void window_network_draw_graph(
     float dataMax = received ? _graphMaxIn : _graphMaxOut;
 
     // Draw box.
-    gfx_draw_line(dpi, x, y, x, y + height, COLOUR_BLACK);
-    gfx_draw_line(dpi, x, y + height, x + width, y + height, COLOUR_BLACK);
+    auto right1 = ScreenCoordsXY{ x, y };
+    auto right2 = ScreenCoordsXY{ x, y + height };
+    gfx_draw_line(dpi, {right1, right2}, COLOUR_BLACK);
 
-    gfx_draw_line(dpi, x, y, x + width, y, COLOUR_BLACK);
-    gfx_draw_line(dpi, x + width, y, x + width, y + height, COLOUR_BLACK);
+    auto left1 = ScreenCoordsXY{ x, y + height };
+    auto left2 = ScreenCoordsXY{ x + width, y + height };
+    gfx_draw_line(dpi, {left1, left2}, COLOUR_BLACK);
+
+    auto bottom1 = ScreenCoordsXY{ x, y };
+    auto bottom2 = ScreenCoordsXY{ x + width, y };
+    gfx_draw_line(dpi, {bottom1, bottom2}, COLOUR_BLACK);
+
+    auto top1 = ScreenCoordsXY{ x + width, y };
+    auto top2 = ScreenCoordsXY{ x + width, y + height };
+    gfx_draw_line(dpi, {top1, top2}, COLOUR_BLACK);
 
     // Draw graph inside box
     x = x + 1;

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -312,19 +312,19 @@ static void window_network_draw_graph(
     // Draw box.
     auto right1 = ScreenCoordsXY{ x, y };
     auto right2 = ScreenCoordsXY{ x, y + height };
-    gfx_draw_line(dpi, {right1, right2}, COLOUR_BLACK);
+    gfx_draw_line(dpi, { right1, right2 }, COLOUR_BLACK);
 
     auto left1 = ScreenCoordsXY{ x, y + height };
     auto left2 = ScreenCoordsXY{ x + width, y + height };
-    gfx_draw_line(dpi, {left1, left2}, COLOUR_BLACK);
+    gfx_draw_line(dpi, { left1, left2 }, COLOUR_BLACK);
 
     auto bottom1 = ScreenCoordsXY{ x, y };
     auto bottom2 = ScreenCoordsXY{ x + width, y };
-    gfx_draw_line(dpi, {bottom1, bottom2}, COLOUR_BLACK);
+    gfx_draw_line(dpi, { bottom1, bottom2 }, COLOUR_BLACK);
 
     auto top1 = ScreenCoordsXY{ x + width, y };
     auto top2 = ScreenCoordsXY{ x + width, y + height };
-    gfx_draw_line(dpi, {top1, top2}, COLOUR_BLACK);
+    gfx_draw_line(dpi, { top1, top2 }, COLOUR_BLACK);
 
     // Draw graph inside box
     x = x + 1;

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -660,21 +660,21 @@ static void draw_category_heading(
     int32_t lineY = y + 4;
     auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY };
     auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
-    gfx_draw_line(dpi, {lightLineLeftTop1, lightLineRightBottom1}, lightColour);
+    gfx_draw_line(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
     auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
     auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY };
-    gfx_draw_line(dpi, {lightLineLeftTop2, lightLineRightBottom2}, lightColour);
+    gfx_draw_line(dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
 
     // Draw dark horizontal rule
     lineY++;
     auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY };
     auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
-    gfx_draw_line(dpi, {darkLineLeftTop1, darkLineRightBottom1}, darkColour);
+    gfx_draw_line(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
 
     auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
     auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY };
-    gfx_draw_line(dpi, {darkLineLeftTop2, darkLineRightBottom2}, darkColour);
+    gfx_draw_line(dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
 }
 
 static void initialise_list_items(rct_window* w)

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -658,13 +658,23 @@ static void draw_category_heading(
 
     // Draw light horizontal rule
     int32_t lineY = y + 4;
-    gfx_draw_line(dpi, left, lineY, strLeft, lineY, lightColour);
-    gfx_draw_line(dpi, strRight, lineY, right, lineY, lightColour);
+    auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY };
+    auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
+    gfx_draw_line(dpi, {lightLineLeftTop1, lightLineRightBottom1}, lightColour);
+
+    auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
+    auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY };
+    gfx_draw_line(dpi, {lightLineLeftTop2, lightLineRightBottom2}, lightColour);
 
     // Draw dark horizontal rule
     lineY++;
-    gfx_draw_line(dpi, left, lineY, strLeft, lineY, darkColour);
-    gfx_draw_line(dpi, strRight, lineY, right, lineY, darkColour);
+    auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY };
+    auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
+    gfx_draw_line(dpi, {darkLineLeftTop1, darkLineRightBottom1}, darkColour);
+
+    auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
+    auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY };
+    gfx_draw_line(dpi, {darkLineLeftTop2, darkLineRightBottom2}, darkColour);
 }
 
 static void initialise_list_items(rct_window* w)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -599,6 +599,7 @@ void gfx_invalidate_pickedup_peep();
 void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 
 // line
+void gfx_draw_line(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour);
 void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_line_software(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_dashed_line(

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -600,7 +600,6 @@ void gfx_draw_pickedup_peep(rct_drawpixelinfo* dpi);
 
 // line
 void gfx_draw_line(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour);
-void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_line_software(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour);
 void gfx_draw_dashed_line(
     rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -212,6 +212,11 @@ void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALE
     }
 }
 
+void gfx_draw_line(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour)
+{
+    gfx_draw_line(dpi, line.GetLeft(), line.GetTop(), line.GetRight(), line.GetBottom(), colour);
+}
+
 void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -218,7 +218,7 @@ void gfx_draw_line(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colou
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-        dc->DrawLine(colour, line.GetLeft(), line.GetTop(), line.GetRight(), line.GetBottom());
+        dc->DrawLine(colour, line.GetX1(), line.GetY1(), line.GetX2(), line.GetY2());
     }
 }
 

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -214,16 +214,11 @@ void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FILTER_PALE
 
 void gfx_draw_line(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour)
 {
-    gfx_draw_line(dpi, line.GetLeft(), line.GetTop(), line.GetRight(), line.GetBottom(), colour);
-}
-
-void gfx_draw_line(rct_drawpixelinfo* dpi, int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t colour)
-{
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext(dpi);
-        dc->DrawLine(colour, x1, y1, x2, y2);
+        dc->DrawLine(colour, line.GetLeft(), line.GetTop(), line.GetRight(), line.GetBottom());
     }
 }
 

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -599,28 +599,28 @@ static void paint_ps_image_with_bounding_boxes(rct_drawpixelinfo* dpi, paint_str
     const auto screenCoordBackBottom = translate_3d_to_2d_with_z(rotation, backBottom);
 
     // bottom square
-    gfx_draw_line(dpi, {screenCoordFrontBottom, screenCoordLeftBottom}, colour);
-    gfx_draw_line(dpi, {screenCoordBackBottom, screenCoordLeftBottom}, colour);
-    gfx_draw_line(dpi, {screenCoordBackBottom, screenCoordRightBottom}, colour);
-    gfx_draw_line(dpi, {screenCoordFrontBottom, screenCoordRightBottom}, colour);
+    gfx_draw_line(dpi, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
+    gfx_draw_line(dpi, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
+    gfx_draw_line(dpi, { screenCoordBackBottom, screenCoordRightBottom }, colour);
+    gfx_draw_line(dpi, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
 
     // vertical back + sides
-    gfx_draw_line(dpi, {screenCoordBackTop, screenCoordBackBottom}, colour);
-    gfx_draw_line(dpi, {screenCoordLeftTop, screenCoordLeftBottom}, colour);
-    gfx_draw_line(dpi, {screenCoordRightTop, screenCoordRightBottom}, colour);
+    gfx_draw_line(dpi, { screenCoordBackTop, screenCoordBackBottom }, colour);
+    gfx_draw_line(dpi, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
+    gfx_draw_line(dpi, { screenCoordRightTop, screenCoordRightBottom }, colour);
 
     // top square back
-    gfx_draw_line(dpi, {screenCoordBackTop, screenCoordLeftTop}, colour);
-    gfx_draw_line(dpi, {screenCoordBackTop, screenCoordRightTop}, colour);
+    gfx_draw_line(dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
+    gfx_draw_line(dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
 
     paint_ps_image(dpi, ps, imageId, x, y);
 
     // vertical front
-    gfx_draw_line(dpi, {screenCoordFrontTop, screenCoordFrontBottom}, colour);
+    gfx_draw_line(dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
 
     // top square
-    gfx_draw_line(dpi, {screenCoordFrontTop, screenCoordLeftTop}, colour);
-    gfx_draw_line(dpi, {screenCoordFrontTop, screenCoordRightTop}, colour);
+    gfx_draw_line(dpi, { screenCoordFrontTop, screenCoordLeftTop }, colour);
+    gfx_draw_line(dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
 }
 
 static void paint_ps_image(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t imageId, int16_t x, int16_t y)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -599,34 +599,28 @@ static void paint_ps_image_with_bounding_boxes(rct_drawpixelinfo* dpi, paint_str
     const auto screenCoordBackBottom = translate_3d_to_2d_with_z(rotation, backBottom);
 
     // bottom square
-    gfx_draw_line(
-        dpi, screenCoordFrontBottom.x, screenCoordFrontBottom.y, screenCoordLeftBottom.x, screenCoordLeftBottom.y, colour);
-    gfx_draw_line(
-        dpi, screenCoordBackBottom.x, screenCoordBackBottom.y, screenCoordLeftBottom.x, screenCoordLeftBottom.y, colour);
-    gfx_draw_line(
-        dpi, screenCoordBackBottom.x, screenCoordBackBottom.y, screenCoordRightBottom.x, screenCoordRightBottom.y, colour);
-    gfx_draw_line(
-        dpi, screenCoordFrontBottom.x, screenCoordFrontBottom.y, screenCoordRightBottom.x, screenCoordRightBottom.y, colour);
+    gfx_draw_line(dpi, {screenCoordFrontBottom, screenCoordLeftBottom}, colour);
+    gfx_draw_line(dpi, {screenCoordBackBottom, screenCoordLeftBottom}, colour);
+    gfx_draw_line(dpi, {screenCoordBackBottom, screenCoordRightBottom}, colour);
+    gfx_draw_line(dpi, {screenCoordFrontBottom, screenCoordRightBottom}, colour);
 
     // vertical back + sides
-    gfx_draw_line(dpi, screenCoordBackTop.x, screenCoordBackTop.y, screenCoordBackBottom.x, screenCoordBackBottom.y, colour);
-    gfx_draw_line(dpi, screenCoordLeftTop.x, screenCoordLeftTop.y, screenCoordLeftBottom.x, screenCoordLeftBottom.y, colour);
-    gfx_draw_line(
-        dpi, screenCoordRightTop.x, screenCoordRightTop.y, screenCoordRightBottom.x, screenCoordRightBottom.y, colour);
+    gfx_draw_line(dpi, {screenCoordBackTop, screenCoordBackBottom}, colour);
+    gfx_draw_line(dpi, {screenCoordLeftTop, screenCoordLeftBottom}, colour);
+    gfx_draw_line(dpi, {screenCoordRightTop, screenCoordRightBottom}, colour);
 
     // top square back
-    gfx_draw_line(dpi, screenCoordBackTop.x, screenCoordBackTop.y, screenCoordLeftTop.x, screenCoordLeftTop.y, colour);
-    gfx_draw_line(dpi, screenCoordBackTop.x, screenCoordBackTop.y, screenCoordRightTop.x, screenCoordRightTop.y, colour);
+    gfx_draw_line(dpi, {screenCoordBackTop, screenCoordLeftTop}, colour);
+    gfx_draw_line(dpi, {screenCoordBackTop, screenCoordRightTop}, colour);
 
     paint_ps_image(dpi, ps, imageId, x, y);
 
     // vertical front
-    gfx_draw_line(
-        dpi, screenCoordFrontTop.x, screenCoordFrontTop.y, screenCoordFrontBottom.x, screenCoordFrontBottom.y, colour);
+    gfx_draw_line(dpi, {screenCoordFrontTop, screenCoordFrontBottom}, colour);
 
     // top square
-    gfx_draw_line(dpi, screenCoordFrontTop.x, screenCoordFrontTop.y, screenCoordLeftTop.x, screenCoordLeftTop.y, colour);
-    gfx_draw_line(dpi, screenCoordFrontTop.x, screenCoordFrontTop.y, screenCoordRightTop.x, screenCoordRightTop.y, colour);
+    gfx_draw_line(dpi, {screenCoordFrontTop, screenCoordLeftTop}, colour);
+    gfx_draw_line(dpi, {screenCoordFrontTop, screenCoordRightTop}, colour);
 }
 
 static void paint_ps_image(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t imageId, int16_t x, int16_t y)


### PR DESCRIPTION
Replace gfx_draw_line to accept a ScreenLine object instead of the coordinates as integers.
I'm not so sure who to test this :/

Closes #12099 
