### PR TITLE
Refactor widget definitions

### DIFF
--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -35,12 +35,12 @@ static constexpr const int32_t WH = 94;
 
 static rct_widget window_clear_scenery_widgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    { WWT_IMGBTN,   0,  27, 70, 17, 48, SPR_LAND_TOOL_SIZE_0,                       STR_NONE },                         // preview box
-    { WWT_TRNBTN,   1,  28, 43, 18, 33, IMAGE_TYPE_REMAP | SPR_LAND_TOOL_DECREASE,        STR_ADJUST_SMALLER_LAND_TIP },      // decrement size
-    { WWT_TRNBTN,   1,  54, 69, 32, 47, IMAGE_TYPE_REMAP | SPR_LAND_TOOL_INCREASE,        STR_ADJUST_LARGER_LAND_TIP },       // increment size
-    { WWT_FLATBTN,  1,  7,  30, 53, 76, IMAGE_TYPE_REMAP | SPR_G2_BUTTON_TREES,           STR_CLEAR_SCENERY_REMOVE_SMALL_SCENERY_TIP }, // small scenery
-    { WWT_FLATBTN,  1,  37, 60, 53, 76, IMAGE_TYPE_REMAP | SPR_G2_BUTTON_LARGE_SCENERY,   STR_CLEAR_SCENERY_REMOVE_LARGE_SCENERY_TIP }, // large scenery
-    { WWT_FLATBTN,  1,  67, 90, 53, 76, IMAGE_TYPE_REMAP | SPR_G2_BUTTON_FOOTPATH,        STR_CLEAR_SCENERY_REMOVE_FOOTPATHS_TIP }, // footpaths
+    MakeWidget     ({27, 17}, {44, 32}, WWT_IMGBTN,  0, SPR_LAND_TOOL_SIZE_0,        STR_NONE),                                   // preview box
+    MakeRemapWidget({28, 18}, {16, 16}, WWT_TRNBTN,  1, SPR_LAND_TOOL_DECREASE,      STR_ADJUST_SMALLER_LAND_TIP),                // decrement size
+    MakeRemapWidget({54, 32}, {16, 16}, WWT_TRNBTN,  1, SPR_LAND_TOOL_INCREASE,      STR_ADJUST_LARGER_LAND_TIP),                 // increment size
+    MakeRemapWidget({ 7, 53}, {24, 24}, WWT_FLATBTN, 1, SPR_G2_BUTTON_TREES,         STR_CLEAR_SCENERY_REMOVE_SMALL_SCENERY_TIP), // small scenery
+    MakeRemapWidget({37, 53}, {24, 24}, WWT_FLATBTN, 1, SPR_G2_BUTTON_LARGE_SCENERY, STR_CLEAR_SCENERY_REMOVE_LARGE_SCENERY_TIP), // large scenery
+    MakeRemapWidget({67, 53}, {24, 24}, WWT_FLATBTN, 1, SPR_G2_BUTTON_FOOTPATH,      STR_CLEAR_SCENERY_REMOVE_FOOTPATHS_TIP),     // footpaths
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -43,16 +43,13 @@ enum WINDOW_LAND_WIDGET_IDX {
 
 static rct_widget window_land_widgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-
-    { WWT_FLATBTN,  1,  19, 42, 19, 42,         SPR_RIDE_CONSTRUCTION_SLOPE_UP,         STR_ENABLE_MOUNTAIN_TOOL_TIP }, // mountain mode
-    { WWT_FLATBTN,  1,  55, 78, 19, 42,         SPR_PAINTBRUSH,                         STR_DISABLE_ELEVATION },        // paint mode
-
-    { WWT_IMGBTN,   0,  27, 70, 48, 79,         SPR_LAND_TOOL_SIZE_0,                   STR_NONE },                     // preview box
-    { WWT_TRNBTN,   1,  28, 43, 49, 64,         IMAGE_TYPE_REMAP | SPR_LAND_TOOL_DECREASE,    STR_ADJUST_SMALLER_LAND_TIP },  // decrement size
-    { WWT_TRNBTN,   1,  54, 69, 63, 78,         IMAGE_TYPE_REMAP | SPR_LAND_TOOL_INCREASE,    STR_ADJUST_LARGER_LAND_TIP },   // increment size
-
-    { WWT_FLATBTN,  1,  2,  48, 106,    141,    0xFFFFFFFF,                             STR_CHANGE_BASE_LAND_TIP },     // floor texture
-    { WWT_FLATBTN,  1,  49, 95, 106,    141,    0xFFFFFFFF,                             STR_CHANGE_VERTICAL_LAND_TIP }, // wall texture
+    MakeWidget     ({19,  19}, {24, 24}, WWT_FLATBTN, 1, SPR_RIDE_CONSTRUCTION_SLOPE_UP, STR_ENABLE_MOUNTAIN_TOOL_TIP), // mountain mode
+    MakeWidget     ({55,  19}, {24, 24}, WWT_FLATBTN, 1, SPR_PAINTBRUSH,                 STR_DISABLE_ELEVATION),        // paint mode
+    MakeWidget     ({27,  48}, {44, 32}, WWT_IMGBTN,  0, SPR_LAND_TOOL_SIZE_0,           STR_NONE),                     // preview box
+    MakeRemapWidget({28,  49}, {16, 16}, WWT_TRNBTN,  1, SPR_LAND_TOOL_DECREASE,         STR_ADJUST_SMALLER_LAND_TIP),  // decrement size
+    MakeRemapWidget({54,  63}, {16, 16}, WWT_TRNBTN,  1, SPR_LAND_TOOL_INCREASE,         STR_ADJUST_LARGER_LAND_TIP),   // increment size
+    MakeWidget     ({ 2, 106}, {47, 36}, WWT_FLATBTN, 1, 0xFFFFFFFF,                     STR_CHANGE_BASE_LAND_TIP),     // floor texture
+    MakeWidget     ({49, 106}, {47, 36}, WWT_FLATBTN, 1, 0xFFFFFFFF,                     STR_CHANGE_VERTICAL_LAND_TIP), // wall texture
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -32,9 +32,9 @@ enum WINDOW_WATER_WIDGET_IDX {
 
 static rct_widget window_water_widgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    { WWT_IMGBTN,   0,  16, 59, 17, 48, SPR_LAND_TOOL_SIZE_0,                   STR_NONE },                         // preview box
-    { WWT_TRNBTN,   2,  17, 32, 18, 33, IMAGE_TYPE_REMAP | SPR_LAND_TOOL_DECREASE,    STR_ADJUST_SMALLER_WATER_TIP },     // decrement size
-    { WWT_TRNBTN,   2,  43, 58, 32, 47, IMAGE_TYPE_REMAP | SPR_LAND_TOOL_INCREASE,    STR_ADJUST_LARGER_WATER_TIP },      // increment size
+    MakeWidget     ({16, 17}, {44, 32}, WWT_IMGBTN, 0, SPR_LAND_TOOL_SIZE_0,   STR_NONE),                     // preview box
+    MakeRemapWidget({17, 18}, {16, 16}, WWT_TRNBTN, 2, SPR_LAND_TOOL_DECREASE, STR_ADJUST_SMALLER_WATER_TIP), // decrement size
+    MakeRemapWidget({43, 32}, {16, 16}, WWT_TRNBTN, 2, SPR_LAND_TOOL_INCREASE, STR_ADJUST_LARGER_WATER_TIP),  // increment size
     { WIDGETS_END },
 };
 

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -10,6 +10,7 @@
 #ifndef _WIDGET_H_
 #define _WIDGET_H_
 
+#include "../localisation/StringIds.h"
 #include "Window.h"
 
 enum WINDOW_WIDGET_TYPES
@@ -59,6 +60,57 @@ enum
 };
 
 constexpr uint8_t SCROLLBAR_WIDTH = 10;
