### PR TITLE
Fix #7037: saving rides starting with sloped turn

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.3.0+ (in development)
 ------------------------------------------------------------------------
+- Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.
 - Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5366,9 +5366,12 @@ void ride_get_start_of_track(CoordsXYE* output)
         bool moveSlowIt = true;
         do
         {
+            // Because we are working backwards, begin_element is the section at the end of a piece of track, whereas
+            // begin_x and begin_y are the coordinates at the start of a piece of track, so we need to pass end_x and
+            // end_y
             CoordsXYE lastGood = {
-                /* .x = */ trackBeginEnd.begin_x,
-                /* .y = */ trackBeginEnd.begin_y,
+                /* .x = */ trackBeginEnd.end_x,
+                /* .y = */ trackBeginEnd.end_y,
                 /* .element = */ trackBeginEnd.begin_element,
             };
 


### PR DESCRIPTION
Fixed a bug in the save track code that would prevent a rollercoaster that started with a banked, sloped turn from being saved.

The `ride_get_start_of_track` function retrieves the coordinates and track element of the first piece of track. The coordinates it retrieves are of the first section of the first piece of track, but the z-location of the element it retrieves is for the last section of the first piece of track. This only affects a very small subset of track pieces: those with multiple sections and the starting z-position is different to the ending z-position - so essentially helixes and banked, sloped turns.

The `TrackDesign::CreateTrackDesignTrack` method passes the coordinates and z-position to `sub_6C683D` which finds the track position at those coordinates. Because the z-position was off, it couldn't find the track piece and so exits gracefully.

A lot of the above is an educated guess as I don't fully understand `how ride_get_start_of_track` works, but given how specific the z-position offsets needed to fix this are, I'm fairly confident that it's right. 