### PR TITLE
Add releases in appdata XML file

### DIFF
--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -64,7 +64,26 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-      <release version="0.2.6" date="2020-04-17" />
-      <release version="0.2.5" date="2020-03-24" />
+      <release version="0.2.6" date="2020-04-17">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.6</url>
+      </release>
+      <release version="0.2.5" date="2020-03-24">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.5</url>
+      </release>
+      <release version="0.2.4" date="2019-10-28">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.4</url>
+      </release>
+      <release version="0.2.3" date="2019-07-10">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.3</url>
+      </release>
+      <release version="0.2.2" date="2019-03-13">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.2</url>
+      </release>
+      <release version="0.2.1" date="2018-08-26">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.1</url>
+      </release>
+      <release version="0.2.0" date="2018-06-10">
+        <url>https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.2.0</url>
+      </release>
   </releases>
 </component>

--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -63,4 +63,8 @@
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
+  <releases>
+      <release version="0.2.6" date="2020-04-17" />
+      <release version="0.2.5" date="2020-03-24" />
+  </releases>
 </component>


### PR DESCRIPTION
This will (hopefully) allow the appdata file to be validated in the Flatpak build.

Ideally this would be updated with each new release. It's also possible to put a whole load of additional metadata with each release - details of changes, URLs, update urgency, etc. - but I believe that's all optional. This is used by software centre type applications (like Gnome software) to present applications and changes in updates. Detailed documentation is at: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases