### PR TITLE
Use MakeWidget for most Title windows and the ToolTip

### DIFF
--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -21,7 +21,7 @@ enum WINDOW_TITLE_EXIT_WIDGET_IDX {
 };
 
 static rct_widget window_title_exit_widgets[] = {
-    { WWT_IMGBTN, 2, 0, 39, 0, 63, SPR_MENU_EXIT, STR_EXIT },
+    MakeWidget({0, 0}, {40, 64}, WWT_IMGBTN, 2, SPR_MENU_EXIT, STR_EXIT),
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -23,7 +23,7 @@ enum
 };
 
 static rct_widget window_title_logo_widgets[] = {
-    { WWT_IMGBTN, 0, 0, WW, 0, WH, STR_NONE, STR_NONE },
+    MakeWidget({ 0, 0 }, { WW + 1, WH + 1 }, WWT_IMGBTN, 0),
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -31,10 +31,10 @@ enum {
 };
 
 static rct_widget window_title_menu_widgets[] = {
-    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
-    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
-    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
-    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
+    MakeWidget({0, 0}, {82, 82}, WWT_IMGBTN, 2, SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
+    MakeWidget({0, 0}, {82, 82}, WWT_IMGBTN, 2, SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
+    MakeWidget({0, 0}, {82, 82}, WWT_IMGBTN, 2, SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
+    MakeWidget({0, 0}, {82, 82}, WWT_IMGBTN, 2, SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -31,10 +31,10 @@ enum {
 };
 
 static rct_widget window_title_menu_widgets[] = {
-    { WWT_IMGBTN, 2, 0, 0, 0, 81, SPR_MENU_NEW_GAME,        STR_START_NEW_GAME_TIP          },
-    { WWT_IMGBTN, 2, 0, 0, 0, 81, SPR_MENU_LOAD_GAME,       STR_CONTINUE_SAVED_GAME_TIP     },
-    { WWT_IMGBTN, 2, 0, 0, 0, 81, SPR_G2_MENU_MULTIPLAYER,  STR_SHOW_MULTIPLAYER_TIP        },
-    { WWT_IMGBTN, 2, 0, 0, 0, 81, SPR_MENU_TOOLBOX,         STR_GAME_TOOLS_TIP              },
+    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
+    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
+    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
+    MakeWidget({0, 0}, {1, 82}, WWT_IMGBTN, 2, SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/TitleScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/TitleScenarioSelect.cpp
@@ -73,16 +73,16 @@ enum {
 
 static rct_widget window_scenarioselect_widgets[] = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
-    { WWT_IMGBTN,   1,  0,      733,    50,     333,    0xFFFFFFFF,                 STR_NONE },             // tab content panel
-    { WWT_TAB,      1,  3,      93,     17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 1
-    { WWT_TAB,      1,  94,     184,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 2
-    { WWT_TAB,      1,  185,    275,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 3
-    { WWT_TAB,      1,  276,    366,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 4
-    { WWT_TAB,      1,  367,    457,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 5
-    { WWT_TAB,      1,  458,    593,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 6
-    { WWT_TAB,      1,  594,    684,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 7
-    { WWT_TAB,      1,  685,    775,    17,     50,     IMAGE_TYPE_REMAP | SPR_TAB_LARGE, STR_NONE },             // tab 8
-    { WWT_SCROLL,   1,  3,      555,    54,     329,    SCROLL_VERTICAL,            STR_NONE },             // level list
+    MakeWidget     ({  0, 50}, {734, 284}, WWT_IMGBTN, 1),                  // tab content panel
+    MakeRemapWidget({  3, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 1
+    MakeRemapWidget({ 94, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 2
+    MakeRemapWidget({185, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 3
+    MakeRemapWidget({276, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 4
+    MakeRemapWidget({367, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 5
+    MakeRemapWidget({458, 17}, {136,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 6
+    MakeRemapWidget({594, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 7
+    MakeRemapWidget({685, 17}, { 91,  34}, WWT_TAB,    1, SPR_TAB_LARGE),   // tab 8
+    MakeWidget     ({  3, 54}, {553, 276}, WWT_SCROLL, 1, SCROLL_VERTICAL), // level list
     { WIDGETS_END },
 };
 

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -21,7 +21,7 @@ enum {
 };
 
 static rct_widget window_tooltip_widgets[] = {
-    { WWT_IMGBTN, 0, 0, 199, 0, 31, 0xFFFFFFFF, STR_NONE },
+    MakeWidget({0, 0}, {200, 32}, WWT_IMGBTN, 0),
     { WIDGETS_END },
 };
 


### PR DESCRIPTION
I wanted to use @AaronVanGeffen's script just for fun. I double checked the results and it works (yay!) , which all seem fine. Some small notes, that we might need if we're in for lots of PRs still (like I believe).
- It doesn't work for widgets that don't use hardcoded numbers, such as https://github.com/OpenRCT2/OpenRCT2/commit/c2503a738ea8a2fda63156e8a706f677975c1d48 and just fails silently
- It adds `// none` comments where there were actually none. It wasn't clear to me if we intended to comment everything or if you just expected everything to have a comment

As a side comment, it's a bit annoying to align every column, but I agree it looks nice :D