### PR TITLE
Add CMake option to build with CCache.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,21 @@ if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! Create a build dir and remove ${CMAKE_SOURCE_DIR}/CMakeCache.txt")
 endif()
 
+# Note: Searching for CCache must be before project() so project() can use CCache too
+# if it is available
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+find_package(CCache)
+
+if (CCache_FOUND)
+    option(OPENRCT2_USE_CCACHE "Use CCache to improve recompilation speed (optional)" ON)
+    if (OPENRCT2_USE_CCACHE)
+        # Use e.g. "ccache clang++" instead of "clang++"
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCache_EXECUTABLE}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "${CCache_EXECUTABLE}")
+    endif (OPENRCT2_USE_CCACHE)
+endif (CCache_FOUND)
+
 project(openrct2 CXX)
 
 include(cmake/platform.cmake)

--- a/cmake/FindCCache.cmake
+++ b/cmake/FindCCache.cmake
@@ -1,0 +1,22 @@
+# To find CCache compiler cache
+
+include(FindPackageHandleStandardArgs)
+
+find_program(CCache_EXECUTABLE ccache)
+
+if (CCache_EXECUTABLE)
+    execute_process(COMMAND "${CCache_EXECUTABLE}" --version
+        OUTPUT_VARIABLE CCache_VERSION_OUTPUT
+    )
+
+    string(REGEX MATCH "version ([0-9]+\\.[0-9]+\\.[0-9]+)" CCache_VERSION_TEMP ${CCache_VERSION_OUTPUT})
+    set(CCache_VERSION "${CMAKE_MATCH_0}")
+endif (CCache_EXECUTABLE)
+
+find_package_handle_standard_args(CCache
+    FOUND_VAR     CCache_FOUND
+    REQUIRED_VARS CCache_EXECUTABLE
+    VERSION_VAR   CCache_VERSION
+)
+
+mark_as_advanced(CCache_EXECUTABLE)


### PR DESCRIPTION
This speeds up CMake recompilation significantly.
The default behaviour is to search for CCache and use it if
available; this can be disabled explicitly by setting
OPENRCT2_ENABLE_CCACHE=OFF in CMake.