### PR TITLE
Fix #12144: Do not require lint commit to pass to run full CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -78,8 +78,8 @@ jobs:
   windows-mingw:
     name: Windows (win32) using mingw
     runs-on: ubuntu-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-mingw
     steps:
@@ -94,8 +94,8 @@ jobs:
   macos:
     name: macOS
     runs-on: macos-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -124,8 +124,8 @@ jobs:
   linux-portable:
     name: Linux (x64, portable)
     runs-on: ubuntu-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic
     steps:
@@ -160,8 +160,8 @@ jobs:
   linux-portable-32:
     name: Linux (i686, portable)
     runs-on: ubuntu-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic32
     steps:
@@ -201,8 +201,8 @@ jobs:
   linux-appimage:
     name: Linux (x64, AppImage)
     runs-on: ubuntu-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic
     steps:
@@ -224,8 +224,8 @@ jobs:
           path: artifacts
   linux-docker:
     name: Linux (docker)
-    needs: [lint-commit, check-code-formatting]
-    if: github.repository == 'OpenRCT2/OpenRCT2' && needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: github.repository == 'OpenRCT2/OpenRCT2' && needs.check-code-formatting.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Build image
@@ -248,8 +248,8 @@ jobs:
   linux-clang:
     name: Linux (Debug, [http, network, OpenGL] disabled) using clang
     runs-on: ubuntu-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic
     steps:
@@ -261,8 +261,8 @@ jobs:
   android:
     name: Android
     runs-on: ubuntu-latest
-    needs: [lint-commit, check-code-formatting]
-    if: needs.lint-commit.result == 'success' && needs.check-code-formatting.result == 'success'
+    needs: [check-code-formatting]
+    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-android
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     name: Windows
     runs-on: windows-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +78,6 @@ jobs:
     name: Windows (win32) using mingw
     runs-on: ubuntu-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-mingw
     steps:
@@ -95,7 +93,6 @@ jobs:
     name: macOS
     runs-on: macos-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -125,7 +122,6 @@ jobs:
     name: Linux (x64, portable)
     runs-on: ubuntu-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic
     steps:
@@ -161,7 +157,6 @@ jobs:
     name: Linux (i686, portable)
     runs-on: ubuntu-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic32
     steps:
@@ -202,7 +197,6 @@ jobs:
     name: Linux (x64, AppImage)
     runs-on: ubuntu-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic
     steps:
@@ -225,7 +219,7 @@ jobs:
   linux-docker:
     name: Linux (docker)
     needs: [check-code-formatting]
-    if: github.repository == 'OpenRCT2/OpenRCT2' && needs.check-code-formatting.result == 'success'
+    if: github.repository == 'OpenRCT2/OpenRCT2'
     runs-on: ubuntu-latest
     steps:
       - name: Build image
@@ -249,7 +243,6 @@ jobs:
     name: Linux (Debug, [http, network, OpenGL] disabled) using clang
     runs-on: ubuntu-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-bionic
     steps:
@@ -262,7 +255,6 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: [check-code-formatting]
-    if: needs.check-code-formatting.result == 'success'
     container:
       image: openrct2/openrct2-build:0.2.4-android
     steps:


### PR DESCRIPTION
~I kept the requirement of it to still run first, it is just not checking the result anymore~

~PS: I did a long commit message intentionally to double check it works, will reword and force push once it is confirmed.~

Turns out that `needs` already requires the jobs before it to be successful [\[1\]][1], so I simplified the CI script in another commit:
> Identifies any jobs that must complete successfully before this job will run. It can be a string or array of strings. If a job fails, all jobs that need it are skipped unless the jobs use a conditional statement that causes the job to continue.

[1]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds