### PR TITLE
Fix GetAdditionEntry trying obtain the object when no additions exist

### DIFF
--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1529,6 +1529,8 @@ ObjectEntryIndex PathElement::GetAdditionEntryIndex() const
 
 rct_scenery_entry* PathElement::GetAdditionEntry() const
 {
+    if (!HasAddition())
+        return nullptr;
     return get_footpath_item_entry(GetAdditionEntryIndex());
 }
 


### PR DESCRIPTION
Without checking for additions first it would use GetAdditionEntryIndex() which looks like following
```
ObjectEntryIndex PathElement::GetAdditionEntryIndex() const
{
    return GetAddition() - 1;
}
```
GetAddition would return 0 and minus one would cause an underflow so it attempted get an object with index 0xFFFF in the object manager. This PR eliminates all the warning spam by simply checking first if its worth going into the object manager.