### PR TITLE
Fix #12402: Refactor MEASUREMENT_FORMAT to use strong enum

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1740,10 +1740,9 @@ static void window_options_invalidate(rct_window* w)
 
             // Distance: metric / imperial / si
             {
-                rct_string_id stringId;
+                rct_string_id stringId = STR_NONE;
                 switch (gConfigGeneral.measurement_format)
                 {
-                    default:
                     case MeasurementFormat::Imperial:
                         stringId = STR_IMPERIAL;
                         break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1143,7 +1143,7 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
 
                     window_options_show_dropdown(w, widget, 3);
 
-                    dropdown_set_checked(gConfigGeneral.measurement_format, true);
+                    dropdown_set_checked(static_cast<int32_t>(gConfigGeneral.measurement_format), true);
                     break;
                 case WIDX_TEMPERATURE_DROPDOWN:
                     gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
@@ -1416,7 +1416,7 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     gfx_invalidate_screen();
                     break;
                 case WIDX_DISTANCE_DROPDOWN:
-                    gConfigGeneral.measurement_format = static_cast<int8_t>(dropdownIndex);
+                    gConfigGeneral.measurement_format = static_cast<MeasurementFormat>(dropdownIndex);
                     config_save_default();
                     window_options_update_height_markers();
                     break;
@@ -1744,13 +1744,13 @@ static void window_options_invalidate(rct_window* w)
                 switch (gConfigGeneral.measurement_format)
                 {
                     default:
-                    case MEASUREMENT_FORMAT_IMPERIAL:
+                    case MeasurementFormat::Imperial:
                         stringId = STR_IMPERIAL;
                         break;
-                    case MEASUREMENT_FORMAT_METRIC:
+                    case MeasurementFormat::Metric:
                         stringId = STR_METRIC;
                         break;
-                    case MEASUREMENT_FORMAT_SI:
+                    case MeasurementFormat::SI:
                         stringId = STR_SI;
                         break;
                 }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1423,7 +1423,7 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw park size
     parkSize = gParkSize * 10;
     stringIndex = STR_PARK_SIZE_METRIC_LABEL;
-    if (gConfigGeneral.measurement_format == MEASUREMENT_FORMAT_IMPERIAL)
+    if (gConfigGeneral.measurement_format == MeasurementFormat::Imperial)
     {
         stringIndex = STR_PARK_SIZE_IMPERIAL_LABEL;
         parkSize = squaredmetres_to_squaredfeet(parkSize);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -438,7 +438,6 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
                             dpi, STR_UNIT2DP_SUFFIX_METRES, &clipHeightValueInMeters, w->colours[0], screenCoords);
                         break;
                     case MeasurementFormat::Imperial:
-                    default:
                         clipHeightValueInFeet = static_cast<fixed16_1dp>(
                             FIXED_1DP(gClipHeight, 0) / 2.0f * 5 - FIXED_1DP(35, 0));
                         gfx_draw_string_left(dpi, STR_UNIT1DP_SUFFIX_FEET, &clipHeightValueInFeet, w->colours[0], screenCoords);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -430,14 +430,14 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Print the value in the configured measurement units.
                 switch (gConfigGeneral.measurement_format)
                 {
-                    case MEASUREMENT_FORMAT_METRIC:
-                    case MEASUREMENT_FORMAT_SI:
+                    case MeasurementFormat::Metric:
+                    case MeasurementFormat::SI:
                         clipHeightValueInMeters = static_cast<fixed32_2dp>(
                             FIXED_2DP(gClipHeight, 0) / 2 * 1.5f - FIXED_2DP(10, 50));
                         gfx_draw_string_left(
                             dpi, STR_UNIT2DP_SUFFIX_METRES, &clipHeightValueInMeters, w->colours[0], screenCoords);
                         break;
-                    case MEASUREMENT_FORMAT_IMPERIAL:
+                    case MeasurementFormat::Imperial:
                     default:
                         clipHeightValueInFeet = static_cast<fixed16_1dp>(
                             FIXED_1DP(gClipHeight, 0) / 2.0f * 5 - FIXED_1DP(35, 0));

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -43,10 +43,10 @@ namespace Config
 {
 #pragma region Enums
 
-    static const auto Enum_MeasurementFormat = ConfigEnum<int32_t>({
-        ConfigEnumEntry<int32_t>("IMPERIAL", MEASUREMENT_FORMAT_IMPERIAL),
-        ConfigEnumEntry<int32_t>("METRIC", MEASUREMENT_FORMAT_METRIC),
-        ConfigEnumEntry<int32_t>("SI", MEASUREMENT_FORMAT_SI),
+    static const auto Enum_MeasurementFormat = ConfigEnum<MeasurementFormat>({
+        ConfigEnumEntry<MeasurementFormat>("IMPERIAL", MeasurementFormat::Imperial),
+        ConfigEnumEntry<MeasurementFormat>("METRIC", MeasurementFormat::Metric),
+        ConfigEnumEntry<MeasurementFormat>("SI", MeasurementFormat::SI),
     });
 
     static const auto Enum_Currency = ConfigEnum<int32_t>({
@@ -156,7 +156,7 @@ namespace Config
             model->rct2_path = reader->GetCString("game_path", nullptr);
             model->landscape_smoothing = reader->GetBoolean("landscape_smoothing", true);
             model->language = reader->GetEnum<int32_t>("language", platform_get_locale_language(), Enum_LanguageEnum);
-            model->measurement_format = reader->GetEnum<int32_t>(
+            model->measurement_format = reader->GetEnum<MeasurementFormat>(
                 "measurement_format", platform_get_locale_measurement_format(), Enum_MeasurementFormat);
             model->play_intro = reader->GetBoolean("play_intro", false);
             model->save_plugin_data = reader->GetBoolean("save_plugin_data", true);
@@ -237,7 +237,7 @@ namespace Config
         writer->WriteString("game_path", model->rct2_path);
         writer->WriteBoolean("landscape_smoothing", model->landscape_smoothing);
         writer->WriteEnum<int32_t>("language", model->language, Enum_LanguageEnum);
-        writer->WriteEnum<int32_t>("measurement_format", model->measurement_format, Enum_MeasurementFormat);
+        writer->WriteEnum<MeasurementFormat>("measurement_format", model->measurement_format, Enum_MeasurementFormat);
         writer->WriteBoolean("play_intro", model->play_intro);
         writer->WriteBoolean("save_plugin_data", model->save_plugin_data);
         writer->WriteBoolean("debugging_tools", model->debugging_tools);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -15,6 +15,7 @@
 
 #include <string>
 
+enum class MeasurementFormat : int32_t;
 enum class TemperatureUnit : int32_t;
 
 struct GeneralConfiguration
@@ -55,7 +56,7 @@ struct GeneralConfiguration
 
     // Localisation
     int32_t language;
-    int32_t measurement_format;
+    MeasurementFormat measurement_format;
     TemperatureUnit temperature_format;
     bool show_height_as_units;
     int32_t date_format;
@@ -221,11 +222,11 @@ enum SCALE_QUALITY
     SCALE_QUALITY_SMOOTH_NN
 };
 
-enum MEASUREMENT_FORMAT
+enum class MeasurementFormat : int32_t
 {
-    MEASUREMENT_FORMAT_IMPERIAL,
-    MEASUREMENT_FORMAT_METRIC,
-    MEASUREMENT_FORMAT_SI
+    Imperial,
+    Metric,
+    SI
 };
 
 extern GeneralConfiguration gConfigGeneral;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1898,7 +1898,7 @@ int16_t get_height_marker_offset()
         return 0;
 
     // Height labels in feet
-    if (gConfigGeneral.measurement_format == MEASUREMENT_FORMAT_IMPERIAL)
+    if (gConfigGeneral.measurement_format == MeasurementFormat::Imperial)
         return 1 * 256;
 
     // Height labels in metres

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -898,11 +898,10 @@ static void format_length(char** dest, size_t* size, int32_t value)
 
 static void format_velocity(char** dest, size_t* size, uint16_t value)
 {
-    rct_string_id stringId;
+    rct_string_id stringId = STR_NONE;
 
     switch (gConfigGeneral.measurement_format)
     {
-        default:
         case MeasurementFormat::Imperial:
             stringId = STR_UNIT_SUFFIX_MILES_PER_HOUR;
             break;

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -886,7 +886,7 @@ static void format_length(char** dest, size_t* size, int32_t value)
 {
     rct_string_id stringId = STR_UNIT_SUFFIX_METRES;
 
-    if (gConfigGeneral.measurement_format == MEASUREMENT_FORMAT_IMPERIAL)
+    if (gConfigGeneral.measurement_format == MeasurementFormat::Imperial)
     {
         value = metres_to_feet(value);
         stringId = STR_UNIT_SUFFIX_FEET;
@@ -903,13 +903,14 @@ static void format_velocity(char** dest, size_t* size, uint16_t value)
     switch (gConfigGeneral.measurement_format)
     {
         default:
+        case MeasurementFormat::Imperial:
             stringId = STR_UNIT_SUFFIX_MILES_PER_HOUR;
             break;
-        case MEASUREMENT_FORMAT_METRIC:
+        case MeasurementFormat::Metric:
             value = mph_to_kmph(value);
             stringId = STR_UNIT_SUFFIX_KILOMETRES_PER_HOUR;
             break;
-        case MEASUREMENT_FORMAT_SI:
+        case MeasurementFormat::SI:
             value = mph_to_dmps(value);
             stringId = STR_UNIT_SUFFIX_METRES_PER_SECOND;
             break;

--- a/src/openrct2/platform/Android.cpp
+++ b/src/openrct2/platform/Android.cpp
@@ -36,9 +36,9 @@ uint8_t platform_get_locale_currency()
     return platform_get_currency_value(NULL);
 }
 
-uint8_t platform_get_locale_measurement_format()
+MeasurementFormat platform_get_locale_measurement_format()
 {
-    return MEASUREMENT_FORMAT_METRIC;
+    return MeasurementFormat::Metric;
 }
 
 float platform_get_default_scale()

--- a/src/openrct2/platform/Linux.cpp
+++ b/src/openrct2/platform/Linux.cpp
@@ -123,7 +123,7 @@ uint8_t platform_get_locale_currency()
     return platform_get_currency_value(lc->int_curr_symbol);
 }
 
-uint8_t platform_get_locale_measurement_format()
+MeasurementFormat platform_get_locale_measurement_format()
 {
 // LC_MEASUREMENT is GNU specific.
 #    ifdef LC_MEASUREMENT
@@ -137,10 +137,10 @@ uint8_t platform_get_locale_measurement_format()
         // using https://en.wikipedia.org/wiki/Metrication#Chronology_and_status_of_conversion_by_country as reference
         if (!fnmatch("*_US*", langstring, 0) || !fnmatch("*_MM*", langstring, 0) || !fnmatch("*_LR*", langstring, 0))
         {
-            return MEASUREMENT_FORMAT_IMPERIAL;
+            return MeasurementFormat::Imperial;
         }
     }
-    return MEASUREMENT_FORMAT_METRIC;
+    return MeasurementFormat::Metric;
 }
 
 bool platform_get_steam_path(utf8* outPath, size_t outSize)

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -308,23 +308,23 @@ uint8_t platform_get_locale_currency()
     return platform_get_currency_value(currCode);
 }
 
-uint8_t platform_get_locale_measurement_format()
+MeasurementFormat platform_get_locale_measurement_format()
 {
     UINT measurement_system;
     if (GetLocaleInfo(
             LOCALE_USER_DEFAULT, LOCALE_IMEASURE | LOCALE_RETURN_NUMBER, (LPSTR)&measurement_system, sizeof(measurement_system))
         == 0)
     {
-        return MEASUREMENT_FORMAT_METRIC;
+        return MeasurementFormat::Metric;
     }
 
     switch (measurement_system)
     {
         case 1:
-            return MEASUREMENT_FORMAT_IMPERIAL;
+            return MeasurementFormat::Imperial;
         case 0:
         default:
-            return MEASUREMENT_FORMAT_METRIC;
+            return MeasurementFormat::Metric;
     }
 }
 

--- a/src/openrct2/platform/macos.mm
+++ b/src/openrct2/platform/macos.mm
@@ -122,7 +122,7 @@ uint8_t platform_get_locale_currency()
     }
 }
 
-uint8_t platform_get_locale_measurement_format()
+MeasurementFormat platform_get_locale_measurement_format()
 {
     @autoreleasepool
     {
@@ -130,10 +130,10 @@ uint8_t platform_get_locale_measurement_format()
 
         if (metricSystem.boolValue)
         {
-            return MEASUREMENT_FORMAT_METRIC;
+            return MeasurementFormat::Metric;
         }
 
-        return MEASUREMENT_FORMAT_IMPERIAL;
+        return MeasurementFormat::Imperial;
     }
 }
 

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -116,7 +116,7 @@ utf8* platform_open_directory_browser(const utf8* title);
 uint8_t platform_get_locale_currency();
 uint8_t platform_get_currency_value(const char* currencyCode);
 uint16_t platform_get_locale_language();
-uint8_t platform_get_locale_measurement_format();
+MeasurementFormat platform_get_locale_measurement_format();
 TemperatureUnit platform_get_locale_temperature_format();
 uint8_t platform_get_locale_date_format();
 bool platform_process_is_elevated();


### PR DESCRIPTION
Introduce a strong enum, MeasurementFormat, to replace the existing MEASUREMENT_FORMAT.

Closes #12402.