### PR TITLE
Fix #12566, #12565, #12562, #12560, #12558: Nullptr deref

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -710,6 +710,12 @@ static Peep* viewport_interaction_get_closest_peep(ScreenCoordsXY screenCoords, 
 CoordsXY sub_68A15E(const ScreenCoordsXY& screenCoords)
 {
     rct_window* window = window_find_from_point(screenCoords);
+    if (window == nullptr || window->viewport == nullptr)
+    {
+        CoordsXY ret{};
+        ret.setNull();
+        return ret;
+    }
     auto viewport = window->viewport;
     auto info = get_map_coordinates_from_pos_window(
         window, screenCoords, VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1761,6 +1761,10 @@ std::optional<CoordsXY> screen_get_map_xy(const ScreenCoordsXY& screenCoords, rc
 {
     // This will get the tile location but we will need the more accuracy
     rct_window* window = window_find_from_point(screenCoords);
+    if (window == nullptr || window->viewport == nullptr)
+    {
+        return std::nullopt;
+    }
     auto myViewport = window->viewport;
     auto info = get_map_coordinates_from_pos_window(window, screenCoords, VIEWPORT_INTERACTION_MASK_TERRAIN);
     if (info.SpriteType == VIEWPORT_INTERACTION_ITEM_NONE)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -248,6 +248,12 @@ void footpath_provisional_update()
 CoordsXY footpath_get_coordinates_from_pos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement)
 {
     rct_window* window = window_find_from_point(screenCoords);
+    if (window == nullptr || window->viewport == nullptr)
+    {
+        CoordsXY position{};
+        position.setNull();
+        return position;
+    }
     auto viewport = window->viewport;
     auto info = get_map_coordinates_from_pos_window(window, screenCoords, VIEWPORT_INTERACTION_MASK_FOOTPATH);
     if (info.SpriteType != VIEWPORT_INTERACTION_ITEM_FOOTPATH
@@ -340,6 +346,12 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
 {
     // First check if we point at an entrance or exit. In that case, we would want the path coming from the entrance/exit.
     rct_window* window = window_find_from_point(screenCoords);
+    if (window == nullptr || window->viewport == nullptr)
+    {
+        CoordsXY ret{};
+        ret.setNull();
+        return ret;
+    }
     auto viewport = window->viewport;
     auto info = get_map_coordinates_from_pos_window(window, screenCoords, VIEWPORT_INTERACTION_MASK_RIDE);
     *tileElement = info.Element;


### PR DESCRIPTION
Fix #12566, #12565, #12562, #12560, #12558: Nullptr deref
Mistake made in refactor meant that a nullptr deref took place when the screen coords were outside of the normal play area