### PR TITLE
Fix #12224: crash in scrolling_text_set_bitmap_for_sprite()

### DIFF
--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1533,6 +1533,9 @@ static void scrolling_text_set_bitmap_for_sprite(
                 continue;
             }
 
+            if (scrollPositionOffsets == nullptr)
+                return;
+
             int16_t scrollPosition = *scrollPositionOffsets;
             if (scrollPosition == -1)
                 return;


### PR DESCRIPTION
Now, I haven't been able to test if this fixes the crash, as I cannot reproduce it myself.