### PR TITLE
Fix #12581: Divide by zero on dodgems on customised vehicles

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6405,7 +6405,10 @@ int32_t Vehicle::UpdateMotionDodgems()
         edx = -edx;
     edx >>= 5;
     eax += edx;
-    eax /= mass;
+    if (mass != 0)
+    {
+        eax /= mass;
+    }
     rct_ride_entry* rideEntry = GetRideEntry();
     rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
 


### PR DESCRIPTION
Fix #12581: Divide by zero on dodgems on customised vehicles

Also fixes #11387
Likely caused by use of the console or a new plugin