### PR TITLE
Change ObjectEntryIndex null value to 0xFFFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.15/objects.zip")
 set(OBJECTS_SHA1 "dfd5864cf7d0449c0fb280c5c6b902a24816df6c")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.15/replays.zip")
-set(REPLAYS_SHA1 "85EBF6760D39FA37BFDEBAA77992CB55A7C8C301")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.16/replays.zip")
+set(REPLAYS_SHA1 "8F5FABE403DE8DE7CC3C084C55EF44442E5CBA8E")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.15/objects.zip</ObjectsUrl>
     <ObjectsSha1>dfd5864cf7d0449c0fb280c5c6b902a24816df6c</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.15/replays.zip</ReplaysUrl>
-    <ReplaysSha1>85EBF6760D39FA37BFDEBAA77992CB55A7C8C301</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.16/replays.zip</ReplaysUrl>
+    <ReplaysSha1>8F5FABE403DE8DE7CC3C084C55EF44442E5CBA8E</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -39,8 +39,8 @@ static uint16_t toolSizeSpriteIndices[] =
 uint16_t gLandToolSize;
 money32 gLandToolRaiseCost;
 money32 gLandToolLowerCost;
-uint8_t gLandToolTerrainSurface;
-uint8_t gLandToolTerrainEdge;
+ObjectEntryIndex gLandToolTerrainSurface;
+ObjectEntryIndex gLandToolTerrainEdge;
 money32 gWaterToolRaiseCost;
 money32 gWaterToolLowerCost;
 

--- a/src/openrct2-ui/interface/LandTool.h
+++ b/src/openrct2-ui/interface/LandTool.h
@@ -21,8 +21,8 @@
 extern uint16_t gLandToolSize;
 extern money32 gLandToolRaiseCost;
 extern money32 gLandToolLowerCost;
-extern uint8_t gLandToolTerrainSurface;
-extern uint8_t gLandToolTerrainEdge;
+extern ObjectEntryIndex gLandToolTerrainSurface;
+extern ObjectEntryIndex gLandToolTerrainEdge;
 extern money32 gWaterToolRaiseCost;
 extern money32 gWaterToolLowerCost;
 

