### PR TITLE
Add missing header

### DIFF
--- a/src/openrct2/rct2/SeaDecrypt.cpp
+++ b/src/openrct2/rct2/SeaDecrypt.cpp
@@ -13,6 +13,7 @@
 #include "RCT2.h"
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <string_view>
 


### PR DESCRIPTION
std::memcpy is defined in <cstring>. The Docker CI would fail because this header was not included.