### PR TITLE
Readme wiki unification for build instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,21 +79,13 @@ Some \*BSD operating systems offer native packages. These packages are usually t
 
 # 3. Building the game
 
-## 3.1 Building prerequisites
-
 OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bought at either [Steam](http://store.steampowered.com/app/285330/) or [GOG.com](http://www.gog.com/game/rollercoaster_tycoon_2).
-
----
-
-## 3.2 Compiling and running
 
 * [Building OpenRCT2 on Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux)
 * [Building OpenRCT2 on macOS using CMake](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-CMake)
 * [Building OpenRCT2 on macOS using Xcode (recommended)](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-Xcode)
 * [Building OpenRCT2 on Windows](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows)
 * [Building OpenRCT2 on Windows Subsystem for Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows-Subsystem-for-Linux)
-
----
 
 # 4. Contributing
 OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 * [Building OpenRCT2 on macOS using CMake](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-CMake)
 * [Building OpenRCT2 on macOS using Xcode (recommended)](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-Xcode)
 * [Building OpenRCT2 on Windows](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows)
+* [Building OpenRCT2 on Windows Subsystem for Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows-Subsystem-for-Linux)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -86,38 +86,17 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 ### macOS:
 - Xcode 8
 
-The program can also be built as a command line program using CMake. This type of build requires:
-
-- Xcode Command Line Tools
-- [Homebrew](http://brew.sh)
-- CMake (available through Homebrew)
-
 ---
 
 ## 3.2 Compiling and running
 
 * [Building OpenRCT2 on Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux)
+* [Building OpenRCT2 on macOS using CMake](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-CMake)
 * [Building OpenRCT2 on Windows](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows)
 
 ### macOS:
 #### Xcode:
 The recommended way of building OpenRCT2 for macOS is with Xcode. The Xcode build will create a self-contained application bundles which include all the necessary game files and dependencies. Open the project file OpenRCT2.xcodeproj in Xcode and build from there. Building this way will handle the dependencies for you automatically. You can also invoke an Xcode build from the command line using `xcodebuild`.
-
-#### CMake:
-A command line version of OpenRCT2 can be built using CMake. This type of build requires you to provide the dependencies yourself. The supported method of doing this is with [Homebrew](http://brew.sh). Once you have Homebrew installed, you can download all the required libraries with this command:
-```
-brew install cmake duktape freetype icu4c jansson libpng libzip openssl pkg-config sdl2 speexdsp
-```
-
-Once you have the dependencies installed, you can build the project using CMake using the following commands:
-```
-mkdir build
-cd build
-cmake ..
-make
-ln -s ../data data
-```
-Then you can run the game by running `./openrct2`.
 
 # 4. Contributing
 OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.

--- a/readme.md
+++ b/readme.md
@@ -83,20 +83,16 @@ Some \*BSD operating systems offer native packages. These packages are usually t
 
 OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bought at either [Steam](http://store.steampowered.com/app/285330/) or [GOG.com](http://www.gog.com/game/rollercoaster_tycoon_2).
 
-### macOS:
-- Xcode 8
-
 ---
 
 ## 3.2 Compiling and running
 
 * [Building OpenRCT2 on Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux)
 * [Building OpenRCT2 on macOS using CMake](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-CMake)
+* [Building OpenRCT2 on macOS using Xcode (recommended)](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-Xcode)
 * [Building OpenRCT2 on Windows](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows)
 
-### macOS:
-#### Xcode:
-The recommended way of building OpenRCT2 for macOS is with Xcode. The Xcode build will create a self-contained application bundles which include all the necessary game files and dependencies. Open the project file OpenRCT2.xcodeproj in Xcode and build from there. Building this way will handle the dependencies for you automatically. You can also invoke an Xcode build from the command line using `xcodebuild`.
+---
 
 # 4. Contributing
 OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.

--- a/readme.md
+++ b/readme.md
@@ -92,29 +92,11 @@ The program can also be built as a command line program using CMake. This type o
 - [Homebrew](http://brew.sh)
 - CMake (available through Homebrew)
 
-
-### Linux:
-- sdl2 (only for UI client)
-- freetype (can be disabled)
-- fontconfig (can be disabled)
-- libzip (>= 1.0)
-- libpng (>= 1.2)
-- speexdsp (only for UI client)
-- curl (only if building with http support)
-- jansson (>= 2.5)
-- openssl (>= 1.0; only if building with multiplayer support)
-- icu (>= 59.0)
-- zlib
-- gl (commonly provided by Mesa or GPU vendors; only for UI client, can be disabled)
-- duktape (unless scripting is disabled)
-- cmake
-
-Refer to https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux#required-packages-general for more information about installing the packages.
-
 ---
 
 ## 3.2 Compiling and running
 
+* [Building OpenRCT2 on Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux)
 * [Building OpenRCT2 on Windows](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows)
 
 ### macOS:
@@ -136,22 +118,6 @@ make
 ln -s ../data data
 ```
 Then you can run the game by running `./openrct2`.
-
-### Linux:
-The standard CMake build procedure is to install the [required libraries](https://github.com/OpenRCT2/OpenRCT2#linux), then:
-```
-mkdir build
-cd build
-cmake ../ # set your standard cmake options, e.g. build type here - For example, -DCMAKE_BUILD_TYPE=RelWithDebInfo
-make # you can parallelise your build job with e.g. -j8 or consider using ninja
-DESTDIR=. make install # the install target creates all the necessary files in places we expect them
-```
-
-You can also use Ninja in place of Make, if you prefer, see Wiki for details.
-
-Detailed instructions can be found on our [wiki](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux).
-
----
 
 # 4. Contributing
 OpenRCT2 uses the [gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow). If you are implementing a new feature or logic from the original game, please branch off and perform pull requests to ```develop```. If you are fixing a bug for the next release, please branch off and perform pull requests to the correct release branch. ```master``` only contains tagged releases, you should never branch off this.

--- a/readme.md
+++ b/readme.md
@@ -83,10 +83,6 @@ Some \*BSD operating systems offer native packages. These packages are usually t
 
 OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bought at either [Steam](http://store.steampowered.com/app/285330/) or [GOG.com](http://www.gog.com/game/rollercoaster_tycoon_2).
 
-### Windows:
-- Visual Studio 2019 (Enterprise / Professional / [Community (Free)](https://www.visualstudio.com/vs/community/))
-  - Desktop development with C++
-
 ### macOS:
 - Xcode 8
 
@@ -118,24 +114,8 @@ Refer to https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux#re
 ---
 
 ## 3.2 Compiling and running
-### Windows:
-1. Check out the repository. This can be done using [GitHub Desktop](https://desktop.github.com) or [other tools](https://help.github.com/articles/which-remote-url-should-i-use).
-2. Open a new Developer Command Prompt for VS 2019, then navigate to the repository (e.g. `cd C:\GitHub\OpenRCT2`).
-3. To build the 64-bit version, use `msbuild openrct2.proj /t:build /p:platform=x64`.
 
-   To build the 32-bit version, use `msbuild openrct2.proj /t:build /p:platform=Win32`.
-4. Run the game, `bin\openrct2`
-
-Once you have ran msbuild once, further development can be done within Visual Studio by opening `openrct2.sln`. Make sure to select the correct target platform for which you ran the build in point #3 (`Win32` for the 32-bit version, `x64` for the 64-bit version), otherwise the build will fail in Visual Studio.
-
-Other examples:
-```
-set platform=x64
-msbuild openrct2.proj /t:clean
-msbuild openrct2.proj /t:rebuild /p:configuration=release
-msbuild openrct2.proj /t:g2
-msbuild openrct2.proj /t:PublishPortable
-```
+* [Building OpenRCT2 on Windows](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Windows)
 
 ### macOS:
 #### Xcode:


### PR DESCRIPTION
I've made sure that the wiki has the same information that is already in our README. Then, I pointed to the wiki. This way:

- We make sure these instructions (that are not for everyone) are contained in another place and not cluttering the README
- We get a single place to keep updated

Check https://github.com/tupaschoal/OpenRCT2/tree/readme-wiki-unification#3-building-the-game for a preview of how it looks live

I guess this is kind of part of #12046 (?) I can reword the commits if so