### PR TITLE
Fix load game showing edge of map

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -543,6 +543,7 @@ void viewport_update_position(rct_window* window)
 
     viewport_set_underground_flag(0, window, viewport);
 
+    // The midpoint relies on the overflow of int16_t to properly load a save on midscreen
     auto viewportMidPoint = ScreenCoordsXY{ static_cast<int16_t>(window->savedViewPos.x + viewport->view_width / 2),
                                             static_cast<int16_t>(window->savedViewPos.y + viewport->view_height / 2) };
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -543,8 +543,8 @@ void viewport_update_position(rct_window* window)
 
     viewport_set_underground_flag(0, window, viewport);
 
-    auto viewportMidPoint = ScreenCoordsXY{ window->savedViewPos.x + viewport->view_width / 2,
-                                            window->savedViewPos.y + viewport->view_height / 2 };
+    auto viewportMidPoint = ScreenCoordsXY{ static_cast<int16_t>(window->savedViewPos.x + viewport->view_width / 2),
+                                            static_cast<int16_t>(window->savedViewPos.y + viewport->view_height / 2) };
 
     auto mapCoord = viewport_coord_to_map_coord(viewportMidPoint.x, viewportMidPoint.y, 0);
 


### PR DESCRIPTION
Introduced by @frutiemax 's https://github.com/OpenRCT2/OpenRCT2/commit/805eec41537b9b3da6cca21f75f8204ea4863587

The code was saving to `int16_t` and when it stopped doing so, the game started loading maps into their edge. Relying on the overflow seems like a very weird thing here, which I haven't investigated yet, but seems to be wrong anyway. 

I've added the casts temporarily so we don't break the behavior