### PR TITLE
Fix #12737: Space Rings draw the same vehicle 4 times

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.
 - Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.
+- Fix: [#12737] Space Rings draw the same vehicle 4 times.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 
 0.3.0 (2020-08-15)

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -44,7 +44,7 @@ static void paint_space_rings_structure(paint_session* session, Ride* ride, uint
         int32_t frameNum = direction;
 
         uint32_t baseImageId = rideEntry->vehicles[0].base_image_id;
-        auto vehicle = GetEntity<Vehicle>(ride->vehicles[0]);
+        auto vehicle = GetEntity<Vehicle>(ride->vehicles[vehicleIndex]);
         if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
         {
             session->InteractionType = VIEWPORT_INTERACTION_ITEM_SPRITE;


### PR DESCRIPTION
paint_space_rings_structure always used vehicle 0 for it's vehicle reference