### PR TITLE
Close #12252: remove of goto in function wall_remove_at

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2396,6 +2396,25 @@ TileElement* map_get_track_element_at_with_direction_from_ride(const CoordsXYZD&
     return nullptr;
 };
 
+WallElement* map_get_wall_element_at(const CoordsXYRangedZ& coords)
+{
+    auto tileElement = map_get_first_element_at(coords);
+
+    if (tileElement != nullptr)
+    {
+        do
+        {
+            if (tileElement->GetType() == TILE_ELEMENT_TYPE_WALL && coords.baseZ < tileElement->GetClearanceZ()
+                && coords.clearanceZ > tileElement->GetBaseZ())
+            {
+                return tileElement->AsWall();
+            }
+        } while (!(tileElement++)->IsLastForTile());
+    }
+
+    return nullptr;
+}
+
 WallElement* map_get_wall_element_at(const CoordsXYZD& wallCoords)
 {
     auto tileWallCoords = TileCoordsXYZ(wallCoords);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -157,6 +157,7 @@ BannerElement* map_get_banner_element_at(const CoordsXYZ& bannerPos, uint8_t dir
 SurfaceElement* map_get_surface_element_at(const CoordsXY& coords);
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc);
 WallElement* map_get_wall_element_at(const CoordsXYZD& wallCoords);
+WallElement* map_get_wall_element_at(const CoordsXYRangedZ& coords);
 SmallSceneryElement* map_get_small_scenery_element_at(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant);
 EntranceElement* map_get_park_entrance_element_at(const CoordsXYZ& entranceCoords, bool ghost);
 EntranceElement* map_get_ride_entrance_element_at(const CoordsXYZ& entranceCoords, bool ghost);

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -35,26 +35,13 @@
  */
 void wall_remove_at(const CoordsXYRangedZ& wallPos)
 {
-    TileElement* tileElement;
-
-repeat:
-    tileElement = map_get_first_element_at(wallPos);
-    if (tileElement == nullptr)
-        return;
-    do
+    for (auto wallElement = map_get_wall_element_at(wallPos); wallElement != nullptr;
+         wallElement = map_get_wall_element_at(wallPos))
     {
-        if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
-            continue;
-        if (wallPos.baseZ >= tileElement->GetClearanceZ())
-            continue;
-        if (wallPos.clearanceZ <= tileElement->GetBaseZ())
-            continue;
-
-        tile_element_remove_banner_entry(tileElement);
-        map_invalidate_tile_zoom1({ wallPos, tileElement->GetBaseZ(), tileElement->GetBaseZ() + 72 });
-        tile_element_remove(tileElement);
-        goto repeat;
-    } while (!(tileElement++)->IsLastForTile());
+        tile_element_remove_banner_entry(reinterpret_cast<TileElement*>(wallElement));
+        map_invalidate_tile_zoom1({ wallPos, wallElement->GetBaseZ(), wallElement->GetBaseZ() + 72 });
+        tile_element_remove(reinterpret_cast<TileElement*>(wallElement));
+    }
 }
 
 /**


### PR DESCRIPTION
* Removed use of goto in function wall_remove_at
* Implemented overload of function map_get_wall_element_at


Replacing pull request #12266. (Sorry, I ended up force pushing). 
I feel that we should have a function to cast stuff to TileElement, as in this case I'd have to return a TileElement from the function map_get_wall_element_at which in turn would make it a lot more different than the other overload. I've made some casts in the function but I'm willing to find a propper solution to this so some suggestions would be great.