### PR TITLE
Fix #12577: Mistake made in refactor #12538

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -512,6 +512,10 @@ static Guest* GetGuest(rct_window* w)
  */
 rct_window* window_guest_open(Peep* peep)
 {
+    if (peep == nullptr)
+    {
+        return nullptr;
+    }
     if (peep->AssignedPeepType == PeepType::Staff)
     {
         return window_staff_open(peep);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1627,7 +1627,7 @@ rct_window* window_ride_open_vehicle(Vehicle* vehicle)
             for (int32_t i = 0; i < 32 && numPeepsLeft > 0; i++)
             {
                 Peep* peep = GetEntity<Peep>(vehicle->peep[i]);
-                if (peep != nullptr)
+                if (peep == nullptr)
                     continue;
 
                 numPeepsLeft--;


### PR DESCRIPTION
Fix #12577: Mistake made in refactor #12538

Loop called the peep window open only when nullptr. Added extra checks for nullptr on window open

Also fixes  #12574, #12564