### PR TITLE
Refactor TEMPERATURE_FORMAT to use strong enum

### DIFF
--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -535,7 +535,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
 
     int32_t temperature = gClimateCurrent.Temperature;
     rct_string_id format = STR_CELSIUS_VALUE;
-    if (gConfigGeneral.temperature_format == TEMPERATURE_FORMAT_F)
+    if (gConfigGeneral.temperature_format == TEMPERATURE_FORMAT::F)
     {
         temperature = climate_celsius_to_fahrenheit(temperature);
         format = STR_FAHRENHEIT_VALUE;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -535,7 +535,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
 
     int32_t temperature = gClimateCurrent.Temperature;
     rct_string_id format = STR_CELSIUS_VALUE;
-    if (gConfigGeneral.temperature_format == TEMPERATURE_FORMAT::F)
+    if (gConfigGeneral.temperature_format == TemperatureFormat::F)
     {
         temperature = climate_celsius_to_fahrenheit(temperature);
         format = STR_FAHRENHEIT_VALUE;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -535,7 +535,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
 
     int32_t temperature = gClimateCurrent.Temperature;
     rct_string_id format = STR_CELSIUS_VALUE;
-    if (gConfigGeneral.temperature_format == TemperatureFormat::F)
+    if (gConfigGeneral.temperature_format == TemperatureUnit::Fahrenheit)
     {
         temperature = climate_celsius_to_fahrenheit(temperature);
         format = STR_FAHRENHEIT_VALUE;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1153,7 +1153,7 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
 
                     window_options_show_dropdown(w, widget, 2);
 
-                    dropdown_set_checked(gConfigGeneral.temperature_format, true);
+                    dropdown_set_checked(static_cast<int32_t>(gConfigGeneral.temperature_format), true);
                     break;
                 case WIDX_LANGUAGE_DROPDOWN:
                     for (size_t i = 1; i < LANGUAGE_COUNT; i++)
@@ -1421,9 +1421,9 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     window_options_update_height_markers();
                     break;
                 case WIDX_TEMPERATURE_DROPDOWN:
-                    if (dropdownIndex != gConfigGeneral.temperature_format)
+                    if (dropdownIndex != static_cast<int32_t>(gConfigGeneral.temperature_format))
                     {
-                        gConfigGeneral.temperature_format = static_cast<int8_t>(dropdownIndex);
+                        gConfigGeneral.temperature_format = static_cast<TEMPERATURE_FORMAT>(dropdownIndex);
                         config_save_default();
                         gfx_invalidate_screen();
                     }
@@ -1761,7 +1761,7 @@ static void window_options_invalidate(rct_window* w)
             window_options_culture_widgets[WIDX_DATE_FORMAT].text = DateFormatStringIds[gConfigGeneral.date_format];
 
             // Temperature: celsius/fahrenheit
-            window_options_culture_widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TEMPERATURE_FORMAT_F
+            window_options_culture_widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TEMPERATURE_FORMAT::F
                 ? STR_FAHRENHEIT
                 : STR_CELSIUS;
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1423,7 +1423,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                 case WIDX_TEMPERATURE_DROPDOWN:
                     if (dropdownIndex != static_cast<int32_t>(gConfigGeneral.temperature_format))
                     {
-                        gConfigGeneral.temperature_format = static_cast<TemperatureFormat>(dropdownIndex);
+                        gConfigGeneral.temperature_format = static_cast<TemperatureUnit>(dropdownIndex);
                         config_save_default();
                         gfx_invalidate_screen();
                     }
@@ -1761,7 +1761,8 @@ static void window_options_invalidate(rct_window* w)
             window_options_culture_widgets[WIDX_DATE_FORMAT].text = DateFormatStringIds[gConfigGeneral.date_format];
 
             // Temperature: celsius/fahrenheit
-            window_options_culture_widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TemperatureFormat::F
+            window_options_culture_widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format
+                    == TemperatureUnit::Fahrenheit
                 ? STR_FAHRENHEIT
                 : STR_CELSIUS;
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1423,7 +1423,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                 case WIDX_TEMPERATURE_DROPDOWN:
                     if (dropdownIndex != static_cast<int32_t>(gConfigGeneral.temperature_format))
                     {
-                        gConfigGeneral.temperature_format = static_cast<TEMPERATURE_FORMAT>(dropdownIndex);
+                        gConfigGeneral.temperature_format = static_cast<TemperatureFormat>(dropdownIndex);
                         config_save_default();
                         gfx_invalidate_screen();
                     }
@@ -1761,7 +1761,7 @@ static void window_options_invalidate(rct_window* w)
             window_options_culture_widgets[WIDX_DATE_FORMAT].text = DateFormatStringIds[gConfigGeneral.date_format];
 
             // Temperature: celsius/fahrenheit
-            window_options_culture_widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TEMPERATURE_FORMAT::F
+            window_options_culture_widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TemperatureFormat::F
                 ? STR_FAHRENHEIT
                 : STR_CELSIUS;
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -88,9 +88,9 @@ namespace Config
         ConfigEnumEntry<int32_t>("OPENGL", DRAWING_ENGINE_OPENGL),
     });
 
-    static const auto Enum_Temperature = ConfigEnum<TEMPERATURE_FORMAT>({
-        ConfigEnumEntry<TEMPERATURE_FORMAT>("CELSIUS", TEMPERATURE_FORMAT::C),
-        ConfigEnumEntry<TEMPERATURE_FORMAT>("FAHRENHEIT", TEMPERATURE_FORMAT::F),
+    static const auto Enum_Temperature = ConfigEnum<TemperatureFormat>({
+        ConfigEnumEntry<TemperatureFormat>("CELSIUS", TemperatureFormat::C),
+        ConfigEnumEntry<TemperatureFormat>("FAHRENHEIT", TemperatureFormat::F),
     });
 
     static const auto Enum_ScaleQuality = ConfigEnum<int32_t>({
@@ -162,7 +162,7 @@ namespace Config
             model->save_plugin_data = reader->GetBoolean("save_plugin_data", true);
             model->debugging_tools = reader->GetBoolean("debugging_tools", false);
             model->show_height_as_units = reader->GetBoolean("show_height_as_units", false);
-            model->temperature_format = reader->GetEnum<TEMPERATURE_FORMAT>(
+            model->temperature_format = reader->GetEnum<TemperatureFormat>(
                 "temperature_format", platform_get_locale_temperature_format(), Enum_Temperature);
             model->window_height = reader->GetInt32("window_height", -1);
             model->window_snap_proximity = reader->GetInt32("window_snap_proximity", 5);
@@ -242,7 +242,7 @@ namespace Config
         writer->WriteBoolean("save_plugin_data", model->save_plugin_data);
         writer->WriteBoolean("debugging_tools", model->debugging_tools);
         writer->WriteBoolean("show_height_as_units", model->show_height_as_units);
-        writer->WriteEnum<TEMPERATURE_FORMAT>("temperature_format", model->temperature_format, Enum_Temperature);
+        writer->WriteEnum<TemperatureFormat>("temperature_format", model->temperature_format, Enum_Temperature);
         writer->WriteInt32("window_height", model->window_height);
         writer->WriteInt32("window_snap_proximity", model->window_snap_proximity);
         writer->WriteInt32("window_width", model->window_width);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -88,9 +88,9 @@ namespace Config
         ConfigEnumEntry<int32_t>("OPENGL", DRAWING_ENGINE_OPENGL),
     });
 
-    static const auto Enum_Temperature = ConfigEnum<int32_t>({
-        ConfigEnumEntry<int32_t>("CELSIUS", TEMPERATURE_FORMAT_C),
-        ConfigEnumEntry<int32_t>("FAHRENHEIT", TEMPERATURE_FORMAT_F),
+    static const auto Enum_Temperature = ConfigEnum<TEMPERATURE_FORMAT>({
+        ConfigEnumEntry<TEMPERATURE_FORMAT>("CELSIUS", TEMPERATURE_FORMAT::C),
+        ConfigEnumEntry<TEMPERATURE_FORMAT>("FAHRENHEIT", TEMPERATURE_FORMAT::F),
     });
 
     static const auto Enum_ScaleQuality = ConfigEnum<int32_t>({
@@ -162,7 +162,7 @@ namespace Config
             model->save_plugin_data = reader->GetBoolean("save_plugin_data", true);
             model->debugging_tools = reader->GetBoolean("debugging_tools", false);
             model->show_height_as_units = reader->GetBoolean("show_height_as_units", false);
-            model->temperature_format = reader->GetEnum<int32_t>(
+            model->temperature_format = reader->GetEnum<TEMPERATURE_FORMAT>(
                 "temperature_format", platform_get_locale_temperature_format(), Enum_Temperature);
             model->window_height = reader->GetInt32("window_height", -1);
             model->window_snap_proximity = reader->GetInt32("window_snap_proximity", 5);
@@ -242,7 +242,7 @@ namespace Config
         writer->WriteBoolean("save_plugin_data", model->save_plugin_data);
         writer->WriteBoolean("debugging_tools", model->debugging_tools);
         writer->WriteBoolean("show_height_as_units", model->show_height_as_units);
-        writer->WriteEnum<int32_t>("temperature_format", model->temperature_format, Enum_Temperature);
+        writer->WriteEnum<TEMPERATURE_FORMAT>("temperature_format", model->temperature_format, Enum_Temperature);
         writer->WriteInt32("window_height", model->window_height);
         writer->WriteInt32("window_snap_proximity", model->window_snap_proximity);
         writer->WriteInt32("window_width", model->window_width);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -88,9 +88,9 @@ namespace Config
         ConfigEnumEntry<int32_t>("OPENGL", DRAWING_ENGINE_OPENGL),
     });
 
-    static const auto Enum_Temperature = ConfigEnum<TemperatureFormat>({
-        ConfigEnumEntry<TemperatureFormat>("CELSIUS", TemperatureFormat::C),
-        ConfigEnumEntry<TemperatureFormat>("FAHRENHEIT", TemperatureFormat::F),
+    static const auto Enum_Temperature = ConfigEnum<TemperatureUnit>({
+        ConfigEnumEntry<TemperatureUnit>("CELSIUS", TemperatureUnit::Celsius),
+        ConfigEnumEntry<TemperatureUnit>("FAHRENHEIT", TemperatureUnit::Fahrenheit),
     });
 
     static const auto Enum_ScaleQuality = ConfigEnum<int32_t>({
@@ -162,7 +162,7 @@ namespace Config
             model->save_plugin_data = reader->GetBoolean("save_plugin_data", true);
             model->debugging_tools = reader->GetBoolean("debugging_tools", false);
             model->show_height_as_units = reader->GetBoolean("show_height_as_units", false);
-            model->temperature_format = reader->GetEnum<TemperatureFormat>(
+            model->temperature_format = reader->GetEnum<TemperatureUnit>(
                 "temperature_format", platform_get_locale_temperature_format(), Enum_Temperature);
             model->window_height = reader->GetInt32("window_height", -1);
             model->window_snap_proximity = reader->GetInt32("window_snap_proximity", 5);
@@ -242,7 +242,7 @@ namespace Config
         writer->WriteBoolean("save_plugin_data", model->save_plugin_data);
         writer->WriteBoolean("debugging_tools", model->debugging_tools);
         writer->WriteBoolean("show_height_as_units", model->show_height_as_units);
-        writer->WriteEnum<TemperatureFormat>("temperature_format", model->temperature_format, Enum_Temperature);
+        writer->WriteEnum<TemperatureUnit>("temperature_format", model->temperature_format, Enum_Temperature);
         writer->WriteInt32("window_height", model->window_height);
         writer->WriteInt32("window_snap_proximity", model->window_snap_proximity);
         writer->WriteInt32("window_width", model->window_width);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -15,7 +15,7 @@
 
 #include <string>
 
-enum class TemperatureFormat : int32_t;
+enum class TemperatureUnit : int32_t;
 
 struct GeneralConfiguration
 {
@@ -56,7 +56,7 @@ struct GeneralConfiguration
     // Localisation
     int32_t language;
     int32_t measurement_format;
-    TemperatureFormat temperature_format;
+    TemperatureUnit temperature_format;
     bool show_height_as_units;
     int32_t date_format;
     int32_t currency_format;
@@ -208,10 +208,10 @@ enum SORT
     SORT_DATE_DESCENDING,
 };
 
-enum class TemperatureFormat : int32_t
+enum class TemperatureUnit : int32_t
 {
-    C,
-    F
+    Celsius,
+    Fahrenheit
 };
 
 enum SCALE_QUALITY

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -15,7 +15,7 @@
 
 #include <string>
 
-enum class TEMPERATURE_FORMAT : int32_t;
+enum class TemperatureFormat : int32_t;
 
 struct GeneralConfiguration
 {
@@ -56,7 +56,7 @@ struct GeneralConfiguration
     // Localisation
     int32_t language;
     int32_t measurement_format;
-    TEMPERATURE_FORMAT temperature_format;
+    TemperatureFormat temperature_format;
     bool show_height_as_units;
     int32_t date_format;
     int32_t currency_format;
@@ -208,7 +208,7 @@ enum SORT
     SORT_DATE_DESCENDING,
 };
 
-enum class TEMPERATURE_FORMAT : int32_t
+enum class TemperatureFormat : int32_t
 {
     C,
     F

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -15,6 +15,8 @@
 
 #include <string>
 
+enum class TEMPERATURE_FORMAT : int32_t;
+
 struct GeneralConfiguration
 {
     // Paths
@@ -54,7 +56,7 @@ struct GeneralConfiguration
     // Localisation
     int32_t language;
     int32_t measurement_format;
-    int32_t temperature_format;
+    TEMPERATURE_FORMAT temperature_format;
     bool show_height_as_units;
     int32_t date_format;
     int32_t currency_format;
@@ -206,10 +208,10 @@ enum SORT
     SORT_DATE_DESCENDING,
 };
 
-enum TEMPERATURE_FORMAT
+enum class TEMPERATURE_FORMAT : int32_t
 {
-    TEMPERATURE_FORMAT_C,
-    TEMPERATURE_FORMAT_F
+    C,
+    F
 };
 
 enum SCALE_QUALITY

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -353,7 +353,7 @@ time_t platform_file_get_modified_time(const utf8* path)
     return 100;
 }
 
-TemperatureFormat platform_get_locale_temperature_format()
+TemperatureUnit platform_get_locale_temperature_format()
 {
 // LC_MEASUREMENT is GNU specific.
 #    ifdef LC_MEASUREMENT
@@ -367,10 +367,10 @@ TemperatureFormat platform_get_locale_temperature_format()
         if (!fnmatch("*_US*", langstring, 0) || !fnmatch("*_BS*", langstring, 0) || !fnmatch("*_BZ*", langstring, 0)
             || !fnmatch("*_PW*", langstring, 0))
         {
-            return TemperatureFormat::F;
+            return TemperatureUnit::Fahrenheit;
         }
     }
-    return TemperatureFormat::C;
+    return TemperatureUnit::Celsius;
 }
 
 uint8_t platform_get_locale_date_format()

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -353,7 +353,7 @@ time_t platform_file_get_modified_time(const utf8* path)
     return 100;
 }
 
-uint8_t platform_get_locale_temperature_format()
+TEMPERATURE_FORMAT platform_get_locale_temperature_format()
 {
 // LC_MEASUREMENT is GNU specific.
 #    ifdef LC_MEASUREMENT
@@ -367,10 +367,10 @@ uint8_t platform_get_locale_temperature_format()
         if (!fnmatch("*_US*", langstring, 0) || !fnmatch("*_BS*", langstring, 0) || !fnmatch("*_BZ*", langstring, 0)
             || !fnmatch("*_PW*", langstring, 0))
         {
-            return TEMPERATURE_FORMAT_F;
+            return TEMPERATURE_FORMAT::F;
         }
     }
-    return TEMPERATURE_FORMAT_C;
+    return TEMPERATURE_FORMAT::C;
 }
 
 uint8_t platform_get_locale_date_format()

--- a/src/openrct2/platform/Posix.cpp
+++ b/src/openrct2/platform/Posix.cpp
@@ -353,7 +353,7 @@ time_t platform_file_get_modified_time(const utf8* path)
     return 100;
 }
 
-TEMPERATURE_FORMAT platform_get_locale_temperature_format()
+TemperatureFormat platform_get_locale_temperature_format()
 {
 // LC_MEASUREMENT is GNU specific.
 #    ifdef LC_MEASUREMENT
@@ -367,10 +367,10 @@ TEMPERATURE_FORMAT platform_get_locale_temperature_format()
         if (!fnmatch("*_US*", langstring, 0) || !fnmatch("*_BS*", langstring, 0) || !fnmatch("*_BZ*", langstring, 0)
             || !fnmatch("*_PW*", langstring, 0))
         {
-            return TEMPERATURE_FORMAT::F;
+            return TemperatureFormat::F;
         }
     }
-    return TEMPERATURE_FORMAT::C;
+    return TemperatureFormat::C;
 }
 
 uint8_t platform_get_locale_date_format()

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -328,7 +328,7 @@ uint8_t platform_get_locale_measurement_format()
     }
 }
 
-TEMPERATURE_FORMAT platform_get_locale_temperature_format()
+TemperatureFormat platform_get_locale_temperature_format()
 {
     UINT fahrenheit;
 
@@ -337,13 +337,13 @@ TEMPERATURE_FORMAT platform_get_locale_temperature_format()
     if (GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_IMEASURE | LOCALE_RETURN_NUMBER, (LPSTR)&fahrenheit, sizeof(fahrenheit)) == 0)
     {
         // Assume celsius by default if function call fails
-        return TEMPERATURE_FORMAT::C;
+        return TemperatureFormat::C;
     }
 
     if (fahrenheit)
-        return TEMPERATURE_FORMAT::F;
+        return TemperatureFormat::F;
     else
-        return TEMPERATURE_FORMAT::C;
+        return TemperatureFormat::C;
 }
 
 uint8_t platform_get_locale_date_format()

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -328,7 +328,7 @@ uint8_t platform_get_locale_measurement_format()
     }
 }
 
-uint8_t platform_get_locale_temperature_format()
+TEMPERATURE_FORMAT platform_get_locale_temperature_format()
 {
     UINT fahrenheit;
 
@@ -337,13 +337,13 @@ uint8_t platform_get_locale_temperature_format()
     if (GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_IMEASURE | LOCALE_RETURN_NUMBER, (LPSTR)&fahrenheit, sizeof(fahrenheit)) == 0)
     {
         // Assume celsius by default if function call fails
-        return TEMPERATURE_FORMAT_C;
+        return TEMPERATURE_FORMAT::C;
     }
 
     if (fahrenheit)
-        return TEMPERATURE_FORMAT_F;
+        return TEMPERATURE_FORMAT::F;
     else
-        return TEMPERATURE_FORMAT_C;
+        return TEMPERATURE_FORMAT::C;
 }
 
 uint8_t platform_get_locale_date_format()

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -328,7 +328,7 @@ uint8_t platform_get_locale_measurement_format()
     }
 }
 
