### PR TITLE
closes #12452: Refactor DIAGNOSTIC_LEVEL to use strong enum

### DIFF
--- a/src/openrct2/Diagnostic.cpp
+++ b/src/openrct2/Diagnostic.cpp
@@ -19,14 +19,14 @@
 #endif
 
 [[maybe_unused]] static bool _log_location_enabled = true;
-bool _log_levels[DIAGNOSTIC_LEVEL_COUNT] = { true, true, true, false, true };
+bool _log_levels[static_cast<uint8_t>(DiagnosticLevel::Count)] = { true, true, true, false, true };
 
-static FILE* diagnostic_get_stream(DIAGNOSTIC_LEVEL level)
+static FILE* diagnostic_get_stream(DiagnosticLevel level)
 {
     switch (level)
     {
-        case DIAGNOSTIC_LEVEL_VERBOSE:
-        case DIAGNOSTIC_LEVEL_INFORMATION:
+        case DiagnosticLevel::Verbose:
+        case DiagnosticLevel::Information:
             return stdout;
         default:
             return stderr;
@@ -35,34 +35,35 @@ static FILE* diagnostic_get_stream(DIAGNOSTIC_LEVEL level)
 
 #ifdef __ANDROID__
 
-int _android_log_priority[DIAGNOSTIC_LEVEL_COUNT] = { ANDROID_LOG_FATAL, ANDROID_LOG_ERROR, ANDROID_LOG_WARN,
-                                                      ANDROID_LOG_VERBOSE, ANDROID_LOG_INFO };
+int _android_log_priority[static_cast<uint8_t>(DiagnosticLevel::Count)] = { ANDROID_LOG_FATAL, ANDROID_LOG_ERROR,
+                                                                            ANDROID_LOG_WARN, ANDROID_LOG_VERBOSE,
+                                                                            ANDROID_LOG_INFO };
 
-void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char* format, ...)
+void diagnostic_log(DiagnosticLevel diagnosticLevel, const char* format, ...)
 {
     va_list args;
 
-    if (!_log_levels[diagnosticLevel])
+    if (!_log_levels[static_cast<uint8_t>(diagnosticLevel)])
         return;
 
     va_start(args, format);
-    __android_log_vprint(_android_log_priority[diagnosticLevel], "OpenRCT2", format, args);
+    __android_log_vprint(_android_log_priority[static_cast<uint8_t>(diagnosticLevel)], "OpenRCT2", format, args);
     va_end(args);
 }
 
 void diagnostic_log_with_location(
-    DIAGNOSTIC_LEVEL diagnosticLevel, const char* file, const char* function, int32_t line, const char* format, ...)
+    DiagnosticLevel diagnosticLevel, const char* file, const char* function, int32_t line, const char* format, ...)
 {
     va_list args;
     char buf[1024];
 
-    if (!_log_levels[diagnosticLevel])
+    if (!_log_levels[static_cast<uint8_t>(diagnosticLevel)])
         return;
 
     snprintf(buf, 1024, "[%s:%d (%s)]: ", file, line, function);
 
     va_start(args, format);
-    __android_log_vprint(_android_log_priority[diagnosticLevel], file, format, args);
+    __android_log_vprint(_android_log_priority[static_cast<uint8_t>(diagnosticLevel)], file, format, args);
     va_end(args);
 }
 
@@ -72,13 +73,13 @@ static constexpr const char* _level_strings[] = {
     "FATAL", "ERROR", "WARNING", "VERBOSE", "INFO",
 };
 
