### PR TITLE
Fix wrong CCache version string

### DIFF
--- a/cmake/FindCCache.cmake
+++ b/cmake/FindCCache.cmake
@@ -9,8 +9,9 @@ if (CCache_EXECUTABLE)
         OUTPUT_VARIABLE CCache_VERSION_OUTPUT
     )
 
-    string(REGEX MATCH "version ([0-9]+\\.[0-9]+\\.[0-9]+)" CCache_VERSION_TEMP ${CCache_VERSION_OUTPUT})
-    set(CCache_VERSION "${CMAKE_MATCH_0}")
+    if (CCache_VERSION_OUTPUT MATCHES "version ([0-9]+\\.[0-9]+\\.[0-9]+)")
+        set(CCache_VERSION "${CMAKE_MATCH_1}")
+    endif ()
 endif (CCache_EXECUTABLE)
 
 find_package_handle_standard_args(CCache


### PR DESCRIPTION
Use CMAKE_MATCH_1 instead of CMAKE_MATCH_0 which holds the entire match.