### PR TITLE
Use big Z coords on some Ride station functions

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -7225,7 +7225,7 @@ TileElement* get_station_platform(int32_t x, int32_t y, int32_t z, int32_t z_tol
             if (!tileElement->AsTrack()->IsStation())
                 continue;
 
-            if (z - z_tolerance > tileElement->base_height || z + z_tolerance < tileElement->base_height)
+            if (z - z_tolerance > tileElement->GetBaseZ() || z + z_tolerance < tileElement->GetBaseZ())
             {
                 /* The base height if tileElement is not within
                  * the z tolerance. */
@@ -7256,7 +7256,7 @@ static bool check_for_adjacent_station(int32_t x, int32_t y, int32_t z, uint8_t 
     {
         adjX += CoordsDirectionDelta[direction].x;
         adjY += CoordsDirectionDelta[direction].y;
-        TileElement* stationElement = get_station_platform(adjX, adjY, z, 2);
+        TileElement* stationElement = get_station_platform(adjX, adjY, z, 2 * COORDS_Z_STEP);
         if (stationElement != nullptr)
         {
             auto rideIndex = stationElement->AsTrack()->GetRideIndex();
@@ -7281,25 +7281,23 @@ bool ride_has_adjacent_station(Ride* ride)
      * adjacent station on either side. */
     for (StationIndex stationNum = 0; stationNum < MAX_STATIONS; stationNum++)
     {
-        auto stationStart = ride->stations[stationNum].Start;
+        auto stationStart = ride->stations[stationNum].GetStart();
         if (!stationStart.isNull())
         {
             /* Get the map element for the station start. */
-            auto stationZ = ride->stations[stationNum].Height;
-
-            TileElement* stationElement = get_station_platform(stationStart.x, stationStart.y, stationZ, 0);
+            TileElement* stationElement = get_station_platform(stationStart.x, stationStart.y, stationStart.z, 0);
             if (stationElement == nullptr)
             {
                 continue;
             }
             /* Check the first side of the station */
             int32_t direction = stationElement->GetDirectionWithOffset(1);
-            found = check_for_adjacent_station(stationStart.x, stationStart.y, stationZ, direction);
+            found = check_for_adjacent_station(stationStart.x, stationStart.y, stationStart.z, direction);
             if (found)
                 break;
             /* Check the other side of the station */
             direction = direction_reverse(direction);
-            found = check_for_adjacent_station(stationStart.x, stationStart.y, stationZ, direction);
+            found = check_for_adjacent_station(stationStart.x, stationStart.y, stationStart.z, direction);
             if (found)
                 break;
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2698,7 +2698,7 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
         return false;
     }
 
-    TileElement* tileElement = get_station_platform(coords.x, coords.y, coords.z, 2);
+    TileElement* tileElement = get_station_platform(coords.x, coords.y, coords.z, 2 * COORDS_Z_STEP);
     if (tileElement == nullptr)
     {
         /* No station platform element found,
@@ -2792,9 +2792,6 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
 static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex station)
 {
     auto location = ride.stations[station].GetStart();
-    int32_t x = location.x;
-    int32_t y = location.y;
-    int32_t z = ride.stations[station].Height;
 
     auto tileElement = map_get_track_element_at(location);
     if (tileElement == nullptr)
@@ -2817,9 +2814,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
     spaceBetween = maxCheckDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1])
     {
-        x += CoordsDirectionDelta[direction].x;
-        y += CoordsDirectionDelta[direction].y;
-        if (try_add_synchronised_station({ x, y, z }))
+        if (try_add_synchronised_station(location + CoordsXYZ{ CoordsDirectionDelta[direction], 0 }))
         {
             spaceBetween = maxCheckDistance;
             continue;
@@ -2830,18 +2825,12 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
         }
     }
 
-    // Reset back to starting tile.
-    x = location.x;
-    y = location.y;
-
     // Other search direction.
     direction = direction_reverse(direction) & 3;
     spaceBetween = maxCheckDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1])
     {
-        x += CoordsDirectionDelta[direction].x;
-        y += CoordsDirectionDelta[direction].y;
-        if (try_add_synchronised_station({ x, y, z }))
+        if (try_add_synchronised_station(location + CoordsXYZ{ CoordsDirectionDelta[direction], 0 }))
         {
             spaceBetween = maxCheckDistance;
             continue;


### PR DESCRIPTION
This was pointed out by @duncanspumpkin on #12171 and #12182 . Note that these PRs themselves don't introduce the error, but they do make it harder to detect

FYI @heliobatimarqui we have two coordinates representations, which we joyfully call "big coords" and "small coords", respectively `CoordsXY(Z)` and `TileCoordsXY(Z)`. If you look closely at `TileCoordsXYZ`, you'll see it converts itself into `CoordsXYZ` by doing a multiplication:
https://github.com/OpenRCT2/OpenRCT2/blob/36c9259a5f867efa4c62259d37d246268eff2d39/src/openrct2/world/Location.hpp#L444

So when we convert to `CoordsXYZ`, we expect all coordinates it holds to be either all "big coords" or all "small coords", which was not happening where Duncan pointed out.