### PR TITLE
closes #12445: Refactor CLIMATE to use strong enum

### DIFF
--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -540,15 +540,15 @@ static void window_editor_scenario_options_show_climate_dropdown(rct_window* w)
 
     dropdownWidget = &w->widgets[WIDX_CLIMATE];
 
-    for (i = 0; i < CLIMATE_COUNT; i++)
+    for (i = 0; i < static_cast<uint8_t>(ClimateType::Count); i++)
     {
         gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
         gDropdownItemsArgs[i] = ClimateNames[i];
     }
     window_dropdown_show_text_custom_width(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, CLIMATE_COUNT, dropdownWidget->width() - 3);
-    dropdown_set_checked(gClimate, true);
+        w->colours[1], 0, DROPDOWN_FLAG_STAY_OPEN, static_cast<uint8_t>(ClimateType::Count), dropdownWidget->width() - 3);
+    dropdown_set_checked(static_cast<uint8_t>(gClimate), true);
 }
 
 /**
@@ -1275,9 +1275,9 @@ static void window_editor_scenario_options_park_dropdown(rct_window* w, rct_widg
             break;
         }
         case WIDX_CLIMATE_DROPDOWN:
-            if (gClimate != static_cast<uint8_t>(dropdownIndex))
+            if (static_cast<uint8_t>(gClimate) != static_cast<uint8_t>(dropdownIndex))
             {
-                auto gameAction = ClimateSetAction(dropdownIndex);
+                auto gameAction = ClimateSetAction(ClimateType{ static_cast<uint8_t>(dropdownIndex) });
                 GameActions::Execute(&gameAction);
             }
             break;
@@ -1445,7 +1445,7 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
 
     // Climate value
     screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_CLIMATE].left + 1, w->widgets[WIDX_CLIMATE].top };
-    stringId = ClimateNames[gClimate];
+    stringId = ClimateNames[static_cast<uint8_t>(gClimate)];
     gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
 }
 

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -61,7 +61,7 @@ void GameState::InitAll(int32_t mapSize)
     reset_sprite_list();
     staff_reset_modes();
     date_reset();
-    climate_reset(CLIMATE_COOL_AND_WET);
+    climate_reset(ClimateType::CoolAndWet);
     News::InitQueue();
 
     gInMapInitCode = false;

--- a/src/openrct2/actions/ClimateSetAction.hpp
+++ b/src/openrct2/actions/ClimateSetAction.hpp
@@ -14,15 +14,13 @@
 
 DEFINE_GAME_ACTION(ClimateSetAction, GAME_COMMAND_SET_CLIMATE, GameActionResult)
 {
-    using climate_t = decltype(gClimate);
-
 private:
-    climate_t _climate;
+    uint8_t _climate;
 
 public:
     ClimateSetAction() = default;
-    ClimateSetAction(climate_t climate)
-        : _climate(climate)
+    ClimateSetAction(ClimateType climate)
+        : _climate(static_cast<uint8_t>(climate))
     {
     }
 
@@ -40,7 +38,7 @@ public:
 
     GameActionResult::Ptr Query() const override
     {
-        if (_climate >= CLIMATE_COUNT)
+        if (_climate >= static_cast<uint8_t>(ClimateType::Count))
         {
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_INVALID_CLIMATE_ID, STR_NONE);
         }
@@ -50,7 +48,7 @@ public:
 
     GameActionResult::Ptr Execute() const override
     {
-        gClimate = _climate;
+        gClimate = ClimateType{ _climate };
 
         gfx_invalidate_screen();
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -637,7 +637,8 @@ static int32_t cc_get(InteractiveConsole& console, const arguments_t& argv)
         }
         else if (argv[0] == "climate")
         {
-            console.WriteFormatLine("climate %s  (%d)", ClimateNames[gClimate], gClimate);
+            console.WriteFormatLine(
+                "climate %s  (%d)", ClimateNames[static_cast<uint8_t>(gClimate)], static_cast<uint8_t>(gClimate));
         }
         else if (argv[0] == "game_speed")
         {
@@ -859,35 +860,37 @@ static int32_t cc_set(InteractiveConsole& console, const arguments_t& argv)
         }
         else if (argv[0] == "climate")
         {
+            uint8_t newClimate = static_cast<uint8_t>(ClimateType::Count);
+            invalidArgs = true;
+
             if (int_valid[0])
             {
-                const auto newClimate = int_val[0];
-                if (newClimate < 0 || newClimate >= CLIMATE_COUNT)
-                {
-                    console.WriteLine(language_get_string(STR_INVALID_CLIMATE_ID));
-                }
-                else
-                {
-                    auto gameAction = ClimateSetAction(newClimate);
-                    GameActions::Execute(&gameAction);
-                }
+                newClimate = static_cast<uint8_t>(int_val[0]);
+                invalidArgs = false;
             }
             else
             {
-                for (i = 0; i < CLIMATE_COUNT; i++)
+                for (newClimate = 0; newClimate < static_cast<uint8_t>(ClimateType::Count); newClimate++)
                 {
-                    if (argv[1] == ClimateNames[i])
+                    if (argv[1] == ClimateNames[newClimate])
                     {
-                        gClimate = i;
+                        invalidArgs = false;
                         break;
                     }
                 }
             }
 
-            if (i == CLIMATE_COUNT)
-                invalidArgs = true;
+            if (invalidArgs)
+            {
+                console.WriteLine(language_get_string(STR_INVALID_CLIMATE_ID));
+            }
             else
+            {
+                auto gameAction = ClimateSetAction(ClimateType{ newClimate });
+                GameActions::Execute(&gameAction);
+
                 console.Execute("get climate");
+            }
         }
         else if (argv[0] == "game_speed" && invalidArguments(&invalidArgs, int_valid[0]))
         {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2662,7 +2662,7 @@ private:
 
     void ImportClimate()
     {
-        gClimate = _s4.climate;
+        gClimate = ClimateType{ _s4.climate };
         gClimateUpdateTimer = _s4.climate_timer;
         gClimateCurrent.Temperature = _s4.temperature;
         gClimateCurrent.Weather = _s4.weather;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -378,7 +378,7 @@ void S6Exporter::Export()
     // unk_13CA73E
     // pad_13CA73F
     // unk_13CA740
-    _s6.climate = gClimate;
+    _s6.climate = static_cast<uint8_t>(gClimate);
     // pad_13CA741;
     // byte_13CA742
     // pad_013CA747

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -405,7 +405,7 @@ public:
         // unk_13CA73E
         // pad_13CA73F
         // unk_13CA740
-        gClimate = _s6.climate;
+        gClimate = ClimateType{ _s6.climate };
         // pad_13CA741;
         // byte_13CA742
         // pad_013CA747

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -47,7 +47,7 @@ extern const WeatherState ClimateWeatherData[6];
 extern const FILTER_PALETTE_ID ClimateWeatherGloomColours[4];
 
 // Climate data
-uint8_t gClimate;
+ClimateType gClimate;
 ClimateState gClimateCurrent;
 ClimateState gClimateNext;
 uint16_t gClimateUpdateTimer;
@@ -79,11 +79,11 @@ int32_t climate_celsius_to_fahrenheit(int32_t celsius)
 /**
  * Set climate and determine start weather.
  */
