### PR TITLE
Fix #12297: OpenGL renderer causing artifacts

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -51,6 +51,7 @@
 - Fix: [#12211] Map Generator shows incorrect map sizes (e.g. "150 x 0").
 - Fix: [#12221] Map Generation tool doesn't place any trees.
 - Fix: [#12285] On-ride photo profit assumes every guest buys one.
+- Fix: [#12297] OpenGL renderer causing artifacts.
 - Fix: [#12312] Softlock when loading save file via command line fails.
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -215,19 +215,19 @@ void TextureCache::EnlargeAtlasesTexture(GLuint newEntries)
 
         // Initial capacity will be 12 which covers most cases of a fully visible park.
         _atlasesTextureCapacity = (_atlasesTextureCapacity + 6) << 1UL;
-    }
 
-    glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
-    glTexImage3D(
-        GL_TEXTURE_2D_ARRAY, 0, GL_R8UI, _atlasesTextureDimensions, _atlasesTextureDimensions, _atlasesTextureCapacity, 0,
-        GL_RED_INTEGER, GL_UNSIGNED_BYTE, nullptr);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, _atlasesTexture);
+        glTexImage3D(
+            GL_TEXTURE_2D_ARRAY, 0, GL_R8UI, _atlasesTextureDimensions, _atlasesTextureDimensions, _atlasesTextureCapacity, 0,
+            GL_RED_INTEGER, GL_UNSIGNED_BYTE, nullptr);
 
-    // Restore old data
-    if (!oldPixels.empty())
-    {
-        glTexSubImage3D(
-            GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, _atlasesTextureDimensions, _atlasesTextureDimensions, _atlasesTextureIndices,
-            GL_RED_INTEGER, GL_UNSIGNED_BYTE, oldPixels.data());
+        // Restore old data
+        if (!oldPixels.empty())
+        {
+            glTexSubImage3D(
+                GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, _atlasesTextureDimensions, _atlasesTextureDimensions, _atlasesTextureIndices,
+                GL_RED_INTEGER, GL_UNSIGNED_BYTE, oldPixels.data());
+        }
     }
 
     _atlasesTextureIndices = newIndices;


### PR DESCRIPTION
Do not re-allocate texture memory if we don't need to and aren't going to restore the old pixels.