### PR TITLE
Part of #11389: Audit calls to memcpy with gCommonFormatArgs

### DIFF
--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -928,7 +928,9 @@ static FilterArguments get_arguments_from_peep(const Peep* peep)
             {
                 std::memset(gCommonFormatArgs, 0, sizeof(gCommonFormatArgs));
                 peep_thought_set_format_args(thought);
-                std::memcpy(result.args, gCommonFormatArgs, std::min(sizeof(gCommonFormatArgs), sizeof(result.args)));
+
+                ft = Formatter::Common();
+                ft.CopyInto<uint8_t*>(result.args, sizeof(result.args));
             }
             break;
         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3764,9 +3764,9 @@ static void window_ride_operating_invalidate(rct_window* w)
         if (ride->type == RIDE_TYPE_TWIST)
         {
             uint16_t arg;
-            std::memcpy(&arg, gCommonFormatArgs + 18, sizeof(uint16_t));
             ft = Formatter::Common();
             ft.Increment(18);
+            ft.CopyInto<uint16_t*>(&arg, 1);
             ft.Add<uint16_t>(arg * 3);
         }
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -708,7 +708,9 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 formatSecondary = STR_QUEUE_EMPTY;
                 {
                     uint16_t arg;
-                    std::memcpy(&arg, gCommonFormatArgs + 2, sizeof(uint16_t));
+                    ft.Rewind();
+                    ft.Increment(2);
+                    ft.CopyInto<uint16_t*>(&arg, 1);
 
                     if (arg == 1)
                         formatSecondary = STR_QUEUE_ONE_PERSON;
@@ -721,7 +723,9 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 formatSecondary = STR_QUEUE_TIME_LABEL;
                 {
                     uint16_t arg;
-                    std::memcpy(&arg, gCommonFormatArgs + 2, sizeof(uint16_t));
+                    ft.Rewind();
+                    ft.Increment(2);
+                    ft.CopyInto<uint16_t*>(&arg, 1);
 
                     if (arg > 1)
                         formatSecondary = STR_QUEUE_TIME_PLURAL_LABEL;

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1462,7 +1462,10 @@ int32_t scrolling_text_setup(
     // Setup scrolling text
     auto scrollText = &_drawScrollTextList[scrollIndex];
     scrollText->string_id = stringId;
-    std::memcpy(scrollText->string_args, gCommonFormatArgs, sizeof(scrollText->string_args));
+
+    auto ft = Formatter::Common();
+    ft.CopyInto<uint8_t*>(scrollText->string_args, sizeof(scrollText->string_args));
+
     scrollText->colour = colour;
     scrollText->position = scroll;
     scrollText->mode = scrollingMode;

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -127,6 +127,15 @@ public:
         return CurrentBuf - StartBuf;
     }
 
+    template<typename TSpecified, typename TDeduced> void CopyInto(TDeduced value, size_t numElements)
+    {
+        if (std::is_same_v<TSpecified, uint16_t*>)
+        {
+            numElements *= 2;
+        }
+        std::memcpy(value, CurrentBuf, numElements);
+    }
+
     template<typename TSpecified, typename TDeduced> Formatter& Add(TDeduced value)
     {
         static_assert(sizeof(TSpecified) <= sizeof(uintptr_t), "Type too large");
@@ -161,5 +170,4 @@ public:
         return *this;
     }
 };
-
 #endif


### PR DESCRIPTION
I've added a CopyInto method to do the value copying. I've also made it so when you call it with uint16_t*, the function doubles the number of bytes to pass into the std::memcpy. I've tested all places where this function is called.