### PR TITLE
Close #12459: Remove unused enum PARK_LOAD_ERROR

### DIFF
--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -10,9 +10,8 @@
 #pragma once
 
 #include "common.h"
-#include "object/Object.h"
-
 #include "core/String.hpp"
+#include "object/Object.h"
 
 #include <memory>
 #include <string>

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -12,15 +12,6 @@
 #include "common.h"
 #include "object/Object.h"
 
-enum PARK_LOAD_ERROR
-{
-    PARK_LOAD_ERROR_OK,
-    PARK_LOAD_ERROR_MISSING_OBJECTS,
-    PARK_LOAD_ERROR_INVALID_EXTENSION,
-    PARK_LOAD_ERROR_UNSUPPORTED_RCTC_FLAG,
-    PARK_LOAD_ERROR_UNKNOWN = 255
-};
-
 #include "core/String.hpp"
 
 #include <memory>


### PR DESCRIPTION
As noted in the comments on the issue the enum isn't used. Using blame it looks like a refactoring a couple of years ago of ParkImporter and ParkLoadResult removed all uses but didn't remove the type. 