### PR TITLE
Reset sprite spatial index on all inits

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -571,9 +571,8 @@ void game_load_init()
     if (network_get_mode() != NETWORK_MODE_CLIENT)
     {
         GameActions::ClearQueue();
-        reset_sprite_spatial_index();
     }
-    reset_all_sprite_quadrant_placements();
+    reset_sprite_spatial_index();
     scenery_set_default_placement_configuration();
 
     auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);


### PR DESCRIPTION
Not sure what I was thinking of course this is needed. We reset the spatial index to 0xFFFF prior to loading the entities so of course we need to refill it with information after loading the entities.
Will get rid of that error on load of multiplayer games.