### PR TITLE
Fix #400: unable to place some saved tracks flush to the the ground (original bug)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.3.0+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#10807] Add 2x and 4x zoom levels (currently limited to OpenGL).
+- Fix: [#400] Unable to place some saved tracks flush to the ground (original bug).
 - Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -198,12 +198,13 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
     z = newCoords->z;
 
     const rct_track_coordinates* trackCoordinates = &TrackCoordinates[trackElement.element->AsTrack()->GetTrackType()];
+    auto trackBlock = get_track_def_from_ride_index(trackElement.element->AsTrack()->GetRideIndex(), trackType);
     // Used in the following loop to know when we have
     // completed all of the elements and are back at the
     // start.
     TileElement* initialMap = trackElement.element;
 
-    CoordsXYZ startPos = { trackElement.x, trackElement.y, z + trackCoordinates->z_begin };
+    CoordsXYZ startPos = { trackElement.x, trackElement.y, z + trackCoordinates->z_begin - trackBlock->z };
     _trackPreviewOrigin = startPos;
 
     do


### PR DESCRIPTION
A bug in the save track code meant that the z-position of the entrance and exit of rides starting with a complex piece (helix, banked sloped turns, etc.) was below the track. When loading a saved track, the origin used is from the start of the first section of the first track piece, but the track saving code was not taking into account the offset of the first track section. This resulted in the entrance and exit being below the track, forcing the track up from the ground when placing the track, as well as the entrance and exit not being placed.

Fixes issue #400. Somewhat dependent on #12676 since you cannot test this without being able to save tracks starting with helixes/banked turns. 