### PR TITLE
Fix #11085: Handle player list before game actions during map load

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#10876] There can be multiple peep spawns on the same location.
 - Fix: [#11002] Rides list shows both red and green light activated.
 - Fix: [#11072] Land and water tools working out of bounds (original bug).
+- Fix: [#11085] Handle player list before game actions during map load.
 - Fix: [#11259] Custom JSON object breaks saves.
 - Fix: [#11290] Perform funds checking for all peeps entering a ride.
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2723,6 +2723,11 @@ void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connecti
 
             // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
             fix_invalid_vehicle_sprite_sizes();
+
+            // NOTE: Game actions are normally processed before processing the player list.
+            // Given that during map load game actions are buffered we have to process the
+            // player list first to have valid players for the queued game actions.
+            ProcessPlayerList();
         }
         else
         {


### PR DESCRIPTION
The issue is the order of how things are processed, its usually game actions then player list, so when the client connected it would have:
a.) Pending game actions.
b.) Pending player list.
Which is also processed in that order. However game actions do require the player list before executing game actions, so this PR ensures that for when we received the map the player list is updated right away.

Closes #11085