### PR TITLE
Fix #12416: Refactor CURRENCY_AFFIX to use strong enum

### DIFF
--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -143,7 +143,7 @@ static void custom_currency_window_mousedown(rct_window* w, rct_widgetindex widg
                 { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0,
                 DROPDOWN_FLAG_STAY_OPEN, 2, widget->width() - 3);
 
-            if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CURRENCY_PREFIX)
+            if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CurrencyAffix::Prefix)
             {
                 dropdown_set_checked(0, true);
             }
@@ -183,13 +183,13 @@ static void custom_currency_window_dropdown([[maybe_unused]] rct_window* w, rct_
     {
         if (dropdownIndex == 0)
         {
-            CurrencyDescriptors[CURRENCY_CUSTOM].affix_ascii = CURRENCY_PREFIX;
-            CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode = CURRENCY_PREFIX;
+            CurrencyDescriptors[CURRENCY_CUSTOM].affix_ascii = CurrencyAffix::Prefix;
+            CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode = CurrencyAffix::Prefix;
         }
         else if (dropdownIndex == 1)
         {
-            CurrencyDescriptors[CURRENCY_CUSTOM].affix_ascii = CURRENCY_SUFFIX;
-            CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode = CURRENCY_SUFFIX;
+            CurrencyDescriptors[CURRENCY_CUSTOM].affix_ascii = CurrencyAffix::Suffix;
+            CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode = CurrencyAffix::Suffix;
         }
 
         gConfigGeneral.custom_currency_affix = CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode;
@@ -258,7 +258,7 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     gfx_draw_string(dpi, CurrencyDescriptors[CURRENCY_CUSTOM].symbol_unicode, w->colours[1], screenCoords);
 
-    if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CURRENCY_PREFIX)
+    if (CurrencyDescriptors[CURRENCY_CUSTOM].affix_unicode == CurrencyAffix::Prefix)
     {
         gfx_draw_string_left(
             dpi, STR_PREFIX, w, w->colours[1],

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -70,9 +70,9 @@ namespace Config
         ConfigEnumEntry<int32_t>("CUSTOM", CURRENCY_CUSTOM),
     });
 
-    static const auto Enum_CurrencySymbolAffix = ConfigEnum<int32_t>({
-        ConfigEnumEntry<int32_t>("PREFIX", CURRENCY_PREFIX),
-        ConfigEnumEntry<int32_t>("SUFFIX", CURRENCY_SUFFIX),
+    static const auto Enum_CurrencySymbolAffix = ConfigEnum<CurrencyAffix>({
+        ConfigEnumEntry<CurrencyAffix>("PREFIX", CurrencyAffix::Prefix),
+        ConfigEnumEntry<CurrencyAffix>("SUFFIX", CurrencyAffix::Suffix),
     });
 
     static const auto Enum_DateFormat = ConfigEnum<int32_t>({
@@ -144,8 +144,8 @@ namespace Config
             model->confirmation_prompt = reader->GetBoolean("confirmation_prompt", false);
             model->currency_format = reader->GetEnum<int32_t>("currency_format", platform_get_locale_currency(), Enum_Currency);
             model->custom_currency_rate = reader->GetInt32("custom_currency_rate", 10);
-            model->custom_currency_affix = reader->GetEnum<int32_t>(
-                "custom_currency_affix", CURRENCY_SUFFIX, Enum_CurrencySymbolAffix);
+            model->custom_currency_affix = reader->GetEnum<CurrencyAffix>(
+                "custom_currency_affix", CurrencyAffix::Suffix, Enum_CurrencySymbolAffix);
             model->custom_currency_symbol = reader->GetCString("custom_currency_symbol", "Ctm");
             model->edge_scrolling = reader->GetBoolean("edge_scrolling", true);
             model->edge_scrolling_speed = reader->GetInt32("edge_scrolling_speed", 12);
@@ -226,7 +226,7 @@ namespace Config
         writer->WriteBoolean("confirmation_prompt", model->confirmation_prompt);
         writer->WriteEnum<int32_t>("currency_format", model->currency_format, Enum_Currency);
         writer->WriteInt32("custom_currency_rate", model->custom_currency_rate);
-        writer->WriteEnum<int32_t>("custom_currency_affix", model->custom_currency_affix, Enum_CurrencySymbolAffix);
+        writer->WriteEnum<CurrencyAffix>("custom_currency_affix", model->custom_currency_affix, Enum_CurrencySymbolAffix);
         writer->WriteString("custom_currency_symbol", model->custom_currency_symbol);
         writer->WriteBoolean("edge_scrolling", model->edge_scrolling);
         writer->WriteInt32("edge_scrolling_speed", model->edge_scrolling_speed);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "../drawing/Drawing.h"
+#include "../localisation/Currency.h"
 
 #include <string>
 
@@ -58,7 +59,7 @@ struct GeneralConfiguration
     int32_t date_format;
     int32_t currency_format;
     int32_t custom_currency_rate;
-    int32_t custom_currency_affix;
+    CurrencyAffix custom_currency_affix;
     utf8* custom_currency_symbol;
 
     // Controls

--- a/src/openrct2/config/IniWriter.hpp
+++ b/src/openrct2/config/IniWriter.hpp
@@ -31,6 +31,8 @@ interface IIniWriter
 
     template<typename T> void WriteEnum(const std::string& name, T value, const IConfigEnum<T>& configEnum)
     {
+        static_assert(sizeof(T) <= sizeof(int32_t), "Type too large");
+
         std::string key = configEnum.GetName(value);
         if (key.empty())
         {

--- a/src/openrct2/config/IniWriter.hpp
+++ b/src/openrct2/config/IniWriter.hpp
@@ -34,7 +34,7 @@ interface IIniWriter
         std::string key = configEnum.GetName(value);
         if (key.empty())
         {
-            WriteInt32(name, value);
+            WriteInt32(name, static_cast<int32_t>(value));
         }
         else
         {

--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -15,24 +15,24 @@
 
 // clang-format off
 currency_descriptor CurrencyDescriptors[CURRENCY_END] = {
-    {   "GBP",  10,     CURRENCY_PREFIX,    "\xC2\xA3",     CURRENCY_SUFFIX,    "GBP",  STR_POUNDS          },  // British Pound
-    {   "USD",  10,     CURRENCY_PREFIX,    "$",            CURRENCY_PREFIX,    "$",    STR_DOLLARS         },  // US Dollar
-    {   "FRF",  10,     CURRENCY_SUFFIX,    "F",            CURRENCY_SUFFIX,    "F",    STR_FRANC           },  // French Franc
-    {   "DEM",  10,     CURRENCY_PREFIX,    "DM",           CURRENCY_PREFIX,    "DM",   STR_DEUTSCHE_MARK   },  // Deutsche Mark
-    {   "JPY",  1000,   CURRENCY_PREFIX,    "\xC2\xA5",     CURRENCY_SUFFIX,    "YEN",  STR_YEN             },  // Japanese Yen
-    {   "ESP",  10,     CURRENCY_SUFFIX,    "Pts",          CURRENCY_SUFFIX,    "Pts",  STR_PESETA          },  // Spanish Peseta
-    {   "ITL",  1000,   CURRENCY_PREFIX,    "L",            CURRENCY_PREFIX,    "L",    STR_LIRA            },  // Italian Lira
-    {   "NLG",  10,     CURRENCY_PREFIX,    "\xC6\x92 ",    CURRENCY_PREFIX,    "fl.",  STR_GUILDERS        },  // Dutch Guilder
-    {   "SEK",  10,     CURRENCY_SUFFIX,    " kr",          CURRENCY_SUFFIX,    " kr",  STR_KRONA           },  // Swedish Krona
-    {   "EUR",  10,     CURRENCY_PREFIX,    "\xE2\x82\xAC", CURRENCY_SUFFIX,    "EUR",  STR_EUROS           },  // Euro
-    {   "KRW",  10000,  CURRENCY_PREFIX,    "\xE2\x82\xA9", CURRENCY_PREFIX,    "W",    STR_WON             },  // South Korean Won
-    {   "RUB",  1000,   CURRENCY_SUFFIX,    "\xE2\x82\xBD", CURRENCY_PREFIX,    "R ",   STR_ROUBLE          },  // Russian Rouble
-    {   "CZK",  100,    CURRENCY_SUFFIX,    " K\xC4\x8D",   CURRENCY_SUFFIX,    " Kc",  STR_CZECH_KORUNA    },  // Czech koruna
-    {   "HKD",  100,    CURRENCY_PREFIX,    "$",            CURRENCY_PREFIX,    "HKD",  STR_HONG_KONG_DOLLAR},  // Hong Kong Dollar
-    {   "TWD",  1000,   CURRENCY_PREFIX,    "NT$",          CURRENCY_PREFIX,    "NT$",  STR_NEW_TAIWAN_DOLLAR}, // New Taiwan Dollar
-    {   "CNY",  100,    CURRENCY_PREFIX,    "CN\xC2\xA5",   CURRENCY_PREFIX,    "CNY",  STR_CHINESE_YUAN    },  // Chinese Yuan
-    {   "HUF",  1000,   CURRENCY_SUFFIX,    " Ft",          CURRENCY_SUFFIX,    " Ft",  STR_HUNGARIAN_FORINT},  // Hungarian Forint
-    {   "CTM",  10,     CURRENCY_PREFIX,    "Ctm",          CURRENCY_PREFIX,    "Ctm",  STR_CUSTOM_CURRENCY },  // Customizable currency
+    {   "GBP",  10,     CurrencyAffix::Prefix,    "\xC2\xA3",     CurrencyAffix::Suffix,    "GBP",  STR_POUNDS          },  // British Pound
+    {   "USD",  10,     CurrencyAffix::Prefix,    "$",            CurrencyAffix::Prefix,    "$",    STR_DOLLARS         },  // US Dollar
+    {   "FRF",  10,     CurrencyAffix::Suffix,    "F",            CurrencyAffix::Suffix,    "F",    STR_FRANC           },  // French Franc
+    {   "DEM",  10,     CurrencyAffix::Prefix,    "DM",           CurrencyAffix::Prefix,    "DM",   STR_DEUTSCHE_MARK   },  // Deutsche Mark
+    {   "JPY",  1000,   CurrencyAffix::Prefix,    "\xC2\xA5",     CurrencyAffix::Suffix,    "YEN",  STR_YEN             },  // Japanese Yen
+    {   "ESP",  10,     CurrencyAffix::Suffix,    "Pts",          CurrencyAffix::Suffix,    "Pts",  STR_PESETA          },  // Spanish Peseta
+    {   "ITL",  1000,   CurrencyAffix::Prefix,    "L",            CurrencyAffix::Prefix,    "L",    STR_LIRA            },  // Italian Lira
+    {   "NLG",  10,     CurrencyAffix::Prefix,    "\xC6\x92 ",    CurrencyAffix::Prefix,    "fl.",  STR_GUILDERS        },  // Dutch Guilder
+    {   "SEK",  10,     CurrencyAffix::Suffix,    " kr",          CurrencyAffix::Suffix,    " kr",  STR_KRONA           },  // Swedish Krona
+    {   "EUR",  10,     CurrencyAffix::Prefix,    "\xE2\x82\xAC", CurrencyAffix::Suffix,    "EUR",  STR_EUROS           },  // Euro
+    {   "KRW",  10000,  CurrencyAffix::Prefix,    "\xE2\x82\xA9", CurrencyAffix::Prefix,    "W",    STR_WON             },  // South Korean Won
+    {   "RUB",  1000,   CurrencyAffix::Suffix,    "\xE2\x82\xBD", CurrencyAffix::Prefix,    "R ",   STR_ROUBLE          },  // Russian Rouble
+    {   "CZK",  100,    CurrencyAffix::Suffix,    " K\xC4\x8D",   CurrencyAffix::Suffix,    " Kc",  STR_CZECH_KORUNA    },  // Czech koruna
+    {   "HKD",  100,    CurrencyAffix::Prefix,    "$",            CurrencyAffix::Prefix,    "HKD",  STR_HONG_KONG_DOLLAR},  // Hong Kong Dollar
+    {   "TWD",  1000,   CurrencyAffix::Prefix,    "NT$",          CurrencyAffix::Prefix,    "NT$",  STR_NEW_TAIWAN_DOLLAR}, // New Taiwan Dollar
+    {   "CNY",  100,    CurrencyAffix::Prefix,    "CN\xC2\xA5",   CurrencyAffix::Prefix,    "CNY",  STR_CHINESE_YUAN    },  // Chinese Yuan
+    {   "HUF",  1000,   CurrencyAffix::Suffix,    " Ft",          CurrencyAffix::Suffix,    " Ft",  STR_HUNGARIAN_FORINT},  // Hungarian Forint
+    {   "CTM",  10,     CurrencyAffix::Prefix,    "Ctm",          CurrencyAffix::Prefix,    "Ctm",  STR_CUSTOM_CURRENCY },  // Customizable currency
 };
 // clang-format on
 

--- a/src/openrct2/localisation/Currency.h
+++ b/src/openrct2/localisation/Currency.h
@@ -38,10 +38,10 @@ enum CURRENCY_TYPE
     CURRENCY_END // Last item
 };
 
-enum CURRENCY_AFFIX
+enum class CurrencyAffix
 {
-    CURRENCY_PREFIX,
-    CURRENCY_SUFFIX
+    Prefix,
+    Suffix
 };
 
 #define CURRENCY_SYMBOL_MAX_SIZE 8
@@ -53,9 +53,9 @@ struct currency_descriptor
     char isoCode[4];
     // Rate is relative to 0.10 GBP
     int32_t rate;
-    uint8_t affix_unicode;
+    CurrencyAffix affix_unicode;
     utf8 symbol_unicode[CURRENCY_SYMBOL_MAX_SIZE];
-    uint8_t affix_ascii;
+    CurrencyAffix affix_ascii;
     char symbol_ascii[CURRENCY_SYMBOL_MAX_SIZE];
     rct_string_id stringId;
 };

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -804,7 +804,7 @@ static void format_currency(char** dest, size_t* size, int64_t value)
 
     // Currency symbol
     const utf8* symbol = currencyDesc->symbol_unicode;
-    uint8_t affix = currencyDesc->affix_unicode;
+    CurrencyAffix affix = currencyDesc->affix_unicode;
     if (!font_supports_string(symbol, FONT_SIZE_MEDIUM))
     {
         symbol = currencyDesc->symbol_ascii;
@@ -812,7 +812,7 @@ static void format_currency(char** dest, size_t* size, int64_t value)
     }
 
     // Prefix
-    if (affix == CURRENCY_PREFIX)
+    if (affix == CurrencyAffix::Prefix)
         format_append_string(dest, size, symbol);
     if ((*size) == 0)
         return;
@@ -822,7 +822,7 @@ static void format_currency(char** dest, size_t* size, int64_t value)
         return;
 
     // Currency symbol suffix
-    if (affix == CURRENCY_SUFFIX)
+    if (affix == CurrencyAffix::Suffix)
         format_append_string(dest, size, symbol);
 }
 
@@ -845,7 +845,7 @@ static void format_currency_2dp(char** dest, size_t* size, int64_t value)
 
     // Currency symbol
     const utf8* symbol = currencyDesc->symbol_unicode;
-    uint8_t affix = currencyDesc->affix_unicode;
+    CurrencyAffix affix = currencyDesc->affix_unicode;
     if (!font_supports_string(symbol, FONT_SIZE_MEDIUM))
     {
         symbol = currencyDesc->symbol_ascii;
@@ -853,7 +853,7 @@ static void format_currency_2dp(char** dest, size_t* size, int64_t value)
     }
 
     // Prefix
-    if (affix == CURRENCY_PREFIX)
+    if (affix == CurrencyAffix::Prefix)
         format_append_string(dest, size, symbol);
     if ((*size) == 0)
         return;
@@ -871,7 +871,7 @@ static void format_currency_2dp(char** dest, size_t* size, int64_t value)
         return;
 
     // Currency symbol suffix
-    if (affix == CURRENCY_SUFFIX)
+    if (affix == CurrencyAffix::Suffix)
         format_append_string(dest, size, symbol);
 }
 


### PR DESCRIPTION
Introduce a strong enum, `CurrencyAffix`, to replace the existing `CURRENCY_AFFIX`.

Closes #12416.