### PR TITLE
Fix #12621: Missing argument for localisation

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3634,6 +3634,7 @@ STR_6375    :Unknown Ride
 STR_6376    :{WINDOW_COLOUR_2}Ride vehicle:{NEWLINE}{BLACK}{STRINGID} for {STRINGID}
 STR_6377    :{WINDOW_COLOUR_2}Type: {BLACK}{STRINGID} for {STRINGID}
 STR_6378    :Receiving objects list: {INT32} / {INT32}
+STR_6379    :Received invalid data
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3876,6 +3876,8 @@ enum
 
     STR_MULTIPLAYER_RECEIVING_OBJECTS_LIST = 6378,
 
+    STR_MULTIPLAYER_RECEIVED_INVALID_DATA = 6379,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2283,7 +2283,7 @@ void NetworkBase::Client_Handle_AUTH(NetworkConnection& connection, NetworkPacke
             connection.Socket->Disconnect();
             break;
         default:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_INCORRECT_SOFTWARE_VERSION);
+            connection.SetLastDisconnectReason(STR_MULTIPLAYER_RECEIVED_INVALID_DATA);
             connection.Socket->Disconnect();
             break;
     }


### PR DESCRIPTION
STR_MULTIPLAYER_INCORRECT_SOFTWARE_VERSION expects a string parameter which was not passed. I've added a more generic string which can be used later for other cases.

Closes #12621