--- a/src/openrct2/actions/SurfaceSetStyleAction.hpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.hpp
@@ -24,15 +24,15 @@ DEFINE_GAME_ACTION(SurfaceSetStyleAction, GAME_COMMAND_CHANGE_SURFACE_STYLE, Gam
 {
 private:
     MapRange _range;
-    uint8_t _surfaceStyle;
-    uint8_t _edgeStyle;
+    ObjectEntryIndex _surfaceStyle;
+    ObjectEntryIndex _edgeStyle;
 
 public:
     SurfaceSetStyleAction()
     {
     }
 
-    SurfaceSetStyleAction(MapRange range, uint8_t surfaceStyle, uint8_t edgeStyle)
+    SurfaceSetStyleAction(MapRange range, ObjectEntryIndex surfaceStyle, ObjectEntryIndex edgeStyle)
         : _range(range)
         , _surfaceStyle(surfaceStyle)
         , _edgeStyle(edgeStyle)

--- a/src/openrct2/network/Network.cpp
+++ b/src/openrct2/network/Network.cpp
@@ -32,7 +32,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "22"
+#define NETWORK_STREAM_VERSION "23"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 using ObjectEntryIndex = uint16_t;
-constexpr const ObjectEntryIndex OBJECT_ENTRY_INDEX_NULL = 255;
+constexpr const ObjectEntryIndex OBJECT_ENTRY_INDEX_NULL = std::numeric_limits<ObjectEntryIndex>::max();
 
 // First 0xF of rct_object_entry->flags
 enum OBJECT_TYPE

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1151,7 +1151,7 @@ private:
 
         dst->sprite_identifier = SPRITE_IDENTIFIER_VEHICLE;
         dst->ride = src->ride;
-        dst->ride_subtype = ride->subtype;
+        dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(ride->subtype);
 
         dst->vehicle_type = vehicleEntryIndex;
         dst->type = src->type;
@@ -2870,7 +2870,7 @@ private:
     void ImportBanner(Banner* dst, const RCT12Banner* src)
     {
         *dst = {};
-        dst->type = src->type;
+        dst->type = RCTEntryIndexToOpenRCT2EntryIndex(src->type);
 
         dst->flags = 0;
         if (src->flags & BANNER_FLAG_NO_ENTRY)

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -1009,7 +1009,7 @@ bool RCT12ResearchItem::IsRandomEndMarker() const
     return rawValue == RCT12_RESEARCHED_ITEMS_END_2;
 }
 
-ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(RCT12ObjectEntryIndex index)
+ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(const RCT12ObjectEntryIndex index)
 {
     if (index == RCT12_OBJECT_ENTRY_INDEX_NULL)
         return OBJECT_ENTRY_INDEX_NULL;
@@ -1017,7 +1017,7 @@ ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(RCT12ObjectEntryIndex index)
     return index;
 }
 
-RCT12ObjectEntryIndex OpenRCT2EntryIndexToRCTEntryIndex(ObjectEntryIndex index)
+RCT12ObjectEntryIndex OpenRCT2EntryIndexToRCTEntryIndex(const ObjectEntryIndex index)
 {
     if (index == OBJECT_ENTRY_INDEX_NULL)
         return RCT12_OBJECT_ENTRY_INDEX_NULL;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -820,5 +820,5 @@ assert_struct_size(RCT12ResearchItem, 5);
 
 #pragma pack(pop)
 
-ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(RCT12ObjectEntryIndex index);
-RCT12ObjectEntryIndex OpenRCT2EntryIndexToRCTEntryIndex(ObjectEntryIndex index);
+ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(const RCT12ObjectEntryIndex index);
+RCT12ObjectEntryIndex OpenRCT2EntryIndexToRCTEntryIndex(const ObjectEntryIndex index);

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -773,7 +773,7 @@ assert_struct_size(RCT12RideMeasurement, 0x4B0C);
 
 struct RCT12Banner
 {
-    uint8_t type;
+    RCT12ObjectEntryIndex type;
     uint8_t flags;            // 0x01
     rct_string_id string_idx; // 0x02
     union

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -501,7 +501,7 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     std::memset(dst, 0, sizeof(rct2_ride));
 
     dst->type = OpenRCT2RideTypeToRCT2RideType(src->type);
-    dst->subtype = src->subtype;
+    dst->subtype = OpenRCT2EntryIndexToRCTEntryIndex(src->subtype);
     // pad_002;
     dst->mode = src->mode;
     dst->colour_scheme_type = src->colour_scheme_type;
@@ -1083,7 +1083,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src)
     dst->var_D3 = src->var_D3;
     dst->mini_golf_current_animation = src->mini_golf_current_animation;
     dst->mini_golf_flags = src->mini_golf_flags;
-    dst->ride_subtype = src->ride_subtype;
+    dst->ride_subtype = OpenRCT2EntryIndexToRCTEntryIndex(src->ride_subtype);
     dst->colours_extended = src->colours_extended;
     dst->seat_rotation = src->seat_rotation;
     dst->target_seat_rotation = src->target_seat_rotation;
@@ -1352,7 +1352,7 @@ void S6Exporter::ExportBanners()
 void S6Exporter::ExportBanner(RCT12Banner& dst, const Banner& src)
 {
     dst = {};
-    dst.type = src.type;
+    dst.type = OpenRCT2EntryIndexToRCTEntryIndex(src.type);
 
     if (!src.IsNull())
     {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -509,16 +509,17 @@ public:
         dst->id = rideIndex;
 
         ObjectEntryIndex rideType = src->type;
+        auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->subtype);
         if (RCT2RideTypeNeedsConversion(src->type))
         {
-            auto* rideEntry = get_ride_entry(src->subtype);
+            auto* rideEntry = get_ride_entry(subtype);
             if (rideEntry != nullptr)
             {
                 rideType = RCT2RideTypeToOpenRCT2RideType(src->type, rideEntry);
             }
         }
         dst->type = rideType;
-        dst->subtype = src->subtype;
+        dst->subtype = subtype;
         // pad_002;
         dst->mode = src->mode;
         dst->colour_scheme_type = src->colour_scheme_type;
@@ -936,7 +937,7 @@ public:
     void ImportBanner(Banner* dst, const RCT12Banner* src)
     {
         *dst = {};
-        dst->type = src->type;
+        dst->type = RCTEntryIndexToOpenRCT2EntryIndex(src->type);
         dst->flags = src->flags;
 
         if (!(src->flags & BANNER_FLAG_LINKED_TO_RIDE) && is_user_string_id(src->string_idx))
@@ -1408,7 +1409,7 @@ public:
         dst->var_D3 = src->var_D3;
         dst->mini_golf_current_animation = src->mini_golf_current_animation;
         dst->mini_golf_flags = src->mini_golf_flags;
-        dst->ride_subtype = src->ride_subtype;
+        dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->ride_subtype);
         dst->colours_extended = src->colours_extended;
         dst->seat_rotation = src->seat_rotation;
         dst->target_seat_rotation = src->target_seat_rotation;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1945,8 +1945,8 @@ static SoundIdVolume sub_6D7AC0(SoundId currentSoundId, uint8_t currentVolume, S
  */
 void Vehicle::Update()
 {
-    // The cable lift uses the ride type of NULL
-    if (ride_subtype == RIDE_TYPE_NULL)
+    // The cable lift uses a ride entry index of NULL
+    if (ride_subtype == RIDE_ENTRY_INDEX_NULL)
     {
         CableLiftUpdate();
         return;
@@ -7621,7 +7621,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, uint16_t* oth
             if (z_diff > 16)
                 continue;
 
-            if (vehicle2->ride_subtype == RIDE_TYPE_NULL)
+            if (vehicle2->ride_subtype == RIDE_ENTRY_INDEX_NULL)
                 continue;
 
             auto collideVehicleEntry = vehicle2->Entry();

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -306,7 +306,7 @@ struct Vehicle : SpriteBase
     uint8_t var_D3;
     uint8_t mini_golf_current_animation;
     uint8_t mini_golf_flags;
-    uint8_t ride_subtype;
+    ObjectEntryIndex ride_subtype;
     uint8_t colours_extended;
     uint8_t seat_rotation;
     uint8_t target_seat_rotation;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -656,9 +656,9 @@ void scenario_fix_ghosts(rct_s6_data* s6)
                     if (bannerIndex != RCT12_BANNER_INDEX_NULL)
                     {
                         auto banner = &s6->banners[bannerIndex];
-                        if (banner->type != BANNER_NULL)
+                        if (banner->type != RCT12_OBJECT_ENTRY_INDEX_NULL)
                         {
-                            banner->type = BANNER_NULL;
+                            banner->type = RCT12_OBJECT_ENTRY_INDEX_NULL;
                             if (is_user_string_id(banner->string_idx))
                                 s6->custom_strings[(banner->string_idx % RCT12_MAX_USER_STRINGS)][0] = 0;
                         }


### PR DESCRIPTION
This is an important step (and also the last, hopefully) towards breaching the 255-object-entries-per-object-type barrier. Considering users want much more than 252 small objects, being able to extend beyond 255 is an important thing for the new save format.