### PR TITLE
Fix compile error when compiling with clang-10

### DIFF
--- a/src/openrct2/core/CircularBuffer.h
+++ b/src/openrct2/core/CircularBuffer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 
 template<typename _TType, size_t _TMax> class CircularBuffer
 {


### PR DESCRIPTION
`<cstddef>` is required for size_t (used in `CircularBuffer.h`)