### PR TITLE
Fix #12728: Paths made in scenario editor don't connect to the map edge

### DIFF
--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -837,6 +837,7 @@ static void loc_6A6D7E(
         {
             neighbour_list_push(neighbourList, 7, direction, 255, 255);
         }
+        loc_6A6FD2(initialTileElementPos, direction, initialTileElement, query);
     }
     else
     {


### PR DESCRIPTION
Fix bug introduced in #12366 that prevented making paths to the edge of the map in the scenario editor. A function call was missed in the original refactor.