### PR TITLE
Disable vcpkg for all projects

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-
   <PropertyGroup>
     <!-- Allow any version of VS and Windows SDK -->
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
@@ -113,4 +112,8 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
+  
+  <PropertyGroup>
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Since we ship pre-compiled libraries this causes some issues, in my case I have gtest installed from Vcpkg and causes build errors. Since we don't use Vcpkg I simply disabled it in all projects.