### PR TITLE
Fix: Brakes keep working during "Brakes failure"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -59,6 +59,7 @@
 - Fix: [#12506] Cannot advertise food if there are no rides in the park.
 - Fix: 'j' character has broken kerning (original bug).
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
+- Fix: Brakes keep working during "Brakes failure".
 - Improved: [#6530] Allow water and land height changes on park borders.
 - Improved: [#11390] Build hash written to screenshot metadata.
 - Improved: [#3205] Make handymen less likely to get stuck in ride queues.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "23"
+#define NETWORK_STREAM_VERSION "24"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3856,8 +3856,9 @@ void Vehicle::UpdateArriving()
             return;
     }
 
-    if (curRide->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN && curRide->breakdown_reason_pending == BREAKDOWN_BRAKES_FAILURE
-        && curRide->inspection_station == current_station
+    bool hasBrakesFailure = curRide->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN
+        && curRide->breakdown_reason_pending == BREAKDOWN_BRAKES_FAILURE;
+    if (hasBrakesFailure && curRide->inspection_station == current_station
         && curRide->mechanic_status != RIDE_MECHANIC_STATUS_HAS_FIXED_STATION_BRAKES)
     {
         unkF64E35 = 0;
@@ -8083,9 +8084,9 @@ loc_6DAEB9:
     }
     else if (trackType == TRACK_ELEM_BRAKES)
     {
-        if (!(curRide->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN
-              && curRide->breakdown_reason_pending == BREAKDOWN_BRAKES_FAILURE
-              && curRide->mechanic_status == RIDE_MECHANIC_STATUS_HAS_FIXED_STATION_BRAKES))
+        bool hasBrakesFailure = curRide->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN
+            && curRide->breakdown_reason_pending == BREAKDOWN_BRAKES_FAILURE;
+        if (!hasBrakesFailure || curRide->mechanic_status == RIDE_MECHANIC_STATUS_HAS_FIXED_STATION_BRAKES)
         {
             regs.eax = brake_speed << 16;
             if (regs.eax < _vehicleVelocityF64E08)


### PR DESCRIPTION
This was an error in the original implementation back in 2015.
Thanks to @duncanspumpkin for checking the assembly.