### PR TITLE
Fix #12257: Fix refactoring of is_sprite_interacted_with_palette_set

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1451,8 +1451,8 @@ static bool is_sprite_interacted_with_palette_set(
     }
 
     int32_t round = std::max(1, 1 * dpi->zoom_level);
-    auto origin = coords;
 
+    auto origin = coords;
     if (g1->flags & G1_FLAG_RLE_COMPRESSION)
     {
         origin.y -= (round - 1);
@@ -1614,8 +1614,7 @@ InteractionInfo set_interaction_info_from_paint_session(paint_session* session, 
 
         for (attached_paint_struct* attached_ps = ps->attached_ps; attached_ps != nullptr; attached_ps = attached_ps->next)
         {
-            if (is_sprite_interacted_with(
-                    dpi, attached_ps->image_id, { (attached_ps->x + ps->x) & 0xFFFF, (attached_ps->y + ps->y) & 0xFFFF }))
+            if (is_sprite_interacted_with(dpi, attached_ps->image_id, { (attached_ps->x + ps->x), (attached_ps->y + ps->y) }))
             {
                 if (PSSpriteTypeIsInFilter(ps, filter))
                 {

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -522,8 +522,7 @@ static void paint_attached_ps(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t
     attached_paint_struct* attached_ps = ps->attached_ps;
     for (; attached_ps; attached_ps = attached_ps->next)
     {
-        auto screenCoords = ScreenCoordsXY{ attached_ps->x + static_cast<int16_t>(ps->x),
-                                            attached_ps->y + static_cast<int16_t>(ps->y) };
+        auto screenCoords = ScreenCoordsXY{ attached_ps->x + ps->x, attached_ps->y + ps->y };
 
         uint32_t imageId = paint_ps_colourify_image(attached_ps->image_id, ps->sprite_type, viewFlags);
         if (attached_ps->flags & PAINT_STRUCT_FLAG_IS_MASKED)
@@ -995,7 +994,7 @@ paint_struct* sub_98199C(
  * @param y (cx)
  * @return (!CF) success
  */
-bool paint_attach_to_previous_attach(paint_session* session, uint32_t image_id, uint16_t x, uint16_t y)
+bool paint_attach_to_previous_attach(paint_session* session, uint32_t image_id, int16_t x, int16_t y)
 {
     if (session->UnkF1AD2C == nullptr)
     {
@@ -1032,7 +1031,7 @@ bool paint_attach_to_previous_attach(paint_session* session, uint32_t image_id, 
  * @param y (cx)
  * @return (!CF) success
  */
-bool paint_attach_to_previous_ps(paint_session* session, uint32_t image_id, uint16_t x, uint16_t y)
+bool paint_attach_to_previous_ps(paint_session* session, uint32_t image_id, int16_t x, int16_t y)
 {
     if (session->NextFreePaintStruct >= session->EndOfPaintStructArray)
     {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -27,8 +27,8 @@ struct attached_paint_struct
         // If masked image_id is masked_id
         uint32_t colour_image_id;
     };
-    uint16_t x;    // 0x08
-    uint16_t y;    // 0x0A
+    int32_t x;     // 0x08
+    int32_t y;     // 0x0A
     uint8_t flags; // 0x0C
     uint8_t pad_0D;
     attached_paint_struct* next; // 0x0E
@@ -66,8 +66,8 @@ struct paint_struct
         uint32_t colour_image_id; // 0x04
     };
     paint_struct_bound_box bounds; // 0x08
-    uint16_t x;                    // 0x14
-    uint16_t y;                    // 0x16
+    int32_t x;                     // 0x14
+    int32_t y;                     // 0x16*/
     uint16_t quadrant_index;
     uint8_t flags;
     uint8_t quadrant_flags;

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -27,8 +27,8 @@ struct attached_paint_struct
         // If masked image_id is masked_id
         uint32_t colour_image_id;
     };
-    int32_t x;     // 0x08
-    int32_t y;     // 0x0A
+    int16_t x;     // 0x08
+    int16_t y;     // 0x0A
     uint8_t flags; // 0x0C
     uint8_t pad_0D;
     attached_paint_struct* next; // 0x0E
@@ -66,8 +66,8 @@ struct paint_struct
         uint32_t colour_image_id; // 0x04
     };
     paint_struct_bound_box bounds; // 0x08
-    int32_t x;                     // 0x14
-    int32_t y;                     // 0x16*/
+    int16_t x;                     // 0x14
+    int16_t y;                     // 0x16
     uint16_t quadrant_index;
     uint8_t flags;
     uint8_t quadrant_flags;
@@ -214,8 +214,8 @@ paint_struct* sub_98199C_rotated(
 
 void paint_util_push_tunnel_rotated(paint_session* session, uint8_t direction, uint16_t height, uint8_t type);
 
-bool paint_attach_to_previous_attach(paint_session* session, uint32_t image_id, uint16_t x, uint16_t y);
-bool paint_attach_to_previous_ps(paint_session* session, uint32_t image_id, uint16_t x, uint16_t y);
+bool paint_attach_to_previous_attach(paint_session* session, uint32_t image_id, int16_t x, int16_t y);
+bool paint_attach_to_previous_ps(paint_session* session, uint32_t image_id, int16_t x, int16_t y);
 void paint_floating_money_effect(
     paint_session* session, money32 amount, rct_string_id string_id, int16_t y, int16_t z, int8_t y_offsets[], int16_t offset_x,
     uint32_t rotation);

--- a/test/testpaint/PaintIntercept.cpp
+++ b/test/testpaint/PaintIntercept.cpp
@@ -371,7 +371,7 @@ paint_struct* sub_98199C(
         bound_box_offset_x, bound_box_offset_y, bound_box_offset_z, session->CurrentRotation);
 }
 
-bool paint_attach_to_previous_ps(paint_session* session, uint32_t image_id, uint16_t x, uint16_t y)
+bool paint_attach_to_previous_ps(paint_session* session, uint32_t image_id, int16_t x, int16_t y)
 {
     return false;
 }


### PR DESCRIPTION
We should reopen #12160: is_sprite_interacted_with_palette_set has a nasty hidden behavior with those integer types I believe.

EDIT : It's fixed now, see my second commit for the correction.