### PR TITLE
Fix #12213. Incorrect viewport invalidation on load.

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -543,9 +543,8 @@ void viewport_update_position(rct_window* window)
 
     viewport_set_underground_flag(0, window, viewport);
 
-    // The midpoint relies on the overflow of int16_t to properly load a save on midscreen
-    auto viewportMidPoint = ScreenCoordsXY{ static_cast<int16_t>(window->savedViewPos.x + viewport->view_width / 2),
-                                            static_cast<int16_t>(window->savedViewPos.y + viewport->view_height / 2) };
+    auto viewportMidPoint = ScreenCoordsXY{ window->savedViewPos.x + viewport->view_width / 2,
+                                            window->savedViewPos.y + viewport->view_height / 2 };
 
     auto mapCoord = viewport_coord_to_map_coord(viewportMidPoint, 0);
 

--- a/src/openrct2/scenario/Scenario.h
+++ b/src/openrct2/scenario/Scenario.h
@@ -256,8 +256,8 @@ struct rct_s6_data
     uint32_t game_ticks_1;
     rct2_ride rides[RCT12_MAX_RIDES_IN_PARK];
     uint16_t saved_age;
-    uint16_t saved_view_x;
-    uint16_t saved_view_y;
+    int16_t saved_view_x;
+    int16_t saved_view_y;
     uint8_t saved_view_zoom;
     uint8_t saved_view_rotation;
     RCT12MapAnimation map_animations[RCT2_MAX_ANIMATED_OBJECTS];


### PR DESCRIPTION
Fix #12213. Incorrect viewport invalidation on load

Mistake made during implementation but issue only surfaces recently when the types were increased to 32bit. Removed #12210 as this was hiding the source issue and is no longer required