### PR TITLE
Fix #12401: Refactor SCALE_QUALITY to use strong enum

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -555,7 +555,7 @@ public:
         {
             scaleQuality = ScaleQuality::Linear;
         }
-        snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", scaleQuality);
+        snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", static_cast<int32_t>(_scaleQuality));
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQualityBuffer);
 
         int32_t width, height;

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -551,11 +551,11 @@ public:
         }
 
         ScaleQuality scaleQuality = _scaleQuality;
-        if (_scaleQuality == ScaleQuality::SmoothNN)
+        if (_scaleQuality == ScaleQuality::SmoothNearestNeighbour)
         {
             scaleQuality = ScaleQuality::Linear;
         }
-        snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", static_cast<int32_t>(_scaleQuality));
+        snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", static_cast<int32_t>(scaleQuality));
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQualityBuffer);
 
         int32_t width, height;

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -72,7 +72,7 @@ private:
     SDL_Window* _window = nullptr;
     int32_t _width = 0;
     int32_t _height = 0;
-    ScaleQuality _scaleQuality = ScaleQuality::NN;
+    ScaleQuality _scaleQuality = ScaleQuality::NearestNeighbour;
 
     std::vector<Resolution> _fsResolutions;
 
@@ -547,7 +547,7 @@ public:
         _scaleQuality = gConfigGeneral.scale_quality;
         if (gConfigGeneral.window_scale == std::floor(gConfigGeneral.window_scale))
         {
-            _scaleQuality = ScaleQuality::NN;
+            _scaleQuality = ScaleQuality::NearestNeighbour;
         }
 
         ScaleQuality scaleQuality = _scaleQuality;

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -72,7 +72,7 @@ private:
     SDL_Window* _window = nullptr;
     int32_t _width = 0;
     int32_t _height = 0;
-    int32_t _scaleQuality = 0;
+    ScaleQuality _scaleQuality = ScaleQuality::NN;
 
     std::vector<Resolution> _fsResolutions;
 
@@ -155,7 +155,7 @@ public:
         return _height;
     }
 
-    int32_t GetScaleQuality() override
+    ScaleQuality GetScaleQuality() override
     {
         return _scaleQuality;
     }
@@ -547,13 +547,13 @@ public:
         _scaleQuality = gConfigGeneral.scale_quality;
         if (gConfigGeneral.window_scale == std::floor(gConfigGeneral.window_scale))
         {
-            _scaleQuality = SCALE_QUALITY_NN;
+            _scaleQuality = ScaleQuality::NN;
         }
 
-        int32_t scaleQuality = _scaleQuality;
-        if (_scaleQuality == SCALE_QUALITY_SMOOTH_NN)
+        ScaleQuality scaleQuality = _scaleQuality;
+        if (_scaleQuality == ScaleQuality::SmoothNN)
         {
-            scaleQuality = SCALE_QUALITY_LINEAR;
+            scaleQuality = ScaleQuality::Linear;
         }
         snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", scaleQuality);
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQualityBuffer);

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -115,10 +115,10 @@ public:
             }
         }
 
-        int32_t scaleQuality = GetContext()->GetUiContext()->GetScaleQuality();
-        if (scaleQuality == SCALE_QUALITY_SMOOTH_NN)
+        ScaleQuality scaleQuality = GetContext()->GetUiContext()->GetScaleQuality();
+        if (scaleQuality == ScaleQuality::SmoothNN)
         {
-            scaleQuality = SCALE_QUALITY_LINEAR;
+            scaleQuality = ScaleQuality::Linear;
             smoothNN = true;
         }
         else

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -134,7 +134,7 @@ public:
             }
 
             char scaleQualityBuffer[4];
-            snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", scaleQuality);
+            snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%u", static_cast<int32_t>(scaleQuality));
             SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
             _screenTexture = SDL_CreateTexture(_sdlRenderer, pixelFormat, SDL_TEXTUREACCESS_STREAMING, width, height);
             SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQualityBuffer);

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -116,7 +116,7 @@ public:
         }
 
         ScaleQuality scaleQuality = GetContext()->GetUiContext()->GetScaleQuality();
-        if (scaleQuality == ScaleQuality::SmoothNN)
+        if (scaleQuality == ScaleQuality::SmoothNearestNeighbour)
         {
             scaleQuality = ScaleQuality::Linear;
             smoothNN = true;

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -465,11 +465,11 @@ private:
             delete _smoothScaleFramebuffer;
             _smoothScaleFramebuffer = nullptr;
         }
-        if (GetContext()->GetUiContext()->GetScaleQuality() > 0)
+        if (GetContext()->GetUiContext()->GetScaleQuality() != ScaleQuality::NN)
         {
             _scaleFramebuffer = new OpenGLFramebuffer(_width, _height, false, false);
         }
-        if (GetContext()->GetUiContext()->GetScaleQuality() == SCALE_QUALITY_SMOOTH_NN)
+        if (GetContext()->GetUiContext()->GetScaleQuality() == ScaleQuality::SmoothNN)
         {
             uint32_t scale = std::ceil(gConfigGeneral.window_scale);
             _smoothScaleFramebuffer = new OpenGLFramebuffer(_width * scale, _height * scale, false, false);

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -465,7 +465,7 @@ private:
             delete _smoothScaleFramebuffer;
             _smoothScaleFramebuffer = nullptr;
         }
-        if (GetContext()->GetUiContext()->GetScaleQuality() != ScaleQuality::NN)
+        if (GetContext()->GetUiContext()->GetScaleQuality() != ScaleQuality::NearestNeighbour)
         {
             _scaleFramebuffer = new OpenGLFramebuffer(_width, _height, false, false);
         }

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -469,7 +469,7 @@ private:
         {
             _scaleFramebuffer = new OpenGLFramebuffer(_width, _height, false, false);
         }
-        if (GetContext()->GetUiContext()->GetScaleQuality() == ScaleQuality::SmoothNN)
+        if (GetContext()->GetUiContext()->GetScaleQuality() == ScaleQuality::SmoothNearestNeighbour)
         {
             uint32_t scale = std::ceil(gConfigGeneral.window_scale);
             _smoothScaleFramebuffer = new OpenGLFramebuffer(_width * scale, _height * scale, false, false);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1069,7 +1069,7 @@ static void window_options_mousedown(rct_window* w, rct_widgetindex widgetIndex,
                     window_options_show_dropdown(w, widget, 2);
 
                     // Note: offset by one to compensate for lack of NN option.
-                    dropdown_set_checked(gConfigGeneral.scale_quality - 1, true);
+                    dropdown_set_checked(static_cast<int32_t>(gConfigGeneral.scale_quality) - 1, true);
                     break;
             }
             break;
@@ -1367,9 +1367,9 @@ static void window_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                     break;
                 case WIDX_SCALE_QUALITY_DROPDOWN:
                     // Note: offset by one to compensate for lack of NN option.
-                    if ((dropdownIndex + 1) != gConfigGeneral.scale_quality)
+                    if (static_cast<ScaleQuality>(dropdownIndex + 1) != gConfigGeneral.scale_quality)
                     {
-                        gConfigGeneral.scale_quality = static_cast<uint8_t>(dropdownIndex) + 1;
+                        gConfigGeneral.scale_quality = static_cast<ScaleQuality>(dropdownIndex + 1);
                         config_save_default();
                         gfx_invalidate_screen();
                         context_trigger_resize();
@@ -1667,7 +1667,7 @@ static void window_options_invalidate(rct_window* w)
                                                                                                             .fullscreen_mode];
             window_options_display_widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[gConfigGeneral.drawing_engine];
             window_options_display_widgets[WIDX_SCALE_QUALITY].text = window_options_scale_quality_names
-                [gConfigGeneral.scale_quality - 1];
+                [static_cast<int32_t>(gConfigGeneral.scale_quality) - 1];
 
             break;
         }

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -93,10 +93,10 @@ namespace Config
         ConfigEnumEntry<TemperatureUnit>("FAHRENHEIT", TemperatureUnit::Fahrenheit),
     });
 