-void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char* format, ...)
+void diagnostic_log(DiagnosticLevel diagnosticLevel, const char* format, ...)
 {
     va_list args;
-    if (_log_levels[diagnosticLevel])
+    if (_log_levels[static_cast<uint8_t>(diagnosticLevel)])
     {
         // Level
-        auto prefix = String::StdFormat("%s: ", _level_strings[diagnosticLevel]);
+        auto prefix = String::StdFormat("%s: ", _level_strings[static_cast<uint8_t>(diagnosticLevel)]);
 
         // Message
         va_start(args, format);
@@ -91,20 +92,21 @@ void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char* format, ...)
 }
 
 void diagnostic_log_with_location(
-    DIAGNOSTIC_LEVEL diagnosticLevel, const char* file, const char* function, int32_t line, const char* format, ...)
+    DiagnosticLevel diagnosticLevel, const char* file, const char* function, int32_t line, const char* format, ...)
 {
     va_list args;
-    if (_log_levels[diagnosticLevel])
+    if (_log_levels[static_cast<uint8_t>(diagnosticLevel)])
     {
         // Level and source code information
         std::string prefix;
         if (_log_location_enabled)
         {
-            prefix = String::StdFormat("%s[%s:%d (%s)]: ", _level_strings[diagnosticLevel], file, line, function);
+            prefix = String::StdFormat(
+                "%s[%s:%d (%s)]: ", _level_strings[static_cast<uint8_t>(diagnosticLevel)], file, line, function);
         }
         else
         {
-            prefix = String::StdFormat("%s: ", _level_strings[diagnosticLevel]);
+            prefix = String::StdFormat("%s: ", _level_strings[static_cast<uint8_t>(diagnosticLevel)]);
         }
 
         // Message

--- a/src/openrct2/Diagnostic.h
+++ b/src/openrct2/Diagnostic.h
@@ -12,14 +12,14 @@
 
 #include <cstdint>
 
-enum DIAGNOSTIC_LEVEL
+enum class DiagnosticLevel
 {
-    DIAGNOSTIC_LEVEL_FATAL,
-    DIAGNOSTIC_LEVEL_ERROR,
-    DIAGNOSTIC_LEVEL_WARNING,
-    DIAGNOSTIC_LEVEL_VERBOSE,
-    DIAGNOSTIC_LEVEL_INFORMATION,
-    DIAGNOSTIC_LEVEL_COUNT
+    Fatal,
+    Error,
+    Warning,
+    Verbose,
+    Information,
+    Count
 };
 
 /**
@@ -69,11 +69,11 @@ enum DIAGNOSTIC_LEVEL
 #    define DEBUG_LEVEL_1 0
 #endif // defined(DEBUG)
 
-extern bool _log_levels[DIAGNOSTIC_LEVEL_COUNT];
+extern bool _log_levels[static_cast<uint8_t>(DiagnosticLevel::Count)];
 
-void diagnostic_log(DIAGNOSTIC_LEVEL diagnosticLevel, const char* format, ...);
+void diagnostic_log(DiagnosticLevel diagnosticLevel, const char* format, ...);
 void diagnostic_log_with_location(
-    DIAGNOSTIC_LEVEL diagnosticLevel, const char* file, const char* function, int32_t line, const char* format, ...);
+    DiagnosticLevel diagnosticLevel, const char* file, const char* function, int32_t line, const char* format, ...);
 
 #ifdef _MSC_VER
 #    define diagnostic_log_macro(level, format, ...)                                                                           \
@@ -83,10 +83,10 @@ void diagnostic_log_with_location(
         diagnostic_log_with_location(level, __FILE__, __func__, __LINE__, format, ##__VA_ARGS__)
 #endif // _MSC_VER
 
-#define log_fatal(format, ...) diagnostic_log_macro(DIAGNOSTIC_LEVEL_FATAL, format, ##__VA_ARGS__)
-#define log_error(format, ...) diagnostic_log_macro(DIAGNOSTIC_LEVEL_ERROR, format, ##__VA_ARGS__)
-#define log_warning(format, ...) diagnostic_log_macro(DIAGNOSTIC_LEVEL_WARNING, format, ##__VA_ARGS__)
-#define log_verbose(format, ...) diagnostic_log(DIAGNOSTIC_LEVEL_VERBOSE, format, ##__VA_ARGS__)
-#define log_info(format, ...) diagnostic_log_macro(DIAGNOSTIC_LEVEL_INFORMATION, format, ##__VA_ARGS__)
+#define log_fatal(format, ...) diagnostic_log_macro(DiagnosticLevel::Fatal, format, ##__VA_ARGS__)
+#define log_error(format, ...) diagnostic_log_macro(DiagnosticLevel::Error, format, ##__VA_ARGS__)
+#define log_warning(format, ...) diagnostic_log_macro(DiagnosticLevel::Warning, format, ##__VA_ARGS__)
+#define log_verbose(format, ...) diagnostic_log(DiagnosticLevel::Verbose, format, ##__VA_ARGS__)
+#define log_info(format, ...) diagnostic_log_macro(DiagnosticLevel::Information, format, ##__VA_ARGS__)
 
 #endif

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -172,7 +172,7 @@ exitcode_t CommandLine::HandleCommandDefault()
     {
         if (_verbose)
         {
-            _log_levels[DIAGNOSTIC_LEVEL_VERBOSE] = true;
+            _log_levels[static_cast<uint8_t>(DiagnosticLevel::Verbose)] = true;
             PrintLaunchInformation();
         }
 

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -179,7 +179,7 @@ private:
         {
             const auto& filePath = scanResult.Files.at(i);
 
-            if (_log_levels[DIAGNOSTIC_LEVEL_VERBOSE])
+            if (_log_levels[static_cast<uint8_t>(DiagnosticLevel::Verbose)])
             {
                 std::lock_guard<std::mutex> lock(printLock);
                 log_verbose("FileIndex:Indexing '%s'", filePath.c_str());


### PR DESCRIPTION
This closes #12452: Refactor DIAGNOSTIC_LEVEL to use strong enum