### PR TITLE
Remove full stop from localisation workflow commit message

### DIFF
--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -36,7 +36,7 @@ jobs:
               git add .
               git config --global user.name "OpenRCT2 git bot"
               git config --global user.email "gitbot@openrct2.org"
-              git commit -m "Merge Localisation/master into OpenRCT2/develop."
+              git commit -m "Merge Localisation/master into OpenRCT2/develop"
               git push
               echo "Complete"
           else


### PR DESCRIPTION
The OpenRCT2 commit guidelines actively discourage people from using a full stop in their commit messages. Let's apply the same principle to our OpenRCT2 Localisation Bot. :wink: