### PR TITLE
Fix #12352: Wrong date format for file names

### DIFF
--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -75,8 +75,8 @@ namespace Platform
         rct2_date outDate;
         outDate.day = localTime->tm_mday;
         outDate.day_of_week = localTime->tm_wday;
-        outDate.month = localTime->tm_mon;
-        outDate.year = localTime->tm_year;
+        outDate.month = localTime->tm_mon + 1;
+        outDate.year = localTime->tm_year + 1900;
         return outDate;
     }
 


### PR DESCRIPTION
This fixes #12352 
I think the issue has come because of 5ae592e.

I've tested that it works fine in Windows 10 and Ubuntu 18.04. (Not tested in macOS)
But I have no idea why @frutiemax removed the code that adds 1900 to year & 1 to month.
So please let me know if there is any problem or it was on purpose ;)