### PR TITLE
Fix #12356: Opening SC4 or SV4 centres viewport on void

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -672,8 +672,8 @@ struct rct1_s4
     uint32_t game_time_counter;
     rct1_ride rides[RCT12_MAX_RIDES_IN_PARK];
     uint16_t unk_game_time_counter;
-    uint16_t view_x;
-    uint16_t view_y;
+    int16_t view_x;
+    int16_t view_y;
     uint8_t view_zoom;
     uint8_t view_rotation;
     RCT12MapAnimation map_animations[RCT1_MAX_ANIMATED_OBJECTS];


### PR DESCRIPTION
Opening an SC6 or SV6 file was likely unaffected as the SV6 importer uses OpenRCT2 data structures, whereas the SV4 importer uses its own.