### PR TITLE
Fix #12308: Cannot use cheats in editor modes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -57,6 +57,7 @@
 - Fix: [#12221] Map Generation tool doesn't place any trees.
 - Fix: [#12285] On-ride photo profit assumes every guest buys one.
 - Fix: [#12297] OpenGL renderer causing artifacts.
+- Fix: [#12308] Cannot use cheats in editor modes.
 - Fix: [#12312] Softlock when loading save file via command line fails.
 - Fix: [#12486] `set-rct2` has a broken g1.dat check.
 - Fix: [#12498] Circus construction ghost does not rotate (original bug).

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/ParkSetDateAction.hpp>
 #include <openrct2/actions/SetCheatAction.hpp>
 #include <openrct2/config/Config.h>
@@ -1168,6 +1169,11 @@ static void window_cheats_invalidate(rct_window* w)
     window_cheats_misc_widgets[WIDX_WEATHER].text = WeatherTypes[gClimateCurrent.Weather];
     // Staff speed
     window_cheats_misc_widgets[WIDX_STAFF_SPEED].text = _staffSpeedNames[_selectedStaffSpeed];
+
+    if (gScreenFlags & SCREEN_FLAGS_EDITOR)
+    {
+        w->disabled_widgets |= (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_NO_MONEY);
+    }
 }
 
 static void window_cheats_paint(rct_window* w, rct_drawpixelinfo* dpi)

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -186,15 +186,20 @@ static constexpr ScreenSize CHEAT_CHECK = {221, 12};
 static constexpr ScreenSize CHEAT_SPINNER = {117, 14};
 static constexpr ScreenSize MINMAX_BUTTON = {55, 17};
 
+static constexpr const int32_t TAB_WIDTH = 31;
+static constexpr const int32_t TAB_HEIGHT = 27;
+static constexpr const int32_t TAB_START = 3;
+
+
 #pragma endregion
 
 #define MAIN_CHEATS_WIDGETS \
     WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
     MakeWidget     ({ 0, 43}, {WW, 257}, WWT_IMGBTN, 1                                      ), /* tab content panel */ \
-    MakeRemapWidget({ 3, 17}, {31,  27}, WWT_TAB,    1, SPR_TAB,    STR_FINANCIAL_CHEATS_TIP), /* tab 1 */ \
-    MakeRemapWidget({34, 17}, {31,  27}, WWT_TAB,    1, SPR_TAB,    STR_GUEST_CHEATS_TIP    ), /* tab 2 */ \
-    MakeRemapWidget({65, 17}, {31,  27}, WWT_TAB,    1, SPR_TAB,    STR_PARK_CHEATS_TIP     ), /* tab 3 */ \
-    MakeRemapWidget({96, 17}, {31,  27}, WWT_TAB,    1, SPR_TAB,    STR_RIDE_CHEATS_TIP     )  /* tab 4 */
+    MakeRemapWidget({ 3, 17}, {TAB_WIDTH, TAB_HEIGHT}, WWT_TAB,    1, SPR_TAB,    STR_FINANCIAL_CHEATS_TIP), /* tab 1 */ \
+    MakeRemapWidget({34, 17}, {TAB_WIDTH, TAB_HEIGHT}, WWT_TAB,    1, SPR_TAB,    STR_GUEST_CHEATS_TIP    ), /* tab 2 */ \
+    MakeRemapWidget({65, 17}, {TAB_WIDTH, TAB_HEIGHT}, WWT_TAB,    1, SPR_TAB,    STR_PARK_CHEATS_TIP     ), /* tab 3 */ \
+    MakeRemapWidget({96, 17}, {TAB_WIDTH, TAB_HEIGHT}, WWT_TAB,    1, SPR_TAB,    STR_RIDE_CHEATS_TIP     )  /* tab 4 */
 
 static rct_widget window_cheats_money_widgets[] =
 {
@@ -1176,8 +1181,30 @@ static void window_cheats_invalidate(rct_window* w)
     }
 }
 
+static void window_cheats_update_tab_positions(rct_window* w)
+{
+    constexpr const uint16_t tabs[] = {
+        WIDX_TAB_1,
+        WIDX_TAB_2,
+        WIDX_TAB_3,
+        WIDX_TAB_4,
+    };
+
+    int32_t left = TAB_START;
+
+    for (auto tab : tabs)
+    {
+        w->widgets[tab].left = left;
+        if (!(w->disabled_widgets & (1ULL << tab)))
+        {
+            left += TAB_WIDTH;
+        }
+    }
+}
+
 static void window_cheats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
+    window_cheats_update_tab_positions(w);
     window_draw_widgets(w, dpi);
     window_cheats_draw_tab_images(dpi, w);
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3477,7 +3477,6 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
 
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
-        dropdown_set_disabled(DDIDX_CHEATS, true);
         dropdown_set_disabled(DDIDX_OBJECT_SELECTION, true);
         dropdown_set_disabled(DDIDX_INVENTIONS_LIST, true);
         dropdown_set_disabled(DDIDX_SCENARIO_OPTIONS, true);
@@ -3497,10 +3496,7 @@ static void top_toolbar_init_cheats_menu(rct_window* w, rct_widget* widget)
         dropdown_set_checked(DDIDX_DISABLE_SUPPORT_LIMITS, true);
     }
 
-    if (!dropdown_is_disabled(DDIDX_CHEATS))
-        gDropdownDefaultIndex = DDIDX_CHEATS;
-    else
-        gDropdownDefaultIndex = DDIDX_TILE_INSPECTOR;
+    gDropdownDefaultIndex = DDIDX_CHEATS;
 }
 
 static void top_toolbar_cheats_menu_dropdown(int16_t dropdownIndex)


### PR DESCRIPTION
This allows opening the cheats window while in editor mode. Some tabs and options are disabled because they are not relevant to these modes.