### PR TITLE
Reduce use of get_sprite

### DIFF
--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -248,7 +248,7 @@ namespace OpenRCT2::Scripting
     private:
         Vehicle* GetVehicle() const
         {
-            return get_sprite(_id)->generic.As<Vehicle>();
+            return ::GetEntity<Vehicle>(_id);
         }
 
         uint8_t rideObject_get() const

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -284,11 +284,12 @@ rct_sprite_checksum sprite_checksum()
         for (size_t i = 0; i < MAX_SPRITES; i++)
         {
             // TODO create a way to copy only the specific type
-            auto sprite = get_sprite(i);
-            if (sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_NULL
-                && sprite->generic.sprite_identifier != SPRITE_IDENTIFIER_MISC)
+            auto sprite = GetEntity(i);
+            if (sprite != nullptr && sprite->sprite_identifier != SPRITE_IDENTIFIER_NULL
+                && sprite->sprite_identifier != SPRITE_IDENTIFIER_MISC)
             {
-                auto copy = *sprite;
+                // Up convert it to rct_sprite so that the full size is copied.
+                auto copy = *reinterpret_cast<rct_sprite*>(sprite);
 
                 // Only required for rendering/invalidation, has no meaning to the game state.
                 copy.generic.sprite_left = copy.generic.sprite_right = copy.generic.sprite_top = copy.generic.sprite_bottom = 0;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -288,7 +288,7 @@ rct_sprite_checksum sprite_checksum()
             if (sprite != nullptr && sprite->sprite_identifier != SPRITE_IDENTIFIER_NULL
                 && sprite->sprite_identifier != SPRITE_IDENTIFIER_MISC)
             {
-                // Up convert it to rct_sprite so that the full size is copied.
+                // Upconvert it to rct_sprite so that the full size is copied.
                 auto copy = *reinterpret_cast<rct_sprite*>(sprite);
 
                 // Only required for rendering/invalidation, has no meaning to the game state.

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -108,7 +108,7 @@ static std::unique_ptr<GameState_t> GetGameState(std::unique_ptr<IContext>& cont
     std::unique_ptr<GameState_t> res = std::make_unique<GameState_t>();
     for (size_t spriteIdx = 0; spriteIdx < MAX_SPRITES; spriteIdx++)
     {
-        rct_sprite* sprite = get_sprite(spriteIdx);
+        rct_sprite* sprite = reinterpret_cast<rct_sprite*>(GetEntity(spriteIdx));
         if (sprite == nullptr)
             res->sprites[spriteIdx].generic.sprite_identifier = SPRITE_IDENTIFIER_NULL;
         else


### PR DESCRIPTION
This reduces the uses of the get_sprite function to just the vehicle.h and peep.h macros.