### PR TITLE
Fix #10751: Save mazes in their entirety

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -150,6 +150,7 @@ The following people are not part of the development team, but have been contrib
 * Chaitanya Thengdi (chaitanyathengdi)
 * Sidney Kuyateh (autinerd)
 * Łukasz Pękalski (Lukasz-Pe)
+* (quale)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -361,7 +361,7 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(const Ride& ride)
     // x is defined here as we can start the search
     // on tile start_x, start_y but then the next row
     // must restart on 0
-    for (int32_t y = startLoc.y, x = startLoc.y; y < MAXIMUM_MAP_SIZE_BIG; y += COORDS_XY_STEP)
+    for (int32_t y = startLoc.y, x = startLoc.x; y < MAXIMUM_MAP_SIZE_BIG; y += COORDS_XY_STEP)
     {
         for (; x < MAXIMUM_MAP_SIZE_BIG; x += COORDS_XY_STEP)
         {


### PR DESCRIPTION
_Someone_ had to spot the typo.