### PR TITLE
Refactor ResearchItem Type to an enum class

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -581,7 +581,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
 
     // Preview image
     int32_t objectEntryType = OBJECT_TYPE_SCENERY_GROUP;
-    if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE)
+    if (researchItem->type == ResearchEntryType::Ride)
         objectEntryType = OBJECT_TYPE_RIDE;
 
     auto chunk = object_entry_get_chunk(objectEntryType, researchItem->entryIndex);
@@ -688,7 +688,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
 
         rct_string_id itemNameId = researchItem.GetName();
 
-        if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE
+        if (researchItem.type == ResearchEntryType::Ride
             && !RideTypeDescriptors[researchItem.baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
         {
             const auto rideEntry = get_ride_entry(researchItem.entryIndex);
@@ -734,7 +734,7 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
     rct_string_id stringId = researchItem->GetName();
 
     ptr = buffer;
-    if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE
+    if (researchItem->type == ResearchEntryType::Ride
         && !RideTypeDescriptors[researchItem->baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
         const auto rideEntry = get_ride_entry(researchItem->entryIndex);
@@ -829,7 +829,7 @@ static rct_string_id window_editor_inventions_list_prepare_name(const ResearchIt
     rct_string_id stringId = researchItem->GetName();
     auto ft = Formatter::Common();
 
-    if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE
+    if (researchItem->type == ResearchEntryType::Ride
         && !RideTypeDescriptors[researchItem->baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
         drawString = withGap ? STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME_DRAG : STR_WINDOW_COLOUR_2_STRINGID_STRINGID;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -581,7 +581,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
 
     // Preview image
     int32_t objectEntryType = OBJECT_TYPE_SCENERY_GROUP;
-    if (researchItem->type == ResearchEntryType::Ride)
+    if (researchItem->type == Research::EntryType::Ride)
         objectEntryType = OBJECT_TYPE_RIDE;
 
     auto chunk = object_entry_get_chunk(objectEntryType, researchItem->entryIndex);
@@ -688,7 +688,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
 
         rct_string_id itemNameId = researchItem.GetName();
 
-        if (researchItem.type == ResearchEntryType::Ride
+        if (researchItem.type == Research::EntryType::Ride
             && !RideTypeDescriptors[researchItem.baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
         {
             const auto rideEntry = get_ride_entry(researchItem.entryIndex);
@@ -734,7 +734,7 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
     rct_string_id stringId = researchItem->GetName();
 
     ptr = buffer;
-    if (researchItem->type == ResearchEntryType::Ride
+    if (researchItem->type == Research::EntryType::Ride
         && !RideTypeDescriptors[researchItem->baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
         const auto rideEntry = get_ride_entry(researchItem->entryIndex);
@@ -829,7 +829,7 @@ static rct_string_id window_editor_inventions_list_prepare_name(const ResearchIt
     rct_string_id stringId = researchItem->GetName();
     auto ft = Formatter::Common();
 
-    if (researchItem->type == ResearchEntryType::Ride
+    if (researchItem->type == Research::EntryType::Ride
         && !RideTypeDescriptors[researchItem->baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
         drawString = withGap ? STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME_DRAG : STR_WINDOW_COLOUR_2_STRINGID_STRINGID;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -775,8 +775,8 @@ static void window_new_ride_invalidate(rct_window* w)
         {
             auto type = gResearchLastItem->type;
             window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_FLATBTN;
-            window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = (type == ResearchEntryType::Ride) ? SPR_NEW_RIDE
-                                                                                                            : SPR_NEW_SCENERY;
+            window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = (type == Research::EntryType::Ride) ? SPR_NEW_RIDE
+                                                                                                              : SPR_NEW_SCENERY;
         }
     }
 }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -773,10 +773,10 @@ static void window_new_ride_invalidate(rct_window* w)
         window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_EMPTY;
         if (gResearchLastItem.has_value())
         {
-            uint8_t type = gResearchLastItem->type;
+            auto type = gResearchLastItem->type;
             window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_FLATBTN;
-            window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = (type == RESEARCH_ENTRY_TYPE_RIDE) ? SPR_NEW_RIDE
-                                                                                                             : SPR_NEW_SCENERY;
+            window_new_ride_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = (type == ResearchEntryType::Ride) ? SPR_NEW_RIDE
+                                                                                                            : SPR_NEW_SCENERY;
         }
     }
 }

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -316,9 +316,9 @@ static void window_research_development_invalidate(rct_window* w)
     window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_EMPTY;
     if (gResearchLastItem.has_value())
     {
-        uint8_t type = gResearchLastItem->type;
+        auto type = gResearchLastItem->type;
         window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_FLATBTN;
-        window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = type == RESEARCH_ENTRY_TYPE_RIDE
+        window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = type == ResearchEntryType::Ride
             ? SPR_NEW_RIDE
             : SPR_NEW_SCENERY;
     }
@@ -370,7 +370,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
             if (gResearchProgressStage != RESEARCH_STAGE_DESIGNING)
             {
                 strings[0] = gResearchNextItem->GetName();
-                if (gResearchNextItem->type == RESEARCH_ENTRY_TYPE_RIDE)
+                if (gResearchNextItem->type == ResearchEntryType::Ride)
                 {
                     auto rtd = RideTypeDescriptors[gResearchNextItem->baseRideType];
                     if (!rtd.HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
@@ -419,8 +419,8 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
     {
         rct_string_id lastDevelopmentFormat = STR_EMPTY;
         std::array<rct_string_id, 2> strings = { gResearchLastItem->GetName(), 0 };
-        uint8_t type = gResearchLastItem->type;
-        if (type == RESEARCH_ENTRY_TYPE_SCENERY)
+        auto type = gResearchLastItem->type;
+        if (type == ResearchEntryType::Scenery)
         {
             lastDevelopmentFormat = STR_RESEARCH_SCENERY_LABEL;
         }

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -318,7 +318,7 @@ static void window_research_development_invalidate(rct_window* w)
     {
         auto type = gResearchLastItem->type;
         window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WWT_FLATBTN;
-        window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = type == ResearchEntryType::Ride
+        window_research_development_widgets[WIDX_LAST_DEVELOPMENT_BUTTON].image = type == Research::EntryType::Ride
             ? SPR_NEW_RIDE
             : SPR_NEW_SCENERY;
     }
@@ -370,7 +370,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
             if (gResearchProgressStage != RESEARCH_STAGE_DESIGNING)
             {
                 strings[0] = gResearchNextItem->GetName();
-                if (gResearchNextItem->type == ResearchEntryType::Ride)
+                if (gResearchNextItem->type == Research::EntryType::Ride)
                 {
                     auto rtd = RideTypeDescriptors[gResearchNextItem->baseRideType];
                     if (!rtd.HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
@@ -420,7 +420,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         rct_string_id lastDevelopmentFormat = STR_EMPTY;
         std::array<rct_string_id, 2> strings = { gResearchLastItem->GetName(), 0 };
         auto type = gResearchLastItem->type;
-        if (type == ResearchEntryType::Scenery)
+        if (type == Research::EntryType::Scenery)
         {
             lastDevelopmentFormat = STR_RESEARCH_SCENERY_LABEL;
         }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -296,7 +296,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
         for (auto rideType : rideEntry->ride_type)
         {
             ResearchItem tmp = {};
-            tmp.type = RESEARCH_ENTRY_TYPE_RIDE;
+            tmp.type = ResearchEntryType::Ride;
             tmp.entryIndex = entry_index;
             tmp.baseRideType = rideType;
             research_remove(&tmp);
@@ -305,7 +305,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
     else if (entry_type == OBJECT_TYPE_SCENERY_GROUP)
     {
         ResearchItem tmp = {};
-        tmp.type = RESEARCH_ENTRY_TYPE_SCENERY;
+        tmp.type = ResearchEntryType::Scenery;
         tmp.entryIndex = entry_index;
         research_remove(&tmp);
     }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -296,7 +296,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
         for (auto rideType : rideEntry->ride_type)
         {
             ResearchItem tmp = {};
-            tmp.type = ResearchEntryType::Ride;
+            tmp.type = Research::EntryType::Ride;
             tmp.entryIndex = entry_index;
             tmp.baseRideType = rideType;
             research_remove(&tmp);
@@ -305,7 +305,7 @@ static void remove_selected_objects_from_research(const rct_object_entry* instal
     else if (entry_type == OBJECT_TYPE_SCENERY_GROUP)
     {
         ResearchItem tmp = {};
-        tmp.type = ResearchEntryType::Scenery;
+        tmp.type = Research::EntryType::Scenery;
         tmp.entryIndex = entry_index;
         research_remove(&tmp);
     }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -374,7 +374,7 @@ void news_item_open_subject(int32_t type, int32_t subject)
         case NEWS_ITEM_RESEARCH:
         {
             auto item = ResearchItem(subject, 0, 0);
-            if (item.type == RESEARCH_ENTRY_TYPE_RIDE)
+            if (item.type == ResearchEntryType::Ride)
             {
                 auto intent = Intent(INTENT_ACTION_NEW_RIDE_OF_TYPE);
                 intent.putExtra(INTENT_EXTRA_RIDE_TYPE, item.baseRideType);

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -374,7 +374,7 @@ void news_item_open_subject(int32_t type, int32_t subject)
         case NEWS_ITEM_RESEARCH:
         {
             auto item = ResearchItem(subject, 0, 0);
-            if (item.type == ResearchEntryType::Ride)
+            if (item.type == Research::EntryType::Ride)
             {
                 auto intent = Intent(INTENT_ACTION_NEW_RIDE_OF_TYPE);
                 intent.putExtra(INTENT_EXTRA_RIDE_TYPE, item.baseRideType);

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -191,7 +191,7 @@ void research_finish_item(ResearchItem* researchItem)
     gResearchLastItem = *researchItem;
     research_invalidate_related_windows();
 
-    if (researchItem->type == ResearchEntryType::Ride)
+    if (researchItem->type == Research::EntryType::Ride)
     {
         // Ride
         uint32_t base_ride_type = researchItem->baseRideType;
@@ -493,7 +493,7 @@ bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, u
 {
     if (rideType != RIDE_TYPE_NULL && entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
-        auto tmpItem = ResearchItem(ResearchEntryType::Ride, entryIndex, rideType, category, 0);
+        auto tmpItem = ResearchItem(Research::EntryType::Ride, entryIndex, rideType, category, 0);
         research_insert(tmpItem, researched);
         return true;
     }
@@ -518,7 +518,8 @@ bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool resea
 {
     if (entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
-        auto tmpItem = ResearchItem(ResearchEntryType::Scenery, entryIndex, RIDE_TYPE_NULL, RESEARCH_CATEGORY_SCENERY_GROUP, 0);
+        auto tmpItem = ResearchItem(
+            Research::EntryType::Scenery, entryIndex, RIDE_TYPE_NULL, RESEARCH_CATEGORY_SCENERY_GROUP, 0);
         research_insert(tmpItem, researched);
         return true;
     }
@@ -682,7 +683,7 @@ void set_every_ride_entry_not_invented()
  */
 rct_string_id ResearchItem::GetName() const
 {
-    if (type == ResearchEntryType::Ride)
+    if (type == Research::EntryType::Ride)
     {
         rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
         if (rideEntry == nullptr)
@@ -732,7 +733,7 @@ void research_fix()
     for (auto it = gResearchItemsInvented.begin(); it != gResearchItemsInvented.end();)
     {
         auto& researchItem = *it;
-        if (researchItem.type == ResearchEntryType::Ride)
+        if (researchItem.type == Research::EntryType::Ride)
         {
             rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
@@ -760,7 +761,7 @@ void research_fix()
     for (auto it = gResearchItemsUninvented.begin(); it != gResearchItemsUninvented.end();)
     {
         auto& researchItem = *it;
-        if (researchItem.type == ResearchEntryType::Ride)
+        if (researchItem.type == Research::EntryType::Ride)
         {
             rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
@@ -896,7 +897,7 @@ static void research_update_first_of_type(ResearchItem* researchItem)
     if (researchItem->IsNull())
         return;
 
-    if (researchItem->type != ResearchEntryType::Ride)
+    if (researchItem->type != Research::EntryType::Ride)
         return;
 
     auto rideType = researchItem->baseRideType;
@@ -934,7 +935,7 @@ void research_determine_first_of_type()
 
     for (const auto& researchItem : gResearchItemsInvented)
     {
-        if (researchItem.type != ResearchEntryType::Ride)
+        if (researchItem.type != Research::EntryType::Ride)
             continue;
 
         auto rideType = researchItem.baseRideType;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -191,7 +191,7 @@ void research_finish_item(ResearchItem* researchItem)
     gResearchLastItem = *researchItem;
     research_invalidate_related_windows();
 
-    if (researchItem->type == RESEARCH_ENTRY_TYPE_RIDE)
+    if (researchItem->type == ResearchEntryType::Ride)
     {
         // Ride
         uint32_t base_ride_type = researchItem->baseRideType;
@@ -493,7 +493,7 @@ bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, u
 {
     if (rideType != RIDE_TYPE_NULL && entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
-        auto tmpItem = ResearchItem(RESEARCH_ENTRY_TYPE_RIDE, entryIndex, rideType, category, 0);
+        auto tmpItem = ResearchItem(ResearchEntryType::Ride, entryIndex, rideType, category, 0);
         research_insert(tmpItem, researched);
         return true;
     }
@@ -518,8 +518,7 @@ bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool resea
 {
     if (entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
-        auto tmpItem = ResearchItem(
-            RESEARCH_ENTRY_TYPE_SCENERY, entryIndex, RIDE_TYPE_NULL, RESEARCH_CATEGORY_SCENERY_GROUP, 0);
+        auto tmpItem = ResearchItem(ResearchEntryType::Scenery, entryIndex, RIDE_TYPE_NULL, RESEARCH_CATEGORY_SCENERY_GROUP, 0);
         research_insert(tmpItem, researched);
         return true;
     }
@@ -683,7 +682,7 @@ void set_every_ride_entry_not_invented()
  */
 rct_string_id ResearchItem::GetName() const
 {
-    if (type == RESEARCH_ENTRY_TYPE_RIDE)
+    if (type == ResearchEntryType::Ride)
     {
         rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
         if (rideEntry == nullptr)
@@ -733,7 +732,7 @@ void research_fix()
     for (auto it = gResearchItemsInvented.begin(); it != gResearchItemsInvented.end();)
     {
         auto& researchItem = *it;
-        if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE)
+        if (researchItem.type == ResearchEntryType::Ride)
         {
             rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
@@ -761,7 +760,7 @@ void research_fix()
     for (auto it = gResearchItemsUninvented.begin(); it != gResearchItemsUninvented.end();)
     {
         auto& researchItem = *it;
-        if (researchItem.type == RESEARCH_ENTRY_TYPE_RIDE)
+        if (researchItem.type == ResearchEntryType::Ride)
         {
             rct_ride_entry* rideEntry = get_ride_entry(researchItem.entryIndex);
             if (rideEntry == nullptr)
@@ -897,7 +896,7 @@ static void research_update_first_of_type(ResearchItem* researchItem)
     if (researchItem->IsNull())
         return;
 
-    if (researchItem->type != RESEARCH_ENTRY_TYPE_RIDE)
+    if (researchItem->type != ResearchEntryType::Ride)
         return;
 
     auto rideType = researchItem->baseRideType;
@@ -935,7 +934,7 @@ void research_determine_first_of_type()
 
     for (const auto& researchItem : gResearchItemsInvented)
     {
-        if (researchItem.type != RESEARCH_ENTRY_TYPE_RIDE)
+        if (researchItem.type != ResearchEntryType::Ride)
             continue;
 
         auto rideType = researchItem.baseRideType;

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -17,10 +17,10 @@
 
 struct rct_ride_entry;
 
-enum
+enum class ResearchEntryType
 {
-    RESEARCH_ENTRY_TYPE_SCENERY = 0,
-    RESEARCH_ENTRY_TYPE_RIDE = 1,
+    Scenery = 0,
+    Ride = 1,
 };
 
 enum
@@ -39,7 +39,7 @@ struct ResearchItem
         {
             ObjectEntryIndex entryIndex;
             uint8_t baseRideType;
-            uint8_t type; // 0: scenery entry, 1: ride entry
+            ResearchEntryType type; // 0: scenery entry, 1: ride entry
         };
     };
     uint8_t flags;
@@ -59,7 +59,8 @@ struct ResearchItem
         , category(_category)
     {
     }
-    ResearchItem(uint8_t _type, ObjectEntryIndex _entryIndex, uint8_t _baseRideType, uint8_t _category, uint8_t _flags)
+    ResearchItem(
+        ResearchEntryType _type, ObjectEntryIndex _entryIndex, uint8_t _baseRideType, uint8_t _category, uint8_t _flags)
         : entryIndex(_entryIndex)
         , baseRideType(_baseRideType)
         , type(_type)
@@ -79,7 +80,7 @@ struct ResearchItem
         {
             retItem.entryIndex = OpenRCT2EntryIndexToRCTEntryIndex(entryIndex);
             retItem.baseRideType = OpenRCT2RideTypeToRCT2RideType(baseRideType);
-            retItem.type = type;
+            retItem.type = static_cast<uint8_t>(type);
             retItem.flags = (flags & ~RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE);
             retItem.category = category;
         }
@@ -103,7 +104,7 @@ struct ResearchItem
             auto* rideEntry = get_ride_entry(entryIndex);
             baseRideType = rideEntry != nullptr ? RCT2RideTypeToOpenRCT2RideType(oldResearchItem.type, rideEntry)
                                                 : oldResearchItem.baseRideType;
-            type = oldResearchItem.type;
+            type = static_cast<ResearchEntryType>(oldResearchItem.type);
             flags = oldResearchItem.flags;
             category = oldResearchItem.category;
         }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -17,11 +17,14 @@
 
 struct rct_ride_entry;
 
-enum class ResearchEntryType : uint8_t
+namespace Research
 {
-    Scenery = 0,
-    Ride = 1,
-};
+    enum class EntryType : uint8_t
+    {
+        Scenery = 0,
+        Ride = 1,
+    };
+}
 
 enum
 {
@@ -39,7 +42,7 @@ struct ResearchItem
         {
             ObjectEntryIndex entryIndex;
             uint8_t baseRideType;
-            ResearchEntryType type; // 0: scenery entry, 1: ride entry
+            Research::EntryType type; // 0: scenery entry, 1: ride entry
         };
     };
     uint8_t flags;
@@ -60,7 +63,7 @@ struct ResearchItem
     {
     }
     ResearchItem(
-        ResearchEntryType _type, ObjectEntryIndex _entryIndex, uint8_t _baseRideType, uint8_t _category, uint8_t _flags)
+        Research::EntryType _type, ObjectEntryIndex _entryIndex, uint8_t _baseRideType, uint8_t _category, uint8_t _flags)
         : entryIndex(_entryIndex)
         , baseRideType(_baseRideType)
         , type(_type)
@@ -104,7 +107,7 @@ struct ResearchItem
             auto* rideEntry = get_ride_entry(entryIndex);
             baseRideType = rideEntry != nullptr ? RCT2RideTypeToOpenRCT2RideType(oldResearchItem.type, rideEntry)
                                                 : oldResearchItem.baseRideType;
-            type = ResearchEntryType{ oldResearchItem.type };
+            type = Research::EntryType{ oldResearchItem.type };
             flags = oldResearchItem.flags;
             category = oldResearchItem.category;
         }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -17,7 +17,7 @@
 
 struct rct_ride_entry;
 
-enum class ResearchEntryType
+enum class ResearchEntryType : uint8_t
 {
     Scenery = 0,
     Ride = 1,
@@ -104,7 +104,7 @@ struct ResearchItem
             auto* rideEntry = get_ride_entry(entryIndex);
             baseRideType = rideEntry != nullptr ? RCT2RideTypeToOpenRCT2RideType(oldResearchItem.type, rideEntry)
                                                 : oldResearchItem.baseRideType;
-            type = static_cast<ResearchEntryType>(oldResearchItem.type);
+            type = ResearchEntryType{ oldResearchItem.type };
             flags = oldResearchItem.flags;
             category = oldResearchItem.category;
         }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2604,7 +2604,7 @@ private:
                     auto rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
                     dst->entryIndex = entryIndex;
                     dst->baseRideType = rideType;
-                    dst->type = ResearchEntryType::Ride;
+                    dst->type = Research::EntryType::Ride;
                     dst->flags = 0;
                     dst->category = RideTypeDescriptors[rideType].Category;
                 }
@@ -2623,7 +2623,7 @@ private:
                     auto rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
                     dst->entryIndex = entryIndex;
                     dst->baseRideType = rideType;
-                    dst->type = ResearchEntryType::Ride;
+                    dst->type = Research::EntryType::Ride;
                     dst->flags = 0;
                     dst->category = RideTypeDescriptors[rideType].Category;
                 }
@@ -2636,7 +2636,7 @@ private:
             if (entryIndex != OBJECT_ENTRY_INDEX_IGNORE && entryIndex != OBJECT_ENTRY_INDEX_NULL)
             {
                 dst->entryIndex = entryIndex;
-                dst->type = ResearchEntryType::Scenery;
+                dst->type = Research::EntryType::Scenery;
                 dst->category = RESEARCH_CATEGORY_SCENERY_GROUP;
                 dst->flags = 0;
             }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2604,7 +2604,7 @@ private:
                     auto rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
                     dst->entryIndex = entryIndex;
                     dst->baseRideType = rideType;
-                    dst->type = RESEARCH_ENTRY_TYPE_RIDE;
+                    dst->type = ResearchEntryType::Ride;
                     dst->flags = 0;
                     dst->category = RideTypeDescriptors[rideType].Category;
                 }
@@ -2623,7 +2623,7 @@ private:
                     auto rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
                     dst->entryIndex = entryIndex;
                     dst->baseRideType = rideType;
-                    dst->type = RESEARCH_ENTRY_TYPE_RIDE;
+                    dst->type = ResearchEntryType::Ride;
                     dst->flags = 0;
                     dst->category = RideTypeDescriptors[rideType].Category;
                 }
@@ -2636,7 +2636,7 @@ private:
             if (entryIndex != OBJECT_ENTRY_INDEX_IGNORE && entryIndex != OBJECT_ENTRY_INDEX_NULL)
             {
                 dst->entryIndex = entryIndex;
-                dst->type = RESEARCH_ENTRY_TYPE_SCENERY;
+                dst->type = ResearchEntryType::Scenery;
                 dst->category = RESEARCH_CATEGORY_SCENERY_GROUP;
                 dst->flags = 0;
             }


### PR DESCRIPTION
Continuing on from #12345 this prevents any future issues by using a proper type for the item.