### PR TITLE
Fix issue with korean file paths

### DIFF
--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -94,7 +94,8 @@ namespace Platform
 
     bool FileExists(const std::string path)
     {
-        fs::path file = path;
+        fs::path file = fs::u8path(path);
+        log_verbose("Checking if file exists: %s", path.c_str());
         return fs::exists(file);
     }
 } // namespace Platform


### PR DESCRIPTION
fs::path incorrectly interpreted the type of std::string to require no conversion for the filesystem.
This is fixed by using the u8path function.
Will need to keep this in mind as more functions start to use the std::filesystem.