### PR TITLE
Increase handyman randomness in queue 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.15/objects.zip")
 set(OBJECTS_SHA1 "dfd5864cf7d0449c0fb280c5c6b902a24816df6c")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.14/replays.zip")
-set(REPLAYS_SHA1 "5A0198B4337A43199702F5ED6069161C8A735332")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.15/replays.zip")
+set(REPLAYS_SHA1 "85EBF6760D39FA37BFDEBAA77992CB55A7C8C301")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/contributors.md
+++ b/contributors.md
@@ -87,6 +87,7 @@ The following people are not part of the development team, but have been contrib
 * Chad Ian Anderson (pizza2004) - Added New Game option, bug fixes, misc.
 * Peter Ryszkiewicz (pRizz) - Added horizontal grid lines to finance charts.
 * Hudson Oliveira (hdpoliveira) - Misc.
+* Jim Verheijde (Jimver) - Make handymen less likely to get stuck in queue lines.
 
 ## Bug fixes
 * (halfbro)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,6 +47,7 @@
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.
+- Improved: [#3205] Make handymen less likely to get stuck in ride queues.
 - Technical: [#8110] OpenRCT2 now uses a single directory name for title sequences instead of three.
 - Technical: [#11517] Windows Vista is supported again (libzip regression in the previous release).
 - Technical: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.15/objects.zip</ObjectsUrl>
     <ObjectsSha1>dfd5864cf7d0449c0fb280c5c6b902a24816df6c</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.14/replays.zip</ReplaysUrl>
-    <ReplaysSha1>5A0198B4337A43199702F5ED6069161C8A735332</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.15/replays.zip</ReplaysUrl>
+    <ReplaysSha1>85EBF6760D39FA37BFDEBAA77992CB55A7C8C301</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -643,7 +643,10 @@ bool Staff::DoHandymanPathFinding()
                 bool chooseRandom = true;
                 if (litterDirection != INVALID_DIRECTION && pathDirections & (1 << litterDirection))
                 {
-                    if ((scenario_rand() & 0xFFFF) >= 0x1999)
+                    /// When in a queue path make the probability of following litter much lower
+                    /// as handymen often get stuck when there is litter on a normal path next to a queue they are in
+                    uint32_t chooseRandomProbability = pathElement->IsQueue() ? (0xFFFF - 0x1999) : 0x1999;
+                    if ((scenario_rand() & 0xFFFF) >= chooseRandomProbability)
                     {
                         chooseRandom = false;
                         newDirection = litterDirection;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -643,9 +643,9 @@ bool Staff::DoHandymanPathFinding()
                 bool chooseRandom = true;
                 if (litterDirection != INVALID_DIRECTION && pathDirections & (1 << litterDirection))
                 {
-                    /// When in a queue path make the probability of following litter much lower
+                    /// When in a queue path make the probability of following litter much lower (10% instead of 90%)
                     /// as handymen often get stuck when there is litter on a normal path next to a queue they are in
-                    uint32_t chooseRandomProbability = pathElement->IsQueue() ? (0xFFFF - 0x1999) : 0x1999;
+                    uint32_t chooseRandomProbability = pathElement->IsQueue() ? 0xE666 : 0x1999;
                     if ((scenario_rand() & 0xFFFF) >= chooseRandomProbability)
                     {
                         chooseRandom = false;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -643,9 +643,11 @@ bool Staff::DoHandymanPathFinding()
                 bool chooseRandom = true;
                 if (litterDirection != INVALID_DIRECTION && pathDirections & (1 << litterDirection))
                 {
+                    /// Check whether path is a queue path and connected to a ride
+                    bool connectedQueue = (pathElement->IsQueue() && pathElement->GetRideIndex() != RIDE_ID_NULL);
                     /// When in a queue path make the probability of following litter much lower (10% instead of 90%)
                     /// as handymen often get stuck when there is litter on a normal path next to a queue they are in
-                    uint32_t chooseRandomProbability = pathElement->IsQueue() ? 0xE666 : 0x1999;
+                    uint32_t chooseRandomProbability = connectedQueue ? 0xE666 : 0x1999;
                     if ((scenario_rand() & 0xFFFF) >= chooseRandomProbability)
                     {
                         chooseRandom = false;


### PR DESCRIPTION
As mentioned in #3205 handymen can get stuck in queue lines when there is litter on an adjacent regular path.

This PR fixes this by increasing the chance that handymen will take a random direction instead of following the nearest litter **while in a queue**.

Previously the handyman will always walk the light blue highlighted line over and over. It can take around 30-40 cycles (according to my tests) until it chooses a random direction to break out of the cycle. (see save file below)
![image](https://user-images.githubusercontent.com/7677699/86613608-255a9a00-bfb2-11ea-8d5a-d6809c6ab3ec.png)

I increased this probability of choosing a (valid) random direction while a handyman is in a queue line such that it is much easier for them to break out of the cycle.

Right now I simply invert the probability when on a queue path `1-P(follow litter)`. Maybe there can be a more appropriate value for this. However it seems to work fine as the handyman now already breaks out of the cycle after only 0-2 cycles.

Of course it is not a proper fix but until the AI is reworked (as mentioned in https://github.com/OpenRCT2/OpenRCT2/issues/1999#issuecomment-654285482) this is the most simple thing I can think of which doesn't add too much complexity.

Attached save file below:
[Canyon Calamities-bug4.zip](https://github.com/OpenRCT2/OpenRCT2/files/4879970/Canyon.Calamities-bug4.zip)
