### PR TITLE
Eliminate Win32 garbage

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -52,7 +52,7 @@
              C4549: 'operator': operator before comma has no effect; did you intend 'operator'?
              C4555: expression has no effect; expected expression with side-effect
       -->
-      <PreprocessorDefinitions>__AVX2__;__SSE4_1__;OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__AVX2__;__SSE4_1__;OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;NOMINMAX;WIN32_LEAN_AND_MEAN%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>ENABLE_SCRIPTING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'!='true'">MultiThreaded</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'=='true'">MultiThreadedDLL</RuntimeLibrary>

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -16,7 +16,11 @@
 #    endif // __MINGW32__
 
 // Windows.h needs to be included first
+// clang-format off
 #    include <windows.h>
+#    include <shellapi.h>
+#    include <commdlg.h>
+// clang-format on
 #    undef CreateWindow
 
 // Then the rest

--- a/src/openrct2-ui/UiContext.h
+++ b/src/openrct2-ui/UiContext.h
@@ -17,26 +17,27 @@ struct SDL_Window;
 
 namespace OpenRCT2
 {
-    INTERFACE IContext;
-    INTERFACE IPlatformEnvironment;
+    struct IContext;
+    struct IPlatformEnvironment;
 
     namespace Ui
     {
         struct FileDialogDesc;
         class InGameConsole;
-        INTERFACE IUiContext;
+        struct IUiContext;
 
-        INTERFACE IPlatformUiContext
+        struct IPlatformUiContext
         {
             virtual ~IPlatformUiContext() = default;
-            virtual void SetWindowIcon(SDL_Window * window) abstract;
+            virtual void SetWindowIcon(SDL_Window* window) abstract;
             virtual bool IsSteamOverlayAttached() abstract;
 
-            virtual void ShowMessageBox(SDL_Window * window, const std::string& message) abstract;
+            virtual void ShowMessageBox(SDL_Window* window, const std::string& message) abstract;
             virtual void OpenFolder(const std::string& path) abstract;
+
             virtual void OpenURL(const std::string& url) abstract;
-            virtual std::string ShowFileDialog(SDL_Window * window, const FileDialogDesc& desc) abstract;
-            virtual std::string ShowDirectoryDialog(SDL_Window * window, const std::string& title) abstract;
+            virtual std::string ShowFileDialog(SDL_Window* window, const FileDialogDesc& desc) abstract;
+            virtual std::string ShowDirectoryDialog(SDL_Window* window, const std::string& title) abstract;
         };
 
         std::unique_ptr<IUiContext> CreateUiContext(const std::shared_ptr<IPlatformEnvironment>& env);

--- a/src/openrct2-ui/UiContext.h
+++ b/src/openrct2-ui/UiContext.h
@@ -17,16 +17,16 @@ struct SDL_Window;
 
 namespace OpenRCT2
 {
-    interface IContext;
-    interface IPlatformEnvironment;
+    INTERFACE IContext;
+    INTERFACE IPlatformEnvironment;
 
     namespace Ui
     {
         struct FileDialogDesc;
         class InGameConsole;
-        interface IUiContext;
+        INTERFACE IUiContext;
 
-        interface IPlatformUiContext
+        INTERFACE IPlatformUiContext
         {
             virtual ~IPlatformUiContext() = default;
             virtual void SetWindowIcon(SDL_Window * window) abstract;

--- a/src/openrct2-ui/WindowManager.h
+++ b/src/openrct2-ui/WindowManager.h
@@ -13,7 +13,7 @@
 
 namespace OpenRCT2::Ui
 {
-    interface IWindowManager;
+    INTERFACE IWindowManager;
 
     IWindowManager* CreateWindowManager();
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/WindowManager.h
+++ b/src/openrct2-ui/WindowManager.h
@@ -13,7 +13,7 @@
 
 namespace OpenRCT2::Ui
 {
-    INTERFACE IWindowManager;
+    struct IWindowManager;
 
     IWindowManager* CreateWindowManager();
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -21,7 +21,7 @@ using SpeexResamplerState = struct SpeexResamplerState_;
 namespace OpenRCT2::Audio
 {
     struct AudioFormat;
-    INTERFACE IAudioContext;
+    struct IAudioContext;
 
 #pragma pack(push, 1)
     struct WaveFormat
@@ -48,16 +48,16 @@ namespace OpenRCT2::Audio
     assert_struct_size(WaveFormatEx, 18);
 #pragma pack(pop)
 
-    INTERFACE ISDLAudioSource : public IAudioSource
+    struct ISDLAudioSource : public IAudioSource
     {
         [[nodiscard]] virtual AudioFormat GetFormat() const abstract;
     };
 
-    INTERFACE ISDLAudioChannel : public IAudioChannel
+    struct ISDLAudioChannel : public IAudioChannel
     {
         [[nodiscard]] virtual AudioFormat GetFormat() const abstract;
         [[nodiscard]] virtual SpeexResamplerState* GetResampler() const abstract;
-        virtual void SetResampler(SpeexResamplerState * value) abstract;
+        virtual void SetResampler(SpeexResamplerState* value) abstract;
     };
 
     namespace AudioSource

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -21,7 +21,7 @@ using SpeexResamplerState = struct SpeexResamplerState_;
 namespace OpenRCT2::Audio
 {
     struct AudioFormat;
-    interface IAudioContext;
+    INTERFACE IAudioContext;
 
 #pragma pack(push, 1)
     struct WaveFormat
@@ -48,12 +48,12 @@ namespace OpenRCT2::Audio
     assert_struct_size(WaveFormatEx, 18);
 #pragma pack(pop)
 
-    interface ISDLAudioSource : public IAudioSource
+    INTERFACE ISDLAudioSource : public IAudioSource
     {
         [[nodiscard]] virtual AudioFormat GetFormat() const abstract;
     };
 
-    interface ISDLAudioChannel : public IAudioChannel
+    INTERFACE ISDLAudioChannel : public IAudioChannel
     {
         [[nodiscard]] virtual AudioFormat GetFormat() const abstract;
         [[nodiscard]] virtual SpeexResamplerState* GetResampler() const abstract;

--- a/src/openrct2-ui/drawing/engines/DrawingEngineFactory.hpp
+++ b/src/openrct2-ui/drawing/engines/DrawingEngineFactory.hpp
@@ -19,7 +19,7 @@ namespace OpenRCT2
     {
         using namespace OpenRCT2::Drawing;
 
-        interface IUiContext;
+        INTERFACE IUiContext;
 
         std::unique_ptr<IDrawingEngine> CreateSoftwareDrawingEngine(const std::shared_ptr<IUiContext>& uiContext);
         std::unique_ptr<IDrawingEngine> CreateHardwareDisplayDrawingEngine(const std::shared_ptr<IUiContext>& uiContext);

--- a/src/openrct2-ui/drawing/engines/DrawingEngineFactory.hpp
+++ b/src/openrct2-ui/drawing/engines/DrawingEngineFactory.hpp
@@ -19,7 +19,7 @@ namespace OpenRCT2
     {
         using namespace OpenRCT2::Drawing;
 
-        INTERFACE IUiContext;
+        struct IUiContext;
 
         std::unique_ptr<IDrawingEngine> CreateSoftwareDrawingEngine(const std::shared_ptr<IUiContext>& uiContext);
         std::unique_ptr<IDrawingEngine> CreateHardwareDisplayDrawingEngine(const std::shared_ptr<IUiContext>& uiContext);

--- a/src/openrct2-ui/input/KeyboardShortcuts.h
+++ b/src/openrct2-ui/input/KeyboardShortcuts.h
@@ -123,7 +123,7 @@ enum KeyboardShortcut
 
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 
     namespace Input
     {

--- a/src/openrct2-ui/input/KeyboardShortcuts.h
+++ b/src/openrct2-ui/input/KeyboardShortcuts.h
@@ -123,7 +123,7 @@ enum KeyboardShortcut
 
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 
     namespace Input
     {

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -280,7 +280,7 @@ private:
                 TitleSequenceParkHandle* parkHandle = TitleSequenceGetParkHandle(_sequence, saveIndex);
                 if (parkHandle != nullptr)
                 {
-                    loadSuccess = LoadParkFromStream(static_cast<IStream*>(parkHandle->Stream), parkHandle->HintPath);
+                    loadSuccess = LoadParkFromStream(static_cast<OpenRCT2::IStream*>(parkHandle->Stream), parkHandle->HintPath);
                     TitleSequenceCloseParkHandle(parkHandle);
                 }
                 if (!loadSuccess)
@@ -389,7 +389,7 @@ private:
      * @param stream The stream to read the park data from.
      * @param hintPath Hint path, the extension is grabbed to determine what importer to use.
      */
-    bool LoadParkFromStream(IStream* stream, const std::string& hintPath)
+    bool LoadParkFromStream(OpenRCT2::IStream* stream, const std::string& hintPath)
     {
         log_verbose("TitleSequencePlayer::LoadParkFromStream(%s)", hintPath.c_str());
         bool success = false;

--- a/src/openrct2-ui/title/TitleSequencePlayer.h
+++ b/src/openrct2-ui/title/TitleSequencePlayer.h
@@ -12,8 +12,8 @@
 #include <memory>
 #include <openrct2/common.h>
 
-interface ITitleSequencePlayer;
-interface IScenarioRepository;
+INTERFACE ITitleSequencePlayer;
+INTERFACE IScenarioRepository;
 
 namespace OpenRCT2
 {

--- a/src/openrct2-ui/title/TitleSequencePlayer.h
+++ b/src/openrct2-ui/title/TitleSequencePlayer.h
@@ -12,8 +12,8 @@
 #include <memory>
 #include <openrct2/common.h>
 
-INTERFACE ITitleSequencePlayer;
-INTERFACE IScenarioRepository;
+struct ITitleSequencePlayer;
+struct IScenarioRepository;
 
 namespace OpenRCT2
 {

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -359,7 +359,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
             if (w->selected_list_item >= 0 && w->selected_list_item < static_cast<int16_t>(_editingTitleSequence->NumSaves))
             {
                 auto handle = TitleSequenceGetParkHandle(_editingTitleSequence, w->selected_list_item);
-                auto stream = static_cast<IStream*>(handle->Stream);
+                auto stream = static_cast<OpenRCT2::IStream*>(handle->Stream);
                 auto hintPath = String::ToStd(handle->HintPath);
                 bool isScenario = ParkImporter::ExtensionIsScenario(hintPath);
                 try

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 // Windows.h needs to be included first
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 // Enable visual styles

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -98,7 +98,7 @@ void CheatsSerialise(DataSerialiser& ds)
 
     if (ds.IsSaving())
     {
-        IStream& stream = ds.GetStream();
+        OpenRCT2::IStream& stream = ds.GetStream();
 
         // Temporarily write 0, will be updated after every cheat is written.
         uint64_t countOffset = stream.GetPosition();

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -18,7 +18,10 @@
 INTERFACE IObjectManager;
 INTERFACE IObjectRepository;
 INTERFACE IScenarioRepository;
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 INTERFACE ITrackDesignRepository;
 INTERFACE IGameStateSnapshots;
 

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -15,15 +15,15 @@
 #include <memory>
 #include <string>
 
-INTERFACE IObjectManager;
-INTERFACE IObjectRepository;
-INTERFACE IScenarioRepository;
+struct IObjectManager;
+struct IObjectRepository;
+struct IScenarioRepository;
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
-INTERFACE ITrackDesignRepository;
-INTERFACE IGameStateSnapshots;
+struct ITrackDesignRepository;
+struct IGameStateSnapshots;
 
 class Intent;
 struct rct_window;
@@ -70,17 +70,17 @@ namespace OpenRCT2
 {
     class GameState;
 
-    INTERFACE IPlatformEnvironment;
-    INTERFACE IReplayManager;
+    struct IPlatformEnvironment;
+    struct IReplayManager;
 
     namespace Audio
     {
-        INTERFACE IAudioContext;
+        struct IAudioContext;
     }
 
     namespace Drawing
     {
-        INTERFACE IDrawingEngine;
+        struct IDrawingEngine;
     }
 
     namespace Localisation
@@ -95,18 +95,18 @@ namespace OpenRCT2
 
     namespace Ui
     {
-        INTERFACE IUiContext;
+        struct IUiContext;
     }
 
     namespace Paint
     {
-        INTERFACE Painter;
+        struct Painter;
     }
 
     /**
      * Represents an instance of OpenRCT2 and can be used to get various services.
      */
-    INTERFACE IContext
+    struct IContext
     {
         virtual ~IContext() = default;
 
@@ -134,8 +134,8 @@ namespace OpenRCT2
         virtual void InitialiseDrawingEngine() abstract;
         virtual void DisposeDrawingEngine() abstract;
         virtual bool LoadParkFromFile(const std::string& path, bool loadTitleScreenOnFail = false) abstract;
-        virtual bool LoadParkFromStream(IStream * stream, const std::string& path, bool loadTitleScreenFirstOnFail = false)
-            abstract;
+        virtual bool LoadParkFromStream(
+            IStream* stream, const std::string& path, bool loadTitleScreenFirstOnFail = false) abstract;
         virtual void WriteLine(const std::string& s) abstract;
         virtual void Finish() abstract;
         virtual void Quit() abstract;

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -15,12 +15,12 @@
 #include <memory>
 #include <string>
 
-interface IObjectManager;
-interface IObjectRepository;
-interface IScenarioRepository;
-interface IStream;
-interface ITrackDesignRepository;
-interface IGameStateSnapshots;
+INTERFACE IObjectManager;
+INTERFACE IObjectRepository;
+INTERFACE IScenarioRepository;
+INTERFACE IStream;
+INTERFACE ITrackDesignRepository;
+INTERFACE IGameStateSnapshots;
 
 class Intent;
 struct rct_window;
@@ -67,17 +67,17 @@ namespace OpenRCT2
 {
     class GameState;
 
-    interface IPlatformEnvironment;
-    interface IReplayManager;
+    INTERFACE IPlatformEnvironment;
+    INTERFACE IReplayManager;
 
     namespace Audio
     {
-        interface IAudioContext;
+        INTERFACE IAudioContext;
     }
 
     namespace Drawing
     {
-        interface IDrawingEngine;
+        INTERFACE IDrawingEngine;
     }
 
     namespace Localisation
@@ -92,18 +92,18 @@ namespace OpenRCT2
 
     namespace Ui
     {
-        interface IUiContext;
+        INTERFACE IUiContext;
     }
 
     namespace Paint
     {
-        interface Painter;
+        INTERFACE Painter;
     }
 
     /**
      * Represents an instance of OpenRCT2 and can be used to get various services.
      */
-    interface IContext
+    INTERFACE IContext
     {
         virtual ~IContext() = default;
 

--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -16,15 +16,15 @@
 #include "scenario/Scenario.h"
 #include "util/SawyerCoding.h"
 
-static bool TryClassifyAsS6(IStream* stream, ClassifiedFileInfo* result);
-static bool TryClassifyAsS4(IStream* stream, ClassifiedFileInfo* result);
-static bool TryClassifyAsTD4_TD6(IStream* stream, ClassifiedFileInfo* result);
+static bool TryClassifyAsS6(OpenRCT2::IStream* stream, ClassifiedFileInfo* result);
+static bool TryClassifyAsS4(OpenRCT2::IStream* stream, ClassifiedFileInfo* result);
+static bool TryClassifyAsTD4_TD6(OpenRCT2::IStream* stream, ClassifiedFileInfo* result);
 
 bool TryClassifyFile(const std::string& path, ClassifiedFileInfo* result)
 {
     try
     {
-        auto fs = FileStream(path, FILE_MODE_OPEN);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
         return TryClassifyFile(&fs, result);
     }
     catch (const std::exception&)
@@ -33,7 +33,7 @@ bool TryClassifyFile(const std::string& path, ClassifiedFileInfo* result)
     }
 }
 
-bool TryClassifyFile(IStream* stream, ClassifiedFileInfo* result)
+bool TryClassifyFile(OpenRCT2::IStream* stream, ClassifiedFileInfo* result)
 {
     // TODO Currently track designs get classified as SC4s because they use the
     //      same checksum algorithm. The only way after to tell the difference
@@ -61,7 +61,7 @@ bool TryClassifyFile(IStream* stream, ClassifiedFileInfo* result)
     return false;
 }
 
-static bool TryClassifyAsS6(IStream* stream, ClassifiedFileInfo* result)
+static bool TryClassifyAsS6(OpenRCT2::IStream* stream, ClassifiedFileInfo* result)
 {
     bool success = false;
     uint64_t originalPosition = stream->GetPosition();
@@ -89,7 +89,7 @@ static bool TryClassifyAsS6(IStream* stream, ClassifiedFileInfo* result)
     return success;
 }
 
-static bool TryClassifyAsS4(IStream* stream, ClassifiedFileInfo* result)
+static bool TryClassifyAsS4(OpenRCT2::IStream* stream, ClassifiedFileInfo* result)
 {
     bool success = false;
     uint64_t originalPosition = stream->GetPosition();
@@ -126,7 +126,7 @@ static bool TryClassifyAsS4(IStream* stream, ClassifiedFileInfo* result)
     return success;
 }
 
-static bool TryClassifyAsTD4_TD6(IStream* stream, ClassifiedFileInfo* result)
+static bool TryClassifyAsTD4_TD6(OpenRCT2::IStream* stream, ClassifiedFileInfo* result)
 {
     bool success = false;
     uint64_t originalPosition = stream->GetPosition();

--- a/src/openrct2/FileClassifier.h
+++ b/src/openrct2/FileClassifier.h
@@ -25,7 +25,7 @@ enum
 
 #include <string>
 
-interface IStream;
+INTERFACE IStream;
 
 enum class FILE_TYPE
 {

--- a/src/openrct2/FileClassifier.h
+++ b/src/openrct2/FileClassifier.h
@@ -25,7 +25,10 @@ enum
 
 #include <string>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 enum class FILE_TYPE
 {
@@ -44,6 +47,6 @@ struct ClassifiedFileInfo
 
 #define FILE_TYPE_S4_CUTOFF 2
 bool TryClassifyFile(const std::string& path, ClassifiedFileInfo* result);
-bool TryClassifyFile(IStream* stream, ClassifiedFileInfo* result);
+bool TryClassifyFile(OpenRCT2::IStream* stream, ClassifiedFileInfo* result);
 
 uint32_t get_file_extension_type(const utf8* path);

--- a/src/openrct2/FileClassifier.h
+++ b/src/openrct2/FileClassifier.h
@@ -27,7 +27,7 @@ enum
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 enum class FILE_TYPE

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -28,8 +28,8 @@ struct GameStateSnapshot_t
     uint32_t tick = InvalidTick;
     uint32_t srand0 = 0;
 
-    MemoryStream storedSprites;
-    MemoryStream parkParameters;
+    OpenRCT2::MemoryStream storedSprites;
+    OpenRCT2::MemoryStream parkParameters;
 
     // Must pass a function that can access the sprite.
     void SerialiseSprites(std::function<rct_sprite*(const size_t)> getEntity, const size_t numSprites, bool saving)

--- a/src/openrct2/GameStateSnapshots.h
+++ b/src/openrct2/GameStateSnapshots.h
@@ -60,7 +60,7 @@ struct GameStateCompareData_t
  * as it may become invalid at any time when a snapshot is created, rather Link the snapshot
  * to a specific tick which can be obtained by that later again assuming its still valid.
  */
-INTERFACE IGameStateSnapshots
+struct IGameStateSnapshots
 {
     virtual ~IGameStateSnapshots() = default;
 
@@ -77,12 +77,12 @@ INTERFACE IGameStateSnapshots
     /*
      * Links the snapshot to a specific game tick.
      */
-    virtual void LinkSnapshot(GameStateSnapshot_t & snapshot, uint32_t tick, uint32_t srand0) = 0;
+    virtual void LinkSnapshot(GameStateSnapshot_t& snapshot, uint32_t tick, uint32_t srand0) = 0;
 
     /*
      * This will fill the snapshot with the current game state in a compact form.
      */
-    virtual void Capture(GameStateSnapshot_t & snapshot) = 0;
+    virtual void Capture(GameStateSnapshot_t& snapshot) = 0;
 
     /*
      * Returns the snapshot for a given tick in the history, nullptr if not found.
@@ -92,7 +92,7 @@ INTERFACE IGameStateSnapshots
     /*
      * Serialisation of GameStateSnapshot_t
      */
-    virtual void SerialiseSnapshot(GameStateSnapshot_t & snapshot, DataSerialiser & serialiser) const = 0;
+    virtual void SerialiseSnapshot(GameStateSnapshot_t& snapshot, DataSerialiser& serialiser) const = 0;
 
     /*
      * Compares two states resulting GameStateCompareData_t with all mismatches stored.

--- a/src/openrct2/GameStateSnapshots.h
+++ b/src/openrct2/GameStateSnapshots.h
@@ -60,7 +60,7 @@ struct GameStateCompareData_t
  * as it may become invalid at any time when a snapshot is created, rather Link the snapshot
  * to a specific tick which can be obtained by that later again assuming its still valid.
  */
-interface IGameStateSnapshots
+INTERFACE IGameStateSnapshots
 {
     virtual ~IGameStateSnapshots() = default;
 

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -17,12 +17,13 @@
 #include <string>
 #include <vector>
 
-INTERFACE IObjectManager;
-INTERFACE IObjectRepository;
+struct IObjectManager;
+struct IObjectRepository;
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
+
 struct scenario_index_entry;
 
 struct ParkLoadResult final
@@ -39,7 +40,7 @@ public:
 /**
  * Interface to import scenarios and saved games.
  */
-INTERFACE IParkImporter
+struct IParkImporter
 {
 public:
     virtual ~IParkImporter() = default;
@@ -48,10 +49,10 @@ public:
     virtual ParkLoadResult LoadSavedGame(const utf8* path, bool skipObjectCheck = false) abstract;
     virtual ParkLoadResult LoadScenario(const utf8* path, bool skipObjectCheck = false) abstract;
     virtual ParkLoadResult LoadFromStream(
-        OpenRCT2::IStream * stream, bool isScenario, bool skipObjectCheck = false, const utf8* path = String::Empty) abstract;
+        OpenRCT2::IStream* stream, bool isScenario, bool skipObjectCheck = false, const utf8* path = String::Empty) abstract;
 
     virtual void Import() abstract;
-    virtual bool GetDetails(scenario_index_entry * dst) abstract;
+    virtual bool GetDetails(scenario_index_entry* dst) abstract;
 };
 
 namespace ParkImporter

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -19,7 +19,10 @@
 
 INTERFACE IObjectManager;
 INTERFACE IObjectRepository;
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 struct scenario_index_entry;
 
 struct ParkLoadResult final
@@ -45,7 +48,7 @@ public:
     virtual ParkLoadResult LoadSavedGame(const utf8* path, bool skipObjectCheck = false) abstract;
     virtual ParkLoadResult LoadScenario(const utf8* path, bool skipObjectCheck = false) abstract;
     virtual ParkLoadResult LoadFromStream(
-        IStream * stream, bool isScenario, bool skipObjectCheck = false, const utf8* path = String::Empty) abstract;
+        OpenRCT2::IStream * stream, bool isScenario, bool skipObjectCheck = false, const utf8* path = String::Empty) abstract;
 
     virtual void Import() abstract;
     virtual bool GetDetails(scenario_index_entry * dst) abstract;

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -17,9 +17,9 @@
 #include <string>
 #include <vector>
 
-interface IObjectManager;
-interface IObjectRepository;
-interface IStream;
+INTERFACE IObjectManager;
+INTERFACE IObjectRepository;
+INTERFACE IStream;
 struct scenario_index_entry;
 
 struct ParkLoadResult final
@@ -36,7 +36,7 @@ public:
 /**
  * Interface to import scenarios and saved games.
  */
-interface IParkImporter
+INTERFACE IParkImporter
 {
 public:
     virtual ~IParkImporter() = default;

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -72,7 +72,7 @@ namespace OpenRCT2
     /**
      * Interface for retrieving paths and other environment related things.
      */
-    interface IPlatformEnvironment
+    INTERFACE IPlatformEnvironment
     {
         virtual ~IPlatformEnvironment() = default;
 

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -72,7 +72,7 @@ namespace OpenRCT2
     /**
      * Interface for retrieving paths and other environment related things.
      */
-    INTERFACE IPlatformEnvironment
+    struct IPlatformEnvironment
     {
         virtual ~IPlatformEnvironment() = default;
 

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -72,7 +72,7 @@ namespace OpenRCT2
         uint32_t magic;
         uint16_t version;
         uint64_t uncompressedSize;
-        MemoryStream data;
+        OpenRCT2::MemoryStream data;
     };
 
     struct ReplayRecordData
@@ -80,9 +80,9 @@ namespace OpenRCT2
         uint32_t magic;
         uint16_t version;
         std::string networkId;
-        MemoryStream parkData;
-        MemoryStream parkParams;
-        MemoryStream cheatData;
+        OpenRCT2::MemoryStream parkData;
+        OpenRCT2::MemoryStream parkParams;
+        OpenRCT2::MemoryStream cheatData;
         std::string name;      // Name of play
         std::string filePath;  // File path of replay.
         uint64_t timeRecorded; // Posix Time.
@@ -91,7 +91,7 @@ namespace OpenRCT2
         std::multiset<ReplayCommand> commands;
         std::vector<std::pair<uint32_t, rct_sprite_checksum>> checksums;
         uint32_t checksumIndex;
-        MemoryStream gameStateSnapshots;
+        OpenRCT2::MemoryStream gameStateSnapshots;
     };
 
     class ReplayManager final : public IReplayManager

--- a/src/openrct2/ReplayManager.h
+++ b/src/openrct2/ReplayManager.h
@@ -32,7 +32,7 @@ namespace OpenRCT2
         std::string FilePath;
     };
 
-    INTERFACE IReplayManager
+    struct IReplayManager
     {
     public:
         enum class RecordType
@@ -56,7 +56,7 @@ namespace OpenRCT2
             const std::string& name, uint32_t maxTicks = k_MaxReplayTicks, RecordType rt = RecordType::NORMAL)
             = 0;
         virtual bool StopRecording(bool discard = false) = 0;
-        virtual bool GetCurrentReplayInfo(ReplayRecordInfo & info) const = 0;
+        virtual bool GetCurrentReplayInfo(ReplayRecordInfo& info) const = 0;
 
         virtual bool StartPlayback(const std::string& file) = 0;
         virtual bool IsPlaybackStateMismatching() const = 0;

--- a/src/openrct2/ReplayManager.h
+++ b/src/openrct2/ReplayManager.h
@@ -32,7 +32,7 @@ namespace OpenRCT2
         std::string FilePath;
     };
 
-    interface IReplayManager
+    INTERFACE IReplayManager
     {
     public:
         enum class RecordType

--- a/src/openrct2/TrackImporter.h
+++ b/src/openrct2/TrackImporter.h
@@ -26,7 +26,7 @@ public:
     virtual ~ITrackImporter() = default;
 
     virtual bool Load(const utf8* path) abstract;
-    virtual bool LoadFromStream(IStream * stream) abstract;
+    virtual bool LoadFromStream(OpenRCT2::IStream * stream) abstract;
 
     virtual std::unique_ptr<TrackDesign> Import() abstract;
 };

--- a/src/openrct2/TrackImporter.h
+++ b/src/openrct2/TrackImporter.h
@@ -20,13 +20,13 @@
 /**
  * Interface to import scenarios and saved games.
  */
-INTERFACE ITrackImporter
+struct ITrackImporter
 {
 public:
     virtual ~ITrackImporter() = default;
 
     virtual bool Load(const utf8* path) abstract;
-    virtual bool LoadFromStream(OpenRCT2::IStream * stream) abstract;
+    virtual bool LoadFromStream(OpenRCT2::IStream* stream) abstract;
 
     virtual std::unique_ptr<TrackDesign> Import() abstract;
 };

--- a/src/openrct2/TrackImporter.h
+++ b/src/openrct2/TrackImporter.h
@@ -20,7 +20,7 @@
 /**
  * Interface to import scenarios and saved games.
  */
-interface ITrackImporter
+INTERFACE ITrackImporter
 {
 public:
     virtual ~ITrackImporter() = default;

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -341,7 +341,7 @@ void audio_init_ride_sounds_and_info()
         {
             try
             {
-                auto fs = FileStream(path, FILE_MODE_OPEN);
+                auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
                 uint32_t head = fs.ReadValue<uint32_t>();
                 if (head == 0x78787878)
                 {

--- a/src/openrct2/audio/AudioChannel.h
+++ b/src/openrct2/audio/AudioChannel.h
@@ -14,13 +14,13 @@
 
 namespace OpenRCT2::Audio
 {
-    INTERFACE IAudioSource;
+    struct IAudioSource;
 
     /**
      * Represents an audio channel that represents an audio source
      * and a number of properties such as volume, pan and loop information.
      */
-    INTERFACE IAudioChannel
+    struct IAudioChannel
     {
         virtual ~IAudioChannel() = default;
 
@@ -62,7 +62,7 @@ namespace OpenRCT2::Audio
 
         virtual bool IsPlaying() const abstract;
 
-        virtual void Play(IAudioSource * source, int32_t loop = 0) abstract;
+        virtual void Play(IAudioSource* source, int32_t loop = 0) abstract;
         virtual void UpdateOldVolume() abstract;
 
         virtual size_t Read(void* dst, size_t len) abstract;

--- a/src/openrct2/audio/AudioChannel.h
+++ b/src/openrct2/audio/AudioChannel.h
@@ -14,13 +14,13 @@
 
 namespace OpenRCT2::Audio
 {
-    interface IAudioSource;
+    INTERFACE IAudioSource;
 
     /**
      * Represents an audio channel that represents an audio source
      * and a number of properties such as volume, pan and loop information.
      */
-    interface IAudioChannel
+    INTERFACE IAudioChannel
     {
         virtual ~IAudioChannel() = default;
 

--- a/src/openrct2/audio/AudioContext.h
+++ b/src/openrct2/audio/AudioContext.h
@@ -17,14 +17,14 @@
 
 namespace OpenRCT2::Audio
 {
-    INTERFACE IAudioChannel;
-    INTERFACE IAudioMixer;
-    INTERFACE IAudioSource;
+    struct IAudioChannel;
+    struct IAudioMixer;
+    struct IAudioSource;
 
     /**
      * Audio services for playing music and sound effects.
      */
-    INTERFACE IAudioContext
+    struct IAudioContext
     {
         virtual ~IAudioContext() = default;
 

--- a/src/openrct2/audio/AudioContext.h
+++ b/src/openrct2/audio/AudioContext.h
@@ -17,14 +17,14 @@
 
 namespace OpenRCT2::Audio
 {
-    interface IAudioChannel;
-    interface IAudioMixer;
-    interface IAudioSource;
+    INTERFACE IAudioChannel;
+    INTERFACE IAudioMixer;
+    INTERFACE IAudioSource;
 
     /**
      * Audio services for playing music and sound effects.
      */
-    interface IAudioContext
+    INTERFACE IAudioContext
     {
         virtual ~IAudioContext() = default;
 

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -26,13 +26,13 @@ namespace OpenRCT2::Audio
         TitleMusic,
     };
 
-    interface IAudioSource;
-    interface IAudioChannel;
+    INTERFACE IAudioSource;
+    INTERFACE IAudioChannel;
 
     /**
      * Provides an audio stream by mixing multiple audio channels together.
      */
-    interface IAudioMixer
+    INTERFACE IAudioMixer
     {
         virtual ~IAudioMixer() = default;
 

--- a/src/openrct2/audio/AudioMixer.h
+++ b/src/openrct2/audio/AudioMixer.h
@@ -26,13 +26,13 @@ namespace OpenRCT2::Audio
         TitleMusic,
     };
 
-    INTERFACE IAudioSource;
-    INTERFACE IAudioChannel;
+    struct IAudioSource;
+    struct IAudioChannel;
 
     /**
      * Provides an audio stream by mixing multiple audio channels together.
      */
-    INTERFACE IAudioMixer
+    struct IAudioMixer
     {
         virtual ~IAudioMixer() = default;
 
@@ -40,8 +40,8 @@ namespace OpenRCT2::Audio
         virtual void Close() abstract;
         virtual void Lock() abstract;
         virtual void Unlock() abstract;
-        virtual IAudioChannel* Play(IAudioSource * source, int32_t loop, bool deleteondone, bool deletesourceondone) abstract;
-        virtual void Stop(IAudioChannel * channel) abstract;
+        virtual IAudioChannel* Play(IAudioSource* source, int32_t loop, bool deleteondone, bool deletesourceondone) abstract;
+        virtual void Stop(IAudioChannel* channel) abstract;
         virtual bool LoadMusic(size_t pathid) abstract;
         virtual void SetVolume(float volume) abstract;
 

--- a/src/openrct2/audio/AudioSource.h
+++ b/src/openrct2/audio/AudioSource.h
@@ -17,7 +17,7 @@ namespace OpenRCT2::Audio
     /**
      * Represents a readable source of audio PCM data.
      */
-    INTERFACE IAudioSource
+    struct IAudioSource
     {
         virtual ~IAudioSource() = default;
 

--- a/src/openrct2/audio/AudioSource.h
+++ b/src/openrct2/audio/AudioSource.h
@@ -17,7 +17,7 @@ namespace OpenRCT2::Audio
     /**
      * Represents a readable source of audio PCM data.
      */
-    interface IAudioSource
+    INTERFACE IAudioSource
     {
         virtual ~IAudioSource() = default;
 

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -165,9 +165,6 @@ using rct_string_id = uint16_t;
         (x) = nullptr;                                                                                                         \
     } while (false)
 
-#ifndef INTERFACE
-#    define INTERFACE struct
-#endif
 #define abstract = 0
 
 #if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -165,8 +165,8 @@ using rct_string_id = uint16_t;
         (x) = nullptr;                                                                                                         \
     } while (false)
 
-#ifndef interface
-#    define interface struct
+#ifndef INTERFACE
+#    define INTERFACE struct
 #endif
 #define abstract = 0
 

--- a/src/openrct2/config/ConfigEnum.hpp
+++ b/src/openrct2/config/ConfigEnum.hpp
@@ -27,7 +27,7 @@ template<typename T> struct ConfigEnumEntry
     }
 };
 
-template<typename T> interface IConfigEnum
+template<typename T> INTERFACE IConfigEnum
 {
     virtual ~IConfigEnum() = default;
     virtual std::string GetName(T value) const abstract;

--- a/src/openrct2/config/ConfigEnum.hpp
+++ b/src/openrct2/config/ConfigEnum.hpp
@@ -27,7 +27,7 @@ template<typename T> struct ConfigEnumEntry
     }
 };
 
-template<typename T> INTERFACE IConfigEnum
+template<typename T> struct IConfigEnum
 {
     virtual ~IConfigEnum() = default;
     virtual std::string GetName(T value) const abstract;

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -96,7 +96,7 @@ private:
     std::unordered_map<std::string, std::string, StringIHash, StringICmp> _values;
 
 public:
-    explicit IniReader(IStream* stream)
+    explicit IniReader(OpenRCT2::IStream* stream)
     {
         uint64_t length = stream->GetLength() - stream->GetPosition();
         _buffer.resize(length);
@@ -437,7 +437,7 @@ utf8* IIniReader::GetCString(const std::string& name, const utf8* defaultValue) 
     return String::Duplicate(szValue.c_str());
 }
 
-IIniReader* CreateIniReader(IStream* stream)
+IIniReader* CreateIniReader(OpenRCT2::IStream* stream)
 {
     return new IniReader(stream);
 }

--- a/src/openrct2/config/IniReader.hpp
+++ b/src/openrct2/config/IniReader.hpp
@@ -13,10 +13,10 @@
 
 #include <string>
 
-interface IStream;
+INTERFACE IStream;
 template<typename T> struct IConfigEnum;
 
-interface IIniReader
+INTERFACE IIniReader
 {
     virtual ~IIniReader() = default;
 

--- a/src/openrct2/config/IniReader.hpp
+++ b/src/openrct2/config/IniReader.hpp
@@ -15,12 +15,12 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 template<typename T> struct IConfigEnum;
 
-INTERFACE IIniReader
+struct IIniReader
 {
     virtual ~IIniReader() = default;
 

--- a/src/openrct2/config/IniReader.hpp
+++ b/src/openrct2/config/IniReader.hpp
@@ -13,7 +13,11 @@
 
 #include <string>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
+
 template<typename T> struct IConfigEnum;
 
 INTERFACE IIniReader
@@ -43,5 +47,5 @@ INTERFACE IIniReader
     utf8* GetCString(const std::string& name, const utf8* defaultValue) const;
 };
 
-IIniReader* CreateIniReader(IStream* stream);
+IIniReader* CreateIniReader(OpenRCT2::IStream* stream);
 IIniReader* CreateDefaultIniReader();

--- a/src/openrct2/config/IniWriter.cpp
+++ b/src/openrct2/config/IniWriter.cpp
@@ -18,11 +18,11 @@
 class IniWriter final : public IIniWriter
 {
 private:
-    IStream* _stream;
+    OpenRCT2::IStream* _stream;
     bool _firstSection = true;
 
 public:
-    explicit IniWriter(IStream* stream)
+    explicit IniWriter(OpenRCT2::IStream* stream)
         : _stream(stream)
     {
     }
@@ -103,7 +103,7 @@ void IIniWriter::WriteString(const std::string& name, const utf8* value)
     WriteString(name, String::ToStd(value));
 }
 
-IIniWriter* CreateIniWriter(IStream* stream)
+IIniWriter* CreateIniWriter(OpenRCT2::IStream* stream)
 {
     return new IniWriter(stream);
 }

--- a/src/openrct2/config/IniWriter.hpp
+++ b/src/openrct2/config/IniWriter.hpp
@@ -13,7 +13,11 @@
 
 #include <string>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
+
 template<typename T> struct IConfigEnum;
 
 INTERFACE IIniWriter
@@ -45,4 +49,4 @@ INTERFACE IIniWriter
     void WriteString(const std::string& name, const utf8* value);
 };
 
-IIniWriter* CreateIniWriter(IStream* stream);
+IIniWriter* CreateIniWriter(OpenRCT2::IStream* stream);

--- a/src/openrct2/config/IniWriter.hpp
+++ b/src/openrct2/config/IniWriter.hpp
@@ -15,12 +15,12 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 template<typename T> struct IConfigEnum;
 
-INTERFACE IIniWriter
+struct IIniWriter
 {
     virtual ~IIniWriter() = default;
 

--- a/src/openrct2/config/IniWriter.hpp
+++ b/src/openrct2/config/IniWriter.hpp
@@ -13,10 +13,10 @@
 
 #include <string>
 
-interface IStream;
+INTERFACE IStream;
 template<typename T> struct IConfigEnum;
 
-interface IIniWriter
+INTERFACE IIniWriter
 {
     virtual ~IIniWriter() = default;
 

--- a/src/openrct2/core/Crypt.CNG.cpp
+++ b/src/openrct2/core/Crypt.CNG.cpp
@@ -21,7 +21,6 @@
 // clang-format off
 // CNG: Cryptography API: Next Generation (CNG)
 //      available in Windows Vista onwards.
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <wincrypt.h>
 #include <bcrypt.h>

--- a/src/openrct2/core/DataSerialiser.h
+++ b/src/openrct2/core/DataSerialiser.h
@@ -10,14 +10,15 @@
 #pragma once
 
 #include "DataSerialiserTraits.h"
+#include "MemoryStream.h"
 
 #include <type_traits>
 
 class DataSerialiser
 {
 private:
-    MemoryStream _stream;
-    IStream& _activeStream;
+    OpenRCT2::MemoryStream _stream;
+    OpenRCT2::IStream& _activeStream;
     bool _isSaving = false;
     bool _isLogging = false;
 
@@ -29,7 +30,7 @@ public:
     {
     }
 
-    DataSerialiser(bool isSaving, IStream& stream, bool isLogging = false)
+    DataSerialiser(bool isSaving, OpenRCT2::IStream& stream, bool isLogging = false)
         : _activeStream(stream)
         , _isSaving(isSaving)
         , _isLogging(isLogging)
@@ -51,7 +52,7 @@ public:
         return _isLogging;
     }
 
-    IStream& GetStream()
+    OpenRCT2::IStream& GetStream()
     {
         return _activeStream;
     }

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -30,25 +30,25 @@
 
 template<typename T> struct DataSerializerTraits
 {
-    static void encode(IStream* stream, const T& v) = delete;
-    static void decode(IStream* stream, T& val) = delete;
-    static void log(IStream* stream, const T& val) = delete;
+    static void encode(OpenRCT2::IStream* stream, const T& v) = delete;
+    static void decode(OpenRCT2::IStream* stream, T& val) = delete;
+    static void log(OpenRCT2::IStream* stream, const T& val) = delete;
 };
 
 template<typename T> struct DataSerializerTraitsIntegral
 {
-    static void encode(IStream* stream, const T& val)
+    static void encode(OpenRCT2::IStream* stream, const T& val)
     {
         T temp = ByteSwapBE(val);
         stream->Write(&temp);
     }
-    static void decode(IStream* stream, T& val)
+    static void decode(OpenRCT2::IStream* stream, T& val)
     {
         T temp;
         stream->Read(&temp);
         val = ByteSwapBE(temp);
     }
-    static void log(IStream* stream, const T& val)
+    static void log(OpenRCT2::IStream* stream, const T& val)
     {
         std::stringstream ss;
         ss << std::hex << std::setw(sizeof(T) * 2) << std::setfill('0') << +val;
@@ -60,15 +60,15 @@ template<typename T> struct DataSerializerTraitsIntegral
 
 template<> struct DataSerializerTraits<bool>
 {
-    static void encode(IStream* stream, const bool& val)
+    static void encode(OpenRCT2::IStream* stream, const bool& val)
     {
         stream->Write(&val);
     }
-    static void decode(IStream* stream, bool& val)
+    static void decode(OpenRCT2::IStream* stream, bool& val)
     {
         stream->Read(&val);
     }
-    static void log(IStream* stream, const bool& val)
+    static void log(OpenRCT2::IStream* stream, const bool& val)
     {
         if (val)
             stream->Write("true", 4);
@@ -111,14 +111,14 @@ template<> struct DataSerializerTraits<int64_t> : public DataSerializerTraitsInt
 
 template<> struct DataSerializerTraits<std::string>
 {
-    static void encode(IStream* stream, const std::string& str)
+    static void encode(OpenRCT2::IStream* stream, const std::string& str)
     {
         uint16_t len = static_cast<uint16_t>(str.size());
         uint16_t swapped = ByteSwapBE(len);
         stream->Write(&swapped);
         stream->WriteArray(str.c_str(), len);
     }
-    static void decode(IStream* stream, std::string& res)
+    static void decode(OpenRCT2::IStream* stream, std::string& res)
     {
         uint16_t len;
         stream->Read(&len);
@@ -129,7 +129,7 @@ template<> struct DataSerializerTraits<std::string>
 
         Memory::FreeArray(str, len);
     }
-    static void log(IStream* stream, const std::string& str)
+    static void log(OpenRCT2::IStream* stream, const std::string& str)
     {
         stream->Write("\"", 1);
         stream->Write(str.data(), str.size());
@@ -139,19 +139,19 @@ template<> struct DataSerializerTraits<std::string>
 
 template<> struct DataSerializerTraits<NetworkPlayerId_t>
 {
-    static void encode(IStream* stream, const NetworkPlayerId_t& val)
+    static void encode(OpenRCT2::IStream* stream, const NetworkPlayerId_t& val)
     {
         uint32_t temp = static_cast<uint32_t>(val.id);
         temp = ByteSwapBE(temp);
         stream->Write(&temp);
     }
-    static void decode(IStream* stream, NetworkPlayerId_t& val)
+    static void decode(OpenRCT2::IStream* stream, NetworkPlayerId_t& val)
     {
         uint32_t temp;
         stream->Read(&temp);
         val.id = static_cast<decltype(val.id)>(ByteSwapBE(temp));
     }
-    static void log(IStream* stream, const NetworkPlayerId_t& val)
+    static void log(OpenRCT2::IStream* stream, const NetworkPlayerId_t& val)
     {
         char playerId[28] = {};
         snprintf(playerId, sizeof(playerId), "%u", val.id);
@@ -174,19 +174,19 @@ template<> struct DataSerializerTraits<NetworkPlayerId_t>
 
 template<> struct DataSerializerTraits<NetworkRideId_t>
 {
-    static void encode(IStream* stream, const NetworkRideId_t& val)
+    static void encode(OpenRCT2::IStream* stream, const NetworkRideId_t& val)
     {
         uint32_t temp = static_cast<uint32_t>(val.id);
         temp = ByteSwapBE(temp);
         stream->Write(&temp);
     }
-    static void decode(IStream* stream, NetworkRideId_t& val)
+    static void decode(OpenRCT2::IStream* stream, NetworkRideId_t& val)
     {
         uint32_t temp;
         stream->Read(&temp);
         val.id = static_cast<decltype(val.id)>(ByteSwapBE(temp));
     }
-    static void log(IStream* stream, const NetworkRideId_t& val)
+    static void log(OpenRCT2::IStream* stream, const NetworkRideId_t& val)
     {
         char rideId[28] = {};
         snprintf(rideId, sizeof(rideId), "%u", val.id);
@@ -207,17 +207,17 @@ template<> struct DataSerializerTraits<NetworkRideId_t>
 
 template<typename T> struct DataSerializerTraits<DataSerialiserTag<T>>
 {
-    static void encode(IStream* stream, const DataSerialiserTag<T>& tag)
+    static void encode(OpenRCT2::IStream* stream, const DataSerialiserTag<T>& tag)
     {
         DataSerializerTraits<T> s;
         s.encode(stream, tag.Data());
     }
-    static void decode(IStream* stream, DataSerialiserTag<T>& tag)
+    static void decode(OpenRCT2::IStream* stream, DataSerialiserTag<T>& tag)
     {
         DataSerializerTraits<T> s;
         s.decode(stream, tag.Data());
     }
-    static void log(IStream* stream, const DataSerialiserTag<T>& tag)
+    static void log(OpenRCT2::IStream* stream, const DataSerialiserTag<T>& tag)
     {
         const char* name = tag.Name();
         stream->Write(name, strlen(name));
@@ -230,16 +230,16 @@ template<typename T> struct DataSerializerTraits<DataSerialiserTag<T>>
     }
 };
 
-template<> struct DataSerializerTraits<MemoryStream>
+template<> struct DataSerializerTraits<OpenRCT2::MemoryStream>
 {
-    static void encode(IStream* stream, const MemoryStream& val)
+    static void encode(OpenRCT2::IStream* stream, const OpenRCT2::MemoryStream& val)
     {
         DataSerializerTraits<uint32_t> s;
         s.encode(stream, val.GetLength());
 
         stream->Write(val.GetData(), val.GetLength());
     }
-    static void decode(IStream* stream, MemoryStream& val)
+    static void decode(OpenRCT2::IStream* stream, OpenRCT2::MemoryStream& val)
     {
         DataSerializerTraits<uint32_t> s;
 
@@ -251,14 +251,14 @@ template<> struct DataSerializerTraits<MemoryStream>
 
         val.Write(buf.get(), length);
     }
-    static void log(IStream* stream, const MemoryStream& tag)
+    static void log(OpenRCT2::IStream* stream, const OpenRCT2::MemoryStream& tag)
     {
     }
 };
 
 template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
 {
-    static void encode(IStream* stream, const _Ty (&val)[_Size])
+    static void encode(OpenRCT2::IStream* stream, const _Ty (&val)[_Size])
     {
         uint16_t len = static_cast<uint16_t>(_Size);
         uint16_t swapped = ByteSwapBE(len);
@@ -270,7 +270,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
             s.encode(stream, sub);
         }
     }
-    static void decode(IStream* stream, _Ty (&val)[_Size])
+    static void decode(OpenRCT2::IStream* stream, _Ty (&val)[_Size])
     {
         uint16_t len;
         stream->Read(&len);
@@ -285,7 +285,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
             s.decode(stream, sub);
         }
     }
-    static void log(IStream* stream, const _Ty (&val)[_Size])
+    static void log(OpenRCT2::IStream* stream, const _Ty (&val)[_Size])
     {
         stream->Write("{", 1);
         DataSerializerTraits<_Ty> s;
@@ -316,7 +316,7 @@ template<size_t _Size> struct DataSerializerTraits<uint64_t[_Size]> : public Dat
 
 template<typename _Ty, size_t _Size> struct DataSerializerTraits<std::array<_Ty, _Size>>
 {
-    static void encode(IStream* stream, const std::array<_Ty, _Size>& val)
+    static void encode(OpenRCT2::IStream* stream, const std::array<_Ty, _Size>& val)
     {
         uint16_t len = static_cast<uint16_t>(_Size);
         uint16_t swapped = ByteSwapBE(len);
@@ -328,7 +328,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits<std::array<_Ty,
             s.encode(stream, sub);
         }
     }
-    static void decode(IStream* stream, std::array<_Ty, _Size>& val)
+    static void decode(OpenRCT2::IStream* stream, std::array<_Ty, _Size>& val)
     {
         uint16_t len;
         stream->Read(&len);
@@ -343,7 +343,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits<std::array<_Ty,
             s.decode(stream, sub);
         }
     }
-    static void log(IStream* stream, const std::array<_Ty, _Size>& val)
+    static void log(OpenRCT2::IStream* stream, const std::array<_Ty, _Size>& val)
     {
         stream->Write("{", 1);
         DataSerializerTraits<_Ty> s;
@@ -358,7 +358,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits<std::array<_Ty,
 
 template<typename _Ty> struct DataSerializerTraits<std::vector<_Ty>>
 {
-    static void encode(IStream* stream, const std::vector<_Ty>& val)
+    static void encode(OpenRCT2::IStream* stream, const std::vector<_Ty>& val)
     {
         uint16_t len = static_cast<uint16_t>(val.size());
         uint16_t swapped = ByteSwapBE(len);
@@ -370,7 +370,7 @@ template<typename _Ty> struct DataSerializerTraits<std::vector<_Ty>>
             s.encode(stream, sub);
         }
     }
-    static void decode(IStream* stream, std::vector<_Ty>& val)
+    static void decode(OpenRCT2::IStream* stream, std::vector<_Ty>& val)
     {
         uint16_t len;
         stream->Read(&len);
@@ -384,7 +384,7 @@ template<typename _Ty> struct DataSerializerTraits<std::vector<_Ty>>
             val.push_back(sub);
         }
     }
-    static void log(IStream* stream, const std::vector<_Ty>& val)
+    static void log(OpenRCT2::IStream* stream, const std::vector<_Ty>& val)
     {
         stream->Write("{", 1);
         DataSerializerTraits<_Ty> s;
@@ -399,14 +399,14 @@ template<typename _Ty> struct DataSerializerTraits<std::vector<_Ty>>
 
 template<> struct DataSerializerTraits<MapRange>
 {
-    static void encode(IStream* stream, const MapRange& v)
+    static void encode(OpenRCT2::IStream* stream, const MapRange& v)
     {
         stream->WriteValue(ByteSwapBE(v.GetLeft()));
         stream->WriteValue(ByteSwapBE(v.GetTop()));
         stream->WriteValue(ByteSwapBE(v.GetRight()));
         stream->WriteValue(ByteSwapBE(v.GetBottom()));
     }
-    static void decode(IStream* stream, MapRange& v)
+    static void decode(OpenRCT2::IStream* stream, MapRange& v)
     {
         auto l = ByteSwapBE(stream->ReadValue<int32_t>());
         auto t = ByteSwapBE(stream->ReadValue<int32_t>());
@@ -414,7 +414,7 @@ template<> struct DataSerializerTraits<MapRange>
         auto b = ByteSwapBE(stream->ReadValue<int32_t>());
         v = MapRange(l, t, r, b);
     }
-    static void log(IStream* stream, const MapRange& v)
+    static void log(OpenRCT2::IStream* stream, const MapRange& v)
     {
         char coords[128] = {};
         snprintf(
@@ -427,7 +427,7 @@ template<> struct DataSerializerTraits<MapRange>
 
 template<> struct DataSerializerTraits<TileElement>
 {
-    static void encode(IStream* stream, const TileElement& tileElement)
+    static void encode(OpenRCT2::IStream* stream, const TileElement& tileElement)
     {
         stream->WriteValue(tileElement.type);
         stream->WriteValue(tileElement.Flags);
@@ -442,7 +442,7 @@ template<> struct DataSerializerTraits<TileElement>
             stream->WriteValue(tileElement.pad_08[i]);
         }
     }
-    static void decode(IStream* stream, TileElement& tileElement)
+    static void decode(OpenRCT2::IStream* stream, TileElement& tileElement)
     {
         tileElement.type = stream->ReadValue<uint8_t>();
         tileElement.Flags = stream->ReadValue<uint8_t>();
@@ -457,7 +457,7 @@ template<> struct DataSerializerTraits<TileElement>
             tileElement.pad_08[i] = stream->ReadValue<uint8_t>();
         }
     }
-    static void log(IStream* stream, const TileElement& tileElement)
+    static void log(OpenRCT2::IStream* stream, const TileElement& tileElement)
     {
         char msg[128] = {};
         snprintf(
@@ -469,18 +469,18 @@ template<> struct DataSerializerTraits<TileElement>
 
 template<> struct DataSerializerTraits<CoordsXY>
 {
-    static void encode(IStream* stream, const CoordsXY& coords)
+    static void encode(OpenRCT2::IStream* stream, const CoordsXY& coords)
     {
         stream->WriteValue(ByteSwapBE(coords.x));
         stream->WriteValue(ByteSwapBE(coords.y));
     }
-    static void decode(IStream* stream, CoordsXY& coords)
+    static void decode(OpenRCT2::IStream* stream, CoordsXY& coords)
     {
         auto x = ByteSwapBE(stream->ReadValue<int32_t>());
         auto y = ByteSwapBE(stream->ReadValue<int32_t>());
         coords = CoordsXY{ x, y };
     }
-    static void log(IStream* stream, const CoordsXY& coords)
+    static void log(OpenRCT2::IStream* stream, const CoordsXY& coords)
     {
         char msg[128] = {};
         snprintf(msg, sizeof(msg), "CoordsXY(x = %d, y = %d)", coords.x, coords.y);
@@ -490,14 +490,14 @@ template<> struct DataSerializerTraits<CoordsXY>
 
 template<> struct DataSerializerTraits<CoordsXYZ>
 {
-    static void encode(IStream* stream, const CoordsXYZ& coord)
+    static void encode(OpenRCT2::IStream* stream, const CoordsXYZ& coord)
     {
         stream->WriteValue(ByteSwapBE(coord.x));
         stream->WriteValue(ByteSwapBE(coord.y));
         stream->WriteValue(ByteSwapBE(coord.z));
     }
 
-    static void decode(IStream* stream, CoordsXYZ& coord)
+    static void decode(OpenRCT2::IStream* stream, CoordsXYZ& coord)
     {
         auto x = ByteSwapBE(stream->ReadValue<int32_t>());
         auto y = ByteSwapBE(stream->ReadValue<int32_t>());
@@ -505,7 +505,7 @@ template<> struct DataSerializerTraits<CoordsXYZ>
         coord = CoordsXYZ{ x, y, z };
     }
 
-    static void log(IStream* stream, const CoordsXYZ& coord)
+    static void log(OpenRCT2::IStream* stream, const CoordsXYZ& coord)
     {
         char msg[128] = {};
         snprintf(msg, sizeof(msg), "CoordsXYZ(x = %d, y = %d, z = %d)", coord.x, coord.y, coord.z);
@@ -515,7 +515,7 @@ template<> struct DataSerializerTraits<CoordsXYZ>
 
 template<> struct DataSerializerTraits<CoordsXYZD>
 {
-    static void encode(IStream* stream, const CoordsXYZD& coord)
+    static void encode(OpenRCT2::IStream* stream, const CoordsXYZD& coord)
     {
         stream->WriteValue(ByteSwapBE(coord.x));
         stream->WriteValue(ByteSwapBE(coord.y));
@@ -523,7 +523,7 @@ template<> struct DataSerializerTraits<CoordsXYZD>
         stream->WriteValue(ByteSwapBE(coord.direction));
     }
 
-    static void decode(IStream* stream, CoordsXYZD& coord)
+    static void decode(OpenRCT2::IStream* stream, CoordsXYZD& coord)
     {
         auto x = ByteSwapBE(stream->ReadValue<int32_t>());
         auto y = ByteSwapBE(stream->ReadValue<int32_t>());
@@ -532,7 +532,7 @@ template<> struct DataSerializerTraits<CoordsXYZD>
         coord = CoordsXYZD{ x, y, z, d };
     }
 
-    static void log(IStream* stream, const CoordsXYZD& coord)
+    static void log(OpenRCT2::IStream* stream, const CoordsXYZD& coord)
     {
         char msg[128] = {};
         snprintf(
@@ -543,18 +543,18 @@ template<> struct DataSerializerTraits<CoordsXYZD>
 
 template<> struct DataSerializerTraits<NetworkCheatType_t>
 {
-    static void encode(IStream* stream, const NetworkCheatType_t& val)
+    static void encode(OpenRCT2::IStream* stream, const NetworkCheatType_t& val)
     {
         uint32_t temp = ByteSwapBE(val.id);
         stream->Write(&temp);
     }
-    static void decode(IStream* stream, NetworkCheatType_t& val)
+    static void decode(OpenRCT2::IStream* stream, NetworkCheatType_t& val)
     {
         uint32_t temp;
         stream->Read(&temp);
         val.id = ByteSwapBE(temp);
     }
-    static void log(IStream* stream, const NetworkCheatType_t& val)
+    static void log(OpenRCT2::IStream* stream, const NetworkCheatType_t& val)
     {
         const char* cheatName = CheatsGetName(static_cast<CheatType>(val.id));
         stream->Write(cheatName, strlen(cheatName));
@@ -563,13 +563,13 @@ template<> struct DataSerializerTraits<NetworkCheatType_t>
 
 template<> struct DataSerializerTraits<rct_object_entry>
 {
-    static void encode(IStream* stream, const rct_object_entry& val)
+    static void encode(OpenRCT2::IStream* stream, const rct_object_entry& val)
     {
         uint32_t temp = ByteSwapBE(val.flags);
         stream->Write(&temp);
         stream->WriteArray(val.nameWOC, 12);
     }
-    static void decode(IStream* stream, rct_object_entry& val)
+    static void decode(OpenRCT2::IStream* stream, rct_object_entry& val)
     {
         uint32_t temp;
         stream->Read(&temp);
@@ -577,7 +577,7 @@ template<> struct DataSerializerTraits<rct_object_entry>
         const char* str = stream->ReadArray<char>(12);
         memcpy(val.nameWOC, str, 12);
     }
-    static void log(IStream* stream, const rct_object_entry& val)
+    static void log(OpenRCT2::IStream* stream, const rct_object_entry& val)
     {
         stream->WriteArray(val.name, 8);
     }
@@ -585,17 +585,17 @@ template<> struct DataSerializerTraits<rct_object_entry>
 
 template<> struct DataSerializerTraits<TrackDesignTrackElement>
 {
-    static void encode(IStream* stream, const TrackDesignTrackElement& val)
+    static void encode(OpenRCT2::IStream* stream, const TrackDesignTrackElement& val)
     {
         stream->Write(&val.flags);
         stream->Write(&val.type);
     }
-    static void decode(IStream* stream, TrackDesignTrackElement& val)
+    static void decode(OpenRCT2::IStream* stream, TrackDesignTrackElement& val)
     {
         stream->Read(&val.flags);
         stream->Read(&val.type);
     }
-    static void log(IStream* stream, const TrackDesignTrackElement& val)
+    static void log(OpenRCT2::IStream* stream, const TrackDesignTrackElement& val)
     {
         char msg[128] = {};
         snprintf(msg, sizeof(msg), "TrackDesignTrackElement(type = %d, flags = %d)", val.type, val.flags);
@@ -605,18 +605,18 @@ template<> struct DataSerializerTraits<TrackDesignTrackElement>
 
 template<> struct DataSerializerTraits<TrackDesignMazeElement>
 {
-    static void encode(IStream* stream, const TrackDesignMazeElement& val)
+    static void encode(OpenRCT2::IStream* stream, const TrackDesignMazeElement& val)
     {
         uint32_t temp = ByteSwapBE(val.all);
         stream->Write(&temp);
     }
-    static void decode(IStream* stream, TrackDesignMazeElement& val)
+    static void decode(OpenRCT2::IStream* stream, TrackDesignMazeElement& val)
     {
         uint32_t temp;
         stream->Read(&temp);
         val.all = ByteSwapBE(temp);
     }
-    static void log(IStream* stream, const TrackDesignMazeElement& val)
+    static void log(OpenRCT2::IStream* stream, const TrackDesignMazeElement& val)
     {
         char msg[128] = {};
         snprintf(msg, sizeof(msg), "TrackDesignMazeElement(all = %d)", val.all);
@@ -626,7 +626,7 @@ template<> struct DataSerializerTraits<TrackDesignMazeElement>
 
 template<> struct DataSerializerTraits<TrackDesignEntranceElement>
 {
-    static void encode(IStream* stream, const TrackDesignEntranceElement& val)
+    static void encode(OpenRCT2::IStream* stream, const TrackDesignEntranceElement& val)
     {
         stream->Write(&val.x);
         stream->Write(&val.y);
@@ -634,7 +634,7 @@ template<> struct DataSerializerTraits<TrackDesignEntranceElement>
         stream->Write(&val.direction);
         stream->Write(&val.isExit);
     }
-    static void decode(IStream* stream, TrackDesignEntranceElement& val)
+    static void decode(OpenRCT2::IStream* stream, TrackDesignEntranceElement& val)
     {
         stream->Read(&val.x);
         stream->Read(&val.y);
@@ -642,7 +642,7 @@ template<> struct DataSerializerTraits<TrackDesignEntranceElement>
         stream->Read(&val.direction);
         stream->Read(&val.isExit);
     }
-    static void log(IStream* stream, const TrackDesignEntranceElement& val)
+    static void log(OpenRCT2::IStream* stream, const TrackDesignEntranceElement& val)
     {
         char msg[128] = {};
         snprintf(
@@ -654,7 +654,7 @@ template<> struct DataSerializerTraits<TrackDesignEntranceElement>
 
 template<> struct DataSerializerTraits<TrackDesignSceneryElement>
 {
-    static void encode(IStream* stream, const TrackDesignSceneryElement& val)
+    static void encode(OpenRCT2::IStream* stream, const TrackDesignSceneryElement& val)
     {
         stream->Write(&val.x);
         stream->Write(&val.y);
@@ -665,7 +665,7 @@ template<> struct DataSerializerTraits<TrackDesignSceneryElement>
         DataSerializerTraits<rct_object_entry> s;
         s.encode(stream, val.scenery_object);
     }
-    static void decode(IStream* stream, TrackDesignSceneryElement& val)
+    static void decode(OpenRCT2::IStream* stream, TrackDesignSceneryElement& val)
     {
         stream->Read(&val.x);
         stream->Read(&val.y);
@@ -676,7 +676,7 @@ template<> struct DataSerializerTraits<TrackDesignSceneryElement>
         DataSerializerTraits<rct_object_entry> s;
         s.decode(stream, val.scenery_object);
     }
-    static void log(IStream* stream, const TrackDesignSceneryElement& val)
+    static void log(OpenRCT2::IStream* stream, const TrackDesignSceneryElement& val)
     {
         char msg[128] = {};
         snprintf(
@@ -689,17 +689,17 @@ template<> struct DataSerializerTraits<TrackDesignSceneryElement>
 
 template<> struct DataSerializerTraits<rct_vehicle_colour>
 {
-    static void encode(IStream* stream, const rct_vehicle_colour& val)
+    static void encode(OpenRCT2::IStream* stream, const rct_vehicle_colour& val)
     {
         stream->Write(&val.body_colour);
         stream->Write(&val.trim_colour);
     }
-    static void decode(IStream* stream, rct_vehicle_colour& val)
+    static void decode(OpenRCT2::IStream* stream, rct_vehicle_colour& val)
     {
         stream->Read(&val.body_colour);
         stream->Read(&val.trim_colour);
     }
-    static void log(IStream* stream, const rct_vehicle_colour& val)
+    static void log(OpenRCT2::IStream* stream, const rct_vehicle_colour& val)
     {
         char msg[128] = {};
         snprintf(msg, sizeof(msg), "rct_vehicle_colour(body_colour = %d, trim_colour = %d)", val.body_colour, val.trim_colour);

--- a/src/openrct2/core/Diagnostics.cpp
+++ b/src/openrct2/core/Diagnostics.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 #if defined(DEBUG) && defined(_WIN32)
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #endif
 

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -87,7 +87,7 @@ namespace File
 
     void WriteAllBytes(const std::string& path, const void* buffer, size_t length)
     {
-        auto fs = FileStream(path, FILE_MODE_WRITE);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
         fs.Write(buffer, length);
     }
 

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #else
 #    include <sys/stat.h>

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -132,12 +132,12 @@ protected:
     /**
      * Serialises an index item to the given stream.
      */
-    virtual void Serialise(IStream* stream, const TItem& item) const abstract;
+    virtual void Serialise(OpenRCT2::IStream* stream, const TItem& item) const abstract;
 
     /**
      * Deserialises an index item from the given stream.
      */
-    virtual TItem Deserialise(IStream* stream) const abstract;
+    virtual TItem Deserialise(OpenRCT2::IStream* stream) const abstract;
 
 private:
     ScanResult Scan() const
@@ -261,7 +261,7 @@ private:
             try
             {
                 log_verbose("FileIndex:Loading index: '%s'", _indexPath.c_str());
-                auto fs = FileStream(_indexPath, FILE_MODE_OPEN);
+                auto fs = OpenRCT2::FileStream(_indexPath, OpenRCT2::FILE_MODE_OPEN);
 
                 // Read header, check if we need to re-scan
                 auto header = fs.ReadValue<FileIndexHeader>();
@@ -300,7 +300,7 @@ private:
         {
             log_verbose("FileIndex:Writing index: '%s'", _indexPath.c_str());
             Path::CreateDirectory(Path::GetDirectory(_indexPath));
-            auto fs = FileStream(_indexPath, FILE_MODE_WRITE);
+            auto fs = OpenRCT2::FileStream(_indexPath, OpenRCT2::FILE_MODE_WRITE);
 
             // Write header
             FileIndexHeader header;

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -10,7 +10,6 @@
 #include "../common.h"
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #endif
 

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -21,7 +21,7 @@ struct FileInfo
     uint64_t LastModified;
 };
 
-INTERFACE IFileScanner
+struct IFileScanner
 {
     virtual ~IFileScanner() = default;
 

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -21,7 +21,7 @@ struct FileInfo
     uint64_t LastModified;
 };
 
-interface IFileScanner
+INTERFACE IFileScanner
 {
     virtual ~IFileScanner() = default;
 

--- a/src/openrct2/core/FileStream.hpp
+++ b/src/openrct2/core/FileStream.hpp
@@ -147,17 +147,17 @@ namespace OpenRCT2
             Seek(position, STREAM_SEEK_BEGIN);
         }
 
-        void Seek(int64_t offset, IStream::SeekType origin) override
+        void Seek(int64_t offset, int32_t origin) override
         {
             switch (origin)
             {
-                case IStream::SeekType.STREAM_SEEK_BEGIN:
+                case STREAM_SEEK_BEGIN:
                     fseeko(_file, offset, SEEK_SET);
                     break;
-                case IStream::SeekType.STREAM_SEEK_CURRENT:
+                case STREAM_SEEK_CURRENT:
                     fseeko(_file, offset, SEEK_CUR);
                     break;
-                case IStream::SeekType.STREAM_SEEK_END:
+                case STREAM_SEEK_END:
                     fseeko(_file, offset, SEEK_END);
                     break;
             }

--- a/src/openrct2/core/FileStream.hpp
+++ b/src/openrct2/core/FileStream.hpp
@@ -29,170 +29,174 @@
 #    define fseeko _fseeki64
 #endif
 
-enum
+namespace OpenRCT2
 {
-    FILE_MODE_OPEN,
-    FILE_MODE_WRITE,
-    FILE_MODE_APPEND,
-};
-
-/**
- * A stream for reading and writing to files.
- */
-class FileStream final : public IStream
-{
-private:
-    FILE* _file = nullptr;
-    bool _ownsFilePtr = false;
-    bool _canRead = false;
-    bool _canWrite = false;
-    bool _disposed = false;
-    uint64_t _fileSize = 0;
-
-public:
-    FileStream(const std::string& path, int32_t fileMode)
-        : FileStream(path.c_str(), fileMode)
+    enum
     {
-    }
+        FILE_MODE_OPEN,
+        FILE_MODE_WRITE,
+        FILE_MODE_APPEND,
+    };
 
-    FileStream(const utf8* path, int32_t fileMode)
+    /**
+     * A stream for reading and writing to files.
+     */
+    class FileStream final : public IStream
     {
-        const char* mode;
-        switch (fileMode)
+    private:
+        FILE* _file = nullptr;
+        bool _ownsFilePtr = false;
+        bool _canRead = false;
+        bool _canWrite = false;
+        bool _disposed = false;
+        uint64_t _fileSize = 0;
+
+    public:
+        FileStream(const std::string& path, int32_t fileMode)
+            : FileStream(path.c_str(), fileMode)
         {
-            case FILE_MODE_OPEN:
-                mode = "rb";
-                _canRead = true;
-                _canWrite = false;
-                break;
-            case FILE_MODE_WRITE:
-                mode = "w+b";
-                _canRead = true;
-                _canWrite = true;
-                break;
-            case FILE_MODE_APPEND:
-                mode = "a";
-                _canRead = false;
-                _canWrite = true;
-                break;
-            default:
-                throw;
         }
 
-#ifdef _WIN32
-        auto pathW = String::ToWideChar(path);
-        auto modeW = String::ToWideChar(mode);
-        _file = _wfopen(pathW.c_str(), modeW.c_str());
-#else
-        if (fileMode == FILE_MODE_OPEN)
+        FileStream(const utf8* path, int32_t fileMode)
         {
-            struct stat fileStat;
-            // Only allow regular files to be opened as its possible to open directories.
-            if (stat(path, &fileStat) == 0 && S_ISREG(fileStat.st_mode))
+            const char* mode;
+            switch (fileMode)
+            {
+                case FILE_MODE_OPEN:
+                    mode = "rb";
+                    _canRead = true;
+                    _canWrite = false;
+                    break;
+                case FILE_MODE_WRITE:
+                    mode = "w+b";
+                    _canRead = true;
+                    _canWrite = true;
+                    break;
+                case FILE_MODE_APPEND:
+                    mode = "a";
+                    _canRead = false;
+                    _canWrite = true;
+                    break;
+                default:
+                    throw;
+            }
+
+#ifdef _WIN32
+            auto pathW = String::ToWideChar(path);
+            auto modeW = String::ToWideChar(mode);
+            _file = _wfopen(pathW.c_str(), modeW.c_str());
+#else
+            if (fileMode == FILE_MODE_OPEN)
+            {
+                struct stat fileStat;
+                // Only allow regular files to be opened as its possible to open directories.
+                if (stat(path, &fileStat) == 0 && S_ISREG(fileStat.st_mode))
+                {
+                    _file = fopen(path, mode);
+                }
+            }
+            else
             {
                 _file = fopen(path, mode);
             }
-        }
-        else
-        {
-            _file = fopen(path, mode);
-        }
 #endif
-        if (_file == nullptr)
-        {
-            throw IOException(String::StdFormat("Unable to open '%s'", path));
+            if (_file == nullptr)
+            {
+                throw IOException(String::StdFormat("Unable to open '%s'", path));
+            }
+
+            Seek(0, STREAM_SEEK_END);
+            _fileSize = GetPosition();
+            Seek(0, STREAM_SEEK_BEGIN);
+
+            _ownsFilePtr = true;
         }
 
-        Seek(0, STREAM_SEEK_END);
-        _fileSize = GetPosition();
-        Seek(0, STREAM_SEEK_BEGIN);
-
-        _ownsFilePtr = true;
-    }
-
-    ~FileStream() override
-    {
-        if (!_disposed)
+        ~FileStream() override
         {
-            _disposed = true;
-            if (_ownsFilePtr)
+            if (!_disposed)
             {
-                fclose(_file);
+                _disposed = true;
+                if (_ownsFilePtr)
+                {
+                    fclose(_file);
+                }
             }
         }
-    }
 
-    bool CanRead() const override
-    {
-        return _canRead;
-    }
-    bool CanWrite() const override
-    {
-        return _canWrite;
-    }
-
-    uint64_t GetLength() const override
-    {
-        return _fileSize;
-    }
-    uint64_t GetPosition() const override
-    {
-        return ftello(_file);
-    }
-
-    void SetPosition(uint64_t position) override
-    {
-        Seek(position, STREAM_SEEK_BEGIN);
-    }
-
-    void Seek(int64_t offset, int32_t origin) override
-    {
-        switch (origin)
+        bool CanRead() const override
         {
-            case STREAM_SEEK_BEGIN:
-                fseeko(_file, offset, SEEK_SET);
-                break;
-            case STREAM_SEEK_CURRENT:
-                fseeko(_file, offset, SEEK_CUR);
-                break;
-            case STREAM_SEEK_END:
-                fseeko(_file, offset, SEEK_END);
-                break;
+            return _canRead;
         }
-    }
-
-    void Read(void* buffer, uint64_t length) override
-    {
-        uint64_t remainingBytes = GetLength() - GetPosition();
-        if (length <= remainingBytes)
+        bool CanWrite() const override
         {
-            if (fread(buffer, static_cast<size_t>(length), 1, _file) == 1)
+            return _canWrite;
+        }
+
+        uint64_t GetLength() const override
+        {
+            return _fileSize;
+        }
+        uint64_t GetPosition() const override
+        {
+            return ftello(_file);
+        }
+
+        void SetPosition(uint64_t position) override
+        {
+            Seek(position, STREAM_SEEK_BEGIN);
+        }
+
+        void Seek(int64_t offset, IStream::SeekType origin) override
+        {
+            switch (origin)
             {
-                return;
+                case IStream::SeekType.STREAM_SEEK_BEGIN:
+                    fseeko(_file, offset, SEEK_SET);
+                    break;
+                case IStream::SeekType.STREAM_SEEK_CURRENT:
+                    fseeko(_file, offset, SEEK_CUR);
+                    break;
+                case IStream::SeekType.STREAM_SEEK_END:
+                    fseeko(_file, offset, SEEK_END);
+                    break;
             }
         }
-        throw IOException("Attempted to read past end of file.");
-    }
 
-    void Write(const void* buffer, uint64_t length) override
-    {
-        if (fwrite(buffer, static_cast<size_t>(length), 1, _file) != 1)
+        void Read(void* buffer, uint64_t length) override
         {
-            throw IOException("Unable to write to file.");
+            uint64_t remainingBytes = GetLength() - GetPosition();
+            if (length <= remainingBytes)
+            {
+                if (fread(buffer, static_cast<size_t>(length), 1, _file) == 1)
+                {
+                    return;
+                }
+            }
+            throw IOException("Attempted to read past end of file.");
         }
 
-        uint64_t position = GetPosition();
-        _fileSize = std::max(_fileSize, position);
-    }
+        void Write(const void* buffer, uint64_t length) override
+        {
+            if (fwrite(buffer, static_cast<size_t>(length), 1, _file) != 1)
+            {
+                throw IOException("Unable to write to file.");
+            }
 
-    uint64_t TryRead(void* buffer, uint64_t length) override
-    {
-        size_t readBytes = fread(buffer, 1, static_cast<size_t>(length), _file);
-        return readBytes;
-    }
+            uint64_t position = GetPosition();
+            _fileSize = std::max(_fileSize, position);
+        }
 
-    const void* GetData() const override
-    {
-        return nullptr;
-    }
-};
+        uint64_t TryRead(void* buffer, uint64_t length) override
+        {
+            size_t readBytes = fread(buffer, 1, static_cast<size_t>(length), _file);
+            return readBytes;
+        }
+
+        const void* GetData() const override
+        {
+            return nullptr;
+        }
+    };
+
+} // namespace OpenRCT2

--- a/src/openrct2/core/FileWatcher.cpp
+++ b/src/openrct2/core/FileWatcher.cpp
@@ -12,7 +12,6 @@
 #include <stdexcept>
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #elif defined(__linux__)
 #    include <fcntl.h>

--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -8,7 +8,6 @@
  *****************************************************************************/
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #endif
 

--- a/src/openrct2/core/Http.WinHttp.cpp
+++ b/src/openrct2/core/Http.WinHttp.cpp
@@ -16,7 +16,6 @@
 
 #    include <cstdio>
 #    include <stdexcept>
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #    include <winhttp.h>
 

--- a/src/openrct2/core/IStream.cpp
+++ b/src/openrct2/core/IStream.cpp
@@ -14,47 +14,51 @@
 
 #include <vector>
 
-utf8* IStream::ReadString()
+namespace OpenRCT2
 {
-    std::vector<utf8> result;
-
-    uint8_t ch;
-    while ((ch = ReadValue<uint8_t>()) != 0)
+    utf8* IStream::ReadString()
     {
-        result.push_back(ch);
+        std::vector<utf8> result;
+
+        uint8_t ch;
+        while ((ch = ReadValue<uint8_t>()) != 0)
+        {
+            result.push_back(ch);
+        }
+        result.push_back(0);
+
+        utf8* resultString = Memory::AllocateArray<utf8>(result.size());
+        std::copy(result.begin(), result.end(), resultString);
+        return resultString;
     }
-    result.push_back(0);
 
-    utf8* resultString = Memory::AllocateArray<utf8>(result.size());
-    std::copy(result.begin(), result.end(), resultString);
-    return resultString;
-}
-
-std::string IStream::ReadStdString()
-{
-    std::string result;
-    uint8_t ch;
-    while ((ch = ReadValue<uint8_t>()) != 0)
+    std::string IStream::ReadStdString()
     {
-        result.push_back(ch);
+        std::string result;
+        uint8_t ch;
+        while ((ch = ReadValue<uint8_t>()) != 0)
+        {
+            result.push_back(ch);
+        }
+        return result;
     }
-    return result;
-}
 
-void IStream::WriteString(const utf8* str)
-{
-    if (str == nullptr)
+    void IStream::WriteString(const utf8* str)
     {
-        WriteValue<uint8_t>(0);
+        if (str == nullptr)
+        {
+            WriteValue<uint8_t>(0);
+        }
+        else
+        {
+            size_t numBytes = String::SizeOf(str) + 1;
+            Write(str, numBytes);
+        }
     }
-    else
-    {
-        size_t numBytes = String::SizeOf(str) + 1;
-        Write(str, numBytes);
-    }
-}
 
-void IStream::WriteString(const std::string& str)
-{
-    WriteString(str.c_str());
-}
+    void IStream::WriteString(const std::string& str)
+    {
+        WriteString(str.c_str());
+    }
+
+} // namespace OpenRCT2

--- a/src/openrct2/core/IStream.hpp
+++ b/src/openrct2/core/IStream.hpp
@@ -36,7 +36,7 @@ namespace OpenRCT2
      * Represents a stream that can be read or written to. Implemented by types such as FileStream, NetworkStream or
      * MemoryStream.
      */
-    INTERFACE IStream
+    struct IStream
     {
         ///////////////////////////////////////////////////////////////////////////
         // Interface methods
@@ -111,7 +111,7 @@ namespace OpenRCT2
         /**
          * Reads the size of the given type from the stream directly into the given address.
          */
-        template<typename T> void Read(T * value)
+        template<typename T> void Read(T* value)
         {
             // Selects the best path at compile time
             if constexpr (sizeof(T) == 1)
@@ -197,7 +197,7 @@ namespace OpenRCT2
             return buffer;
         }
 
-        template<typename T> void WriteArray(T * buffer, size_t count)
+        template<typename T> void WriteArray(T* buffer, size_t count)
         {
             Write(buffer, sizeof(T) * count);
         }

--- a/src/openrct2/core/IStream.hpp
+++ b/src/openrct2/core/IStream.hpp
@@ -17,193 +17,198 @@
 #include <string>
 #include <vector>
 
-enum
-{
-    STREAM_SEEK_BEGIN,
-    STREAM_SEEK_CURRENT,
-    STREAM_SEEK_END
-};
-
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #    pragma GCC diagnostic ignored "-Wsuggest-final-types"
 #endif
 
-/**
- * Represents a stream that can be read or written to. Implemented by types such as FileStream, NetworkStream or MemoryStream.
- */
-interface IStream
+namespace OpenRCT2
 {
-    ///////////////////////////////////////////////////////////////////////////
-    // Interface methods
-    ///////////////////////////////////////////////////////////////////////////
-    virtual ~IStream()
+    enum
     {
-    }
-
-    virtual bool CanRead() const abstract;
-    virtual bool CanWrite() const abstract;
-
-    virtual uint64_t GetLength() const abstract;
-    virtual uint64_t GetPosition() const abstract;
-    virtual void SetPosition(uint64_t position) abstract;
-    virtual void Seek(int64_t offset, int32_t origin) abstract;
-
-    virtual void Read(void* buffer, uint64_t length) abstract;
-    virtual void Write(const void* buffer, uint64_t length) abstract;
-
-    virtual uint64_t TryRead(void* buffer, uint64_t length) abstract;
-
-    virtual const void* GetData() const abstract;
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Fast path methods, class can override them to use specialised copies.
-    ///////////////////////////////////////////////////////////////////////////
-    virtual void Read1(void* buffer)
-    {
-        Read(buffer, 1);
-    }
-    virtual void Read2(void* buffer)
-    {
-        Read(buffer, 2);
-    }
-    virtual void Read4(void* buffer)
-    {
-        Read(buffer, 4);
-    }
-    virtual void Read8(void* buffer)
-    {
-        Read(buffer, 8);
-    }
-    virtual void Read16(void* buffer)
-    {
-        Read(buffer, 16);
-    }
-
-    virtual void Write1(const void* buffer)
-    {
-        Write(buffer, 1);
-    }
-    virtual void Write2(const void* buffer)
-    {
-        Write(buffer, 2);
-    }
-    virtual void Write4(const void* buffer)
-    {
-        Write(buffer, 4);
-    }
-    virtual void Write8(const void* buffer)
-    {
-        Write(buffer, 8);
-    }
-    virtual void Write16(const void* buffer)
-    {
-        Write(buffer, 16);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Helper methods
-    ///////////////////////////////////////////////////////////////////////////
-    /**
-     * Reads the size of the given type from the stream directly into the given address.
-     */
-    template<typename T> void Read(T * value)
-    {
-        // Selects the best path at compile time
-        if constexpr (sizeof(T) == 1)
-        {
-            Read1(value);
-        }
-        else if constexpr (sizeof(T) == 2)
-        {
-            Read2(value);
-        }
-        else if constexpr (sizeof(T) == 4)
-        {
-            Read4(value);
-        }
-        else if constexpr (sizeof(T) == 8)
-        {
-            Read8(value);
-        }
-        else if constexpr (sizeof(T) == 16)
-        {
-            Read16(value);
-        }
-        else
-        {
-            Read(value, sizeof(T));
-        }
-    }
+        STREAM_SEEK_BEGIN,
+        STREAM_SEEK_CURRENT,
+        STREAM_SEEK_END
+    };
 
     /**
-     * Writes the size of the given type to the stream directly from the given address.
+     * Represents a stream that can be read or written to. Implemented by types such as FileStream, NetworkStream or
+     * MemoryStream.
      */
-    template<typename T> void Write(const T* value)
+    INTERFACE IStream
     {
-        // Selects the best path at compile time
-        if constexpr (sizeof(T) == 1)
+        ///////////////////////////////////////////////////////////////////////////
+        // Interface methods
+        ///////////////////////////////////////////////////////////////////////////
+        virtual ~IStream()
         {
-            Write1(value);
         }
-        else if constexpr (sizeof(T) == 2)
-        {
-            Write2(value);
-        }
-        else if constexpr (sizeof(T) == 4)
-        {
-            Write4(value);
-        }
-        else if constexpr (sizeof(T) == 8)
-        {
-            Write8(value);
-        }
-        else if constexpr (sizeof(T) == 16)
-        {
-            Write16(value);
-        }
-        else
-        {
-            Write(value, sizeof(T));
-        }
-    }
 
-    /**
-     * Reads the given type from the stream. Use this only for small types (e.g. int8_t, int64_t, double)
-     */
-    template<typename T> T ReadValue()
-    {
-        T buffer;
-        Read(&buffer);
-        return buffer;
-    }
+        virtual bool CanRead() const abstract;
+        virtual bool CanWrite() const abstract;
 
-    /**
-     * Writes the given type to the stream. Use this only for small types (e.g. int8_t, int64_t, double)
-     */
-    template<typename T> void WriteValue(const T value)
-    {
-        Write(&value);
-    }
+        virtual uint64_t GetLength() const abstract;
+        virtual uint64_t GetPosition() const abstract;
+        virtual void SetPosition(uint64_t position) abstract;
+        virtual void Seek(int64_t offset, int32_t origin) abstract;
 
-    template<typename T> T* ReadArray(size_t count)
-    {
-        T* buffer = Memory::AllocateArray<T>(count);
-        Read(buffer, sizeof(T) * count);
-        return buffer;
-    }
+        virtual void Read(void* buffer, uint64_t length) abstract;
+        virtual void Write(const void* buffer, uint64_t length) abstract;
 
-    template<typename T> void WriteArray(T * buffer, size_t count)
-    {
-        Write(buffer, sizeof(T) * count);
-    }
+        virtual uint64_t TryRead(void* buffer, uint64_t length) abstract;
 
-    utf8* ReadString();
-    std::string ReadStdString();
-    void WriteString(const utf8* str);
-    void WriteString(const std::string& string);
-};
+        virtual const void* GetData() const abstract;
+
+        ///////////////////////////////////////////////////////////////////////////
+        // Fast path methods, class can override them to use specialised copies.
+        ///////////////////////////////////////////////////////////////////////////
+        virtual void Read1(void* buffer)
+        {
+            Read(buffer, 1);
+        }
+        virtual void Read2(void* buffer)
+        {
+            Read(buffer, 2);
+        }
+        virtual void Read4(void* buffer)
+        {
+            Read(buffer, 4);
+        }
+        virtual void Read8(void* buffer)
+        {
+            Read(buffer, 8);
+        }
+        virtual void Read16(void* buffer)
+        {
+            Read(buffer, 16);
+        }
+
+        virtual void Write1(const void* buffer)
+        {
+            Write(buffer, 1);
+        }
+        virtual void Write2(const void* buffer)
+        {
+            Write(buffer, 2);
+        }
+        virtual void Write4(const void* buffer)
+        {
+            Write(buffer, 4);
+        }
+        virtual void Write8(const void* buffer)
+        {
+            Write(buffer, 8);
+        }
+        virtual void Write16(const void* buffer)
+        {
+            Write(buffer, 16);
+        }
+
+        ///////////////////////////////////////////////////////////////////////////
+        // Helper methods
+        ///////////////////////////////////////////////////////////////////////////
+        /**
+         * Reads the size of the given type from the stream directly into the given address.
+         */
+        template<typename T> void Read(T * value)
+        {
+            // Selects the best path at compile time
+            if constexpr (sizeof(T) == 1)
+            {
+                Read1(value);
+            }
+            else if constexpr (sizeof(T) == 2)
+            {
+                Read2(value);
+            }
+            else if constexpr (sizeof(T) == 4)
+            {
+                Read4(value);
+            }
+            else if constexpr (sizeof(T) == 8)
+            {
+                Read8(value);
+            }
+            else if constexpr (sizeof(T) == 16)
+            {
+                Read16(value);
+            }
+            else
+            {
+                Read(value, sizeof(T));
+            }
+        }
+
+        /**
+         * Writes the size of the given type to the stream directly from the given address.
+         */
+        template<typename T> void Write(const T* value)
+        {
+            // Selects the best path at compile time
+            if constexpr (sizeof(T) == 1)
+            {
+                Write1(value);
+            }
+            else if constexpr (sizeof(T) == 2)
+            {
+                Write2(value);
+            }
+            else if constexpr (sizeof(T) == 4)
+            {
+                Write4(value);
+            }
+            else if constexpr (sizeof(T) == 8)
+            {
+                Write8(value);
+            }
+            else if constexpr (sizeof(T) == 16)
+            {
+                Write16(value);
+            }
+            else
+            {
+                Write(value, sizeof(T));
+            }
+        }
+
+        /**
+         * Reads the given type from the stream. Use this only for small types (e.g. int8_t, int64_t, double)
+         */
+        template<typename T> T ReadValue()
+        {
+            T buffer;
+            Read(&buffer);
+            return buffer;
+        }
+
+        /**
+         * Writes the given type to the stream. Use this only for small types (e.g. int8_t, int64_t, double)
+         */
+        template<typename T> void WriteValue(const T value)
+        {
+            Write(&value);
+        }
+
+        template<typename T> T* ReadArray(size_t count)
+        {
+            T* buffer = Memory::AllocateArray<T>(count);
+            Read(buffer, sizeof(T) * count);
+            return buffer;
+        }
+
+        template<typename T> void WriteArray(T * buffer, size_t count)
+        {
+            Write(buffer, sizeof(T) * count);
+        }
+
+        utf8* ReadString();
+        std::string ReadStdString();
+        void WriteString(const utf8* str);
+        void WriteString(const std::string& string);
+    };
+
+} // namespace OpenRCT2
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
 #    pragma GCC diagnostic pop

--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -18,7 +18,7 @@ namespace Json
     json_t* ReadFromFile(const utf8* path, size_t maxSize)
     {
         json_t* json = nullptr;
-        auto fs = FileStream(path, FILE_MODE_OPEN);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
 
         size_t fileLength = static_cast<size_t>(fs.GetLength());
         if (fileLength > maxSize)
@@ -48,7 +48,7 @@ namespace Json
         const char* jsonOutput = json_dumps(json, flags);
 
         // Write to file
-        auto fs = FileStream(path, FILE_MODE_WRITE);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
         size_t jsonOutputSize = String::SizeOf(jsonOutput);
         fs.Write(jsonOutput, jsonOutputSize);
     }

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -14,243 +14,247 @@
 #include <algorithm>
 #include <cstring>
 
-MemoryStream::MemoryStream(const MemoryStream& copy)
+namespace OpenRCT2
 {
-    _access = copy._access;
-    _dataCapacity = copy._dataCapacity;
-    _dataSize = copy._dataSize;
-
-    if (_access & MEMORY_ACCESS::OWNER)
+    MemoryStream::MemoryStream(const MemoryStream& copy)
     {
-        _data = Memory::Allocate<void>(_dataCapacity);
-        std::memcpy(_data, copy._data, _dataCapacity);
-        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_data) + copy.GetPosition());
-    }
-}
+        _access = copy._access;
+        _dataCapacity = copy._dataCapacity;
+        _dataSize = copy._dataSize;
 
-MemoryStream::MemoryStream(size_t capacity)
-{
-    _dataCapacity = capacity;
-    _data = Memory::Allocate<void>(capacity);
-    _position = _data;
-}
-
-MemoryStream::MemoryStream(void* data, size_t dataSize, uint8_t access)
-{
-    _access = access;
-    _dataCapacity = dataSize;
-    _dataSize = dataSize;
-    _data = data;
-    _position = _data;
-}
-
-MemoryStream::MemoryStream(const void* data, size_t dataSize)
-    : MemoryStream(const_cast<void*>(data), dataSize, MEMORY_ACCESS::READ)
-{
-}
-
-MemoryStream::MemoryStream(MemoryStream&& mv) noexcept
-{
-    *this = std::move(mv);
-}
-
-MemoryStream::~MemoryStream()
-{
-    if (_access & MEMORY_ACCESS::OWNER)
-    {
-        Memory::Free(_data);
-    }
-    _dataCapacity = 0;
-    _dataSize = 0;
-    _data = nullptr;
-}
-
-MemoryStream& MemoryStream::operator=(MemoryStream&& mv) noexcept
-{
-    _access = mv._access;
-    _dataCapacity = mv._dataCapacity;
-    _data = mv._data;
-    _position = mv._position;
-
-    mv._data = nullptr;
-    mv._position = nullptr;
-    mv._dataCapacity = 0;
-    mv._dataSize = 0;
-
-    return *this;
-}
-
-const void* MemoryStream::GetData() const
-{
-    return _data;
-}
-
-void* MemoryStream::GetDataCopy() const
-{
-    auto result = Memory::Allocate<void>(_dataSize);
-    std::memcpy(result, _data, _dataSize);
-    return result;
-}
-
-void* MemoryStream::TakeData()
-{
-    _access &= ~MEMORY_ACCESS::OWNER;
-    return _data;
-}
-
-bool MemoryStream::CanRead() const
-{
-    return (_access & MEMORY_ACCESS::READ) != 0;
-}
-
-bool MemoryStream::CanWrite() const
-{
-    return (_access & MEMORY_ACCESS::WRITE) != 0;
-}
-
-uint64_t MemoryStream::GetLength() const
-{
-    return _dataSize;
-}
-
-uint64_t MemoryStream::GetPosition() const
-{
-    return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(_position) - reinterpret_cast<uintptr_t>(_data));
-}
-
-void MemoryStream::SetPosition(uint64_t position)
-{
-    Seek(position, STREAM_SEEK_BEGIN);
-}
-
-void MemoryStream::Seek(int64_t offset, int32_t origin)
-{
-    uint64_t newPosition;
-    switch (origin)
-    {
-        default:
-        case STREAM_SEEK_BEGIN:
-            newPosition = offset;
-            break;
-        case STREAM_SEEK_CURRENT:
-            newPosition = GetPosition() + offset;
-            break;
-        case STREAM_SEEK_END:
-            newPosition = _dataSize + offset;
-            break;
+        if (_access & MEMORY_ACCESS::OWNER)
+        {
+            _data = Memory::Allocate<void>(_dataCapacity);
+            std::memcpy(_data, copy._data, _dataCapacity);
+            _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_data) + copy.GetPosition());
+        }
     }
 
-    if (newPosition > _dataSize)
+    MemoryStream::MemoryStream(size_t capacity)
     {
-        throw IOException("New position out of bounds.");
-    }
-    _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_data) + static_cast<uintptr_t>(newPosition));
-}
-
-void MemoryStream::Read(void* buffer, uint64_t length)
-{
-    uint64_t position = GetPosition();
-    if (position + length > _dataSize)
-    {
-        throw IOException("Attempted to read past end of stream.");
+        _dataCapacity = capacity;
+        _data = Memory::Allocate<void>(capacity);
+        _position = _data;
     }
 
-    std::memcpy(buffer, _position, length);
-    _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + length);
-}
+    MemoryStream::MemoryStream(void* data, size_t dataSize, uint8_t access)
+    {
+        _access = access;
+        _dataCapacity = dataSize;
+        _dataSize = dataSize;
+        _data = data;
+        _position = _data;
+    }
 
-void MemoryStream::Read1(void* buffer)
-{
-    Read<1>(buffer);
-}
+    MemoryStream::MemoryStream(const void* data, size_t dataSize)
+        : MemoryStream(const_cast<void*>(data), dataSize, MEMORY_ACCESS::READ)
+    {
+    }
 
-void MemoryStream::Read2(void* buffer)
-{
-    Read<2>(buffer);
-}
+    MemoryStream::MemoryStream(MemoryStream&& mv) noexcept
+    {
+        *this = std::move(mv);
+    }
 
-void MemoryStream::Read4(void* buffer)
-{
-    Read<4>(buffer);
-}
-
-void MemoryStream::Read8(void* buffer)
-{
-    Read<8>(buffer);
-}
-
-void MemoryStream::Read16(void* buffer)
-{
-    Read<16>(buffer);
-}
-
-uint64_t MemoryStream::TryRead(void* buffer, uint64_t length)
-{
-    uint64_t remainingBytes = GetLength() - GetPosition();
-    uint64_t bytesToRead = std::min(length, remainingBytes);
-    Read(buffer, bytesToRead);
-    return bytesToRead;
-}
-
-void MemoryStream::Write(const void* buffer, uint64_t length)
-{
-    uint64_t position = GetPosition();
-    uint64_t nextPosition = position + length;
-    if (nextPosition > _dataCapacity)
+    MemoryStream::~MemoryStream()
     {
         if (_access & MEMORY_ACCESS::OWNER)
         {
-            EnsureCapacity(static_cast<size_t>(nextPosition));
+            Memory::Free(_data);
         }
-        else
-        {
-            throw IOException("Attempted to write past end of stream.");
-        }
+        _dataCapacity = 0;
+        _dataSize = 0;
+        _data = nullptr;
     }
 
-    std::memcpy(_position, buffer, length);
-    _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + length);
-    _dataSize = std::max<size_t>(_dataSize, static_cast<size_t>(nextPosition));
-}
-
-void MemoryStream::Write1(const void* buffer)
-{
-    Write<1>(buffer);
-}
-
-void MemoryStream::Write2(const void* buffer)
-{
-    Write<2>(buffer);
-}
-
-void MemoryStream::Write4(const void* buffer)
-{
-    Write<4>(buffer);
-}
-
-void MemoryStream::Write8(const void* buffer)
-{
-    Write<8>(buffer);
-}
-
-void MemoryStream::Write16(const void* buffer)
-{
-    Write<16>(buffer);
-}
-
-void MemoryStream::EnsureCapacity(size_t capacity)
-{
-    if (_dataCapacity < capacity)
+    MemoryStream& MemoryStream::operator=(MemoryStream&& mv) noexcept
     {
-        size_t newCapacity = std::max<size_t>(8, _dataCapacity);
-        while (newCapacity < capacity)
+        _access = mv._access;
+        _dataCapacity = mv._dataCapacity;
+        _data = mv._data;
+        _position = mv._position;
+
+        mv._data = nullptr;
+        mv._position = nullptr;
+        mv._dataCapacity = 0;
+        mv._dataSize = 0;
+
+        return *this;
+    }
+
+    const void* MemoryStream::GetData() const
+    {
+        return _data;
+    }
+
+    void* MemoryStream::GetDataCopy() const
+    {
+        auto result = Memory::Allocate<void>(_dataSize);
+        std::memcpy(result, _data, _dataSize);
+        return result;
+    }
+
+    void* MemoryStream::TakeData()
+    {
+        _access &= ~MEMORY_ACCESS::OWNER;
+        return _data;
+    }
+
+    bool MemoryStream::CanRead() const
+    {
+        return (_access & MEMORY_ACCESS::READ) != 0;
+    }
+
+    bool MemoryStream::CanWrite() const
+    {
+        return (_access & MEMORY_ACCESS::WRITE) != 0;
+    }
+
+    uint64_t MemoryStream::GetLength() const
+    {
+        return _dataSize;
+    }
+
+    uint64_t MemoryStream::GetPosition() const
+    {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(_position) - reinterpret_cast<uintptr_t>(_data));
+    }
+
+    void MemoryStream::SetPosition(uint64_t position)
+    {
+        Seek(position, STREAM_SEEK_BEGIN);
+    }
+
+    void MemoryStream::Seek(int64_t offset, int32_t origin)
+    {
+        uint64_t newPosition;
+        switch (origin)
         {
-            newCapacity *= 2;
+            default:
+            case STREAM_SEEK_BEGIN:
+                newPosition = offset;
+                break;
+            case STREAM_SEEK_CURRENT:
+                newPosition = GetPosition() + offset;
+                break;
+            case STREAM_SEEK_END:
+                newPosition = _dataSize + offset;
+                break;
         }
 
-        uint64_t position = GetPosition();
-        _dataCapacity = newCapacity;
-        _data = Memory::Reallocate(_data, _dataCapacity);
-        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_data) + static_cast<uintptr_t>(position));
+        if (newPosition > _dataSize)
+        {
+            throw IOException("New position out of bounds.");
+        }
+        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_data) + static_cast<uintptr_t>(newPosition));
     }
-}
+
+    void MemoryStream::Read(void* buffer, uint64_t length)
+    {
+        uint64_t position = GetPosition();
+        if (position + length > _dataSize)
+        {
+            throw IOException("Attempted to read past end of stream.");
+        }
+
+        std::memcpy(buffer, _position, length);
+        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + length);
+    }
+
+    void MemoryStream::Read1(void* buffer)
+    {
+        Read<1>(buffer);
+    }
+
+    void MemoryStream::Read2(void* buffer)
+    {
+        Read<2>(buffer);
+    }
+
+    void MemoryStream::Read4(void* buffer)
+    {
+        Read<4>(buffer);
+    }
+
+    void MemoryStream::Read8(void* buffer)
+    {
+        Read<8>(buffer);
+    }
+
+    void MemoryStream::Read16(void* buffer)
+    {
+        Read<16>(buffer);
+    }
+
+    uint64_t MemoryStream::TryRead(void* buffer, uint64_t length)
+    {
+        uint64_t remainingBytes = GetLength() - GetPosition();
+        uint64_t bytesToRead = std::min(length, remainingBytes);
+        Read(buffer, bytesToRead);
+        return bytesToRead;
+    }
+
+    void MemoryStream::Write(const void* buffer, uint64_t length)
+    {
+        uint64_t position = GetPosition();
+        uint64_t nextPosition = position + length;
+        if (nextPosition > _dataCapacity)
+        {
+            if (_access & MEMORY_ACCESS::OWNER)
+            {
+                EnsureCapacity(static_cast<size_t>(nextPosition));
+            }
+            else
+            {
+                throw IOException("Attempted to write past end of stream.");
+            }
+        }
+
+        std::memcpy(_position, buffer, length);
+        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + length);
+        _dataSize = std::max<size_t>(_dataSize, static_cast<size_t>(nextPosition));
+    }
+
+    void MemoryStream::Write1(const void* buffer)
+    {
+        Write<1>(buffer);
+    }
+
+    void MemoryStream::Write2(const void* buffer)
+    {
+        Write<2>(buffer);
+    }
+
+    void MemoryStream::Write4(const void* buffer)
+    {
+        Write<4>(buffer);
+    }
+
+    void MemoryStream::Write8(const void* buffer)
+    {
+        Write<8>(buffer);
+    }
+
+    void MemoryStream::Write16(const void* buffer)
+    {
+        Write<16>(buffer);
+    }
+
+    void MemoryStream::EnsureCapacity(size_t capacity)
+    {
+        if (_dataCapacity < capacity)
+        {
+            size_t newCapacity = std::max<size_t>(8, _dataCapacity);
+            while (newCapacity < capacity)
+            {
+                newCapacity *= 2;
+            }
+
+            uint64_t position = GetPosition();
+            _dataCapacity = newCapacity;
+            _data = Memory::Reallocate(_data, _dataCapacity);
+            _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_data) + static_cast<uintptr_t>(position));
+        }
+    }
+
+} // namespace OpenRCT2

--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -14,100 +14,104 @@
 
 #include <algorithm>
 
-namespace MEMORY_ACCESS
+namespace OpenRCT2
 {
-    constexpr uint8_t READ = 1 << 0;
-    constexpr uint8_t WRITE = 1 << 1;
-    constexpr uint8_t OWNER = 1 << 2;
-}; // namespace MEMORY_ACCESS
-
-/**
- * A stream for reading and writing to a buffer in memory. By default this buffer can grow.
- */
-class MemoryStream final : public IStream
-{
-private:
-    uint8_t _access = MEMORY_ACCESS::READ | MEMORY_ACCESS::WRITE | MEMORY_ACCESS::OWNER;
-    size_t _dataCapacity = 0;
-    size_t _dataSize = 0;
-    void* _data = nullptr;
-    void* _position = nullptr;
-
-public:
-    MemoryStream() = default;
-    MemoryStream(const MemoryStream& copy);
-    MemoryStream(MemoryStream&& mv) noexcept;
-    explicit MemoryStream(size_t capacity);
-    MemoryStream(void* data, size_t dataSize, uint8_t access = MEMORY_ACCESS::READ);
-    MemoryStream(const void* data, size_t dataSize);
-    virtual ~MemoryStream();
-
-    MemoryStream& operator=(MemoryStream&& mv) noexcept;
-
-    const void* GetData() const override;
-    void* GetDataCopy() const;
-    void* TakeData();
-
-    ///////////////////////////////////////////////////////////////////////////
-    // ISteam methods
-    ///////////////////////////////////////////////////////////////////////////
-    bool CanRead() const override;
-    bool CanWrite() const override;
-
-    uint64_t GetLength() const override;
-    uint64_t GetPosition() const override;
-    void SetPosition(uint64_t position) override;
-    void Seek(int64_t offset, int32_t origin) override;
-
-    void Read(void* buffer, uint64_t length) override;
-    void Read1(void* buffer) override;
-    void Read2(void* buffer) override;
-    void Read4(void* buffer) override;
-    void Read8(void* buffer) override;
-    void Read16(void* buffer) override;
-
-    template<size_t N> void Read(void* buffer)
+    namespace MEMORY_ACCESS
     {
-        uint64_t position = GetPosition();
-        if (position + N > _dataSize)
+        constexpr uint8_t READ = 1 << 0;
+        constexpr uint8_t WRITE = 1 << 1;
+        constexpr uint8_t OWNER = 1 << 2;
+    }; // namespace MEMORY_ACCESS
+
+    /**
+     * A stream for reading and writing to a buffer in memory. By default this buffer can grow.
+     */
+    class MemoryStream final : public IStream
+    {
+    private:
+        uint8_t _access = MEMORY_ACCESS::READ | MEMORY_ACCESS::WRITE | MEMORY_ACCESS::OWNER;
+        size_t _dataCapacity = 0;
+        size_t _dataSize = 0;
+        void* _data = nullptr;
+        void* _position = nullptr;
+
+    public:
+        MemoryStream() = default;
+        MemoryStream(const MemoryStream& copy);
+        MemoryStream(MemoryStream&& mv) noexcept;
+        explicit MemoryStream(size_t capacity);
+        MemoryStream(void* data, size_t dataSize, uint8_t access = MEMORY_ACCESS::READ);
+        MemoryStream(const void* data, size_t dataSize);
+        virtual ~MemoryStream();
+
+        MemoryStream& operator=(MemoryStream&& mv) noexcept;
+
+        const void* GetData() const override;
+        void* GetDataCopy() const;
+        void* TakeData();
+
+        ///////////////////////////////////////////////////////////////////////////
+        // ISteam methods
+        ///////////////////////////////////////////////////////////////////////////
+        bool CanRead() const override;
+        bool CanWrite() const override;
+
+        uint64_t GetLength() const override;
+        uint64_t GetPosition() const override;
+        void SetPosition(uint64_t position) override;
+        void Seek(int64_t offset, int32_t origin) override;
+
+        void Read(void* buffer, uint64_t length) override;
+        void Read1(void* buffer) override;
+        void Read2(void* buffer) override;
+        void Read4(void* buffer) override;
+        void Read8(void* buffer) override;
+        void Read16(void* buffer) override;
+
+        template<size_t N> void Read(void* buffer)
         {
-            throw IOException("Attempted to read past end of stream.");
+            uint64_t position = GetPosition();
+            if (position + N > _dataSize)
+            {
+                throw IOException("Attempted to read past end of stream.");
+            }
+
+            std::memcpy(buffer, _position, N);
+            _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + N);
         }
 
-        std::memcpy(buffer, _position, N);
-        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + N);
-    }
+        void Write(const void* buffer, uint64_t length) override;
+        void Write1(const void* buffer) override;
+        void Write2(const void* buffer) override;
+        void Write4(const void* buffer) override;
+        void Write8(const void* buffer) override;
+        void Write16(const void* buffer) override;
 
-    void Write(const void* buffer, uint64_t length) override;
-    void Write1(const void* buffer) override;
-    void Write2(const void* buffer) override;
-    void Write4(const void* buffer) override;
-    void Write8(const void* buffer) override;
-    void Write16(const void* buffer) override;
-
-    template<size_t N> void Write(const void* buffer)
-    {
-        uint64_t position = GetPosition();
-        uint64_t nextPosition = position + N;
-        if (nextPosition > _dataCapacity)
+        template<size_t N> void Write(const void* buffer)
         {
-            if (_access & MEMORY_ACCESS::OWNER)
+            uint64_t position = GetPosition();
+            uint64_t nextPosition = position + N;
+            if (nextPosition > _dataCapacity)
             {
-                EnsureCapacity(static_cast<size_t>(nextPosition));
+                if (_access & MEMORY_ACCESS::OWNER)
+                {
+                    EnsureCapacity(static_cast<size_t>(nextPosition));
+                }
+                else
+                {
+                    throw IOException("Attempted to write past end of stream.");
+                }
             }
-            else
-            {
-                throw IOException("Attempted to write past end of stream.");
-            }
+
+            std::memcpy(_position, buffer, N);
+            _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + N);
+            _dataSize = std::max<size_t>(_dataSize, static_cast<size_t>(nextPosition));
         }
 
-        std::memcpy(_position, buffer, N);
-        _position = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_position) + N);
-        _dataSize = std::max<size_t>(_dataSize, static_cast<size_t>(nextPosition));
-    }
+        uint64_t TryRead(void* buffer, uint64_t length) override;
 
-    uint64_t TryRead(void* buffer, uint64_t length) override;
+    private:
+        void EnsureCapacity(size_t capacity);
+    };
 
-private:
-    void EnsureCapacity(size_t capacity);
-};
+} // namespace OpenRCT2

--- a/src/openrct2/core/Registration.hpp
+++ b/src/openrct2/core/Registration.hpp
@@ -17,7 +17,7 @@ namespace OpenRCT2
      * Represents a registration of some service which when deleted will be
      * unregistered.
      */
-    INTERFACE IRegistration
+    struct IRegistration
     {
         virtual ~IRegistration() = default;
     };

--- a/src/openrct2/core/Registration.hpp
+++ b/src/openrct2/core/Registration.hpp
@@ -17,7 +17,7 @@ namespace OpenRCT2
      * Represents a registration of some service which when deleted will be
      * unregistered.
      */
-    interface IRegistration
+    INTERFACE IRegistration
     {
         virtual ~IRegistration() = default;
     };

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -24,10 +24,6 @@
 #endif
 
 #ifdef _WIN32
-#    ifndef NOMINMAX
-#        define NOMINMAX
-#    endif
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #endif
 

--- a/src/openrct2/core/StringReader.hpp
+++ b/src/openrct2/core/StringReader.hpp
@@ -14,7 +14,7 @@
 #include "../util/Util.h"
 #include "String.hpp"
 
-interface IStringReader
+INTERFACE IStringReader
 {
     virtual ~IStringReader() = default;
 

--- a/src/openrct2/core/StringReader.hpp
+++ b/src/openrct2/core/StringReader.hpp
@@ -14,12 +14,12 @@
 #include "../util/Util.h"
 #include "String.hpp"
 
-INTERFACE IStringReader
+struct IStringReader
 {
     virtual ~IStringReader() = default;
 
-    virtual bool TryPeek(codepoint_t * outCodepoint) abstract;
-    virtual bool TryRead(codepoint_t * outCodepoint) abstract;
+    virtual bool TryPeek(codepoint_t* outCodepoint) abstract;
+    virtual bool TryRead(codepoint_t* outCodepoint) abstract;
     virtual void Skip() abstract;
     virtual bool CanRead() const abstract;
 };

--- a/src/openrct2/core/Zip.h
+++ b/src/openrct2/core/Zip.h
@@ -18,7 +18,7 @@
 /**
  * Represents a zip file.
  */
-interface IZipArchive
+INTERFACE IZipArchive
 {
     virtual ~IZipArchive()
     {

--- a/src/openrct2/core/Zip.h
+++ b/src/openrct2/core/Zip.h
@@ -18,7 +18,7 @@
 /**
  * Represents a zip file.
  */
-INTERFACE IZipArchive
+struct IZipArchive
 {
     virtual ~IZipArchive()
     {

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -22,12 +22,12 @@ struct ScreenLine;
 struct ScreenRect;
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Drawing
 {
-    INTERFACE IDrawingEngine;
+    struct IDrawingEngine;
 }
 
 struct PaletteBGRA

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -22,12 +22,12 @@ struct ScreenLine;
 struct ScreenRect;
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Drawing
 {
-    interface IDrawingEngine;
+    INTERFACE IDrawingEngine;
 }
 
 struct PaletteBGRA

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -14,9 +14,9 @@
 
 namespace OpenRCT2::Drawing
 {
-    interface IDrawingEngine;
+    INTERFACE IDrawingEngine;
 
-    interface IDrawingContext
+    INTERFACE IDrawingContext
     {
         virtual ~IDrawingContext()
         {

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -14,9 +14,9 @@
 
 namespace OpenRCT2::Drawing
 {
-    INTERFACE IDrawingEngine;
+    struct IDrawingEngine;
 
-    INTERFACE IDrawingContext
+    struct IDrawingContext
     {
         virtual ~IDrawingContext()
         {

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -38,15 +38,15 @@ struct GamePalette;
 
 namespace OpenRCT2::Ui
 {
-    INTERFACE IUiContext;
+    struct IUiContext;
 } // namespace OpenRCT2::Ui
 
 namespace OpenRCT2::Drawing
 {
     enum class DRAWING_ENGINE_TYPE;
-    INTERFACE IDrawingContext;
+    struct IDrawingContext;
 
-    INTERFACE IDrawingEngine
+    struct IDrawingEngine
     {
         virtual ~IDrawingEngine()
         {
@@ -67,7 +67,7 @@ namespace OpenRCT2::Drawing
         virtual void CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy) abstract;
         virtual std::string Screenshot() abstract;
 
-        virtual IDrawingContext* GetDrawingContext(rct_drawpixelinfo * dpi) abstract;
+        virtual IDrawingContext* GetDrawingContext(rct_drawpixelinfo* dpi) abstract;
         virtual rct_drawpixelinfo* GetDrawingPixelInfo() abstract;
 
         virtual DRAWING_ENGINE_FLAGS GetFlags() abstract;
@@ -75,7 +75,7 @@ namespace OpenRCT2::Drawing
         virtual void InvalidateImage(uint32_t image) abstract;
     };
 
-    INTERFACE IDrawingEngineFactory
+    struct IDrawingEngineFactory
     {
         virtual ~IDrawingEngineFactory()
         {
@@ -84,7 +84,7 @@ namespace OpenRCT2::Drawing
             DRAWING_ENGINE_TYPE type, const std::shared_ptr<OpenRCT2::Ui::IUiContext>& uiContext) abstract;
     };
 
-    INTERFACE IRainDrawer
+    struct IRainDrawer
     {
         virtual ~IRainDrawer()
         {

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -38,15 +38,15 @@ struct GamePalette;
 
 namespace OpenRCT2::Ui
 {
-    interface IUiContext;
+    INTERFACE IUiContext;
 } // namespace OpenRCT2::Ui
 
 namespace OpenRCT2::Drawing
 {
     enum class DRAWING_ENGINE_TYPE;
-    interface IDrawingContext;
+    INTERFACE IDrawingContext;
 
-    interface IDrawingEngine
+    INTERFACE IDrawingEngine
     {
         virtual ~IDrawingEngine()
         {
@@ -75,7 +75,7 @@ namespace OpenRCT2::Drawing
         virtual void InvalidateImage(uint32_t image) abstract;
     };
 
-    interface IDrawingEngineFactory
+    INTERFACE IDrawingEngineFactory
     {
         virtual ~IDrawingEngineFactory()
         {
@@ -84,7 +84,7 @@ namespace OpenRCT2::Drawing
             DRAWING_ENGINE_TYPE type, const std::shared_ptr<OpenRCT2::Ui::IUiContext>& uiContext) abstract;
     };
 
-    interface IRainDrawer
+    INTERFACE IRainDrawer
     {
         virtual ~IRainDrawer()
         {

--- a/src/openrct2/drawing/Rain.h
+++ b/src/openrct2/drawing/Rain.h
@@ -15,7 +15,7 @@ struct rct_drawpixelinfo;
 
 namespace OpenRCT2::Drawing
 {
-    INTERFACE IRainDrawer;
+    struct IRainDrawer;
 }
 
 // clang-format off

--- a/src/openrct2/drawing/Rain.h
+++ b/src/openrct2/drawing/Rain.h
@@ -15,7 +15,7 @@ struct rct_drawpixelinfo;
 
 namespace OpenRCT2::Drawing
 {
-    interface IRainDrawer;
+    INTERFACE IRainDrawer;
 }
 
 // clang-format off

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -17,7 +17,7 @@ namespace OpenRCT2
 {
     namespace Ui
     {
-        INTERFACE IUiContext;
+        struct IUiContext;
     } // namespace Ui
 
     namespace Drawing

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -17,7 +17,7 @@ namespace OpenRCT2
 {
     namespace Ui
     {
-        interface IUiContext;
+        INTERFACE IUiContext;
     } // namespace Ui
 
     namespace Drawing

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -77,7 +77,7 @@ public:
         utf8* fileData = nullptr;
         try
         {
-            FileStream fs = FileStream(path, FILE_MODE_OPEN);
+            OpenRCT2::FileStream fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
 
             size_t fileLength = static_cast<size_t>(fs.GetLength());
             if (fileLength > MAX_LANGUAGE_SIZE)

--- a/src/openrct2/localisation/LanguagePack.h
+++ b/src/openrct2/localisation/LanguagePack.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <string_view>
 
-INTERFACE ILanguagePack
+struct ILanguagePack
 {
     virtual ~ILanguagePack() = default;
 

--- a/src/openrct2/localisation/LanguagePack.h
+++ b/src/openrct2/localisation/LanguagePack.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <string_view>
 
-interface ILanguagePack
+INTERFACE ILanguagePack
 {
     virtual ~ILanguagePack() = default;
 

--- a/src/openrct2/localisation/LocalisationService.h
+++ b/src/openrct2/localisation/LocalisationService.h
@@ -17,12 +17,12 @@
 #include <string_view>
 #include <tuple>
 
-interface ILanguagePack;
-interface IObjectManager;
+INTERFACE ILanguagePack;
+INTERFACE IObjectManager;
 
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Localisation

--- a/src/openrct2/localisation/LocalisationService.h
+++ b/src/openrct2/localisation/LocalisationService.h
@@ -17,12 +17,12 @@
 #include <string_view>
 #include <tuple>
 
-INTERFACE ILanguagePack;
-INTERFACE IObjectManager;
+struct ILanguagePack;
+struct IObjectManager;
 
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Localisation

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1430,7 +1430,7 @@ uint8_t* NetworkBase::save_for_network(size_t& out_size, const std::vector<const
     bool RLEState = gUseRLE;
     gUseRLE = false;
 
-    auto ms = MemoryStream();
+    auto ms = OpenRCT2::MemoryStream();
     if (!SaveMap(&ms, objects))
     {
         log_warning("Failed to export map.");

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -68,7 +68,7 @@ public: // Server
     void RemovePlayer(std::unique_ptr<NetworkConnection>& connection);
     void UpdateServer();
     void ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection);
-    bool SaveMap(IStream* stream, const std::vector<const ObjectRepositoryItem*>& objects) const;
+    bool SaveMap(OpenRCT2::IStream* stream, const std::vector<const ObjectRepositoryItem*>& objects) const;
     uint8_t* save_for_network(size_t& out_size, const std::vector<const ObjectRepositoryItem*>& objects) const;
     std::string MakePlayerNameUnique(const std::string& name);
 
@@ -120,7 +120,7 @@ public: // Client
     bool IsDesynchronised();
     NetworkServerState_t GetServerState() const;
     void ServerClientDisconnected();
-    bool LoadMap(IStream* stream);
+    bool LoadMap(OpenRCT2::IStream* stream);
     void UpdateClient();
 
     // Packet dispatchers.
@@ -218,7 +218,7 @@ private: // Client Data
     std::string _chatLogPath;
     std::string _chatLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
     std::string _password;
-    MemoryStream _serverGameState;
+    OpenRCT2::MemoryStream _serverGameState;
     NetworkServerState_t _serverState;
     uint32_t _lastSentHeartbeat = 0;
     uint32_t last_ping_sent_time = 0;

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -44,7 +44,7 @@ bool NetworkKey::Generate()
     }
 }
 
-bool NetworkKey::LoadPrivate(IStream* stream)
+bool NetworkKey::LoadPrivate(OpenRCT2::IStream* stream)
 {
     Guard::ArgumentNotNull(stream);
 
@@ -76,7 +76,7 @@ bool NetworkKey::LoadPrivate(IStream* stream)
     }
 }
 
-bool NetworkKey::LoadPublic(IStream* stream)
+bool NetworkKey::LoadPublic(OpenRCT2::IStream* stream)
 {
     Guard::ArgumentNotNull(stream);
 
@@ -108,7 +108,7 @@ bool NetworkKey::LoadPublic(IStream* stream)
     }
 }
 
-bool NetworkKey::SavePrivate(IStream* stream)
+bool NetworkKey::SavePrivate(OpenRCT2::IStream* stream)
 {
     try
     {
@@ -127,7 +127,7 @@ bool NetworkKey::SavePrivate(IStream* stream)
     }
 }
 
-bool NetworkKey::SavePublic(IStream* stream)
+bool NetworkKey::SavePublic(OpenRCT2::IStream* stream)
 {
     try
     {

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -18,7 +18,10 @@
 #    include <string>
 #    include <vector>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 namespace Crypt
 {
@@ -31,10 +34,10 @@ public:
     NetworkKey();
     ~NetworkKey();
     bool Generate();
-    bool LoadPrivate(IStream* stream);
-    bool LoadPublic(IStream* stream);
-    bool SavePrivate(IStream* stream);
-    bool SavePublic(IStream* stream);
+    bool LoadPrivate(OpenRCT2::IStream* stream);
+    bool LoadPublic(OpenRCT2::IStream* stream);
+    bool SavePrivate(OpenRCT2::IStream* stream);
+    bool SavePublic(OpenRCT2::IStream* stream);
     std::string PublicKeyString();
     std::string PublicKeyHash();
     void Unload();

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -18,7 +18,7 @@
 #    include <string>
 #    include <vector>
 
-interface IStream;
+INTERFACE IStream;
 
 namespace Crypt
 {

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -20,7 +20,7 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 namespace Crypt

--- a/src/openrct2/network/NetworkServerAdvertiser.h
+++ b/src/openrct2/network/NetworkServerAdvertiser.h
@@ -20,7 +20,7 @@ enum class ADVERTISE_STATUS
     REGISTERED,
 };
 
-interface INetworkServerAdvertiser
+INTERFACE INetworkServerAdvertiser
 {
     virtual ~INetworkServerAdvertiser()
     {

--- a/src/openrct2/network/NetworkServerAdvertiser.h
+++ b/src/openrct2/network/NetworkServerAdvertiser.h
@@ -20,7 +20,7 @@ enum class ADVERTISE_STATUS
     REGISTERED,
 };
 
-INTERFACE INetworkServerAdvertiser
+struct INetworkServerAdvertiser
 {
     virtual ~INetworkServerAdvertiser()
     {

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -35,7 +35,7 @@ enum NETWORK_READPACKET
 /**
  * Represents an address and port.
  */
-INTERFACE INetworkEndpoint
+struct INetworkEndpoint
 {
     virtual ~INetworkEndpoint()
     {
@@ -47,7 +47,7 @@ INTERFACE INetworkEndpoint
 /**
  * Represents a TCP socket / connection or listener.
  */
-INTERFACE ITcpSocket
+struct ITcpSocket
 {
 public:
     virtual ~ITcpSocket() = default;
@@ -74,7 +74,7 @@ public:
 /**
  * Represents a UDP socket / listener.
  */
-INTERFACE IUdpSocket
+struct IUdpSocket
 {
 public:
     virtual ~IUdpSocket() = default;

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -35,7 +35,7 @@ enum NETWORK_READPACKET
 /**
  * Represents an address and port.
  */
-interface INetworkEndpoint
+INTERFACE INetworkEndpoint
 {
     virtual ~INetworkEndpoint()
     {
@@ -47,7 +47,7 @@ interface INetworkEndpoint
 /**
  * Represents a TCP socket / connection or listener.
  */
-interface ITcpSocket
+INTERFACE ITcpSocket
 {
 public:
     virtual ~ITcpSocket() = default;
@@ -74,7 +74,7 @@ public:
 /**
  * Represents a UDP socket / listener.
  */
-interface IUdpSocket
+INTERFACE IUdpSocket
 {
 public:
     virtual ~IUdpSocket() = default;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -32,7 +32,7 @@ enum class PermissionState : uint8_t;
 
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
 void network_set_env(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -32,7 +32,7 @@ enum class PermissionState : uint8_t;
 
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
 void network_set_env(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -17,14 +17,14 @@
 #include "ObjectJsonHelpers.h"
 #include "ObjectList.h"
 
-void BannerObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void BannerObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(6, STREAM_SEEK_CURRENT);
+    stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.banner.scrolling_mode = stream->ReadValue<uint8_t>();
     _legacyType.banner.flags = stream->ReadValue<uint8_t>();
     _legacyType.banner.price = stream->ReadValue<int16_t>();
     _legacyType.banner.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
-    stream->Seek(2, STREAM_SEEK_CURRENT);
+    stream->Seek(2, OpenRCT2::STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
 

--- a/src/openrct2/object/BannerObject.h
+++ b/src/openrct2/object/BannerObject.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../core/IStream.hpp"
 #include "../world/Scenery.h"
 #include "SceneryObject.h"
 
@@ -28,7 +29,7 @@ public:
         return &_legacyType;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -15,9 +15,9 @@
 #include "../localisation/Localisation.h"
 #include "ObjectJsonHelpers.h"
 
-void EntranceObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void EntranceObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(6, STREAM_SEEK_CURRENT);
+    stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.scrolling_mode = stream->ReadValue<uint8_t>();
     _legacyType.text_height = stream->ReadValue<uint8_t>();
 

--- a/src/openrct2/object/EntranceObject.h
+++ b/src/openrct2/object/EntranceObject.h
@@ -28,7 +28,7 @@ public:
         return &_legacyType;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -20,15 +20,15 @@
 
 #include <unordered_map>
 
-void FootpathItemObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(6, STREAM_SEEK_CURRENT);
+    stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.path_bit.flags = stream->ReadValue<uint16_t>();
     _legacyType.path_bit.draw_type = stream->ReadValue<uint8_t>();
     _legacyType.path_bit.tool_id = stream->ReadValue<uint8_t>();
     _legacyType.path_bit.price = stream->ReadValue<int16_t>();
     _legacyType.path_bit.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
-    stream->Seek(2, STREAM_SEEK_CURRENT);
+    stream->Seek(2, OpenRCT2::STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
 

--- a/src/openrct2/object/FootpathItemObject.h
+++ b/src/openrct2/object/FootpathItemObject.h
@@ -28,7 +28,7 @@ public:
         return &_legacyType;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -15,13 +15,13 @@
 #include "../world/Footpath.h"
 #include "ObjectJsonHelpers.h"
 
-void FootpathObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void FootpathObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(10, STREAM_SEEK_CURRENT);
+    stream->Seek(10, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.support_type = static_cast<RailingEntrySupportType>(stream->ReadValue<uint8_t>());
     _legacyType.flags = stream->ReadValue<uint8_t>();
     _legacyType.scrolling_mode = stream->ReadValue<uint8_t>();
-    stream->Seek(1, STREAM_SEEK_CURRENT);
+    stream->Seek(1, OpenRCT2::STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
     GetImageTable().Read(context, stream);

--- a/src/openrct2/object/FootpathObject.h
+++ b/src/openrct2/object/FootpathObject.h
@@ -46,7 +46,7 @@ public:
         return &_pathRailingsEntry;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -28,7 +28,7 @@ ImageTable::~ImageTable()
     }
 }
 
-void ImageTable::Read(IReadObjectContext* context, IStream* stream)
+void ImageTable::Read(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
     if (gOpenRCT2NoGraphics)
     {

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -15,8 +15,8 @@
 #include <memory>
 #include <vector>
 
-interface IReadObjectContext;
-interface IStream;
+INTERFACE IReadObjectContext;
+INTERFACE IStream;
 
 class ImageTable
 {

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -16,7 +16,10 @@
 #include <vector>
 
 INTERFACE IReadObjectContext;
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 class ImageTable
 {
@@ -30,7 +33,7 @@ public:
     ImageTable& operator=(const ImageTable&) = delete;
     ~ImageTable();
 
-    void Read(IReadObjectContext* context, IStream* stream);
+    void Read(IReadObjectContext* context, OpenRCT2::IStream* stream);
     const rct_g1_element* GetImages() const
     {
         return _entries.data();

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -15,10 +15,10 @@
 #include <memory>
 #include <vector>
 
-INTERFACE IReadObjectContext;
+struct IReadObjectContext;
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 class ImageTable

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -23,17 +23,17 @@
 #include <algorithm>
 #include <iterator>
 
-void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(6, STREAM_SEEK_CURRENT);
+    stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.large_scenery.tool_id = stream->ReadValue<uint8_t>();
     _legacyType.large_scenery.flags = stream->ReadValue<uint8_t>();
     _legacyType.large_scenery.price = stream->ReadValue<int16_t>();
     _legacyType.large_scenery.removal_price = stream->ReadValue<int16_t>();
-    stream->Seek(5, STREAM_SEEK_CURRENT);
+    stream->Seek(5, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.large_scenery.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
     _legacyType.large_scenery.scrolling_mode = stream->ReadValue<uint8_t>();
-    stream->Seek(4, STREAM_SEEK_CURRENT);
+    stream->Seek(4, OpenRCT2::STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);
 
@@ -108,12 +108,12 @@ void LargeSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
     gfx_draw_sprite(dpi, imageId, screenCoords, 0);
 }
 
-std::vector<rct_large_scenery_tile> LargeSceneryObject::ReadTiles(IStream* stream)
+std::vector<rct_large_scenery_tile> LargeSceneryObject::ReadTiles(OpenRCT2::IStream* stream)
 {
     auto tiles = std::vector<rct_large_scenery_tile>();
     while (stream->ReadValue<uint16_t>() != 0xFFFF)
     {
-        stream->Seek(-2, STREAM_SEEK_CURRENT);
+        stream->Seek(-2, OpenRCT2::STREAM_SEEK_CURRENT);
         auto tile = stream->ReadValue<rct_large_scenery_tile>();
         tiles.push_back(tile);
     }

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -34,7 +34,7 @@ public:
         return &_legacyType;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;
@@ -42,7 +42,7 @@ public:
     void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
 
 private:
-    static std::vector<rct_large_scenery_tile> ReadTiles(IStream* stream);
+    static std::vector<rct_large_scenery_tile> ReadTiles(OpenRCT2::IStream* stream);
     static std::vector<rct_large_scenery_tile> ReadJsonTiles(const json_t* jTiles);
     static std::unique_ptr<rct_large_scenery_text> ReadJson3dFont(const json_t* j3dFont);
     static std::vector<LocationXY16> ReadJsonOffsets(const json_t* jOffsets);

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -32,7 +32,7 @@ void* Object::GetLegacyData()
     throw std::runtime_error("Not supported.");
 }
 
-void Object::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void Object::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
     throw std::runtime_error("Not supported.");
 }

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -134,13 +134,13 @@ struct rct_object_filters
 assert_struct_size(rct_object_filters, 3);
 #pragma pack(pop)
 
-interface IObjectRepository;
-interface IStream;
+INTERFACE IObjectRepository;
+INTERFACE IStream;
 struct ObjectRepositoryItem;
 struct rct_drawpixelinfo;
 struct json_t;
 
-interface IReadObjectContext
+INTERFACE IReadObjectContext
 {
     virtual ~IReadObjectContext() = default;
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -135,7 +135,10 @@ assert_struct_size(rct_object_filters, 3);
 #pragma pack(pop)
 
 INTERFACE IObjectRepository;
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 struct ObjectRepositoryItem;
 struct rct_drawpixelinfo;
 struct json_t;
@@ -223,7 +226,7 @@ public:
     virtual void ReadJson(IReadObjectContext* /*context*/, const json_t* /*root*/)
     {
     }
-    virtual void ReadLegacy(IReadObjectContext* context, IStream* stream);
+    virtual void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream);
     virtual void Load() abstract;
     virtual void Unload() abstract;
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -134,16 +134,16 @@ struct rct_object_filters
 assert_struct_size(rct_object_filters, 3);
 #pragma pack(pop)
 
-INTERFACE IObjectRepository;
+struct IObjectRepository;
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 struct ObjectRepositoryItem;
 struct rct_drawpixelinfo;
 struct json_t;
 
-INTERFACE IReadObjectContext
+struct IReadObjectContext
 {
     virtual ~IReadObjectContext() = default;
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -40,7 +40,7 @@
 #include <algorithm>
 #include <unordered_map>
 
-INTERFACE IFileDataRetriever
+struct IFileDataRetriever
 {
     virtual ~IFileDataRetriever() = default;
     virtual std::vector<uint8_t> GetData(const std::string_view& path) const abstract;

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -40,7 +40,7 @@
 #include <algorithm>
 #include <unordered_map>
 
-interface IFileDataRetriever
+INTERFACE IFileDataRetriever
 {
     virtual ~IFileDataRetriever() = default;
     virtual std::vector<uint8_t> GetData(const std::string_view& path) const abstract;

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -179,7 +179,7 @@ namespace ObjectFactory
         return (result != LookupTable.end()) ? result->second : OBJECT_SOURCE_CUSTOM;
     }
 
-    static void ReadObjectLegacy(Object* object, IReadObjectContext* context, IStream* stream)
+    static void ReadObjectLegacy(Object* object, IReadObjectContext* context, OpenRCT2::IStream* stream)
     {
         try
         {
@@ -203,7 +203,7 @@ namespace ObjectFactory
         Object* result = nullptr;
         try
         {
-            auto fs = FileStream(path, FILE_MODE_OPEN);
+            auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
             auto chunkReader = SawyerChunkReader(&fs);
 
             rct_object_entry entry = fs.ReadValue<rct_object_entry>();
@@ -219,7 +219,7 @@ namespace ObjectFactory
                 auto chunk = chunkReader.ReadChunk();
                 log_verbose("  size: %zu", chunk->GetLength());
 
-                auto chunkStream = MemoryStream(chunk->GetData(), chunk->GetLength());
+                auto chunkStream = OpenRCT2::MemoryStream(chunk->GetData(), chunk->GetLength());
                 auto readContext = ReadObjectContext(objectRepository, objectName, !gOpenRCT2NoGraphics, nullptr);
                 ReadObjectLegacy(result, &readContext, &chunkStream);
                 if (readContext.WasError())
@@ -251,7 +251,7 @@ namespace ObjectFactory
             object_entry_get_name_fixed(objectName, sizeof(objectName), entry);
 
             auto readContext = ReadObjectContext(objectRepository, objectName, !gOpenRCT2NoGraphics, nullptr);
-            auto chunkStream = MemoryStream(data, dataSize);
+            auto chunkStream = OpenRCT2::MemoryStream(data, dataSize);
             ReadObjectLegacy(result, &readContext, &chunkStream);
 
             if (readContext.WasError())

--- a/src/openrct2/object/ObjectFactory.h
+++ b/src/openrct2/object/ObjectFactory.h
@@ -13,7 +13,7 @@
 
 #include <string_view>
 
-INTERFACE IObjectRepository;
+struct IObjectRepository;
 class Object;
 struct rct_object_entry;
 

--- a/src/openrct2/object/ObjectFactory.h
+++ b/src/openrct2/object/ObjectFactory.h
@@ -13,7 +13,7 @@
 
 #include <string_view>
 
-interface IObjectRepository;
+INTERFACE IObjectRepository;
 class Object;
 struct rct_object_entry;
 

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -14,11 +14,11 @@
 
 #include <vector>
 
-INTERFACE IObjectRepository;
+struct IObjectRepository;
 class Object;
 struct ObjectRepositoryItem;
 
-INTERFACE IObjectManager
+struct IObjectManager
 {
     virtual ~IObjectManager()
     {

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -14,11 +14,11 @@
 
 #include <vector>
 
-interface IObjectRepository;
+INTERFACE IObjectRepository;
 class Object;
 struct ObjectRepositoryItem;
 
-interface IObjectManager
+INTERFACE IObjectManager
 {
     virtual ~IObjectManager()
     {

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -611,7 +611,7 @@ private:
         return String::Convert(normalisedName, CODE_PAGE::CP_1252, CODE_PAGE::CP_UTF8);
     }
 
-    void WritePackedObject(IStream* stream, const rct_object_entry* entry)
+    void WritePackedObject(OpenRCT2::IStream* stream, const rct_object_entry* entry)
     {
         const ObjectRepositoryItem* item = FindObject(entry);
         if (item == nullptr)
@@ -620,7 +620,7 @@ private:
         }
 
         // Read object data from file
-        auto fs = FileStream(item->Path, FILE_MODE_OPEN);
+        auto fs = OpenRCT2::FileStream(item->Path, OpenRCT2::FILE_MODE_OPEN);
         auto fileEntry = fs.ReadValue<rct_object_entry>();
         if (!object_entry_compare(entry, &fileEntry))
         {

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -18,13 +18,13 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 class Object;
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Localisation
@@ -62,7 +62,7 @@ struct ObjectRepositoryItem
     }
 };
 
-INTERFACE IObjectRepository
+struct IObjectRepository
 {
     virtual ~IObjectRepository() = default;
 
@@ -80,8 +80,8 @@ INTERFACE IObjectRepository
     virtual void AddObject(const rct_object_entry* objectEntry, const void* data, size_t dataSize) abstract;
     virtual void AddObjectFromFile(const std::string_view& objectName, const void* data, size_t dataSize) abstract;
 
-    virtual void ExportPackedObject(OpenRCT2::IStream * stream) abstract;
-    virtual void WritePackedObjects(OpenRCT2::IStream * stream, std::vector<const ObjectRepositoryItem*> & objects) abstract;
+    virtual void ExportPackedObject(OpenRCT2::IStream* stream) abstract;
+    virtual void WritePackedObjects(OpenRCT2::IStream* stream, std::vector<const ObjectRepositoryItem*>& objects) abstract;
 };
 
 std::unique_ptr<IObjectRepository> CreateObjectRepository(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -16,7 +16,11 @@
 #include <memory>
 #include <vector>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
+
 class Object;
 namespace OpenRCT2
 {
@@ -76,8 +80,8 @@ INTERFACE IObjectRepository
     virtual void AddObject(const rct_object_entry* objectEntry, const void* data, size_t dataSize) abstract;
     virtual void AddObjectFromFile(const std::string_view& objectName, const void* data, size_t dataSize) abstract;
 
-    virtual void ExportPackedObject(IStream * stream) abstract;
-    virtual void WritePackedObjects(IStream * stream, std::vector<const ObjectRepositoryItem*> & objects) abstract;
+    virtual void ExportPackedObject(OpenRCT2::IStream * stream) abstract;
+    virtual void WritePackedObjects(OpenRCT2::IStream * stream, std::vector<const ObjectRepositoryItem*> & objects) abstract;
 };
 
 std::unique_ptr<IObjectRepository> CreateObjectRepository(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -16,11 +16,11 @@
 #include <memory>
 #include <vector>
 
-interface IStream;
+INTERFACE IStream;
 class Object;
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Localisation
@@ -58,7 +58,7 @@ struct ObjectRepositoryItem
     }
 };
 
-interface IObjectRepository
+INTERFACE IObjectRepository
 {
     virtual ~IObjectRepository() = default;
 

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../core/IStream.hpp"
 #include "../ride/Ride.h"
 #include "Object.h"
 
@@ -34,7 +35,7 @@ public:
     }
 
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void Load() override;
     void Unload() override;
 
@@ -46,7 +47,7 @@ public:
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 
 private:
-    void ReadLegacyVehicle(IReadObjectContext* context, IStream* stream, rct_ride_entry_vehicle* vehicle);
+    void ReadLegacyVehicle(IReadObjectContext* context, OpenRCT2::IStream* stream, rct_ride_entry_vehicle* vehicle);
 
     void ReadJsonVehicleInfo(IReadObjectContext* context, const json_t* properties);
     std::vector<rct_ride_entry_vehicle> ReadJsonCars(const json_t* jCars);

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -34,7 +34,7 @@ public:
     }
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void Load() override;
     void Unload() override;
     void UpdateEntryIndexes();
@@ -44,7 +44,7 @@ public:
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 
 private:
-    static std::vector<rct_object_entry> ReadItems(IStream* stream);
+    static std::vector<rct_object_entry> ReadItems(OpenRCT2::IStream* stream);
     static uint32_t ReadJsonEntertainerCostumes(const json_t* jCostumes);
     static uint32_t ParseEntertainerCostume(const std::string& s);
     static std::vector<rct_object_entry> ReadJsonEntries(const json_t* jEntries);

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -23,15 +23,15 @@
 
 #include <algorithm>
 
-void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(6, STREAM_SEEK_CURRENT);
+    stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.small_scenery.flags = stream->ReadValue<uint32_t>();
     _legacyType.small_scenery.height = stream->ReadValue<uint8_t>();
     _legacyType.small_scenery.tool_id = stream->ReadValue<uint8_t>();
     _legacyType.small_scenery.price = stream->ReadValue<int16_t>();
     _legacyType.small_scenery.removal_price = stream->ReadValue<int16_t>();
-    stream->Seek(4, STREAM_SEEK_CURRENT);
+    stream->Seek(4, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.small_scenery.animation_delay = stream->ReadValue<uint16_t>();
     _legacyType.small_scenery.animation_mask = stream->ReadValue<uint16_t>();
     _legacyType.small_scenery.num_frames = stream->ReadValue<uint16_t>();
@@ -139,7 +139,7 @@ void SmallSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
     }
 }
 
-std::vector<uint8_t> SmallSceneryObject::ReadFrameOffsets(IStream* stream)
+std::vector<uint8_t> SmallSceneryObject::ReadFrameOffsets(OpenRCT2::IStream* stream)
 {
     uint8_t frameOffset;
     auto data = std::vector<uint8_t>();

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -31,7 +31,7 @@ public:
         return &_legacyType;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;
@@ -39,7 +39,7 @@ public:
     void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
 
 private:
-    static std::vector<uint8_t> ReadFrameOffsets(IStream* stream);
+    static std::vector<uint8_t> ReadFrameOffsets(OpenRCT2::IStream* stream);
     static std::vector<uint8_t> ReadJsonFrameOffsets(const json_t* jFrameOffsets);
     void PerformFixes();
     rct_object_entry GetScgPiratHeader();

--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -47,7 +47,7 @@ static bool StringIsBlank(const utf8* str)
     return true;
 }
 
-void StringTable::Read(IReadObjectContext* context, IStream* stream, uint8_t id)
+void StringTable::Read(IReadObjectContext* context, OpenRCT2::IStream* stream, uint8_t id)
 {
     try
     {

--- a/src/openrct2/object/StringTable.h
+++ b/src/openrct2/object/StringTable.h
@@ -15,8 +15,8 @@
 #include <string>
 #include <vector>
 
-interface IReadObjectContext;
-interface IStream;
+INTERFACE IReadObjectContext;
+INTERFACE IStream;
 
 enum OBJ_STRING_ID : uint8_t
 {

--- a/src/openrct2/object/StringTable.h
+++ b/src/openrct2/object/StringTable.h
@@ -16,7 +16,10 @@
 #include <vector>
 
 INTERFACE IReadObjectContext;
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 enum OBJ_STRING_ID : uint8_t
 {
@@ -47,7 +50,7 @@ public:
     StringTable(const StringTable&) = delete;
     StringTable& operator=(const StringTable&) = delete;
 
-    void Read(IReadObjectContext* context, IStream* stream, uint8_t id);
+    void Read(IReadObjectContext* context, OpenRCT2::IStream* stream, uint8_t id);
     void Sort();
     std::string GetString(uint8_t id) const;
     std::string GetString(uint8_t language, uint8_t id) const;

--- a/src/openrct2/object/StringTable.h
+++ b/src/openrct2/object/StringTable.h
@@ -15,10 +15,10 @@
 #include <string>
 #include <vector>
 
-INTERFACE IReadObjectContext;
+struct IReadObjectContext;
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 enum OBJ_STRING_ID : uint8_t

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -17,16 +17,16 @@
 #include "../world/Banner.h"
 #include "ObjectJsonHelpers.h"
 
-void WallObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void WallObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(6, STREAM_SEEK_CURRENT);
+    stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.wall.tool_id = stream->ReadValue<uint8_t>();
     _legacyType.wall.flags = stream->ReadValue<uint8_t>();
     _legacyType.wall.height = stream->ReadValue<uint8_t>();
     _legacyType.wall.flags2 = stream->ReadValue<uint8_t>();
     _legacyType.wall.price = stream->ReadValue<uint16_t>();
     _legacyType.wall.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
-    stream->Seek(1, STREAM_SEEK_CURRENT);
+    stream->Seek(1, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.wall.scrolling_mode = stream->ReadValue<uint8_t>();
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);

--- a/src/openrct2/object/WallObject.h
+++ b/src/openrct2/object/WallObject.h
@@ -28,7 +28,7 @@ public:
         return &_legacyType;
     }
 
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
     void Load() override;
     void Unload() override;

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -20,9 +20,9 @@
 
 #include <memory>
 
-void WaterObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
+void WaterObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
-    stream->Seek(14, STREAM_SEEK_CURRENT);
+    stream->Seek(14, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.flags = stream->ReadValue<uint16_t>();
 
     GetStringTable().Read(context, stream, OBJ_STRING_ID_NAME);

--- a/src/openrct2/object/WaterObject.h
+++ b/src/openrct2/object/WaterObject.h
@@ -31,7 +31,7 @@ public:
     }
 
     void ReadJson(IReadObjectContext* context, const json_t* root) override;
-    void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
+    void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
     void Load() override;
     void Unload() override;
 

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -22,17 +22,17 @@ namespace OpenRCT2
 {
     namespace Drawing
     {
-        interface IDrawingEngine;
+        INTERFACE IDrawingEngine;
     } // namespace Drawing
 
     namespace Ui
     {
-        interface IUiContext;
+        INTERFACE IUiContext;
     } // namespace Ui
 
     namespace Paint
     {
-        interface Painter final
+        INTERFACE Painter final
         {
         private:
             std::shared_ptr<Ui::IUiContext> const _uiContext;

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -22,17 +22,17 @@ namespace OpenRCT2
 {
     namespace Drawing
     {
-        INTERFACE IDrawingEngine;
+        struct IDrawingEngine;
     } // namespace Drawing
 
     namespace Ui
     {
-        INTERFACE IUiContext;
+        struct IUiContext;
     } // namespace Ui
 
     namespace Paint
     {
-        INTERFACE Painter final
+        struct Painter final
         {
         private:
             std::shared_ptr<Ui::IUiContext> const _uiContext;
@@ -44,14 +44,14 @@ namespace OpenRCT2
 
         public:
             explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
-            void Paint(Drawing::IDrawingEngine & de);
+            void Paint(Drawing::IDrawingEngine& de);
 
-            paint_session* CreateSession(rct_drawpixelinfo * dpi, uint32_t viewFlags);
-            void ReleaseSession(paint_session * session);
+            paint_session* CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags);
+            void ReleaseSession(paint_session* session);
 
         private:
-            void PaintReplayNotice(rct_drawpixelinfo * dpi, const char* text);
-            void PaintFPS(rct_drawpixelinfo * dpi);
+            void PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text);
+            void PaintFPS(rct_drawpixelinfo* dpi);
             void MeasureFPS();
         };
     } // namespace Paint

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -225,7 +225,7 @@ namespace Platform
         auto hModule = GetModuleHandleA("ntdll.dll");
         if (hModule != nullptr)
         {
-            using RtlGetVersionPtr = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
+            using RtlGetVersionPtr = long(WINAPI*)(PRTL_OSVERSIONINFOW);
 #    if defined(__GNUC__) && __GNUC__ >= 8
 #        pragma GCC diagnostic push
 #        pragma GCC diagnostic ignored "-Wcast-function-type"

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -10,7 +10,6 @@
 #include "../common.h"
 
 #ifdef _WIN32
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #else
 #    include <unistd.h>

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -16,7 +16,10 @@
 #ifdef _WIN32
 
 // Windows.h needs to be included first
+// clang-format off
 #    include <windows.h>
+#    include <shellapi.h>
+// clang-format on
 
 // Then the rest
 #    include "../OpenRCT2.h"

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -28,7 +28,7 @@
 class TD4Importer final : public ITrackImporter
 {
 private:
-    MemoryStream _stream;
+    OpenRCT2::MemoryStream _stream;
     std::string _name;
 
 public:
@@ -42,7 +42,7 @@ public:
         if (String::Equals(extension, ".td4", true))
         {
             _name = GetNameFromTrackPath(path);
-            auto fs = FileStream(path, FILE_MODE_OPEN);
+            auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
             return LoadFromStream(&fs);
         }
         else
@@ -51,7 +51,7 @@ public:
         }
     }
 
-    bool LoadFromStream(IStream* stream) override
+    bool LoadFromStream(OpenRCT2::IStream* stream) override
     {
         auto checksumType = SawyerEncoding::ValidateTrackChecksum(stream);
         if (!gConfigGeneral.allow_loading_with_incorrect_checksum && checksumType == RCT12TrackDesignVersion::unknown)

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -41,7 +41,7 @@ public:
     }
 };
 
-SawyerChunkReader::SawyerChunkReader(IStream* stream)
+SawyerChunkReader::SawyerChunkReader(OpenRCT2::IStream* stream)
     : _stream(stream)
 {
 }
@@ -52,7 +52,7 @@ void SawyerChunkReader::SkipChunk()
     try
     {
         auto header = _stream->ReadValue<sawyercoding_chunk_header>();
-        _stream->Seek(header.length, STREAM_SEEK_CURRENT);
+        _stream->Seek(header.length, OpenRCT2::STREAM_SEEK_CURRENT);
     }
     catch (const std::exception&)
     {

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -15,7 +15,6 @@
 // memory on a special debug heap and then initialises all the memory to 0xCC.
 #if defined(_WIN32) && defined(DEBUG)
 #    define __USE_HEAP_ALLOC__
-#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
 #endif
 

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -17,7 +17,7 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 /**

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-interface IStream;
+INTERFACE IStream;
 
 /**
  * Reads sawyer encoding chunks from a data stream. This can be used to read

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -15,7 +15,10 @@
 
 #include <memory>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 /**
  * Reads sawyer encoding chunks from a data stream. This can be used to read
@@ -24,10 +27,10 @@ INTERFACE IStream;
 class SawyerChunkReader final
 {
 private:
-    IStream* const _stream = nullptr;
+    OpenRCT2::IStream* const _stream = nullptr;
 
 public:
-    explicit SawyerChunkReader(IStream* stream);
+    explicit SawyerChunkReader(OpenRCT2::IStream* stream);
 
     /**
      * Skips the next chunk in the stream without decoding or reading its data

--- a/src/openrct2/rct12/SawyerChunkWriter.cpp
+++ b/src/openrct2/rct12/SawyerChunkWriter.cpp
@@ -15,7 +15,7 @@
 // Maximum buffer size to store compressed data, maximum of 16 MiB
 constexpr size_t MAX_COMPRESSED_CHUNK_SIZE = 16 * 1024 * 1024;
 
-SawyerChunkWriter::SawyerChunkWriter(IStream* stream)
+SawyerChunkWriter::SawyerChunkWriter(OpenRCT2::IStream* stream)
     : _stream(stream)
 {
 }

--- a/src/openrct2/rct12/SawyerChunkWriter.h
+++ b/src/openrct2/rct12/SawyerChunkWriter.h
@@ -14,7 +14,10 @@
 
 #include <memory>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 /**
  * Writes sawyer encoding chunks to a data stream. This can be used to write
@@ -23,10 +26,10 @@ INTERFACE IStream;
 class SawyerChunkWriter final
 {
 private:
-    IStream* const _stream = nullptr;
+    OpenRCT2::IStream* const _stream = nullptr;
 
 public:
-    explicit SawyerChunkWriter(IStream* stream);
+    explicit SawyerChunkWriter(OpenRCT2::IStream* stream);
 
     /**
      * Writes a chunk to the stream.

--- a/src/openrct2/rct12/SawyerChunkWriter.h
+++ b/src/openrct2/rct12/SawyerChunkWriter.h
@@ -16,7 +16,7 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 /**

--- a/src/openrct2/rct12/SawyerChunkWriter.h
+++ b/src/openrct2/rct12/SawyerChunkWriter.h
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-interface IStream;
+INTERFACE IStream;
 
 /**
  * Writes sawyer encoding chunks to a data stream. This can be used to write

--- a/src/openrct2/rct12/SawyerEncoding.cpp
+++ b/src/openrct2/rct12/SawyerEncoding.cpp
@@ -16,7 +16,7 @@
 
 namespace SawyerEncoding
 {
-    bool ValidateChecksum(IStream* stream)
+    bool ValidateChecksum(OpenRCT2::IStream* stream)
     {
         uint64_t initialPosition = stream->GetPosition();
         uint64_t dataSize = stream->GetLength() - initialPosition;
@@ -60,7 +60,7 @@ namespace SawyerEncoding
     }
 
     // Returns version number
-    RCT12TrackDesignVersion ValidateTrackChecksum(IStream* stream)
+    RCT12TrackDesignVersion ValidateTrackChecksum(OpenRCT2::IStream* stream)
     {
         uint64_t initialPosition = stream->GetPosition();
         uint64_t dataSize = stream->GetLength() - initialPosition;

--- a/src/openrct2/rct12/SawyerEncoding.h
+++ b/src/openrct2/rct12/SawyerEncoding.h
@@ -11,7 +11,7 @@
 
 #include "../common.h"
 
-interface IStream;
+INTERFACE IStream;
 
 enum class RCT12TrackDesignVersion : uint8_t;
 

--- a/src/openrct2/rct12/SawyerEncoding.h
+++ b/src/openrct2/rct12/SawyerEncoding.h
@@ -11,12 +11,15 @@
 
 #include "../common.h"
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 enum class RCT12TrackDesignVersion : uint8_t;
 
 namespace SawyerEncoding
 {
-    bool ValidateChecksum(IStream* stream);
-    RCT12TrackDesignVersion ValidateTrackChecksum(IStream* stream);
+    bool ValidateChecksum(OpenRCT2::IStream* stream);
+    RCT12TrackDesignVersion ValidateTrackChecksum(OpenRCT2::IStream* stream);
 } // namespace SawyerEncoding

--- a/src/openrct2/rct12/SawyerEncoding.h
+++ b/src/openrct2/rct12/SawyerEncoding.h
@@ -13,7 +13,7 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 enum class RCT12TrackDesignVersion : uint8_t;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -61,27 +61,27 @@ S6Exporter::S6Exporter()
 
 void S6Exporter::SaveGame(const utf8* path)
 {
-    auto fs = FileStream(path, FILE_MODE_WRITE);
+    auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
     SaveGame(&fs);
 }
 
-void S6Exporter::SaveGame(IStream* stream)
+void S6Exporter::SaveGame(OpenRCT2::IStream* stream)
 {
     Save(stream, false);
 }
 
 void S6Exporter::SaveScenario(const utf8* path)
 {
-    auto fs = FileStream(path, FILE_MODE_WRITE);
+    auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
     SaveScenario(&fs);
 }
 
-void S6Exporter::SaveScenario(IStream* stream)
+void S6Exporter::SaveScenario(OpenRCT2::IStream* stream)
 {
     Save(stream, true);
 }
 
-void S6Exporter::Save(IStream* stream, bool isScenario)
+void S6Exporter::Save(OpenRCT2::IStream* stream, bool isScenario)
 {
     _s6.header.type = isScenario ? S6_TYPE_SCENARIO : S6_TYPE_SAVEDGAME;
     _s6.header.classic_flag = 0;

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -18,7 +18,11 @@
 #include <string_view>
 #include <vector>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
+
 struct ObjectRepositoryItem;
 struct RCT12SpriteBase;
 struct SpriteBase;
@@ -35,9 +39,9 @@ public:
     S6Exporter();
 
     void SaveGame(const utf8* path);
-    void SaveGame(IStream* stream);
+    void SaveGame(OpenRCT2::IStream* stream);
     void SaveScenario(const utf8* path);
-    void SaveScenario(IStream* stream);
+    void SaveScenario(OpenRCT2::IStream* stream);
     void Export();
     void ExportParkName();
     void ExportRides();
@@ -54,7 +58,7 @@ private:
     rct_s6_data _s6{};
     std::vector<std::string> _userStrings;
 
-    void Save(IStream* stream, bool isScenario);
+    void Save(OpenRCT2::IStream* stream, bool isScenario);
     static uint32_t GetLoanHash(money32 initialCash, money32 bankLoan, uint32_t maxBankLoan);
     void ExportResearchedRideTypes();
     void ExportResearchedRideEntries();

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -20,7 +20,7 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 struct ObjectRepositoryItem;

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <vector>
 
-interface IStream;
+INTERFACE IStream;
 struct ObjectRepositoryItem;
 struct RCT12SpriteBase;
 struct SpriteBase;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -93,7 +93,7 @@ public:
 
     ParkLoadResult LoadSavedGame(const utf8* path, bool skipObjectCheck = false) override
     {
-        auto fs = FileStream(path, FILE_MODE_OPEN);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
         auto result = LoadFromStream(&fs, false, skipObjectCheck);
         _s6Path = path;
         return result;
@@ -101,14 +101,14 @@ public:
 
     ParkLoadResult LoadScenario(const utf8* path, bool skipObjectCheck = false) override
     {
-        auto fs = FileStream(path, FILE_MODE_OPEN);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
         auto result = LoadFromStream(&fs, true, skipObjectCheck);
         _s6Path = path;
         return result;
     }
 
     ParkLoadResult LoadFromStream(
-        IStream* stream, bool isScenario, [[maybe_unused]] bool skipObjectCheck = false,
+        OpenRCT2::IStream* stream, bool isScenario, [[maybe_unused]] bool skipObjectCheck = false,
         const utf8* path = String::Empty) override
     {
         if (isScenario && !gConfigGeneral.allow_loading_with_incorrect_checksum && !SawyerEncoding::ValidateChecksum(stream))

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -35,7 +35,7 @@ bool T6Exporter::SaveTrack(const utf8* path)
 {
     try
     {
-        auto fs = FileStream(path, FILE_MODE_WRITE);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
         return SaveTrack(&fs);
     }
     catch (const std::exception& e)
@@ -45,9 +45,9 @@ bool T6Exporter::SaveTrack(const utf8* path)
     }
 }
 
-bool T6Exporter::SaveTrack(IStream* stream)
+bool T6Exporter::SaveTrack(OpenRCT2::IStream* stream)
 {
-    MemoryStream tempStream;
+    OpenRCT2::MemoryStream tempStream;
     tempStream.WriteValue<uint8_t>(_trackDesign->type);
     tempStream.WriteValue<uint8_t>(_trackDesign->vehicle_type);
     tempStream.WriteValue<uint32_t>(_trackDesign->flags);

--- a/src/openrct2/rct2/T6Exporter.h
+++ b/src/openrct2/rct2/T6Exporter.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-interface IStream;
+INTERFACE IStream;
 
 /**
  * Class to export RollerCoaster Tycoon 2 track designs (*.TD6).

--- a/src/openrct2/rct2/T6Exporter.h
+++ b/src/openrct2/rct2/T6Exporter.h
@@ -14,7 +14,10 @@
 
 #include <vector>
 
-INTERFACE IStream;
+namespace OpenRCT2
+{
+    INTERFACE IStream;
+}
 
 /**
  * Class to export RollerCoaster Tycoon 2 track designs (*.TD6).
@@ -25,7 +28,7 @@ public:
     T6Exporter(TrackDesign* trackDesign);
 
     bool SaveTrack(const utf8* path);
-    bool SaveTrack(IStream* stream);
+    bool SaveTrack(OpenRCT2::IStream* stream);
 
 private:
     TrackDesign* _trackDesign;

--- a/src/openrct2/rct2/T6Exporter.h
+++ b/src/openrct2/rct2/T6Exporter.h
@@ -16,7 +16,7 @@
 
 namespace OpenRCT2
 {
-    INTERFACE IStream;
+    struct IStream;
 }
 
 /**

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -26,7 +26,7 @@
 class TD6Importer final : public ITrackImporter
 {
 private:
-    MemoryStream _stream;
+    OpenRCT2::MemoryStream _stream;
     std::string _name;
 
 public:
@@ -40,7 +40,7 @@ public:
         if (String::Equals(extension, ".td6", true))
         {
             _name = GetNameFromTrackPath(path);
-            auto fs = FileStream(path, FILE_MODE_OPEN);
+            auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
             return LoadFromStream(&fs);
         }
         else
@@ -49,7 +49,7 @@ public:
         }
     }
 
-    bool LoadFromStream(IStream* stream) override
+    bool LoadFromStream(OpenRCT2::IStream* stream) override
     {
         if (!gConfigGeneral.allow_loading_with_incorrect_checksum
             && SawyerEncoding::ValidateTrackChecksum(stream) != RCT12TrackDesignVersion::TD6)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -21,7 +21,7 @@
 #include <limits>
 #include <string_view>
 
-interface IObjectManager;
+INTERFACE IObjectManager;
 class Formatter;
 class StationObject;
 struct Peep;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -21,7 +21,7 @@
 #include <limits>
 #include <string_view>
 
-INTERFACE IObjectManager;
+struct IObjectManager;
 class Formatter;
 class StationObject;
 struct Peep;

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -24,17 +24,17 @@ struct track_design_file_ref
 
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
-INTERFACE ITrackDesignRepository
+struct ITrackDesignRepository
 {
     virtual ~ITrackDesignRepository() = default;
 
     virtual size_t GetCount() const abstract;
     virtual size_t GetCountForObjectEntry(uint8_t rideType, const std::string& entry) const abstract;
-    virtual std::vector<track_design_file_ref> GetItemsForObjectEntry(uint8_t rideType, const std::string& entry)
-        const abstract;
+    virtual std::vector<track_design_file_ref> GetItemsForObjectEntry(
+        uint8_t rideType, const std::string& entry) const abstract;
 
     virtual void Scan(int32_t language) abstract;
     virtual bool Delete(const std::string& path) abstract;

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -24,10 +24,10 @@ struct track_design_file_ref
 
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
-interface ITrackDesignRepository
+INTERFACE ITrackDesignRepository
 {
     virtual ~ITrackDesignRepository() = default;
 

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -48,10 +48,10 @@ struct scenario_index_entry
 
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
-INTERFACE IScenarioRepository
+struct IScenarioRepository
 {
     virtual ~IScenarioRepository() = default;
 
@@ -69,8 +69,8 @@ INTERFACE IScenarioRepository
     virtual const scenario_index_entry* GetByInternalName(const utf8* name) const abstract;
     virtual const scenario_index_entry* GetByPath(const utf8* path) const abstract;
 
-    virtual bool TryRecordHighscore(int32_t language, const utf8* scenarioFileName, money32 companyValue, const utf8* name)
-        abstract;
+    virtual bool TryRecordHighscore(
+        int32_t language, const utf8* scenarioFileName, money32 companyValue, const utf8* name) abstract;
 };
 
 std::unique_ptr<IScenarioRepository> CreateScenarioRepository(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -48,10 +48,10 @@ struct scenario_index_entry
 
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
-interface IScenarioRepository
+INTERFACE IScenarioRepository
 {
     virtual ~IScenarioRepository() = default;
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -37,7 +37,7 @@ class InteractiveConsole;
 
 namespace OpenRCT2
 {
-    interface IPlatformEnvironment;
+    INTERFACE IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -37,7 +37,7 @@ class InteractiveConsole;
 
 namespace OpenRCT2
 {
-    INTERFACE IPlatformEnvironment;
+    struct IPlatformEnvironment;
 }
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -12,7 +12,7 @@
 #include "../common.h"
 #include "../drawing/Drawing.h"
 
-interface ITitleSequencePlayer;
+INTERFACE ITitleSequencePlayer;
 
 namespace OpenRCT2
 {

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -12,7 +12,7 @@
 #include "../common.h"
 #include "../drawing/Drawing.h"
 
-INTERFACE ITitleSequencePlayer;
+struct ITitleSequencePlayer;
 
 namespace OpenRCT2
 {

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -33,7 +33,7 @@
 static std::vector<utf8*> GetSaves(const utf8* path);
 static std::vector<utf8*> GetSaves(IZipArchive* zip);
 static std::vector<TitleCommand> LegacyScriptRead(utf8* script, size_t scriptLength, std::vector<utf8*> saves);
-static void LegacyScriptGetLine(IStream* stream, char* parts);
+static void LegacyScriptGetLine(OpenRCT2::IStream* stream, char* parts);
 static std::vector<uint8_t> ReadScriptFile(const utf8* path);
 static std::string LegacyScriptWrite(TitleSequence* seq);
 
@@ -131,7 +131,8 @@ TitleSequenceParkHandle* TitleSequenceGetParkHandle(TitleSequence* seq, size_t i
                 auto data = zip->GetFileData(filename);
                 auto dataForMs = Memory::Allocate<uint8_t>(data.size());
                 std::copy_n(data.data(), data.size(), dataForMs);
-                auto ms = new MemoryStream(dataForMs, data.size(), MEMORY_ACCESS::READ | MEMORY_ACCESS::OWNER);
+                auto ms = new OpenRCT2::MemoryStream(
+                    dataForMs, data.size(), OpenRCT2::MEMORY_ACCESS::READ | OpenRCT2::MEMORY_ACCESS::OWNER);
 
                 handle = Memory::Allocate<TitleSequenceParkHandle>();
                 handle->Stream = ms;
@@ -148,10 +149,10 @@ TitleSequenceParkHandle* TitleSequenceGetParkHandle(TitleSequence* seq, size_t i
             String::Set(absolutePath, sizeof(absolutePath), seq->Path);
             Path::Append(absolutePath, sizeof(absolutePath), filename);
 
-            FileStream* fileStream = nullptr;
+            OpenRCT2::FileStream* fileStream = nullptr;
             try
             {
-                fileStream = new FileStream(absolutePath, FILE_MODE_OPEN);
+                fileStream = new OpenRCT2::FileStream(absolutePath, OpenRCT2::FILE_MODE_OPEN);
             }
             catch (const IOException& exception)
             {
@@ -174,7 +175,7 @@ void TitleSequenceCloseParkHandle(TitleSequenceParkHandle* handle)
     if (handle != nullptr)
     {
         Memory::Free(handle->HintPath);
-        delete (static_cast<IStream*>(handle->Stream));
+        delete (static_cast<OpenRCT2::IStream*>(handle->Stream));
         Memory::Free(handle);
     }
 }
@@ -386,7 +387,7 @@ static std::vector<utf8*> GetSaves(IZipArchive* zip)
 static std::vector<TitleCommand> LegacyScriptRead(utf8* script, size_t scriptLength, std::vector<utf8*> saves)
 {
     std::vector<TitleCommand> commands;
-    auto fs = MemoryStream(script, scriptLength);
+    auto fs = OpenRCT2::MemoryStream(script, scriptLength);
     do
     {
         char parts[3 * 128], *token, *part1, *part2;
@@ -472,7 +473,7 @@ static std::vector<TitleCommand> LegacyScriptRead(utf8* script, size_t scriptLen
     return commands;
 }
 
-static void LegacyScriptGetLine(IStream* stream, char* parts)
+static void LegacyScriptGetLine(OpenRCT2::IStream* stream, char* parts)
 {
     for (int32_t i = 0; i < 3; i++)
     {
@@ -543,7 +544,7 @@ static std::vector<uint8_t> ReadScriptFile(const utf8* path)
     std::vector<uint8_t> result;
     try
     {
-        auto fs = FileStream(path, FILE_MODE_OPEN);
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
         auto size = static_cast<size_t>(fs.GetLength());
         result.resize(size);
         fs.Read(result.data(), size);

--- a/src/openrct2/title/TitleSequencePlayer.h
+++ b/src/openrct2/title/TitleSequencePlayer.h
@@ -11,7 +11,7 @@
 
 #include "../common.h"
 
-interface ITitleSequencePlayer
+INTERFACE ITitleSequencePlayer
 {
     virtual ~ITitleSequencePlayer() = default;
 

--- a/src/openrct2/title/TitleSequencePlayer.h
+++ b/src/openrct2/title/TitleSequencePlayer.h
@@ -11,7 +11,7 @@
 
 #include "../common.h"
 
-INTERFACE ITitleSequencePlayer
+struct ITitleSequencePlayer
 {
     virtual ~ITitleSequencePlayer() = default;
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -19,21 +19,21 @@
 
 struct ScreenCoordsXY;
 struct rct_drawpixelinfo;
-interface ITitleSequencePlayer;
+INTERFACE ITitleSequencePlayer;
 
 namespace OpenRCT2
 {
     namespace Drawing
     {
-        interface IDrawingEngineFactory;
-        interface IRainDrawer;
+        INTERFACE IDrawingEngineFactory;
+        INTERFACE IRainDrawer;
         using DrawRainFunc = void (*)(
             OpenRCT2::Drawing::IRainDrawer* rainDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
     } // namespace Drawing
 
     namespace Ui
     {
-        interface IWindowManager;
+        INTERFACE IWindowManager;
 
         enum class FULLSCREEN_MODE
         {
@@ -87,7 +87,7 @@ namespace OpenRCT2
         /**
          * Represents the window or screen that OpenRCT2 is presented on.
          */
-        interface IUiContext
+        INTERFACE IUiContext
         {
             virtual ~IUiContext() = default;
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -19,21 +19,21 @@
 
 struct ScreenCoordsXY;
 struct rct_drawpixelinfo;
-INTERFACE ITitleSequencePlayer;
+struct ITitleSequencePlayer;
 
 namespace OpenRCT2
 {
     namespace Drawing
     {
-        INTERFACE IDrawingEngineFactory;
-        INTERFACE IRainDrawer;
+        struct IDrawingEngineFactory;
+        struct IRainDrawer;
         using DrawRainFunc = void (*)(
             OpenRCT2::Drawing::IRainDrawer* rainDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
     } // namespace Drawing
 
     namespace Ui
     {
-        INTERFACE IWindowManager;
+        struct IWindowManager;
 
         enum class FULLSCREEN_MODE
         {
@@ -87,13 +87,13 @@ namespace OpenRCT2
         /**
          * Represents the window or screen that OpenRCT2 is presented on.
          */
-        INTERFACE IUiContext
+        struct IUiContext
         {
             virtual ~IUiContext() = default;
 
             virtual void Initialise() abstract;
             virtual void Update() abstract;
-            virtual void Draw(rct_drawpixelinfo * dpi) abstract;
+            virtual void Draw(rct_drawpixelinfo* dpi) abstract;
 
             // Window
             virtual void CreateWindow() abstract;
@@ -133,12 +133,12 @@ namespace OpenRCT2
             // Drawing
             virtual std::shared_ptr<Drawing::IDrawingEngineFactory> GetDrawingEngineFactory() abstract;
             virtual void DrawRainAnimation(
-                OpenRCT2::Drawing::IRainDrawer * rainDrawer, rct_drawpixelinfo * dpi, OpenRCT2::Drawing::DrawRainFunc drawFunc)
-                abstract;
+                OpenRCT2::Drawing::IRainDrawer* rainDrawer, rct_drawpixelinfo* dpi,
+                OpenRCT2::Drawing::DrawRainFunc drawFunc) abstract;
 
             // Text input
             virtual bool IsTextInputActive() abstract;
-            virtual TextInputSession* StartTextInput(utf8 * buffer, size_t bufferSize) abstract;
+            virtual TextInputSession* StartTextInput(utf8* buffer, size_t bufferSize) abstract;
             virtual void StopTextInput() abstract;
 
             // In-game UI

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -20,7 +20,7 @@ namespace OpenRCT2::Ui
     /**
      * Manager of in-game windows and widgets.
      */
-    interface IWindowManager
+    INTERFACE IWindowManager
     {
         virtual ~IWindowManager() = default;
         virtual void Init() abstract;

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -20,14 +20,14 @@ namespace OpenRCT2::Ui
     /**
      * Manager of in-game windows and widgets.
      */
-    INTERFACE IWindowManager
+    struct IWindowManager
     {
         virtual ~IWindowManager() = default;
         virtual void Init() abstract;
         virtual rct_window* OpenWindow(rct_windowclass wc) abstract;
         virtual rct_window* OpenView(uint8_t view) abstract;
         virtual rct_window* OpenDetails(uint8_t type, int32_t id) abstract;
-        virtual rct_window* OpenIntent(Intent * intent) abstract;
+        virtual rct_window* OpenIntent(Intent* intent) abstract;
         virtual void BroadcastIntent(const Intent& intent) abstract;
         virtual rct_window* ShowError(rct_string_id title, rct_string_id message) abstract;
         virtual rct_window* ShowError(const std::string_view& title, const std::string_view& message) abstract;

--- a/test/testpaint/TestTrack.cpp
+++ b/test/testpaint/TestTrack.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <vector>
 
-interface ITestTrackFilter
+struct ITestTrackFilter
 {
 public:
     virtual ~ITestTrackFilter()

--- a/test/tests/IniReaderTest.cpp
+++ b/test/tests/IniReaderTest.cpp
@@ -29,7 +29,7 @@ static auto Enum_Currency = ConfigEnum<int32_t>({});
 
 TEST_F(IniReaderTest, create_empty)
 {
-    MemoryStream ms(0);
+    OpenRCT2::MemoryStream ms(0);
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), true);
     IIniReader* ir = CreateIniReader(&ms);
@@ -46,7 +46,7 @@ TEST_F(IniReaderTest, create_empty)
 
 TEST_F(IniReaderTest, read_prepared)
 {
-    MemoryStream ms(predefined.c_str(), predefined.size());
+    OpenRCT2::MemoryStream ms(predefined.c_str(), predefined.size());
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), false);
     IIniReader* ir = CreateIniReader(&ms);
@@ -76,7 +76,7 @@ TEST_F(IniReaderTest, read_prepared)
 
 TEST_F(IniReaderTest, read_duplicate)
 {
-    MemoryStream ms(duplicate.c_str(), duplicate.size());
+    OpenRCT2::MemoryStream ms(duplicate.c_str(), duplicate.size());
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), false);
     IIniReader* ir = CreateIniReader(&ms);
@@ -102,7 +102,7 @@ TEST_F(IniReaderTest, read_duplicate)
 
 TEST_F(IniReaderTest, read_untrimmed)
 {
-    MemoryStream ms(untrimmed.c_str(), untrimmed.size());
+    OpenRCT2::MemoryStream ms(untrimmed.c_str(), untrimmed.size());
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), false);
     IIniReader* ir = CreateIniReader(&ms);
@@ -120,7 +120,7 @@ TEST_F(IniReaderTest, read_untrimmed)
 
 TEST_F(IniReaderTest, read_case_insensitive)
 {
-    MemoryStream ms(caseInsensitive.c_str(), caseInsensitive.size());
+    OpenRCT2::MemoryStream ms(caseInsensitive.c_str(), caseInsensitive.size());
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), false);
     IIniReader* ir = CreateIniReader(&ms);

--- a/test/tests/IniWriterTest.cpp
+++ b/test/tests/IniWriterTest.cpp
@@ -26,7 +26,7 @@ static auto Enum_Currency = ConfigEnum<int32_t>({
 
 TEST_F(IniWriterTest, create_empty)
 {
-    MemoryStream ms(0);
+    OpenRCT2::MemoryStream ms(0);
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), true);
     IIniWriter* iw = CreateIniWriter(&ms);
@@ -36,7 +36,7 @@ TEST_F(IniWriterTest, create_empty)
 
 TEST_F(IniWriterTest, create_one_section)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("OpenRCT2");
@@ -54,7 +54,7 @@ TEST_F(IniWriterTest, create_one_section)
 
 TEST_F(IniWriterTest, create_multiple_sections)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("OpenRCT1");
@@ -78,7 +78,7 @@ TEST_F(IniWriterTest, create_multiple_sections)
 
 TEST_F(IniWriterTest, create_loose_bool_entry)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteBoolean("boolval", true);
@@ -96,7 +96,7 @@ TEST_F(IniWriterTest, create_loose_bool_entry)
 
 TEST_F(IniWriterTest, create_loose_enum_entry)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteEnum("by_string", "stringval");
@@ -115,7 +115,7 @@ TEST_F(IniWriterTest, create_loose_enum_entry)
 
 TEST_F(IniWriterTest, create_loose_float_entry)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteFloat("one", 1.);
@@ -134,7 +134,7 @@ TEST_F(IniWriterTest, create_loose_float_entry)
 
 TEST_F(IniWriterTest, create_loose_int32_t_entry)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteInt32("one", 1);
@@ -159,7 +159,7 @@ TEST_F(IniWriterTest, create_loose_int32_t_entry)
 
 TEST_F(IniWriterTest, create_loose_string_entry)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteString("path", u8"C:'\\some/dir\\here/神鷹暢遊");
@@ -177,7 +177,7 @@ TEST_F(IniWriterTest, create_loose_string_entry)
 
 TEST_F(IniWriterTest, create_multiple_section_with_values)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("bool");
@@ -205,7 +205,7 @@ TEST_F(IniWriterTest, create_multiple_section_with_values)
 
 TEST_F(IniWriterTest, create_duplicate_sections)
 {
-    MemoryStream ms(1000);
+    OpenRCT2::MemoryStream ms(1000);
     IIniWriter* iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("section");

--- a/test/tests/sawyercoding_test.cpp
+++ b/test/tests/sawyercoding_test.cpp
@@ -34,7 +34,7 @@ protected:
         ASSERT_GT(encodedDataSize, sizeof(sawyercoding_chunk_header));
 
         // Decode
-        MemoryStream ms(encodedDataBuffer, encodedDataSize);
+        OpenRCT2::MemoryStream ms(encodedDataBuffer, encodedDataSize);
         SawyerChunkReader reader(&ms);
         auto chunk = reader.ReadChunk();
         ASSERT_EQ(static_cast<uint8_t>(chunk->GetEncoding()), chdr_in.encoding);
@@ -51,7 +51,7 @@ protected:
         auto chdr_in = reinterpret_cast<const sawyercoding_chunk_header*>(data);
         ASSERT_EQ(chdr_in->length, expectedLength);
 
-        MemoryStream ms(data, size);
+        OpenRCT2::MemoryStream ms(data, size);
         SawyerChunkReader reader(&ms);
         auto chunk = reader.ReadChunk();
         ASSERT_EQ(static_cast<uint8_t>(chunk->GetEncoding()), chdr_in->encoding);


### PR DESCRIPTION
I've added WIN32_LEAN_AND_MEAN to the common.props and it revealed that we have a bunch of include errors which I fix in this PR. This also revealed that we have a clash with ```define interface struct``` and ```interface IStream``` so I had to rename interface to INTERFACE, we should discuss on dropping this define. Also to eliminate the name clash of IStream I moved IStream, MemoryStream, FileStream into OpenRCT2 namespace, we want to re-organize into namespaces so its a good start.