### PR TITLE
Fix #12486: `set-rct2` has a broken g1.dat check

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -148,6 +148,7 @@ The following people are not part of the development team, but have been contrib
 * Reid Baris (Rdbaris)
 * Deanna Baris (dbaris)
 * Chaitanya Thengdi (chaitanyathengdi)
+* Sidney Kuyateh (autinerd)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -53,6 +53,7 @@
 - Fix: [#12285] On-ride photo profit assumes every guest buys one.
 - Fix: [#12297] OpenGL renderer causing artifacts.
 - Fix: [#12312] Softlock when loading save file via command line fails.
+- Fix: [#12486] `set-rct2` has a broken g1.dat check.
 - Fix: 'j' character has broken kerning (original bug).
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Improved: [#6530] Allow water and land height changes on park borders.

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -367,7 +367,7 @@ static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator* enumerator)
     String::Set(pathG1Check, sizeof(pathG1Check), path);
     Path::Append(pathG1Check, sizeof(pathG1Check), "Data");
     Path::Append(pathG1Check, sizeof(pathG1Check), "g1.dat");
-    if (Platform::FileExists(pathG1Check))
+    if (!Platform::FileExists(pathG1Check))
     {
         Console::Error::WriteLine("RCT2 path not valid.");
         Console::Error::WriteLine("Unable to find %s.", pathG1Check);


### PR DESCRIPTION
This fixes #12486, where the path of g1.dat is valid in `openrct2 set-rct2` when it doesn't exist.