-TemperatureFormat platform_get_locale_temperature_format()
+TemperatureUnit platform_get_locale_temperature_format()
 {
     UINT fahrenheit;
 
@@ -337,13 +337,13 @@ TemperatureFormat platform_get_locale_temperature_format()
     if (GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_IMEASURE | LOCALE_RETURN_NUMBER, (LPSTR)&fahrenheit, sizeof(fahrenheit)) == 0)
     {
         // Assume celsius by default if function call fails
-        return TemperatureFormat::C;
+        return TemperatureUnit::Celsius;
     }
 
     if (fahrenheit)
-        return TemperatureFormat::F;
+        return TemperatureUnit::Fahrenheit;
     else
-        return TemperatureFormat::C;
+        return TemperatureUnit::Celsius;
 }
 
 uint8_t platform_get_locale_date_format()

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -117,7 +117,7 @@ uint8_t platform_get_locale_currency();
 uint8_t platform_get_currency_value(const char* currencyCode);
 uint16_t platform_get_locale_language();
 uint8_t platform_get_locale_measurement_format();
-TEMPERATURE_FORMAT platform_get_locale_temperature_format();
+TemperatureFormat platform_get_locale_temperature_format();
 uint8_t platform_get_locale_date_format();
 bool platform_process_is_elevated();
 bool platform_get_steam_path(utf8* outPath, size_t outSize);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -117,7 +117,7 @@ uint8_t platform_get_locale_currency();
 uint8_t platform_get_currency_value(const char* currencyCode);
 uint16_t platform_get_locale_language();
 uint8_t platform_get_locale_measurement_format();
-TemperatureFormat platform_get_locale_temperature_format();
+TemperatureUnit platform_get_locale_temperature_format();
 uint8_t platform_get_locale_date_format();
 bool platform_process_is_elevated();
 bool platform_get_steam_path(utf8* outPath, size_t outSize);

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -11,6 +11,7 @@
 #define _PLATFORM_H_
 
 #include "../common.h"
+#include "../config/Config.h"
 
 #include <string>
 #include <time.h>
@@ -116,7 +117,7 @@ uint8_t platform_get_locale_currency();
 uint8_t platform_get_currency_value(const char* currencyCode);
 uint16_t platform_get_locale_language();
 uint8_t platform_get_locale_measurement_format();
-uint8_t platform_get_locale_temperature_format();
+TEMPERATURE_FORMAT platform_get_locale_temperature_format();
 uint8_t platform_get_locale_date_format();
 bool platform_process_is_elevated();
 bool platform_get_steam_path(utf8* outPath, size_t outSize);


### PR DESCRIPTION
Closes [#12400](https://github.com/OpenRCT2/OpenRCT2/issues/12400)  Refactor TEMPERATURE_FORMAT to use strong enum