### PR TITLE
Fix #7969, #8175, #12501: Loading landscape resets money, inventions and objective

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#6119] Advertising campaign for ride window not updated properly (original bug).
 - Fix: [#7006] Submarine Ride is in the wrong research group.
 - Fix: [#7324] Research window shows vehicle name instead of ride name.
+- Fix: [#7969, #8175, #12501] When loading a landscape in the Scenario Editor, the inventions list, financial settings and objective settings are reset.
 - Fix: [#10634] Guests are unable to use uphill paths out of toilets.
 - Fix: [#10876] When removing a path, its guest entry point is not removed.
 - Fix: [#10876] There can be multiple peep spawns on the same location.

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -270,6 +270,7 @@ namespace Editor
     static bool ReadS6(const char* path)
     {
         auto extension = path_get_extension(path);
+        auto loadedFromSave = false;
         if (_stricmp(extension, ".sc6") == 0)
         {
             load_from_sc6(path);
@@ -277,9 +278,10 @@ namespace Editor
         else if (_stricmp(extension, ".sv6") == 0 || _stricmp(extension, ".sv7") == 0)
         {
             load_from_sv6(path);
+            loadedFromSave = true;
         }
 
-        ClearMapForEditing(true);
+        ClearMapForEditing(loadedFromSave);
 
         gS6Info.editor_step = EDITOR_STEP_LANDSCAPE_EDITOR;
         gScreenAge = 0;


### PR DESCRIPTION
This bug was introduced during a refactor: 7fd3fd00049ee2c2b8f45c6374e5b6ed30138990