### PR TITLE
Fix #12433 Refactor STAFF_TYPE to use strong enum

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -152,6 +152,7 @@ The following people are not part of the development team, but have been contrib
 * Łukasz Pękalski (Lukasz-Pe)
 * (quale)
 * Arran Ireland (ion232)
+* Ryan Bello (ryan-bello)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -613,7 +613,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
 
             auto clipCoords = ScreenCoordsXY{ 10, 19 };
 
-            if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
+            if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == StaffType::Entertainer)
             {
                 clipCoords.y += 3;
             }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -613,7 +613,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
 
             auto clipCoords = ScreenCoordsXY{ 10, 19 };
 
-            if (peep->AssignedPeepType == PeepType::Staff && peep->StaffType == STAFF_TYPE_ENTERTAINER)
+            if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
             {
                 clipCoords.y += 3;
             }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -908,7 +908,7 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
         return;
     }
 
-    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
+    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == StaffType::Entertainer)
         screenCoords.y++;
 
     int32_t animationFrame = g_peep_animation_entries[peep->SpriteType].sprite_animation->base_image + 1;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -908,7 +908,7 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
         return;
     }
 
-    if (peep->AssignedPeepType == PeepType::Staff && peep->StaffType == STAFF_TYPE_ENTERTAINER)
+    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
         screenCoords.y++;
 
     int32_t animationFrame = g_peep_animation_entries[peep->SpriteType].sprite_animation->base_image + 1;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -309,7 +309,7 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
                     if (peep->AssignedPeepType == PeepType::Staff)
                     {
                         sprite_type = peep->SpriteType;
-                        if (peep->StaffType == STAFF_TYPE_ENTERTAINER)
+                        if (peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
                         {
                             clipCoords.y += 3;
                         }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -309,7 +309,7 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
                     if (peep->AssignedPeepType == PeepType::Staff)
                     {
                         sprite_type = peep->SpriteType;
-                        if (peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
+                        if (peep->AssignedStaffType == StaffType::Entertainer)
                         {
                             clipCoords.y += 3;
                         }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4264,7 +4264,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 for (auto peep : EntityList<Staff>(EntityListId::Peep))
                 {
-                    if (peep->AssignedStaffType == STAFF_TYPE_MECHANIC)
+                    if (peep->AssignedStaffType == StaffType::Mechanic)
                     {
                         stringId = STR_CALLING_MECHANIC;
                         break;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4264,7 +4264,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 for (auto peep : EntityList<Staff>(EntityListId::Peep))
                 {
-                    if (peep->StaffType == STAFF_TYPE_MECHANIC)
+                    if (peep->AssignedStaffType == STAFF_TYPE_MECHANIC)
                     {
                         stringId = STR_CALLING_MECHANIC;
                         break;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -359,7 +359,7 @@ void window_staff_disable_widgets(rct_window* w)
     }
     uint64_t disabled_widgets = 0;
 
-    if (peep != nullptr && peep->StaffType == STAFF_TYPE_SECURITY)
+    if (peep != nullptr && peep->AssignedStaffType == STAFF_TYPE_SECURITY)
     {
         disabled_widgets |= (1 << WIDX_TAB_2);
     }
@@ -848,7 +848,7 @@ void window_staff_options_invalidate(rct_window* w)
     auto ft = Formatter::Common();
     peep->FormatNameTo(ft);
 
-    switch (peep->StaffType)
+    switch (peep->AssignedStaffType)
     {
         case STAFF_TYPE_ENTERTAINER:
             window_staff_options_widgets[WIDX_CHECKBOX_1].type = WWT_EMPTY;
@@ -1073,7 +1073,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    if (peep->AssignedPeepType == PeepType::Staff && peep->StaffType == STAFF_TYPE_ENTERTAINER)
+    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
         screenCoords.y++;
 
     int32_t ebx = g_peep_animation_entries[peep->SpriteType].sprite_animation->base_image + 1;
@@ -1149,7 +1149,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        Formatter::Common().Add<money32>(gStaffWageTable[peep->StaffType]);
+        Formatter::Common().Add<money32>(gStaffWageTable[peep->AssignedStaffType]);
         gfx_draw_string_left(dpi, STR_STAFF_STAT_WAGES, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
@@ -1157,7 +1157,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_draw_string_left(dpi, STR_STAFF_STAT_EMPLOYED_FOR, static_cast<void*>(&peep->TimeInPark), COLOUR_BLACK, screenCoords);
     screenCoords.y += LIST_ROW_HEIGHT;
 
-    switch (peep->StaffType)
+    switch (peep->AssignedStaffType)
     {
         case STAFF_TYPE_HANDYMAN:
             gfx_draw_string_left(

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -359,7 +359,7 @@ void window_staff_disable_widgets(rct_window* w)
     }
     uint64_t disabled_widgets = 0;
 
-    if (peep != nullptr && peep->AssignedStaffType == STAFF_TYPE_SECURITY)
+    if (peep != nullptr && peep->AssignedStaffType == StaffType::Security)
     {
         disabled_widgets |= (1 << WIDX_TAB_2);
     }
@@ -850,7 +850,7 @@ void window_staff_options_invalidate(rct_window* w)
 
     switch (peep->AssignedStaffType)
     {
-        case STAFF_TYPE_ENTERTAINER:
+        case StaffType::Entertainer:
             window_staff_options_widgets[WIDX_CHECKBOX_1].type = WWT_EMPTY;
             window_staff_options_widgets[WIDX_CHECKBOX_2].type = WWT_EMPTY;
             window_staff_options_widgets[WIDX_CHECKBOX_3].type = WWT_EMPTY;
@@ -859,7 +859,7 @@ void window_staff_options_invalidate(rct_window* w)
             window_staff_options_widgets[WIDX_COSTUME_BTN].type = WWT_BUTTON;
             window_staff_options_widgets[WIDX_COSTUME_BOX].text = StaffCostumeNames[peep->SpriteType - 4];
             break;
-        case STAFF_TYPE_HANDYMAN:
+        case StaffType::Handyman:
             window_staff_options_widgets[WIDX_CHECKBOX_1].type = WWT_CHECKBOX;
             window_staff_options_widgets[WIDX_CHECKBOX_1].text = STR_STAFF_OPTION_SWEEP_FOOTPATHS;
             window_staff_options_widgets[WIDX_CHECKBOX_2].type = WWT_CHECKBOX;
@@ -874,7 +874,7 @@ void window_staff_options_invalidate(rct_window* w)
                 (1 << WIDX_CHECKBOX_1) | (1 << WIDX_CHECKBOX_2) | (1 << WIDX_CHECKBOX_3) | (1 << WIDX_CHECKBOX_4));
             w->pressed_widgets |= peep->StaffOrders << WIDX_CHECKBOX_1;
             break;
-        case STAFF_TYPE_MECHANIC:
+        case StaffType::Mechanic:
             window_staff_options_widgets[WIDX_CHECKBOX_1].type = WWT_CHECKBOX;
             window_staff_options_widgets[WIDX_CHECKBOX_1].text = STR_INSPECT_RIDES;
             window_staff_options_widgets[WIDX_CHECKBOX_2].type = WWT_CHECKBOX;
@@ -886,8 +886,10 @@ void window_staff_options_invalidate(rct_window* w)
             w->pressed_widgets &= ~((1 << WIDX_CHECKBOX_1) | (1 << WIDX_CHECKBOX_2));
             w->pressed_widgets |= peep->StaffOrders << WIDX_CHECKBOX_1;
             break;
-        case STAFF_TYPE_SECURITY:
+        case StaffType::Security:
             // Security guards don't have an options screen.
+            break;
+        case StaffType::Count:
             break;
     }
 
@@ -1073,7 +1075,7 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
+    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == StaffType::Entertainer)
         screenCoords.y++;
 
     int32_t ebx = g_peep_animation_entries[peep->SpriteType].sprite_animation->base_image + 1;
@@ -1149,7 +1151,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        Formatter::Common().Add<money32>(gStaffWageTable[peep->AssignedStaffType]);
+        Formatter::Common().Add<money32>(gStaffWageTable[static_cast<uint8_t>(peep->AssignedStaffType)]);
         gfx_draw_string_left(dpi, STR_STAFF_STAT_WAGES, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
@@ -1159,7 +1161,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     switch (peep->AssignedStaffType)
     {
-        case STAFF_TYPE_HANDYMAN:
+        case StaffType::Handyman:
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_LAWNS_MOWN, static_cast<void*>(&peep->StaffLawnsMown), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
@@ -1173,13 +1175,17 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_BINS_EMPTIED, static_cast<void*>(&peep->StaffBinsEmptied), COLOUR_BLACK, screenCoords);
             break;
-        case STAFF_TYPE_MECHANIC:
+        case StaffType::Mechanic:
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_RIDES_INSPECTED, static_cast<void*>(&peep->StaffRidesInspected), COLOUR_BLACK,
                 screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
             gfx_draw_string_left(
                 dpi, STR_STAFF_STAT_RIDES_FIXED, static_cast<void*>(&peep->StaffRidesFixed), COLOUR_BLACK, screenCoords);
+            break;
+        case StaffType::Security:
+        case StaffType::Entertainer:
+        case StaffType::Count:
             break;
     }
 }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -192,7 +192,7 @@ void WindowStaffListRefresh()
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
         sprite_set_flashing(peep, false);
-        if (peep->StaffType != _windowStaffListSelectedTab)
+        if (peep->AssignedStaffType != _windowStaffListSelectedTab)
             continue;
         sprite_set_flashing(peep, true);
 
@@ -342,7 +342,7 @@ void window_staff_list_update(rct_window* w)
             {
                 sprite_set_flashing(peep, false);
 
-                if (peep->StaffType == _windowStaffListSelectedTab)
+                if (peep->AssignedStaffType == _windowStaffListSelectedTab)
                 {
                     sprite_set_flashing(peep, true);
                 }
@@ -378,7 +378,7 @@ static void window_staff_list_tooldown(rct_window* w, rct_widgetindex widgetInde
 
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            if (peep->StaffType != selectedPeepType)
+            if (peep->AssignedStaffType != selectedPeepType)
                 continue;
 
             if (isPatrolAreaSet)
@@ -726,7 +726,7 @@ void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
             }
 
             auto staffOrderIcon_x = nameColumnSize + 20;
-            if (peep->StaffType != 3)
+            if (peep->AssignedStaffType != 3)
             {
                 auto staffOrders = peep->StaffOrders;
                 auto staffOrderSprite = staffOrderBaseSprites[_windowStaffListSelectedTab];

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -192,7 +192,7 @@ void WindowStaffListRefresh()
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
         sprite_set_flashing(peep, false);
-        if (peep->AssignedStaffType != _windowStaffListSelectedTab)
+        if (static_cast<uint8_t>(peep->AssignedStaffType) != _windowStaffListSelectedTab)
             continue;
         sprite_set_flashing(peep, true);
 
@@ -230,9 +230,9 @@ static void window_staff_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
             break;
         case WIDX_STAFF_LIST_HIRE_BUTTON:
         {
-            STAFF_TYPE staffType = static_cast<STAFF_TYPE>(_windowStaffListSelectedTab);
+            StaffType staffType = static_cast<StaffType>(_windowStaffListSelectedTab);
             ENTERTAINER_COSTUME costume = ENTERTAINER_COSTUME_COUNT;
-            if (staffType == STAFF_TYPE_ENTERTAINER)
+            if (staffType == StaffType::Entertainer)
             {
                 costume = static_cast<ENTERTAINER_COSTUME>(window_staff_list_get_random_entertainer_costume());
             }
@@ -301,7 +301,8 @@ static void window_staff_list_mousedown(rct_window* w, rct_widgetindex widgetInd
             window_staff_list_cancel_tools(w);
             break;
         case WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER:
-            window_dropdown_show_colour(w, widget, w->colours[1], staff_get_colour(_windowStaffListSelectedTab));
+            window_dropdown_show_colour(
+                w, widget, w->colours[1], staff_get_colour(static_cast<StaffType>(_windowStaffListSelectedTab)));
             break;
     }
 }
@@ -314,7 +315,7 @@ static void window_staff_list_dropdown(rct_window* w, rct_widgetindex widgetInde
 {
     if (widgetIndex == WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER && dropdownIndex != -1)
     {
-        auto action = StaffSetColourAction(_windowStaffListSelectedTab, dropdownIndex);
+        auto action = StaffSetColourAction(static_cast<StaffType>(_windowStaffListSelectedTab), dropdownIndex);
         GameActions::Execute(&action);
     }
 }
@@ -342,7 +343,7 @@ void window_staff_list_update(rct_window* w)
             {
                 sprite_set_flashing(peep, false);
 
-                if (peep->AssignedStaffType == _windowStaffListSelectedTab)
+                if (static_cast<uint8_t>(peep->AssignedStaffType) == _windowStaffListSelectedTab)
                 {
                     sprite_set_flashing(peep, true);
                 }
@@ -371,14 +372,14 @@ static void window_staff_list_tooldown(rct_window* w, rct_widgetindex widgetInde
         if (footpathCoords.isNull())
             return;
 
-        bool isPatrolAreaSet = staff_is_patrol_area_set_for_type(static_cast<STAFF_TYPE>(selectedPeepType), footpathCoords);
+        bool isPatrolAreaSet = staff_is_patrol_area_set_for_type(static_cast<StaffType>(selectedPeepType), footpathCoords);
 
         Peep* closestPeep = nullptr;
         int32_t closestPeepDistance = std::numeric_limits<int32_t>::max();
 
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            if (peep->AssignedStaffType != selectedPeepType)
+            if (static_cast<uint8_t>(peep->AssignedStaffType) != selectedPeepType)
                 continue;
 
             if (isPatrolAreaSet)
@@ -529,7 +530,8 @@ void window_staff_list_invalidate(rct_window* w)
     if (tabIndex < 3)
     {
         window_staff_list_widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WWT_COLOURBTN;
-        auto spriteIdPalette = SPRITE_ID_PALETTE_COLOUR_1(static_cast<uint32_t>(staff_get_colour(tabIndex)));
+        auto spriteIdPalette = SPRITE_ID_PALETTE_COLOUR_1(
+            static_cast<uint32_t>(staff_get_colour(static_cast<StaffType>(tabIndex))));
         window_staff_list_widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].image = spriteIdPalette | IMAGE_TYPE_TRANSPARENT
             | SPR_PALETTE_BTN;
     }
@@ -726,7 +728,7 @@ void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
             }
 
             auto staffOrderIcon_x = nameColumnSize + 20;
-            if (peep->AssignedStaffType != 3)
+            if (peep->AssignedStaffType != StaffType::Entertainer)
             {
                 auto staffOrders = peep->StaffOrders;
                 auto staffOrderSprite = staffOrderBaseSprites[_windowStaffListSelectedTab];

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -184,7 +184,7 @@ private:
                 ++newStaffId;
                 for (auto searchPeep : EntityList<Staff>(EntityListId::Peep))
                 {
-                    if (searchPeep->StaffType != _staffType)
+                    if (searchPeep->AssignedStaffType != _staffType)
                         continue;
 
                     if (searchPeep->Id == newStaffId)
@@ -199,7 +199,7 @@ private:
             }
 
             newPeep->Id = newStaffId;
-            newPeep->StaffType = _staffType;
+            newPeep->AssignedStaffType = _staffType;
 
             PeepSpriteType spriteType = spriteTypes[_staffType];
             if (_staffType == STAFF_TYPE_ENTERTAINER)

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -54,15 +54,15 @@ DEFINE_GAME_ACTION(StaffHireNewAction, GAME_COMMAND_HIRE_NEW_STAFF_MEMBER, Staff
 {
 private:
     bool _autoPosition = false;
-    uint8_t _staffType = STAFF_TYPE::STAFF_TYPE_COUNT;
+    uint8_t _staffType = static_cast<uint8_t>(StaffType::Count);
     uint8_t _entertainerType = ENTERTAINER_COSTUME::ENTERTAINER_COSTUME_COUNT;
     uint32_t _staffOrders = 0;
 
 public:
     StaffHireNewAction() = default;
-    StaffHireNewAction(bool autoPosition, STAFF_TYPE staffType, ENTERTAINER_COSTUME entertainerType, uint32_t staffOrders)
+    StaffHireNewAction(bool autoPosition, StaffType staffType, ENTERTAINER_COSTUME entertainerType, uint32_t staffOrders)
         : _autoPosition(autoPosition)
-        , _staffType(staffType)
+        , _staffType(static_cast<uint8_t>(staffType))
         , _entertainerType(entertainerType)
         , _staffOrders(staffOrders)
     {
@@ -97,7 +97,7 @@ private:
 
         res->Expenditure = ExpenditureType::Wages;
 
-        if (_staffType >= STAFF_TYPE_COUNT)
+        if (_staffType >= static_cast<uint8_t>(StaffType::Count))
         {
             // Invalid staff type.
             log_error("Tried to use invalid staff type: %u", static_cast<uint32_t>(_staffType));
@@ -110,7 +110,7 @@ private:
             return MakeResult(GA_ERROR::NO_FREE_ELEMENTS, STR_TOO_MANY_PEOPLE_IN_GAME);
         }
 
-        if (_staffType == STAFF_TYPE_ENTERTAINER)
+        if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
         {
             if (_entertainerType >= ENTERTAINER_COSTUME_COUNT)
             {
@@ -184,7 +184,7 @@ private:
                 ++newStaffId;
                 for (auto searchPeep : EntityList<Staff>(EntityListId::Peep))
                 {
-                    if (searchPeep->AssignedStaffType != _staffType)
+                    if (static_cast<uint8_t>(searchPeep->AssignedStaffType) != _staffType)
                         continue;
 
                     if (searchPeep->Id == newStaffId)
@@ -199,10 +199,10 @@ private:
             }
 
             newPeep->Id = newStaffId;
-            newPeep->AssignedStaffType = _staffType;
+            newPeep->AssignedStaffType = static_cast<StaffType>(_staffType);
 
             PeepSpriteType spriteType = spriteTypes[_staffType];
-            if (_staffType == STAFF_TYPE_ENTERTAINER)
+            if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
             {
                 spriteType = static_cast<PeepSpriteType>(PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + _entertainerType);
             }
@@ -233,7 +233,7 @@ private:
             newPeep->PathfindGoal.z = 0xFF;
             newPeep->PathfindGoal.direction = INVALID_DIRECTION;
 
-            uint8_t colour = staff_get_colour(_staffType);
+            uint8_t colour = staff_get_colour(static_cast<StaffType>(_staffType));
             newPeep->TshirtColour = colour;
             newPeep->TrousersColour = colour;
 

--- a/src/openrct2/actions/StaffSetColourAction.hpp
+++ b/src/openrct2/actions/StaffSetColourAction.hpp
@@ -30,8 +30,8 @@ public:
     StaffSetColourAction()
     {
     }
-    StaffSetColourAction(uint8_t staffType, uint8_t colour)
-        : _staffType(staffType)
+    StaffSetColourAction(StaffType staffType, uint8_t colour)
+        : _staffType(static_cast<uint8_t>(staffType))
         , _colour(colour)
     {
     }
@@ -49,7 +49,8 @@ public:
 
     GameActionResult::Ptr Query() const override
     {
-        if (_staffType != STAFF_TYPE_HANDYMAN && _staffType != STAFF_TYPE_MECHANIC && _staffType != STAFF_TYPE_SECURITY)
+        auto staffType = static_cast<StaffType>(_staffType);
+        if (staffType != StaffType::Handyman && staffType != StaffType::Mechanic && staffType != StaffType::Security)
         {
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
         }
@@ -59,7 +60,7 @@ public:
     GameActionResult::Ptr Execute() const override
     {
         // Update global uniform colour property
-        if (!staff_set_colour(_staffType, _colour))
+        if (!staff_set_colour(static_cast<StaffType>(_staffType), _colour))
         {
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
         }
@@ -67,7 +68,7 @@ public:
         // Update each staff member's uniform
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            if (peep->AssignedStaffType == _staffType)
+            if (peep->AssignedStaffType == static_cast<StaffType>(_staffType))
             {
                 peep->TshirtColour = _colour;
                 peep->TrousersColour = _colour;

--- a/src/openrct2/actions/StaffSetColourAction.hpp
+++ b/src/openrct2/actions/StaffSetColourAction.hpp
@@ -67,7 +67,7 @@ public:
         // Update each staff member's uniform
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            if (peep->StaffType == _staffType)
+            if (peep->AssignedStaffType == _staffType)
             {
                 peep->TshirtColour = _colour;
                 peep->TrousersColour = _colour;

--- a/src/openrct2/actions/StaffSetOrdersAction.hpp
+++ b/src/openrct2/actions/StaffSetOrdersAction.hpp
@@ -54,7 +54,7 @@ public:
         }
 
         auto* staff = TryGetEntity<Staff>(_spriteIndex);
-        if (staff == nullptr || (staff->StaffType != STAFF_TYPE_HANDYMAN && staff->StaffType != STAFF_TYPE_MECHANIC))
+        if (staff == nullptr || (staff->AssignedStaffType != STAFF_TYPE_HANDYMAN && staff->AssignedStaffType != STAFF_TYPE_MECHANIC))
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);

--- a/src/openrct2/actions/StaffSetOrdersAction.hpp
+++ b/src/openrct2/actions/StaffSetOrdersAction.hpp
@@ -54,7 +54,8 @@ public:
         }
 
         auto* staff = TryGetEntity<Staff>(_spriteIndex);
-        if (staff == nullptr || (staff->AssignedStaffType != STAFF_TYPE_HANDYMAN && staff->AssignedStaffType != STAFF_TYPE_MECHANIC))
+        if (staff == nullptr
+            || (staff->AssignedStaffType != StaffType::Handyman && staff->AssignedStaffType != StaffType::Mechanic))
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -494,7 +494,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
                     console.WriteLineError("Invalid staff ID");
                     return 1;
                 }
-                if (staff->AssignedStaffType != STAFF_TYPE_ENTERTAINER)
+                if (staff->AssignedStaffType != StaffType::Entertainer)
                 {
                     console.WriteLineError("Specified staff is not entertainer");
                     return 1;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -439,7 +439,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
             {
                 auto name = peep->GetName();
                 console.WriteFormatLine(
-                    "staff id %03d type: %02u energy %03u name %s", peep->sprite_index, peep->StaffType, peep->Energy,
+                    "staff id %03d type: %02u energy %03u name %s", peep->sprite_index, peep->AssignedStaffType, peep->Energy,
                     name.c_str());
             }
         }
@@ -494,7 +494,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
                     console.WriteLineError("Invalid staff ID");
                     return 1;
                 }
-                if (staff->StaffType != STAFF_TYPE_ENTERTAINER)
+                if (staff->AssignedStaffType != STAFF_TYPE_ENTERTAINER)
                 {
                     console.WriteLineError("Specified staff is not entertainer");
                     return 1;

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -273,7 +273,7 @@ static bool award_is_deserved_best_staff(int32_t activeAwardTypes)
         if (peep->AssignedPeepType == PeepType::Staff)
         {
             staffCount++;
-            staffTypeFlags |= (1 << peep->StaffType);
+            staffTypeFlags |= (1 << peep->AssignedStaffType);
         }
         else
         {

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -273,7 +273,7 @@ static bool award_is_deserved_best_staff(int32_t activeAwardTypes)
         if (peep->AssignedPeepType == PeepType::Staff)
         {
             staffCount++;
-            staffTypeFlags |= (1 << peep->AssignedStaffType);
+            staffTypeFlags |= (1 << static_cast<uint8_t>(peep->AssignedStaffType));
         }
         else
         {

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -113,7 +113,7 @@ void finance_pay_wages()
 
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
-        finance_payment(gStaffWageTable[peep->StaffType] / 4, ExpenditureType::Wages);
+        finance_payment(gStaffWageTable[peep->AssignedStaffType] / 4, ExpenditureType::Wages);
     }
 }
 
@@ -248,7 +248,7 @@ void finance_update_daily_profit()
         // Staff costs
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            current_profit -= gStaffWageTable[peep->StaffType];
+            current_profit -= gStaffWageTable[peep->AssignedStaffType];
         }
 
         // Research costs

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -113,7 +113,7 @@ void finance_pay_wages()
 
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
-        finance_payment(gStaffWageTable[peep->AssignedStaffType] / 4, ExpenditureType::Wages);
+        finance_payment(gStaffWageTable[static_cast<uint8_t>(peep->AssignedStaffType)] / 4, ExpenditureType::Wages);
     }
 }
 
@@ -248,7 +248,7 @@ void finance_update_daily_profit()
         // Staff costs
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            current_profit -= gStaffWageTable[peep->AssignedStaffType];
+            current_profit -= gStaffWageTable[static_cast<uint8_t>(peep->AssignedStaffType)];
         }
 
         // Research costs

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -50,7 +50,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
             const auto peep = spr->As<Peep>();
             if (peep != nullptr)
             {
-                if (!(peep->AssignedPeepType == PeepType::Staff && peep->StaffType == STAFF_TYPE_HANDYMAN))
+                if (!(peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_HANDYMAN))
                 {
                     continue;
                 }

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -50,7 +50,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
             const auto peep = spr->As<Peep>();
             if (peep != nullptr)
             {
-                if (!(peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_HANDYMAN))
+                if (!(peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == StaffType::Handyman))
                 {
                     continue;
                 }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -912,7 +912,7 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
                 {
                     patrolColour = COLOUR_GREY;
                 }
-                staffType = staff->StaffType;
+                staffType = staff->AssignedStaffType;
             }
         }
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -912,11 +912,11 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
                 {
                     patrolColour = COLOUR_GREY;
                 }
-                staffType = staff->AssignedStaffType;
+                staffType = static_cast<uint8_t>(staff->AssignedStaffType);
             }
         }
 
-        if (staff_is_patrol_area_set_for_type(static_cast<STAFF_TYPE>(staffType), session->MapPosition))
+        if (staff_is_patrol_area_set_for_type(static_cast<StaffType>(staffType), session->MapPosition))
         {
             uint32_t imageId = 2618;
             int32_t patrolAreaBaseZ = tile_element->GetBaseZ();

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1095,11 +1095,11 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
                 {
                     patrolColour = COLOUR_GREY;
                 }
-                staffType = staff->AssignedStaffType;
+                staffType = static_cast<uint8_t>(staff->AssignedStaffType);
             }
         }
 
-        if (staff_is_patrol_area_set_for_type(static_cast<STAFF_TYPE>(staffType), session->MapPosition))
+        if (staff_is_patrol_area_set_for_type(static_cast<StaffType>(staffType), session->MapPosition))
         {
             assert(surfaceShape < std::size(byte_97B444));
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1095,7 +1095,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
                 {
                     patrolColour = COLOUR_GREY;
                 }
-                staffType = staff->StaffType;
+                staffType = staff->AssignedStaffType;
             }
         }
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -6277,7 +6277,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
 
     for (auto inner_peep : EntityList<Staff>(EntityListId::Peep))
     {
-        if (inner_peep->StaffType != STAFF_TYPE_SECURITY)
+        if (inner_peep->AssignedStaffType != STAFF_TYPE_SECURITY)
             continue;
 
         if (inner_peep->x == LOCATION_NULL)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -6277,7 +6277,7 @@ static void peep_update_walking_break_scenery(Peep* peep)
 
     for (auto inner_peep : EntityList<Staff>(EntityListId::Peep))
     {
-        if (inner_peep->AssignedStaffType != STAFF_TYPE_SECURITY)
+        if (inner_peep->AssignedStaffType != StaffType::Security)
             continue;
 
         if (inner_peep->x == LOCATION_NULL)

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -625,7 +625,7 @@ static void peep_pathfind_heuristic_search(
     }
 
     bool nextInPatrolArea = inPatrolArea;
-    if (peep->AssignedPeepType == PeepType::Staff && peep->StaffType == STAFF_TYPE_MECHANIC)
+    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_MECHANIC)
     {
         nextInPatrolArea = peep->AsStaff()->IsLocationInPatrol(loc.ToCoordsXY());
         if (inPatrolArea && !nextInPatrolArea)
@@ -1400,7 +1400,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
             uint8_t endDirectionList[16] = { 0 };
 
             bool inPatrolArea = false;
-            if (peep->AssignedPeepType == PeepType::Staff && peep->StaffType == STAFF_TYPE_MECHANIC)
+            if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_MECHANIC)
             {
                 /* Mechanics are the only staff type that
                  * pathfind to a destination. Determine if the

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -625,7 +625,7 @@ static void peep_pathfind_heuristic_search(
     }
 
     bool nextInPatrolArea = inPatrolArea;
-    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_MECHANIC)
+    if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == StaffType::Mechanic)
     {
         nextInPatrolArea = peep->AsStaff()->IsLocationInPatrol(loc.ToCoordsXY());
         if (inPatrolArea && !nextInPatrolArea)
@@ -1400,7 +1400,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
             uint8_t endDirectionList[16] = { 0 };
 
             bool inPatrolArea = false;
-            if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == STAFF_TYPE_MECHANIC)
+            if (peep->AssignedPeepType == PeepType::Staff && peep->AssignedStaffType == StaffType::Mechanic)
             {
                 /* Mechanics are the only staff type that
                  * pathfind to a destination. Determine if the

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1940,7 +1940,7 @@ void Peep::FormatNameTo(Formatter& ft) const
                 STR_ENTERTAINER_X,
             };
 
-            auto staffNameIndex = StaffType;
+            auto staffNameIndex = AssignedStaffType;
             if (staffNameIndex > sizeof(staffNames))
             {
                 staffNameIndex = 0;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1940,7 +1940,7 @@ void Peep::FormatNameTo(Formatter& ft) const
                 STR_ENTERTAINER_X,
             };
 
-            auto staffNameIndex = AssignedStaffType;
+            auto staffNameIndex = static_cast<uint8_t>(AssignedStaffType);
             if (staffNameIndex > sizeof(staffNames))
             {
                 staffNameIndex = 0;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -609,7 +609,7 @@ struct Peep : SpriteBase
     PeepType AssignedPeepType;
     union
     {
-        uint8_t StaffType;
+        uint8_t AssignedStaffType;
         uint8_t GuestNumRides;
     };
     uint8_t TshirtColour;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -60,6 +60,16 @@ enum class PeepType : uint8_t
     Invalid = 0xFF
 };
 
+enum class StaffType : uint8_t
+{
+    Handyman,
+    Mechanic,
+    Security,
+    Entertainer,
+
+    Count
+};
+
 enum PeepThoughtType : uint8_t
 {
     PEEP_THOUGHT_TYPE_CANT_AFFORD_0 = 0,      // "I can't afford"
@@ -609,7 +619,7 @@ struct Peep : SpriteBase
     PeepType AssignedPeepType;
     union
     {
-        uint8_t AssignedStaffType;
+        StaffType AssignedStaffType;
         uint8_t GuestNumRides;
     };
     uint8_t TshirtColour;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -47,7 +47,7 @@
  *
  * rct2: 0x00992A00
  */
-const money32 gStaffWageTable[STAFF_TYPE_COUNT] = {
+const money32 gStaffWageTable[static_cast<uint8_t>(StaffType::Count)] = {
     MONEY(50, 00), // Handyman
     MONEY(80, 00), // Mechanic
     MONEY(60, 00), // Security guard
@@ -72,8 +72,8 @@ const rct_string_id StaffCostumeNames[] = {
 
 // Every staff member has STAFF_PATROL_AREA_SIZE elements assigned to in this array, indexed by their StaffId
 // Additionally there is a patrol area for each staff type, which is the union of the patrols of all staff members of that type
-uint32_t gStaffPatrolAreas[(STAFF_MAX_COUNT + STAFF_TYPE_COUNT) * STAFF_PATROL_AREA_SIZE];
-uint8_t gStaffModes[STAFF_MAX_COUNT + STAFF_TYPE_COUNT];
+uint32_t gStaffPatrolAreas[(STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)) * STAFF_PATROL_AREA_SIZE];
+uint8_t gStaffModes[STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)];
 uint16_t gStaffDrawPatrolAreas;
 colour_t gStaffHandymanColour;
 colour_t gStaffMechanicColour;
@@ -94,7 +94,7 @@ void staff_reset_modes()
     for (int32_t i = 0; i < STAFF_MAX_COUNT; i++)
         gStaffModes[i] = STAFF_MODE_NONE;
 
-    for (int32_t i = STAFF_MAX_COUNT; i < (STAFF_MAX_COUNT + STAFF_TYPE_COUNT); i++)
+    for (int32_t i = STAFF_MAX_COUNT; i < (STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)); i++)
         gStaffModes[i] = STAFF_MODE_WALK;
 
     staff_update_greyed_patrol_areas();
@@ -103,7 +103,7 @@ void staff_reset_modes()
 /**
  * Hires a new staff member of the given type.
  */
-bool staff_hire_new_member(STAFF_TYPE staffType, ENTERTAINER_COSTUME entertainerType)
+bool staff_hire_new_member(StaffType staffType, ENTERTAINER_COSTUME entertainerType)
 {
     bool autoPosition = gConfigGeneral.auto_staff_placement;
     if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
@@ -113,7 +113,7 @@ bool staff_hire_new_member(STAFF_TYPE staffType, ENTERTAINER_COSTUME entertainer
 
     uint32_t staffOrders = 0;
 
-    if (staffType == STAFF_TYPE_HANDYMAN)
+    if (staffType == StaffType::Handyman)
     {
         staffOrders = STAFF_ORDERS_SWEEPING | STAFF_ORDERS_WATER_FLOWERS | STAFF_ORDERS_EMPTY_BINS;
         if (gConfigGeneral.handymen_mow_default)
@@ -121,7 +121,7 @@ bool staff_hire_new_member(STAFF_TYPE staffType, ENTERTAINER_COSTUME entertainer
             staffOrders |= STAFF_ORDERS_MOWING;
         }
     }
-    else if (staffType == STAFF_TYPE_MECHANIC)
+    else if (staffType == StaffType::Mechanic)
     {
         staffOrders = STAFF_ORDERS_INSPECT_RIDES | STAFF_ORDERS_FIX_RIDES;
     }
@@ -148,7 +148,7 @@ bool staff_hire_new_member(STAFF_TYPE staffType, ENTERTAINER_COSTUME entertainer
  */
 void staff_update_greyed_patrol_areas()
 {
-    for (int32_t staff_type = 0; staff_type < STAFF_TYPE_COUNT; ++staff_type)
+    for (int32_t staff_type = 0; staff_type < static_cast<uint8_t>(StaffType::Count); ++staff_type)
     {
         int32_t staffPatrolOffset = (staff_type + STAFF_MAX_COUNT) * STAFF_PATROL_AREA_SIZE;
         for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
@@ -158,7 +158,7 @@ void staff_update_greyed_patrol_areas()
 
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            if (peep->AssignedStaffType == staff_type)
+            if (static_cast<uint8_t>(peep->AssignedStaffType) == staff_type)
             {
                 int32_t peepPatrolOffset = peep->StaffId * STAFF_PATROL_AREA_SIZE;
                 for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
@@ -398,9 +398,9 @@ bool Staff::IsPatrolAreaSet(const CoordsXY& coords) const
     return staff_is_patrol_area_set(StaffId, coords);
 }
 
-bool staff_is_patrol_area_set_for_type(STAFF_TYPE type, const CoordsXY& coords)
+bool staff_is_patrol_area_set_for_type(StaffType type, const CoordsXY& coords)
 {
-    return staff_is_patrol_area_set(STAFF_MAX_COUNT + type, coords);
+    return staff_is_patrol_area_set(STAFF_MAX_COUNT + static_cast<uint8_t>(type), coords);
 }
 
 void staff_set_patrol_area(int32_t staffIndex, const CoordsXY& coords, bool value)
@@ -1075,13 +1075,13 @@ bool Staff::DoPathFinding()
 {
     switch (AssignedStaffType)
     {
-        case STAFF_TYPE_HANDYMAN:
+        case StaffType::Handyman:
             return DoHandymanPathFinding();
-        case STAFF_TYPE_MECHANIC:
+        case StaffType::Mechanic:
             return DoMechanicPathFinding();
-        case STAFF_TYPE_SECURITY:
+        case StaffType::Security:
             return DoMiscPathFinding();
-        case STAFF_TYPE_ENTERTAINER:
+        case StaffType::Entertainer:
             return DoEntertainerPathFinding();
 
         default:
@@ -1100,17 +1100,17 @@ void Staff::SetCostume(uint8_t value)
     SpriteType = static_cast<PeepSpriteType>(value + PEEP_SPRITE_TYPE_ENTERTAINER_PANDA);
 }
 
-colour_t staff_get_colour(uint8_t staffType)
+colour_t staff_get_colour(StaffType staffType)
 {
     switch (staffType)
     {
-        case STAFF_TYPE_HANDYMAN:
+        case StaffType::Handyman:
             return gStaffHandymanColour;
-        case STAFF_TYPE_MECHANIC:
+        case StaffType::Mechanic:
             return gStaffMechanicColour;
-        case STAFF_TYPE_SECURITY:
+        case StaffType::Security:
             return gStaffSecurityColour;
-        case STAFF_TYPE_ENTERTAINER:
+        case StaffType::Entertainer:
             return 0;
         default:
             assert(false);
@@ -1118,17 +1118,17 @@ colour_t staff_get_colour(uint8_t staffType)
     }
 }
 
-bool staff_set_colour(uint8_t staffType, colour_t value)
+bool staff_set_colour(StaffType staffType, colour_t value)
 {
     switch (staffType)
     {
-        case STAFF_TYPE_HANDYMAN:
+        case StaffType::Handyman:
             gStaffHandymanColour = value;
             break;
-        case STAFF_TYPE_MECHANIC:
+        case StaffType::Mechanic:
             gStaffMechanicColour = value;
             break;
-        case STAFF_TYPE_SECURITY:
+        case StaffType::Security:
             gStaffSecurityColour = value;
             break;
         default:
@@ -1828,7 +1828,7 @@ static int32_t peep_update_patrolling_find_sweeping(Peep* peep)
 
 void Staff::Tick128UpdateStaff()
 {
-    if (AssignedStaffType != STAFF_TYPE_SECURITY)
+    if (AssignedStaffType != StaffType::Security)
         return;
 
     PeepSpriteType newSpriteType = PEEP_SPRITE_TYPE_SECURITY_ALT;
@@ -1857,7 +1857,8 @@ void Staff::Tick128UpdateStaff()
 bool Staff::IsMechanic() const
 {
     return (
-        sprite_identifier == SPRITE_IDENTIFIER_PEEP && AssignedPeepType == PeepType::Staff && AssignedStaffType == STAFF_TYPE_MECHANIC);
+        sprite_identifier == SPRITE_IDENTIFIER_PEEP && AssignedPeepType == PeepType::Staff
+        && AssignedStaffType == StaffType::Mechanic);
 }
 
 void Staff::UpdateStaff(uint32_t stepsToTake)
@@ -1928,7 +1929,7 @@ void Staff::UpdatePatrolling()
         }
     }
 
-    if (AssignedStaffType != STAFF_TYPE_HANDYMAN)
+    if (AssignedStaffType != StaffType::Handyman)
         return;
 
     if (peep_update_patrolling_find_sweeping(this))

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -158,7 +158,7 @@ void staff_update_greyed_patrol_areas()
 
         for (auto peep : EntityList<Staff>(EntityListId::Peep))
         {
-            if (peep->StaffType == staff_type)
+            if (peep->AssignedStaffType == staff_type)
             {
                 int32_t peepPatrolOffset = peep->StaffId * STAFF_PATROL_AREA_SIZE;
                 for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
@@ -1073,7 +1073,7 @@ bool Staff::DoEntertainerPathFinding()
  */
 bool Staff::DoPathFinding()
 {
-    switch (StaffType)
+    switch (AssignedStaffType)
     {
         case STAFF_TYPE_HANDYMAN:
             return DoHandymanPathFinding();
@@ -1828,7 +1828,7 @@ static int32_t peep_update_patrolling_find_sweeping(Peep* peep)
 
 void Staff::Tick128UpdateStaff()
 {
-    if (StaffType != STAFF_TYPE_SECURITY)
+    if (AssignedStaffType != STAFF_TYPE_SECURITY)
         return;
 
     PeepSpriteType newSpriteType = PEEP_SPRITE_TYPE_SECURITY_ALT;
@@ -1857,7 +1857,7 @@ void Staff::Tick128UpdateStaff()
 bool Staff::IsMechanic() const
 {
     return (
-        sprite_identifier == SPRITE_IDENTIFIER_PEEP && AssignedPeepType == PeepType::Staff && StaffType == STAFF_TYPE_MECHANIC);
+        sprite_identifier == SPRITE_IDENTIFIER_PEEP && AssignedPeepType == PeepType::Staff && AssignedStaffType == STAFF_TYPE_MECHANIC);
 }
 
 void Staff::UpdateStaff(uint32_t stepsToTake)
@@ -1928,7 +1928,7 @@ void Staff::UpdatePatrolling()
         }
     }
 
-    if (StaffType != STAFF_TYPE_HANDYMAN)
+    if (AssignedStaffType != STAFF_TYPE_HANDYMAN)
         return;
 
     if (peep_update_patrolling_find_sweeping(this))

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -25,16 +25,6 @@ enum STAFF_MODE
     STAFF_MODE_PATROL = 3
 };
 
-enum STAFF_TYPE : uint8_t
-{
-    STAFF_TYPE_HANDYMAN,
-    STAFF_TYPE_MECHANIC,
-    STAFF_TYPE_SECURITY,
-    STAFF_TYPE_ENTERTAINER,
-
-    STAFF_TYPE_COUNT
-};
-
 enum STAFF_ORDERS
 {
     STAFF_ORDERS_SWEEPING = (1 << 0),
@@ -62,12 +52,12 @@ enum ENTERTAINER_COSTUME : uint8_t
     ENTERTAINER_COSTUME_COUNT
 };
 
-extern const money32 gStaffWageTable[STAFF_TYPE_COUNT];
+extern const money32 gStaffWageTable[static_cast<uint8_t>(StaffType::Count)];
 
 extern const rct_string_id StaffCostumeNames[ENTERTAINER_COSTUME_COUNT];
 
-extern uint32_t gStaffPatrolAreas[(STAFF_MAX_COUNT + STAFF_TYPE_COUNT) * STAFF_PATROL_AREA_SIZE];
-extern uint8_t gStaffModes[STAFF_MAX_COUNT + STAFF_TYPE_COUNT];
+extern uint32_t gStaffPatrolAreas[(STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)) * STAFF_PATROL_AREA_SIZE];
+extern uint8_t gStaffModes[STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)];
 extern uint16_t gStaffDrawPatrolAreas;
 extern colour_t gStaffHandymanColour;
 extern colour_t gStaffMechanicColour;
@@ -75,16 +65,16 @@ extern colour_t gStaffSecurityColour;
 
 void staff_reset_modes();
 void staff_set_name(uint16_t spriteIndex, const char* name);
-bool staff_hire_new_member(STAFF_TYPE staffType, ENTERTAINER_COSTUME entertainerType);
+bool staff_hire_new_member(StaffType staffType, ENTERTAINER_COSTUME entertainerType);
 void staff_update_greyed_patrol_areas();
 bool staff_is_location_on_patrol_edge(Peep* mechanic, const CoordsXY& loc);
 bool staff_can_ignore_wide_flag(Peep* mechanic, const CoordsXYZ& staffPos, TileElement* path);
 void staff_reset_stats();
-bool staff_is_patrol_area_set_for_type(STAFF_TYPE type, const CoordsXY& coords);
+bool staff_is_patrol_area_set_for_type(StaffType type, const CoordsXY& coords);
 void staff_set_patrol_area(int32_t staffIndex, const CoordsXY& coords, bool value);
 void staff_toggle_patrol_area(int32_t staffIndex, const CoordsXY& coords);
-colour_t staff_get_colour(uint8_t staffType);
-bool staff_set_colour(uint8_t staffType, colour_t value);
+colour_t staff_get_colour(StaffType staffType);
+bool staff_set_colour(StaffType staffType, colour_t value);
 uint32_t staff_get_available_entertainer_costumes();
 int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList);
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1124,7 +1124,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
                 STR_SECURITY_GUARD_X,
                 STR_ENTERTAINER_X,
             };
-            dst->name_string_idx = staffNames[src->AssignedStaffType % sizeof(staffNames)];
+            dst->name_string_idx = staffNames[static_cast<uint8_t>(src->AssignedStaffType) % sizeof(staffNames)];
         }
         else if (gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1124,7 +1124,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
                 STR_SECURITY_GUARD_X,
                 STR_ENTERTAINER_X,
             };
-            dst->name_string_idx = staffNames[src->StaffType % sizeof(staffNames)];
+            dst->name_string_idx = staffNames[src->AssignedStaffType % sizeof(staffNames)];
         }
         else if (gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2700,7 +2700,7 @@ Peep* find_closest_mechanic(const CoordsXY& entrancePosition, int32_t forInspect
 
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
-        if (peep->StaffType != STAFF_TYPE_MECHANIC)
+        if (peep->AssignedStaffType != STAFF_TYPE_MECHANIC)
             continue;
 
         if (!forInspection)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2700,7 +2700,7 @@ Peep* find_closest_mechanic(const CoordsXY& entrancePosition, int32_t forInspect
 
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
-        if (peep->AssignedStaffType != STAFF_TYPE_MECHANIC)
+        if (peep->AssignedStaffType != StaffType::Mechanic)
             continue;
 
         if (!forInspection)

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1087,14 +1087,16 @@ namespace OpenRCT2::Scripting
             {
                 switch (peep->AssignedStaffType)
                 {
-                    case STAFF_TYPE_HANDYMAN:
+                    case StaffType::Handyman:
                         return "handyman";
-                    case STAFF_TYPE_MECHANIC:
+                    case StaffType::Mechanic:
                         return "mechanic";
-                    case STAFF_TYPE_SECURITY:
+                    case StaffType::Security:
                         return "security";
-                    case STAFF_TYPE_ENTERTAINER:
+                    case StaffType::Entertainer:
                         return "entertainer";
+                    case StaffType::Count:
+                        break;
                 }
             }
             return "";
@@ -1106,24 +1108,24 @@ namespace OpenRCT2::Scripting
             auto peep = GetStaff();
             if (peep != nullptr)
             {
-                if (value == "handyman" && peep->AssignedStaffType != STAFF_TYPE_HANDYMAN)
+                if (value == "handyman" && peep->AssignedStaffType != StaffType::Handyman)
                 {
-                    peep->AssignedStaffType = STAFF_TYPE_HANDYMAN;
+                    peep->AssignedStaffType = StaffType::Handyman;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_HANDYMAN;
                 }
-                else if (value == "mechanic" && peep->AssignedStaffType != STAFF_TYPE_MECHANIC)
+                else if (value == "mechanic" && peep->AssignedStaffType != StaffType::Mechanic)
                 {
-                    peep->AssignedStaffType = STAFF_TYPE_MECHANIC;
+                    peep->AssignedStaffType = StaffType::Mechanic;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_MECHANIC;
                 }
-                else if (value == "security" && peep->AssignedStaffType != STAFF_TYPE_SECURITY)
+                else if (value == "security" && peep->AssignedStaffType != StaffType::Security)
                 {
-                    peep->AssignedStaffType = STAFF_TYPE_SECURITY;
+                    peep->AssignedStaffType = StaffType::Security;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_SECURITY;
                 }
-                else if (value == "entertainer" && peep->AssignedStaffType != STAFF_TYPE_ENTERTAINER)
+                else if (value == "entertainer" && peep->AssignedStaffType != StaffType::Entertainer)
                 {
-                    peep->AssignedStaffType = STAFF_TYPE_ENTERTAINER;
+                    peep->AssignedStaffType = StaffType::Entertainer;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_ENTERTAINER_PANDA;
                 }
             }
@@ -1149,7 +1151,7 @@ namespace OpenRCT2::Scripting
         uint8_t costume_get() const
         {
             auto peep = GetStaff();
-            if (peep != nullptr && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
+            if (peep != nullptr && peep->AssignedStaffType == StaffType::Entertainer)
             {
                 return peep->GetCostume();
             }

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1085,7 +1085,7 @@ namespace OpenRCT2::Scripting
             auto peep = GetStaff();
             if (peep != nullptr)
             {
-                switch (peep->StaffType)
+                switch (peep->AssignedStaffType)
                 {
                     case STAFF_TYPE_HANDYMAN:
                         return "handyman";
@@ -1106,24 +1106,24 @@ namespace OpenRCT2::Scripting
             auto peep = GetStaff();
             if (peep != nullptr)
             {
-                if (value == "handyman" && peep->StaffType != STAFF_TYPE_HANDYMAN)
+                if (value == "handyman" && peep->AssignedStaffType != STAFF_TYPE_HANDYMAN)
                 {
-                    peep->StaffType = STAFF_TYPE_HANDYMAN;
+                    peep->AssignedStaffType = STAFF_TYPE_HANDYMAN;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_HANDYMAN;
                 }
-                else if (value == "mechanic" && peep->StaffType != STAFF_TYPE_MECHANIC)
+                else if (value == "mechanic" && peep->AssignedStaffType != STAFF_TYPE_MECHANIC)
                 {
-                    peep->StaffType = STAFF_TYPE_MECHANIC;
+                    peep->AssignedStaffType = STAFF_TYPE_MECHANIC;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_MECHANIC;
                 }
-                else if (value == "security" && peep->StaffType != STAFF_TYPE_SECURITY)
+                else if (value == "security" && peep->AssignedStaffType != STAFF_TYPE_SECURITY)
                 {
-                    peep->StaffType = STAFF_TYPE_SECURITY;
+                    peep->AssignedStaffType = STAFF_TYPE_SECURITY;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_SECURITY;
                 }
-                else if (value == "entertainer" && peep->StaffType != STAFF_TYPE_ENTERTAINER)
+                else if (value == "entertainer" && peep->AssignedStaffType != STAFF_TYPE_ENTERTAINER)
                 {
-                    peep->StaffType = STAFF_TYPE_ENTERTAINER;
+                    peep->AssignedStaffType = STAFF_TYPE_ENTERTAINER;
                     peep->SpriteType = PeepSpriteType::PEEP_SPRITE_TYPE_ENTERTAINER_PANDA;
                 }
             }
@@ -1149,7 +1149,7 @@ namespace OpenRCT2::Scripting
         uint8_t costume_get() const
         {
             auto peep = GetStaff();
-            if (peep != nullptr && peep->StaffType == STAFF_TYPE_ENTERTAINER)
+            if (peep != nullptr && peep->AssignedStaffType == STAFF_TYPE_ENTERTAINER)
             {
                 return peep->GetCostume();
             }


### PR DESCRIPTION
Changed to a strongly typed enum called StaffType.

To prevent conflict and confusion with peep->StaffType, I renamed it to peep->AssignedStaffType

Tested and works fine.