### PR TITLE
Close #12269: remove goto from x8_drawing_engine

### DIFF
--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -403,32 +403,32 @@ void X8DrawingEngine::DrawAllDirtyBlocks()
             uint32_t columns = xx - x;
 
             // Check rows
-            uint32_t yy;
-            bool reachedEndOfRow = false;
-            for (yy = y; yy < dirtyBlockRows; yy++)
-            {
-                uint32_t yyOffset = yy * dirtyBlockColumns;
-                for (xx = x; xx < x + columns; xx++)
-                {
-                    if (dirtyBlocks[yyOffset + xx] == 0)
-                    {
-                        uint32_t rows = yy - y;
-                        DrawDirtyBlocks(x, y, columns, rows);
-                        reachedEndOfRow = true;
-                        break;
-                    }
-                }
-                if (reachedEndOfRow)
-                    break;
-            }
-
-            if (!reachedEndOfRow)
+            uint32_t yy = y;
+            if(CheckRows(yy, y, xx, x, dirtyBlockRows, dirtyBlockColumns, columns, dirtyBlocks))
             {
                 uint32_t rows = yy - y;
                 DrawDirtyBlocks(x, y, columns, rows);
             }
         }
     }
+}
+
+bool X8DrawingEngine::CheckRows(uint32_t yy, uint32_t y, uint32_t xx, uint32_t x, uint32_t dirtyBlockRows, uint32_t dirtyBlockColumns, uint32_t columns, uint8_t* dirtyBlocks)
+{
+    for (yy = y; yy < dirtyBlockRows; yy++)
+    {
+        uint32_t yyOffset = yy * dirtyBlockColumns;
+        for (xx = x; xx < x + columns; xx++)
+        {
+            if (dirtyBlocks[yyOffset + xx] == 0)
+            {
+                uint32_t rows = yy - y;
+                DrawDirtyBlocks(x, y, columns, rows);
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 void X8DrawingEngine::DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows)

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -406,19 +406,21 @@ void X8DrawingEngine::DrawAllDirtyBlocks()
             uint32_t yy;
             for (yy = y; yy < dirtyBlockRows; yy++)
             {
+                bool shouldBreak = false;
                 uint32_t yyOffset = yy * dirtyBlockColumns;
                 for (xx = x; xx < x + columns; xx++)
                 {
                     if (dirtyBlocks[yyOffset + xx] == 0)
                     {
-                        goto endRowCheck;
+                        uint32_t rows = yy - y;
+                        DrawDirtyBlocks(x, y, columns, rows);
+                        shouldBreak = true;
+                        break;
                     }
                 }
+                if(shouldBreak)
+                    break;
             }
-
-        endRowCheck:
-            uint32_t rows = yy - y;
-            DrawDirtyBlocks(x, y, columns, rows);
         }
     }
 }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -418,7 +418,7 @@ void X8DrawingEngine::DrawAllDirtyBlocks()
                         break;
                     }
                 }
-                if(shouldBreak)
+                if (shouldBreak)
                     break;
             }
         }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -404,9 +404,9 @@ void X8DrawingEngine::DrawAllDirtyBlocks()
 
             // Check rows
             uint32_t yy;
+            bool reachedEndOfRow = false;
             for (yy = y; yy < dirtyBlockRows; yy++)
             {
-                bool shouldBreak = false;
                 uint32_t yyOffset = yy * dirtyBlockColumns;
                 for (xx = x; xx < x + columns; xx++)
                 {
@@ -414,12 +414,18 @@ void X8DrawingEngine::DrawAllDirtyBlocks()
                     {
                         uint32_t rows = yy - y;
                         DrawDirtyBlocks(x, y, columns, rows);
-                        shouldBreak = true;
+                        reachedEndOfRow = true;
                         break;
                     }
                 }
-                if (shouldBreak)
+                if (reachedEndOfRow)
                     break;
+            }
+
+            if (!reachedEndOfRow)
+            {
+                uint32_t rows = yy - y;
+                DrawDirtyBlocks(x, y, columns, rows);
             }
         }
     }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -377,58 +377,50 @@ void X8DrawingEngine::ConfigureDirtyGrid()
 
 void X8DrawingEngine::DrawAllDirtyBlocks()
 {
-    uint32_t dirtyBlockColumns = _dirtyGrid.BlockColumns;
-    uint32_t dirtyBlockRows = _dirtyGrid.BlockRows;
-    uint8_t* dirtyBlocks = _dirtyGrid.Blocks;
-
-    for (uint32_t x = 0; x < dirtyBlockColumns; x++)
+    for (uint32_t x = 0; x < _dirtyGrid.BlockColumns; x++)
     {
-        for (uint32_t y = 0; y < dirtyBlockRows; y++)
+        for (uint32_t y = 0; y < _dirtyGrid.BlockRows; y++)
         {
-            uint32_t yOffset = y * dirtyBlockColumns;
-            if (dirtyBlocks[yOffset + x] == 0)
+            uint32_t yOffset = y * _dirtyGrid.BlockColumns;
+            if (_dirtyGrid.Blocks[yOffset + x] == 0)
             {
                 continue;
             }
 
             // Determine columns
             uint32_t xx;
-            for (xx = x; xx < dirtyBlockColumns; xx++)
+            for (xx = x; xx < _dirtyGrid.BlockColumns; xx++)
             {
-                if (dirtyBlocks[yOffset + xx] == 0)
+                if (_dirtyGrid.Blocks[yOffset + xx] == 0)
                 {
                     break;
                 }
             }
-            uint32_t columns = xx - x;
 
             // Check rows
-            uint32_t yy = y;
-            if(CheckRows(yy, y, xx, x, dirtyBlockRows, dirtyBlockColumns, columns, dirtyBlocks))
-            {
-                uint32_t rows = yy - y;
-                DrawDirtyBlocks(x, y, columns, rows);
-            }
+            uint32_t columns = xx - x;
+            auto rows = GetNumDirtyRows(x, y, columns);
+            DrawDirtyBlocks(x, y, columns, rows);
         }
     }
 }
 
-bool X8DrawingEngine::CheckRows(uint32_t yy, uint32_t y, uint32_t xx, uint32_t x, uint32_t dirtyBlockRows, uint32_t dirtyBlockColumns, uint32_t columns, uint8_t* dirtyBlocks)
+uint32_t X8DrawingEngine::GetNumDirtyRows(const uint32_t x, const uint32_t y, const uint32_t columns)
 {
-    for (yy = y; yy < dirtyBlockRows; yy++)
+    uint32_t yy = y;
+
+    for (yy = y; yy < _dirtyGrid.BlockRows; yy++)
     {
-        uint32_t yyOffset = yy * dirtyBlockColumns;
-        for (xx = x; xx < x + columns; xx++)
+        uint32_t yyOffset = yy * _dirtyGrid.BlockColumns;
+        for (uint32_t xx = x; xx < x + columns; xx++)
         {
-            if (dirtyBlocks[yyOffset + xx] == 0)
+            if (_dirtyGrid.Blocks[yyOffset + xx] == 0)
             {
-                uint32_t rows = yy - y;
-                DrawDirtyBlocks(x, y, columns, rows);
-                return false;
+                return yy - y;
             }
         }
     }
-    return true;
+    return yy - y;
 }
 
 void X8DrawingEngine::DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows)

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -123,7 +123,7 @@ namespace OpenRCT2
             void ConfigureDirtyGrid();
             static void ResetWindowVisbilities();
             void DrawAllDirtyBlocks();
-            bool CheckRows(uint32_t yy, uint32_t y, uint32_t xx, uint32_t x, uint32_t dirtyBlockRows, uint32_t dirtyBlockColumns, uint32_t columns, uint8_t* dirtyBlocks);
+            uint32_t GetNumDirtyRows(const uint32_t x, const uint32_t y, const uint32_t columns);
             void DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows);
         };
 #ifdef __WARN_SUGGEST_FINAL_TYPES__

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -123,6 +123,7 @@ namespace OpenRCT2
             void ConfigureDirtyGrid();
             static void ResetWindowVisbilities();
             void DrawAllDirtyBlocks();
+            bool CheckRows(uint32_t yy, uint32_t y, uint32_t xx, uint32_t x, uint32_t dirtyBlockRows, uint32_t dirtyBlockColumns, uint32_t columns, uint8_t* dirtyBlocks);
             void DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, uint32_t rows);
         };
 #ifdef __WARN_SUGGEST_FINAL_TYPES__


### PR DESCRIPTION
refactored function DrawAllDirtyBlocks with the intent of removing a goto statement