### PR TITLE
Fix: Map Generator shows incorrect map sizes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -44,6 +44,7 @@
 - Fix: [#12068] Incorrect Entrance/Exit location on track design preview. Incorrect track design previews with track that contain diagonal track elements.
 - Fix: [#12093] Staff window tab animation was no longer updating.
 - Fix: [#12123] Long server descriptions are not cut off properly.
+- Fix: [#12211] Map Generator shows incorrect map sizes (e.g. "150 x 0").
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -787,7 +787,8 @@ static void window_mapgen_base_paint(rct_window* w, rct_drawpixelinfo* dpi)
         w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_FLOOR_TEXTURE].top + 1 });
 
     // The practical map size is 2 lower than the technical map size
-    TileCoordsXY mapSizeArgs = { _mapSize - 2, _mapSize - 2 };
+    // This needs to be cast down to a uint16_t because that's what the STR_RESOLUTION_X_BY_Y string takes.
+    uint16_t mapSizeArgs[] = { static_cast<uint16_t>(_mapSize - 2), static_cast<uint16_t>(_mapSize - 2) };
     gfx_draw_string_left(
         dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, w->colours[1],
         w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_MAP_SIZE].left + 1, w->widgets[WIDX_MAP_SIZE].top + 1 });
@@ -1130,8 +1131,9 @@ static void window_mapgen_simplex_paint(rct_window* w, rct_drawpixelinfo* dpi)
         dpi, STR_MAPGEN_OPTION_PLACE_TREES, nullptr, textColour,
         w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_PLACE_TREES_CHECKBOX].top + 1 });
 
-    // The practical map size is 2 lower than the technical map size
-    TileCoordsXY mapSizeArgs = { _mapSize - 2, _mapSize - 2 };
+    // The practical map size is 2 lower than the technical map size.
+    // This needs to be cast down to a uint16_t because that's what the STR_RESOLUTION_X_BY_Y string takes.
+    uint16_t mapSizeArgs[] = { static_cast<uint16_t>(_mapSize - 2), static_cast<uint16_t>(_mapSize - 2) };
     gfx_draw_string_left(
         dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, textColour,
         w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_MAP_SIZE].left + 1, w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1 });


### PR DESCRIPTION
I added a changelog entry because this issue has been in the game from December 2019.