### PR TITLE
Fix #12535, #12536: RCT1 import can crash when too many misc entities

### DIFF
--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1659,6 +1659,11 @@ private:
             {
                 rct1_unk_sprite* src = &sprite.unknown;
                 SpriteGeneric* dst = reinterpret_cast<SpriteGeneric*>(create_sprite(SPRITE_IDENTIFIER_MISC));
+                if (dst == nullptr)
+                {
+                    log_warning("SV4 has too many misc entities. No more misc entities will be imported!");
+                    break;
+                }
                 dst->sprite_identifier = src->sprite_identifier;
                 dst->type = src->type;
                 dst->flags = src->flags;


### PR DESCRIPTION
Fix #12535, Fix #12536: RCT1 import can crash when too many misc entities

Eventually this can be fixed properly in the new save format