### PR TITLE
Fix #12701 Disable upgrade pop-up at slient install

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.
+- Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway
 
 0.3.0 (2020-08-15)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.
-- Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway
+- Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.
 
 0.3.0 (2020-08-15)
 ------------------------------------------------------------------------

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -499,6 +499,7 @@ Function .onInit
     SectionSetFlags 0 17
 
 ShowWelcomeMessage:
+    IfSilent FinishCallback
     ReadRegStr $R8 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OpenRCT2" "Version"
     IfErrors FinishCallback
 


### PR DESCRIPTION
If slient mode is activate, ignore previous version check and jump to FinishCallback.

Processor architecture warning(Installing 32bit version at 64bit windows, or vice versa) will still be shown since It's recommended to install 64bit version if windows version is 64bit, and installing 64bit version at  32bit windows will not work.