### PR TITLE
Allow game to run with GUI while without audio.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -40,6 +40,7 @@
 - Change: [#16493] Boat Hire and Submarine Ride support costs now match their visual appearance.
 - Change: [#16710] Changed default view of Guest List to 'Thoughts' and selected tab will default to 'Summarised' (when opened from the menu).
 - Fix: [#11752] Track pieces with fractional cost are too cheap to build.
+- Fix: [#12556] Allow game to run without audio devices.
 - Fix: [#12774] [Plugin] Scripts will not be re-initialised when a new scenario is loaded from within a running scenario.
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).
 - Fix: [#14155] Map Generator sometimes places non-tree objects as trees.

--- a/src/openrct2-ui/SDLException.cpp
+++ b/src/openrct2-ui/SDLException.cpp
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2022 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "SDLException.h"
+
+#include <SDL.h>
+
+SDLException::SDLException(const std::string& message)
+    : runtime_error(message.c_str())
+{
+}
+
+SDLException::SDLException(const char* message)
+    : runtime_error(message)
+{
+}
+
+void SDLException::Throw(const char* call)
+{
+    std::string message = std::string(call) + ": " + std::string(SDL_GetError());
+    throw SDLException(message);
+}

--- a/src/openrct2-ui/SDLException.h
+++ b/src/openrct2-ui/SDLException.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2022 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <SDL.h>
 #include <stdexcept>
 #include <string>
 
@@ -19,24 +18,13 @@
 class SDLException : public std::runtime_error
 {
 public:
-    explicit SDLException(const std::string& message)
-        : runtime_error(message.c_str())
-    {
-        SDL_GetError();
-    }
+    explicit SDLException(const std::string& message);
 
-    explicit SDLException(const char* message)
-        : runtime_error(message)
-    {
-    }
+    explicit SDLException(const char* message);
 
     /**
      * Throws an SDL exception with a message containing the given call information
      * and the message given by SDL_GetError.
      */
-    static void Throw(const char* call)
-    {
-        std::string message = std::string(call) + ": " + std::string(SDL_GetError());
-        throw SDLException(message);
-    }
+    static void Throw(const char* call);
 };

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -61,9 +61,9 @@ int main(int argc, const char** argv)
             {
                 audioContext = ToShared(CreateAudioContext());
             }
-            catch (const SDLException&)
+            catch (const SDLException& e)
             {
-                log_warning("Failed to create audio context. Using dummy audio context.");
+                log_warning("Failed to create audio context. Using dummy audio context. Error message was: %s", e.what());
                 audioContext = ToShared(CreateDummyAudioContext());
             }
             auto uiContext = ToShared(CreateUiContext(env));

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -9,6 +9,7 @@
 
 #include "Ui.h"
 
+#include "SDLException.h"
 #include "UiContext.h"
 #include "audio/AudioContext.h"
 #include "drawing/BitmapReader.h"
@@ -55,7 +56,16 @@ int main(int argc, const char** argv)
         {
             // Run OpenRCT2 with a UI context
             auto env = ToShared(CreatePlatformEnvironment());
-            auto audioContext = ToShared(CreateAudioContext());
+            std::shared_ptr<IAudioContext> audioContext;
+            try
+            {
+                audioContext = ToShared(CreateAudioContext());
+            }
+            catch (const SDLException&)
+            {
+                log_warning("Failed to create audio context. Using dummy audio context.");
+                audioContext = ToShared(CreateDummyAudioContext());
+            }
             auto uiContext = ToShared(CreateUiContext(env));
             context = CreateContext(env, audioContext, uiContext);
         }

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -109,6 +109,7 @@
     <ClCompile Include="scripting\CustomMenu.cpp" />
     <ClCompile Include="scripting\CustomWindow.cpp" />
     <ClCompile Include="scripting\UiExtensions.cpp" />
+    <ClCompile Include="SDLException.cpp" />	
     <ClCompile Include="TextComposition.cpp" />
     <ClCompile Include="title\TitleSequencePlayer.cpp" />
     <ClCompile Include="Ui.cpp" />

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1447,7 +1447,7 @@ private:
         rct_string_id audioDeviceStringId = STR_OPTIONS_SOUND_VALUE_DEFAULT;
         const char* audioDeviceName = nullptr;
         const int32_t currentDeviceIndex = OpenRCT2::Audio::GetCurrentDeviceIndex();
-        if (currentDeviceIndex == -1)
+        if (currentDeviceIndex == -1 || OpenRCT2::Audio::GetDeviceCount() == 0)
         {
             audioDeviceStringId = STR_SOUND_NONE;
         }


### PR DESCRIPTION
I had hastily built a Gentoo system and was unable to play OpenRCT2 because I hadn't installed anything related to audio. SDL2 wasn't build with either ALSA or PulseAudio. An exception would be thrown immediately because SDL2 couldn't create an audio context.

I doubt this issue pops up very often, but this seems to solve it.

I'd like the sound options to be completely grayed out, but at the moment there's just a single "No Audio Device" device populated in the audio devices drop down box. This gives some indication of why there's no audio, should a user have this happen.