### PR TITLE
GitHub CI: use Release configuration for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Build OpenRCT2
         run: |
           . scripts/setenv
-          xcodebuild
+          xcodebuild -configuration Release
           mkdir -p artifacts
           mv build/Release/OpenRCT2.app artifacts
           echo -e "\033[0;36mCompressing OpenRCT2.app...\033[0m"


### PR DESCRIPTION
Instead of using the release configuration, the macOS version of v0.3.0 is a debug build. This changes the GitHub CI such that `xcodebuild` generates release builds instead.