+
+constexpr rct_widget MakeWidget(
+    ScreenCoordsXY origin, ScreenSize size, uint8_t type, uint8_t colour, uint32_t content = 0xFFFFFFFF,
+    rct_string_id tooltip = STR_NONE)
+{
+    rct_widget out = {};
+    out.left = origin.x;
+    out.right = origin.x + size.width - 1;
+    out.top = origin.y;
+    out.bottom = origin.y + size.height - 1;
+    out.type = type;
+    out.colour = colour;
+    out.content = content;
+    out.tooltip = tooltip;
+
+    return out;
+}
+
+constexpr rct_widget MakeRemapWidget(
+    ScreenCoordsXY origin, ScreenSize size, uint8_t type, uint8_t colour, uint32_t content = 0xFFFFFFFF,
+    rct_string_id tooltip = STR_NONE)
+{
+    return MakeWidget(origin, size, type, colour, IMAGE_TYPE_REMAP | content, tooltip);
+}
+
+#define MakeSpinnerWidgets(...)                                                                                                \
+    MakeWidget(__VA_ARGS__), MakeSpinnerDecreaseWidget(__VA_ARGS__), MakeSpinnerIncreaseWidget(__VA_ARGS__)
+
+constexpr rct_widget MakeSpinnerDecreaseWidget(
+    ScreenCoordsXY origin, ScreenSize size, [[maybe_unused]] uint8_t type, uint8_t colour,
+    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, rct_string_id tooltip = STR_NONE)
+{
+    const int16_t xPos = origin.x + size.width - 25;
+    const int16_t yPos = origin.y + 1;
+    const uint16_t width = 12;
+    const uint16_t height = size.height - 2;
+
+    return MakeWidget({ xPos, yPos }, { width, height }, WWT_BUTTON, colour, STR_NUMERIC_DOWN, tooltip);
+}
+
+constexpr rct_widget MakeSpinnerIncreaseWidget(
+    ScreenCoordsXY origin, ScreenSize size, [[maybe_unused]] uint8_t type, uint8_t colour,
+    [[maybe_unused]] uint32_t content = 0xFFFFFFFF, rct_string_id tooltip = STR_NONE)
+{
+    const int16_t xPos = origin.x + size.width - 13;
+    const int16_t yPos = origin.y + 1;
+    const uint16_t width = 12;
+    const uint16_t height = size.height - 2;
+
+    return MakeWidget({ xPos, yPos }, { width, height }, WWT_BUTTON, colour, STR_NUMERIC_UP, tooltip);
+}
 
 void widget_scroll_update_thumbs(rct_window* w, rct_widgetindex widget_index);
 void widget_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -62,7 +62,7 @@ enum
 constexpr uint8_t SCROLLBAR_WIDTH = 10;
 
 constexpr rct_widget MakeWidget(
-    ScreenCoordsXY origin, ScreenSize size, uint8_t type, uint8_t colour, uint32_t content = 0xFFFFFFFF,
+    const ScreenCoordsXY& origin, const ScreenSize& size, uint8_t type, uint8_t colour, uint32_t content = 0xFFFFFFFF,
     rct_string_id tooltip = STR_NONE)
 {
     rct_widget out = {};
@@ -79,7 +79,7 @@ constexpr rct_widget MakeWidget(
 }
 
 constexpr rct_widget MakeRemapWidget(
-    ScreenCoordsXY origin, ScreenSize size, uint8_t type, uint8_t colour, uint32_t content = 0xFFFFFFFF,
+    const ScreenCoordsXY& origin, const ScreenSize& size, uint8_t type, uint8_t colour, uint32_t content = 0xFFFFFFFF,
     rct_string_id tooltip = STR_NONE)
 {
     return MakeWidget(origin, size, type, colour, IMAGE_TYPE_REMAP | content, tooltip);
@@ -89,7 +89,7 @@ constexpr rct_widget MakeRemapWidget(
     MakeWidget(__VA_ARGS__), MakeSpinnerDecreaseWidget(__VA_ARGS__), MakeSpinnerIncreaseWidget(__VA_ARGS__)
 
 constexpr rct_widget MakeSpinnerDecreaseWidget(
-    ScreenCoordsXY origin, ScreenSize size, [[maybe_unused]] uint8_t type, uint8_t colour,
+    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] uint8_t type, uint8_t colour,
     [[maybe_unused]] uint32_t content = 0xFFFFFFFF, rct_string_id tooltip = STR_NONE)
 {
     const int16_t xPos = origin.x + size.width - 25;
@@ -101,7 +101,7 @@ constexpr rct_widget MakeSpinnerDecreaseWidget(
 }
 
 constexpr rct_widget MakeSpinnerIncreaseWidget(
-    ScreenCoordsXY origin, ScreenSize size, [[maybe_unused]] uint8_t type, uint8_t colour,
+    const ScreenCoordsXY& origin, const ScreenSize& size, [[maybe_unused]] uint8_t type, uint8_t colour,
     [[maybe_unused]] uint32_t content = 0xFFFFFFFF, rct_string_id tooltip = STR_NONE)
 {
     const int16_t xPos = origin.x + size.width - 13;


### PR DESCRIPTION
Recently, there has been a discussion about the way we define widgets internally. Currently, they use four parameters with absolute positions (top, bottom, left, right). With this PR, I propose to change this to the way we do this in OpenLoco: one parameter for position (x, y) and dimensions (x, y).

Streamlining widgets throughout all windows will require quite a bit of refactoring. Generally, it's best to separate changing the underlying structure from the desired end result. I therefore propose we change all this with an intermediary function before we change the actual widget structure. 

The way I picture this, is to introduce a constexpr `MakeWidget` function that replaces the current 'hardcoded' widget definitions. This way, we don't have to change the widget structure yet ­— we can first focus on defining widgets 'new style' in our widget lists. I have [written a Python script](https://gist.github.com/AaronVanGeffen/fb2e5bf4612ca157cd8a29c2e09c6820) to assist in the conversion.

Aside from the `MakeWidget` function, I have also added a helper function `MakeRemapWidget`, which adds the `IMAGE_TYPE_REMAP` flag, as well as `MakeSpinnerWidgets`, which replaces the current `SPINNER_WIDGETS` macro. We can discuss their names; nothing here is set in stone.

For this PR, I have changed the widget definitions for the three terraforming tools: the clear scenery window, land tool, and water tool windows. This gives us a few concrete examples to talk about; I imagine there might be some discussion about how the new definitions should be ordered or formatted.

I hope this change will make it much easier to add and move widgets around. Personally, I also hope it will remove the need for many of the macros in the cheats and tile inspector windows, too. However, tackling those is beyond the scope of what I aim to achieve with this first PR.