-    static const auto Enum_ScaleQuality = ConfigEnum<int32_t>({
-        ConfigEnumEntry<int32_t>("NEAREST_NEIGHBOUR", SCALE_QUALITY_NN),
-        ConfigEnumEntry<int32_t>("LINEAR", SCALE_QUALITY_LINEAR),
-        ConfigEnumEntry<int32_t>("SMOOTH_NEAREST_NEIGHBOUR", SCALE_QUALITY_SMOOTH_NN),
+    static const auto Enum_ScaleQuality = ConfigEnum<ScaleQuality>({
+        ConfigEnumEntry<ScaleQuality>("NEAREST_NEIGHBOUR", ScaleQuality::NN),
+        ConfigEnumEntry<ScaleQuality>("LINEAR", ScaleQuality::Linear),
+        ConfigEnumEntry<ScaleQuality>("SMOOTH_NEAREST_NEIGHBOUR", ScaleQuality::SmoothNN),
     });
 
     static const auto Enum_VirtualFloorStyle = ConfigEnum<int32_t>({
@@ -192,7 +192,7 @@ namespace Config
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);
             model->steam_overlay_pause = reader->GetBoolean("steam_overlay_pause", true);
             model->window_scale = reader->GetFloat("window_scale", platform_get_default_scale());
-            model->scale_quality = reader->GetEnum<int32_t>("scale_quality", SCALE_QUALITY_SMOOTH_NN, Enum_ScaleQuality);
+            model->scale_quality = reader->GetEnum<ScaleQuality>("scale_quality", ScaleQuality::SmoothNN, Enum_ScaleQuality);
             model->show_fps = reader->GetBoolean("show_fps", false);
             model->multithreading = reader->GetBoolean("multi_threading", false);
             model->trap_cursor = reader->GetBoolean("trap_cursor", false);
@@ -266,7 +266,7 @@ namespace Config
         writer->WriteBoolean("allow_loading_with_incorrect_checksum", model->allow_loading_with_incorrect_checksum);
         writer->WriteBoolean("steam_overlay_pause", model->steam_overlay_pause);
         writer->WriteFloat("window_scale", model->window_scale);
-        writer->WriteEnum<int32_t>("scale_quality", model->scale_quality, Enum_ScaleQuality);
+        writer->WriteEnum<ScaleQuality>("scale_quality", model->scale_quality, Enum_ScaleQuality);
         writer->WriteBoolean("show_fps", model->show_fps);
         writer->WriteBoolean("multi_threading", model->multithreading);
         writer->WriteBoolean("trap_cursor", model->trap_cursor);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -94,7 +94,7 @@ namespace Config
     });
 
     static const auto Enum_ScaleQuality = ConfigEnum<ScaleQuality>({
-        ConfigEnumEntry<ScaleQuality>("NEAREST_NEIGHBOUR", ScaleQuality::NN),
+        ConfigEnumEntry<ScaleQuality>("NEAREST_NEIGHBOUR", ScaleQuality::NearestNeighbour),
         ConfigEnumEntry<ScaleQuality>("LINEAR", ScaleQuality::Linear),
         ConfigEnumEntry<ScaleQuality>("SMOOTH_NEAREST_NEIGHBOUR", ScaleQuality::SmoothNN),
     });

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -96,7 +96,7 @@ namespace Config
     static const auto Enum_ScaleQuality = ConfigEnum<ScaleQuality>({
         ConfigEnumEntry<ScaleQuality>("NEAREST_NEIGHBOUR", ScaleQuality::NearestNeighbour),
         ConfigEnumEntry<ScaleQuality>("LINEAR", ScaleQuality::Linear),
-        ConfigEnumEntry<ScaleQuality>("SMOOTH_NEAREST_NEIGHBOUR", ScaleQuality::SmoothNN),
+        ConfigEnumEntry<ScaleQuality>("SMOOTH_NEAREST_NEIGHBOUR", ScaleQuality::SmoothNearestNeighbour),
     });
 
     static const auto Enum_VirtualFloorStyle = ConfigEnum<int32_t>({
@@ -192,7 +192,8 @@ namespace Config
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);
             model->steam_overlay_pause = reader->GetBoolean("steam_overlay_pause", true);
             model->window_scale = reader->GetFloat("window_scale", platform_get_default_scale());
-            model->scale_quality = reader->GetEnum<ScaleQuality>("scale_quality", ScaleQuality::SmoothNN, Enum_ScaleQuality);
+            model->scale_quality = reader->GetEnum<ScaleQuality>(
+                "scale_quality", ScaleQuality::SmoothNearestNeighbour, Enum_ScaleQuality);
             model->show_fps = reader->GetBoolean("show_fps", false);
             model->multithreading = reader->GetBoolean("multi_threading", false);
             model->trap_cursor = reader->GetBoolean("trap_cursor", false);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -219,7 +219,7 @@ enum class ScaleQuality : int32_t
 {
     NearestNeighbour,
     Linear,
-    SmoothNN
+    SmoothNearestNeighbour
 };
 
 enum MEASUREMENT_FORMAT

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -16,6 +16,7 @@
 #include <string>
 
 enum class TemperatureUnit : int32_t;
+enum class ScaleQuality : int32_t;
 
 struct GeneralConfiguration
 {
@@ -32,7 +33,7 @@ struct GeneralConfiguration
     int32_t fullscreen_height;
     float window_scale;
     int32_t drawing_engine;
-    int32_t scale_quality;
+    ScaleQuality scale_quality;
     bool uncap_fps;
     bool use_vsync;
     bool show_fps;
@@ -214,11 +215,11 @@ enum class TemperatureUnit : int32_t
     Fahrenheit
 };
 
-enum SCALE_QUALITY
+enum class ScaleQuality : int32_t
 {
-    SCALE_QUALITY_NN,
-    SCALE_QUALITY_LINEAR,
-    SCALE_QUALITY_SMOOTH_NN
+    NN, //Nearest Neighbour
+    Linear,
+    SmoothNN
 };
 
 enum MEASUREMENT_FORMAT

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -217,7 +217,7 @@ enum class TemperatureUnit : int32_t
 
 enum class ScaleQuality : int32_t
 {
-    NN, //Nearest Neighbour
+    NearestNeighbour,
     Linear,
     SmoothNN
 };

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -7,10 +7,10 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "../config/Config.h"
 #include "../drawing/X8DrawingEngine.h"
 #include "UiContext.h"
 #include "WindowManager.h"
-#include "../config/Config.h"
 
 using namespace OpenRCT2::Drawing;
 

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -10,6 +10,7 @@
 #include "../drawing/X8DrawingEngine.h"
 #include "UiContext.h"
 #include "WindowManager.h"
+#include "../config/Config.h"
 
 using namespace OpenRCT2::Drawing;
 
@@ -55,9 +56,9 @@ namespace OpenRCT2::Ui
         {
             return 0;
         }
-        int32_t GetScaleQuality() override
+        ScaleQuality GetScaleQuality() override
         {
-            return 0;
+            return ScaleQuality::NN;
         }
         void SetFullscreenMode(FULLSCREEN_MODE /*mode*/) override
         {

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -58,7 +58,7 @@ namespace OpenRCT2::Ui
         }
         ScaleQuality GetScaleQuality() override
         {
-            return ScaleQuality::NN;
+            return ScaleQuality::NearestNeighbour;
         }
         void SetFullscreenMode(FULLSCREEN_MODE /*mode*/) override
         {

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -12,6 +12,7 @@
 #include "../Context.h"
 #include "../common.h"
 #include "../interface/Cursors.h"
+#include "../config/Config.h"
 
 #include <memory>
 #include <string>
@@ -102,7 +103,7 @@ namespace OpenRCT2
             virtual void* GetWindow() abstract;
             virtual int32_t GetWidth() abstract;
             virtual int32_t GetHeight() abstract;
-            virtual int32_t GetScaleQuality() abstract;
+            virtual ScaleQuality GetScaleQuality() abstract;
             virtual void SetFullscreenMode(FULLSCREEN_MODE mode) abstract;
             virtual const std::vector<Resolution>& GetFullscreenResolutions() abstract;
             virtual bool HasFocus() abstract;

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -11,8 +11,8 @@
 
 #include "../Context.h"
 #include "../common.h"
-#include "../interface/Cursors.h"
 #include "../config/Config.h"
+#include "../interface/Cursors.h"
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
Moved to a new enum class ScaleQuality.

Closes #12401

Tested and everything seems to work the same as before.