### PR TITLE
Use only ScreenCoordsXY for Text.cpp

### DIFF
--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -31,7 +31,7 @@ StaticLayout::StaticLayout(utf8string source, TextPaint paint, int32_t width)
     LineHeight = font_get_line_height(fontSpriteBase);
 }
 
-void StaticLayout::Draw(rct_drawpixelinfo* dpi, int32_t x, int32_t y)
+void StaticLayout::Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords)
 {
     gCurrentFontFlags = 0;
     gCurrentFontSpriteBase = Paint.SpriteBase;
@@ -39,27 +39,25 @@ void StaticLayout::Draw(rct_drawpixelinfo* dpi, int32_t x, int32_t y)
     TextPaint tempPaint = Paint;
 
     gCurrentFontFlags = 0;
-    int32_t lineY = y;
-    int32_t lineX = x;
+    auto lineCoords = coords;
     switch (Paint.Alignment)
     {
         case TextAlignment::LEFT:
-            lineX = x;
             break;
         case TextAlignment::CENTRE:
-            lineX = x + MaxWidth / 2;
+            lineCoords.x += MaxWidth / 2;
             break;
         case TextAlignment::RIGHT:
-            lineX = x + MaxWidth;
+            lineCoords.x += MaxWidth;
             break;
     }
     utf8* buffer = Buffer;
     for (int32_t line = 0; line < LineCount; ++line)
     {
-        DrawText(dpi, { lineX, lineY }, &tempPaint, buffer);
+        DrawText(dpi, lineCoords, &tempPaint, buffer);
         tempPaint.Colour = TEXT_COLOUR_254;
         buffer = get_string_end(buffer) + 1;
-        lineY += LineHeight;
+        lineCoords.y += LineHeight;
     }
 }
 
@@ -227,7 +225,7 @@ int32_t gfx_draw_string_left_wrapped(
     _legacyPaint.SpriteBase = gCurrentFontSpriteBase;
 
     StaticLayout layout(buffer, _legacyPaint, width);
-    layout.Draw(dpi, coords.x, coords.y);
+    layout.Draw(dpi, coords);
 
     return layout.GetHeight();
 }
@@ -252,7 +250,7 @@ int32_t gfx_draw_string_centred_wrapped(
     int32_t lineHeight = layout.GetHeight() / lineCount;
     int32_t yOffset = (lineCount - 1) * lineHeight / 2;
 
-    layout.Draw(dpi, coords.x - layout.GetWidth() / 2, coords.y - yOffset);
+    layout.Draw(dpi, coords - ScreenCoordsXY{ layout.GetWidth() / 2, yOffset });
 
     return layout.GetHeight();
 }

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -119,7 +119,7 @@ static void DrawText(
 }
 
 static void DrawTextCompat(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, rct_string_id format, const void* args, uint8_t colour,
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, uint8_t colour,
     TextAlignment alignment, bool underline = false)
 {
     _legacyPaint.UnderlineText = underline;
@@ -127,7 +127,7 @@ static void DrawTextCompat(
     _legacyPaint.Alignment = alignment;
     _legacyPaint.SpriteBase = FONT_SPRITE_BASE_MEDIUM;
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    DrawText(dpi, { x, y }, &_legacyPaint, format, args);
+    DrawText(dpi, coords, &_legacyPaint, format, args);
 }
 
 static void DrawTextEllipsisedCompat(
@@ -160,37 +160,37 @@ void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t co
 void gfx_draw_string_left(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::LEFT);
+    DrawTextCompat(dpi, coords, format, args, colour, TextAlignment::LEFT);
 }
 
 void gfx_draw_string_centred(
     rct_drawpixelinfo* dpi, rct_string_id format, const ScreenCoordsXY& coords, uint8_t colour, const void* args)
 {
-    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::CENTRE);
+    DrawTextCompat(dpi, coords, format, args, colour, TextAlignment::CENTRE);
 }
 
 void gfx_draw_string_right(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::RIGHT);
+    DrawTextCompat(dpi, coords, format, args, colour, TextAlignment::RIGHT);
 }
 // Underline
 void draw_string_left_underline(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::LEFT, true);
+    DrawTextCompat(dpi, coords, format, args, colour, TextAlignment::LEFT, true);
 }
 
 void draw_string_centred_underline(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::CENTRE, true);
+    DrawTextCompat(dpi, coords, format, args, colour, TextAlignment::CENTRE, true);
 }
 
 void draw_string_right_underline(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    DrawTextCompat(dpi, coords.x, coords.y, format, args, colour, TextAlignment::RIGHT, true);
+    DrawTextCompat(dpi, coords, format, args, colour, TextAlignment::RIGHT, true);
 }
 
 // Ellipsised

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -131,7 +131,7 @@ static void DrawTextCompat(
 }
 
 static void DrawTextEllipsisedCompat(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t width, rct_string_id format, void* args, uint8_t colour,
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, void* args, uint8_t colour,
     TextAlignment alignment, bool underline = false)
 {
     _legacyPaint.UnderlineText = underline;
@@ -144,7 +144,7 @@ static void DrawTextEllipsisedCompat(
     format_string(buffer, sizeof(buffer), format, args);
     gfx_clip_string(buffer, width);
 
-    DrawText(dpi, { x, y }, &_legacyPaint, buffer);
+    DrawText(dpi, coords, &_legacyPaint, buffer);
 }
 
 void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords)
@@ -197,19 +197,19 @@ void draw_string_right_underline(
 void gfx_draw_string_left_clipped(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width)
 {
-    DrawTextEllipsisedCompat(dpi, coords.x, coords.y, width, format, args, colour, TextAlignment::LEFT);
+    DrawTextEllipsisedCompat(dpi, coords, width, format, args, colour, TextAlignment::LEFT);
 }
 
 void gfx_draw_string_centred_clipped(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width)
 {
-    DrawTextEllipsisedCompat(dpi, coords.x, coords.y, width, format, args, colour, TextAlignment::CENTRE);
+    DrawTextEllipsisedCompat(dpi, coords, width, format, args, colour, TextAlignment::CENTRE);
 }
 
 void gfx_draw_string_right_clipped(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords, int32_t width)
 {
-    DrawTextEllipsisedCompat(dpi, coords.x, coords.y, width, format, args, colour, TextAlignment::RIGHT);
+    DrawTextEllipsisedCompat(dpi, coords, width, format, args, colour, TextAlignment::RIGHT);
 }
 
 // Wrapping

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 
+struct ScreenCoordsXY;
 struct rct_drawpixelinfo;
 
 enum class TextAlignment
@@ -42,7 +43,7 @@ private:
 
 public:
     StaticLayout(utf8string source, TextPaint paint, int32_t width);
-    void Draw(rct_drawpixelinfo* dpi, int32_t x, int32_t y);
+    void Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords);
     int32_t GetHeight();
     int32_t GetWidth();
     int32_t GetLineCount();


### PR DESCRIPTION
Now that most of the callers of these functions are using `ScreenCoordsXY`, it makes sense to change them too and probably reap some benefit.