### PR TITLE
Fix freezes on incomplete packet transmission

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1721,8 +1721,10 @@ bool NetworkBase::ProcessConnection(NetworkConnection& connection)
                 // could not read anything from socket
                 break;
         }
-    } while (packetStatus == NETWORK_READPACKET_MORE_DATA || packetStatus == NETWORK_READPACKET_SUCCESS);
+    } while (packetStatus == NETWORK_READPACKET_SUCCESS);
+
     connection.SendQueuedPackets();
+
     if (!connection.ReceivedPacketRecently())
     {
         if (!connection.GetLastDisconnectReason())
@@ -1731,6 +1733,7 @@ bool NetworkBase::ProcessConnection(NetworkConnection& connection)
         }
         return false;
     }
+
     return true;
 }
 

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -18,7 +18,7 @@
 #    include "network.h"
 
 constexpr size_t NETWORK_DISCONNECT_REASON_BUFFER_SIZE = 256;
-constexpr size_t NetworkBufferSize = 1024;
+constexpr size_t NetworkBufferSize = 1024 * 64; // 64 KiB, maximum packet size.
 
 NetworkConnection::NetworkConnection()
 {


### PR DESCRIPTION
The loop would keep going for as long the packet was not fully received which never allowed the game to actually buffer the packets causing freezes, especially during a connect this is very noticeable. Now the loop only goes on for as long it has complete packets available and keeps buffering for when it requires more data.