### PR TITLE
Fix #11623: Erratic zoom behavior when pointing outside of the map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Fix: [#11405] Building a path through walls does not always remove the walls.
 - Fix: [#11450] Rides with unsuitable track can't be opened even with "Enable all drawable track pieces" cheat.
 - Fix: [#11455] Object Selection window cuts off scenery names.
+- Fix: [#11623] Erratic zoom behavior when pointing outside of the map.
 - Fix: [#11640] Objects with a blank description in one language do not fall back to other languages anymore.
 - Fix: [#11676] Spiral Roller Coaster has regular lift hill available.
 - Fix: [#11695] Mechanics walk to tile 0, 0 at entrance only stations when trying to fix them.

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -953,8 +953,8 @@ void window_viewport_get_map_coords_by_cursor(
     auto mouseCoords = context_get_cursor_position_scaled();
 
     // Compute map coordinate by mouse position.
-    CoordsXY mapCoords;
-    get_map_coordinates_from_pos(mouseCoords, VIEWPORT_INTERACTION_MASK_NONE, mapCoords, nullptr, nullptr, nullptr);
+    auto viewportPos = screen_coord_to_viewport_coord(w->viewport, mouseCoords);
+    auto mapCoords = viewport_coord_to_map_coord(viewportPos, 0);
     *map_x = mapCoords.x;
     *map_y = mapCoords.y;
 


### PR DESCRIPTION
The way the zoom worked when 'Zoom to mouse position' is enabled was by looking for the tile the mouse pointed at, it used the same code as the interaction part, this would obviously fail if you point outside the map causing the function get_map_coordinates_from_pos to always result x=0, y=0 which is incorrect. Also get_map_coordinates_from_pos had to setup a paint session in order to find the tile pointing at which is not really required for this function. This PR instead just translates the screen coordinates to map coordinates which also adds a bit of a performance improvement which is sadly not really noticeable but its there.
Now the zoom works as expected.
![b3yE6XlAJo](https://user-images.githubusercontent.com/5415177/88466470-ddea6e00-cecc-11ea-8078-5a6f84ac9fde.gif)

Closes #11623