-void climate_reset(int32_t climate)
+void climate_reset(ClimateType climate)
 {
     uint8_t weather = WEATHER_PARTIALLY_CLOUDY;
     int32_t month = date_get_month(gDateMonthsElapsed);
-    const WeatherTransition* transition = &ClimateTransitions[climate][month];
+    const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(climate)][month];
     const WeatherState* weatherState = &ClimateWeatherData[weather];
 
     gClimate = climate;
@@ -262,8 +262,8 @@ static void climate_determine_future_weather(int32_t randomDistribution)
 
     // Generate a random variable with values 0 up to DistributionSize-1 and chose weather from the distribution table
     // accordingly
-    const WeatherTransition* transition = &ClimateTransitions[gClimate][month];
-    int8_t nextWeather = transition->Distribution[((randomDistribution & 0xFF) * transition->DistributionSize) >> 8];
+    const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(gClimate)][month];
+    int8_t nextWeather = (transition->Distribution[((randomDistribution & 0xFF) * transition->DistributionSize) >> 8]);
     gClimateNext.Weather = nextWeather;
 
     const auto nextWeatherState = &ClimateWeatherData[nextWeather];

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -12,13 +12,13 @@
 #include "../common.h"
 #include "../drawing/Drawing.h"
 
-enum CLIMATE
+enum class ClimateType : uint8_t
 {
-    CLIMATE_COOL_AND_WET,
-    CLIMATE_WARM,
-    CLIMATE_HOT_AND_DRY,
-    CLIMATE_COLD,
-    CLIMATE_COUNT,
+    CoolAndWet,
+    Warm,
+    HotAndDry,
+    Cold,
+    Count
 };
 
 enum WEATHER
@@ -63,14 +63,14 @@ struct ClimateState
     RainLevel Level;
 };
 
-extern uint8_t gClimate;
+extern ClimateType gClimate;
 extern ClimateState gClimateCurrent;
 extern ClimateState gClimateNext;
 extern uint16_t gClimateUpdateTimer;
 extern uint16_t gClimateLightningFlash;
 
 int32_t climate_celsius_to_fahrenheit(int32_t celsius);
-void climate_reset(int32_t climate);
+void climate_reset(ClimateType climate);
 void climate_update();
 void climate_update_sound();
 void climate_force_weather(uint8_t weather);


### PR DESCRIPTION
This closes #12445: Refactor CLIMATE to use strong enum