### PR TITLE
Feature #11817: Show authors field in object selection

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Feature: [#11959] Hacked go-kart tracks can now use 2x2 bends, 3x3 bends and S-bends.
 - Feature: [#12090] Boosters for the Wooden Roller Coaster (if the "Show all track pieces" cheat is enabled).
 - Feature: [#12184] .sea (RCT Classic) scenario files can now be imported.
+- Feature: [#12591] Show authors of an object on the object selection dialog. 
 - Change: [#11209] Warn when user is running OpenRCT2 through Wine.
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Change: [#11449] Remove complete circuit requirement from Air Powered Vertical Coaster (for RCT1 parity).

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1124,8 +1124,9 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         }
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(authorsString.c_str());
-        gfx_draw_string_right(
-            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, screenPos.y });
+        gfx_draw_string_right_clipped(
+            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, screenPos.y },
+            w->width - w->widgets[WIDX_LIST].right - 4);
     }
 }
 /**

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1113,7 +1113,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     // Draw object author (will be blank space if no author in file or a non JSON object)
     {
         auto ft = Formatter::Common();
-        std::string authorsString = "";
+        std::string authorsString;
         for (size_t i = 0; i < listItem->repositoryItem->Authors.size(); i++)
         {
             if (i > 0)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1100,14 +1100,34 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     screenPos.y += LIST_ROW_HEIGHT;
 
     // Draw object dat name
-    const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
-    auto ft = Formatter::Common();
-    ft.Add<rct_string_id>(STR_STRING);
-    ft.Add<const char*>(path);
-    gfx_draw_string_right(
-        dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, screenPos.y });
-}
+    {
+        const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
+        auto ft = Formatter::Common();
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(path);
+        gfx_draw_string_right(
+            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, screenPos.y });
+        screenPos.y += LIST_ROW_HEIGHT;
+    }
 
+    // Draw object author (will be blank space if no author in file or a non JSON object)
+    {
+        auto ft = Formatter::Common();
+        std::string authorsString = "";
+        for (int i = 0; i < listItem->repositoryItem->Authors.size(); i++)
+        {
+            if (i > 0)
+            {
+                authorsString.append(", ");
+            }
+            authorsString.append(listItem->repositoryItem->Authors[i]);
+        }
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(authorsString.c_str());
+        gfx_draw_string_right(
+            dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { w->windowPos.x + w->width - 5, screenPos.y });
+    }
+}
 /**
  *
  *  rct2: 0x006AADA3

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1083,7 +1083,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
             dpi, gCommonFormatArgs, screenPos + ScreenCoordsXY{ 0, 5 }, width, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_BLACK);
     }
 
-    auto screenPos = w->windowPos + ScreenCoordsXY{ w->width - 5, w->height - (LIST_ROW_HEIGHT * 4) };
+    auto screenPos = w->windowPos + ScreenCoordsXY{ w->width - 5, w->height - (LIST_ROW_HEIGHT * 5) };
 
     // Draw ride type.
     if (get_selected_object_type(w) == OBJECT_TYPE_RIDE)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1114,7 +1114,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     {
         auto ft = Formatter::Common();
         std::string authorsString = "";
-        for (int i = 0; i < listItem->repositoryItem->Authors.size(); i++)
+        for (size_t i = 0; i < listItem->repositoryItem->Authors.size(); i++)
         {
             if (i > 0)
             {

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -116,7 +116,7 @@ void rct_object_entry::SetName(const std::string_view& value)
     std::memcpy(name, value.data(), std::min(sizeof(name), value.size()));
 }
 
-const std::vector<std::string>& Object::GetAuthors()
+const std::vector<std::string>& Object::GetAuthors() const
 {
     return _authors;
 }

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -116,6 +116,16 @@ void rct_object_entry::SetName(const std::string_view& value)
     std::memcpy(name, value.data(), std::min(sizeof(name), value.size()));
 }
 
+std::vector<std::string> Object::GetAuthors()
+{
+    return _authors;
+}
+
+void Object::SetAuthors(std::vector<std::string> authors)
+{
+    _authors = authors;
+}
+
 std::optional<uint8_t> rct_object_entry::GetSceneryType() const
 {
     switch (GetType())

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -116,12 +116,12 @@ void rct_object_entry::SetName(const std::string_view& value)
     std::memcpy(name, value.data(), std::min(sizeof(name), value.size()));
 }
 
-std::vector<std::string> Object::GetAuthors()
+const std::vector<std::string>& Object::GetAuthors()
 {
     return _authors;
 }
 
-void Object::SetAuthors(std::vector<std::string> authors)
+void Object::SetAuthors(const std::vector<std::string>& authors)
 {
     _authors = authors;
 }

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -121,7 +121,7 @@ const std::vector<std::string>& Object::GetAuthors() const
     return _authors;
 }
 
-void Object::SetAuthors(const std::vector<std::string>& authors)
+void Object::SetAuthors(const std::vector<std::string>&& authors)
 {
     _authors = authors;
 }

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -246,7 +246,7 @@ public:
     void SetSourceGames(const std::vector<uint8_t>& sourceGames);
 
     const std::vector<std::string>& GetAuthors() const;
-    void SetAuthors(const std::vector<std::string>& authors);
+    void SetAuthors(const std::vector<std::string>&& authors);
 
     const ImageTable& GetImageTable() const
     {

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -245,7 +245,7 @@ public:
     std::vector<uint8_t> GetSourceGames();
     void SetSourceGames(const std::vector<uint8_t>& sourceGames);
 
-    const std::vector<std::string>& GetAuthors();
+    const std::vector<std::string>& GetAuthors() const;
     void SetAuthors(const std::vector<std::string>& authors);
 
     const ImageTable& GetImageTable() const

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -166,6 +166,7 @@ private:
     StringTable _stringTable;
     ImageTable _imageTable;
     std::vector<uint8_t> _sourceGames;
+    std::vector<std::string> _authors;
     bool _isJsonObject{};
 
 protected:
@@ -243,6 +244,9 @@ public:
     }
     std::vector<uint8_t> GetSourceGames();
     void SetSourceGames(const std::vector<uint8_t>& sourceGames);
+
+    std::vector<std::string> GetAuthors();
+    void SetAuthors(std::vector<std::string> authors);
 
     const ImageTable& GetImageTable() const
     {

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -245,8 +245,8 @@ public:
     std::vector<uint8_t> GetSourceGames();
     void SetSourceGames(const std::vector<uint8_t>& sourceGames);
 
-    std::vector<std::string> GetAuthors();
-    void SetAuthors(std::vector<std::string> authors);
+    const std::vector<std::string>& GetAuthors();
+    void SetAuthors(const std::vector<std::string>& authors);
 
     const ImageTable& GetImageTable() const
     {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -442,6 +442,31 @@ namespace ObjectFactory
                 {
                     throw std::runtime_error("Object has errors");
                 }
+                auto authors = json_object_get(jRoot, "authors");
+                if (authors != nullptr)
+                {
+                    if (json_is_array(authors))
+                    {
+                        std::vector<std::string> authorVector;
+                        for (size_t j = 0; j < json_array_size(authors); j++)
+                        {
+                            json_t* tryString = json_array_get(authors, j);
+                            if (json_is_string(tryString))
+                            {
+                                authorVector.push_back(json_string_value(tryString));
+                            }
+                        }
+                        result->SetAuthors(authorVector);
+                    }
+                    else if (json_is_string(authors))
+                    {
+                        result->SetAuthors({ json_string_value(authors) });
+                    }
+                }
+                else
+                {
+                    result->SetAuthors({ "" });
+                }
                 auto sourceGames = json_object_get(jRoot, "sourceGame");
                 if (json_is_array(sourceGames))
                 {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -456,7 +456,7 @@ namespace ObjectFactory
                                 authorVector.emplace_back(json_string_value(tryString));
                             }
                         }
-                        result->SetAuthors(authorVector);
+                        result->SetAuthors(std::move(authorVector));
                     }
                     else if (json_is_string(authors))
                     {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -453,7 +453,7 @@ namespace ObjectFactory
                             json_t* tryString = json_array_get(authors, j);
                             if (json_is_string(tryString))
                             {
-                                authorVector.push_back(json_string_value(tryString));
+                                authorVector.emplace_back(json_string_value(tryString));
                             }
                         }
                         result->SetAuthors(authorVector);
@@ -462,10 +462,6 @@ namespace ObjectFactory
                     {
                         result->SetAuthors({ json_string_value(authors) });
                     }
-                }
-                else
-                {
-                    result->SetAuthors({ "" });
                 }
                 auto sourceGames = json_object_get(jRoot, "sourceGame");
                 if (json_is_array(sourceGames))

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -442,27 +442,26 @@ namespace ObjectFactory
                 {
                     throw std::runtime_error("Object has errors");
                 }
+
                 auto authors = json_object_get(jRoot, "authors");
-                if (authors != nullptr)
+                if (json_is_array(authors))
                 {
-                    if (json_is_array(authors))
+                    std::vector<std::string> authorVector;
+                    for (size_t j = 0; j < json_array_size(authors); j++)
                     {
-                        std::vector<std::string> authorVector;
-                        for (size_t j = 0; j < json_array_size(authors); j++)
+                        json_t* tryString = json_array_get(authors, j);
+                        if (json_is_string(tryString))
                         {
-                            json_t* tryString = json_array_get(authors, j);
-                            if (json_is_string(tryString))
-                            {
-                                authorVector.emplace_back(json_string_value(tryString));
-                            }
+                            authorVector.emplace_back(json_string_value(tryString));
                         }
-                        result->SetAuthors(std::move(authorVector));
                     }
-                    else if (json_is_string(authors))
-                    {
-                        result->SetAuthors({ json_string_value(authors) });
-                    }
+                    result->SetAuthors(std::move(authorVector));
                 }
+                else if (json_is_string(authors))
+                {
+                    result->SetAuthors({ json_string_value(authors) });
+                }
+
                 auto sourceGames = json_object_get(jRoot, "sourceGame");
                 if (json_is_array(sourceGames))
                 {

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -139,7 +139,7 @@ protected:
 
         uint8_t authorsLength = static_cast<uint8_t>(item.Authors.size());
         stream->WriteValue(authorsLength);
-        for (auto author : item.Authors)
+        for (const auto& author : item.Authors)
         {
             stream->WriteString(author);
         }
@@ -186,7 +186,7 @@ protected:
         for (size_t i = 0; i < authorsLength; i++)
         {
             auto author = stream->ReadStdString();
-            item.Authors.push_back(author);
+            item.Authors.emplace_back(author);
         }
 
         switch (item.ObjectEntry.GetType())

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -74,7 +74,7 @@ class ObjectFileIndex final : public FileIndex<ObjectRepositoryItem>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x5844494F; // OIDX
-    static constexpr uint16_t VERSION = 20;
+    static constexpr uint16_t VERSION = 21;
     static constexpr auto PATTERN = "*.dat;*.pob;*.json;*.parkobj";
 
     IObjectRepository& _objectRepository;
@@ -114,6 +114,7 @@ public:
             item.ObjectEntry = *object->GetObjectEntry();
             item.Path = path;
             item.Name = object->GetName();
+            item.Authors = object->GetAuthors();
             item.Sources = object->GetSourceGames();
             object->SetRepositoryItem(&item);
             delete object;
@@ -128,11 +129,19 @@ protected:
         stream->WriteValue(item.ObjectEntry);
         stream->WriteString(item.Path);
         stream->WriteString(item.Name);
+
         uint8_t sourceLength = static_cast<uint8_t>(item.Sources.size());
         stream->WriteValue(sourceLength);
         for (auto source : item.Sources)
         {
             stream->WriteValue(source);
+        }
+
+        uint8_t authorsLength = static_cast<uint8_t>(item.Authors.size());
+        stream->WriteValue(authorsLength);
+        for (auto author : item.Authors)
+        {
+            stream->WriteString(author);
         }
 
         switch (item.ObjectEntry.GetType())
@@ -165,11 +174,19 @@ protected:
         item.ObjectEntry = stream->ReadValue<rct_object_entry>();
         item.Path = stream->ReadStdString();
         item.Name = stream->ReadStdString();
+
         auto sourceLength = stream->ReadValue<uint8_t>();
         for (size_t i = 0; i < sourceLength; i++)
         {
             auto value = stream->ReadValue<uint8_t>();
             item.Sources.push_back(value);
+        }
+
+        auto authorsLength = stream->ReadValue<uint8_t>();
+        for (size_t i = 0; i < authorsLength; i++)
+        {
+            auto author = stream->ReadStdString();
+            item.Authors.push_back(author);
         }
 
         switch (item.ObjectEntry.GetType())

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -36,6 +36,7 @@ struct ObjectRepositoryItem
     rct_object_entry ObjectEntry;
     std::string Path;
     std::string Name;
+    std::vector<std::string> Authors;
     std::vector<uint8_t> Sources;
     Object* LoadedObject{};
     struct


### PR DESCRIPTION
This closes #11817 by adding the authors to the bottom right of the object selection dialogue. It's the last lines, other lines are shifted 1 up. If there's no authors field it just shows an empty space instead (I think basically every object does have one, but it seemed better to be consistent in positioning if not). It also serialises to the object index and bumps the object index version (I think that's enough to get it recreated?) 

Obviously very open to changing how it displays and willing to fix anything or completely change my approach on this.

![image](https://user-images.githubusercontent.com/43040194/89449297-c626ab80-d750-11ea-8f1d-8644ee5e0001.png)

