### PR TITLE
Fix #12764: Rides don't start aged anymore

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Fix: [#12694] Crash when switching ride types with construction window open.
 - Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.
 - Fix: [#12737] Space Rings draw the same vehicle 4 times.
+- Fix: [#12764] Rides don't start aged anymore.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 
 0.3.0 (2020-08-15)

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -742,7 +742,7 @@ static void window_finances_summary_scrollpaint(rct_window* w, rct_drawpixelinfo
     }
 
     // Expenditure / Income values for each month
-    int16_t currentMonthYear = gDateMonthsElapsed;
+    int16_t currentMonthYear = static_cast<int16_t>(gDateMonthsElapsed);
     for (int32_t i = summary_max_available_month(); i >= 0; i--)
     {
         screenCoords.y = 0;

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -276,7 +276,7 @@ void GameState::UpdateLogic()
 #endif
 
     date_update();
-    _date = Date(gDateMonthsElapsed, gDateMonthTicks);
+    _date = Date(static_cast<uint32_t>(gDateMonthsElapsed), gDateMonthTicks);
 
     scenario_update();
     climate_update();

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -286,7 +286,7 @@ public:
         ride->num_riders = 0;
         ride->slide_in_use = 0;
         ride->maze_tiles = 0;
-        ride->build_date = static_cast<int32_t>(gDateMonthsElapsed);
+        ride->build_date = gDateMonthsElapsed;
         ride->music_tune_id = 255;
 
         ride->breakdown_reason = 255;

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -286,7 +286,7 @@ public:
         ride->num_riders = 0;
         ride->slide_in_use = 0;
         ride->maze_tiles = 0;
-        ride->build_date = gDateMonthsElapsed;
+        ride->build_date = static_cast<int32_t>(gDateMonthsElapsed);
         ride->music_tune_id = 255;
 
         ride->breakdown_reason = 255;

--- a/src/openrct2/localisation/Date.h
+++ b/src/openrct2/localisation/Date.h
@@ -48,7 +48,7 @@ extern const rct_string_id DateFormatStringIds[];
 extern const rct_string_id DateFormatStringFormatIds[];
 
 extern uint16_t gDateMonthTicks;
-extern uint16_t gDateMonthsElapsed;
+extern int32_t gDateMonthsElapsed;
 
 extern openrct2_timeofday gRealTimeOfDay;
 

--- a/src/openrct2/localisation/Localisation.Date.cpp
+++ b/src/openrct2/localisation/Localisation.Date.cpp
@@ -15,7 +15,7 @@
 #include <time.h>
 
 uint16_t gDateMonthTicks;
-uint16_t gDateMonthsElapsed;
+int32_t gDateMonthsElapsed;
 
 // rct2: 0x00993988
 const int16_t days_in_month[MONTH_COUNT] = { 31, 30, 31, 30, 31, 31, 30, 31 };

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -318,7 +318,7 @@ News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t
     newsItem->Flags = 0;
     newsItem->Assoc = assoc;
     newsItem->Ticks = 0;
-    newsItem->MonthYear = gDateMonthsElapsed;
+    newsItem->MonthYear = static_cast<uint16_t>(gDateMonthsElapsed);
     newsItem->Day = ((days_in_month[date_get_month(newsItem->MonthYear)] * gDateMonthTicks) >> 16) + 1;
     safe_strcpy(newsItem->Text, text, sizeof(newsItem->Text));
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -176,7 +176,7 @@ struct rct1_ride
     uint8_t pad_11F[0x7];              // 0x11F
     uint8_t spiral_slide_progress;     // 0x126
     uint8_t pad_127[0x9];              // 0x127
-    uint16_t build_date;               // 0x130
+    int16_t build_date;                // 0x130
     money16 upkeep_cost;               // 0x131
     uint16_t race_winner;              // 0x132
     uint8_t unk_134[2];                // 0x134

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -875,7 +875,7 @@ private:
         SetRideColourScheme(dst, src);
 
         // Maintenance
-        dst->build_date = src->build_date;
+        dst->build_date = static_cast<int32_t>(src->build_date);
         dst->inspection_interval = src->inspection_interval;
         dst->last_inspection = src->last_inspection;
         dst->reliability = src->reliability;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2523,7 +2523,7 @@ private:
         // Date and srand
         gScenarioTicks = _s4.ticks;
         scenario_rand_seed(_s4.random_a, _s4.random_b);
-        gDateMonthsElapsed = _s4.month;
+        gDateMonthsElapsed = static_cast<int32_t>(_s4.month);
         gDateMonthTicks = _s4.day;
 
         // Park rating

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -256,7 +256,7 @@ struct rct2_ride
     uint8_t pad_16F[0x7];              // 0x16F
     uint8_t spiral_slide_progress;     // 0x176
     uint8_t pad_177[0x9];              // 0x177
-    uint16_t build_date;               // 0x180
+    int16_t build_date;                // 0x180
     money16 upkeep_cost;               // 0x182
     uint16_t race_winner;              // 0x184
     uint8_t pad_186[0x02];             // 0x186

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -703,7 +703,7 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     // pad_16F[0x7];
     dst->spiral_slide_progress = src->spiral_slide_progress;
     // pad_177[0x9];
-    dst->build_date = src->build_date;
+    dst->build_date = static_cast<int16_t>(src->build_date);
     dst->upkeep_cost = src->upkeep_cost;
     dst->race_winner = src->race_winner;
     // pad_186[0x02];

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -186,7 +186,7 @@ void S6Exporter::Export()
         }
     }
 
-    _s6.elapsed_months = gDateMonthsElapsed;
+    _s6.elapsed_months = static_cast<uint16_t>(gDateMonthsElapsed);
     _s6.current_day = gDateMonthTicks;
     _s6.scenario_ticks = gScenarioTicks;
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -718,7 +718,7 @@ public:
         // pad_16F[0x7];
         dst->spiral_slide_progress = src->spiral_slide_progress;
         // pad_177[0x9];
-        dst->build_date = src->build_date;
+        dst->build_date = static_cast<int32_t>(src->build_date);
         dst->upkeep_cost = src->upkeep_cost;
         dst->race_winner = src->race_winner;
         // pad_186[0x02];

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -216,7 +216,7 @@ public:
             safe_strcpy(gS6Info.details, _s6.info.details, sizeof(gS6Info.details));
         }
 
-        gDateMonthsElapsed = _s6.elapsed_months;
+        gDateMonthsElapsed = static_cast<int32_t>(_s6.elapsed_months);
         gDateMonthTicks = _s6.current_day;
         gScenarioTicks = _s6.scenario_ticks;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -932,7 +932,7 @@ void reset_all_ride_build_dates()
 {
     for (auto& ride : GetRideManager())
     {
-        ride.build_date = gDateMonthsElapsed;
+        ride.build_date -= static_cast<int32_t>(gDateMonthsElapsed);
     }
 }
 
@@ -7114,7 +7114,7 @@ void Ride::Delete()
 void Ride::Renew()
 {
     // Set build date to current date (so the ride is brand new)
-    build_date = gDateMonthsElapsed;
+    build_date = static_cast<int32_t>(gDateMonthsElapsed);
     reliability = RIDE_INITIAL_RELIABILITY;
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -280,7 +280,7 @@ size_t Ride::GetNumPrices() const
 
 int32_t Ride::GetAge() const
 {
-    return static_cast<int32_t>(gDateMonthsElapsed) - build_date;
+    return gDateMonthsElapsed - build_date;
 }
 
 int32_t Ride::GetTotalQueueLength() const
@@ -932,7 +932,7 @@ void reset_all_ride_build_dates()
 {
     for (auto& ride : GetRideManager())
     {
-        ride.build_date -= static_cast<int32_t>(gDateMonthsElapsed);
+        ride.build_date -= gDateMonthsElapsed;
     }
 }
 
@@ -7114,7 +7114,7 @@ void Ride::Delete()
 void Ride::Renew()
 {
     // Set build date to current date (so the ride is brand new)
-    build_date = static_cast<int32_t>(gDateMonthsElapsed);
+    build_date = gDateMonthsElapsed;
     reliability = RIDE_INITIAL_RELIABILITY;
 }
 

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -306,7 +306,7 @@ struct Ride
     };
     uint8_t slide_peep_t_shirt_colour;
     uint8_t spiral_slide_progress;
-    uint16_t build_date;
+    int32_t build_date;
     money16 upkeep_cost;
     uint16_t race_winner;
     uint32_t music_position;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -715,7 +715,7 @@ static void scenario_objective_check_guests_by()
 {
     uint8_t objectiveYear = gScenarioObjectiveYear;
     int16_t parkRating = gParkRating;
-    int16_t currentMonthYear = gDateMonthsElapsed;
+    int32_t currentMonthYear = gDateMonthsElapsed;
 
     if (currentMonthYear == MONTH_COUNT * objectiveYear || gConfigGeneral.allow_early_completion)
     {
@@ -733,7 +733,7 @@ static void scenario_objective_check_guests_by()
 static void scenario_objective_check_park_value_by()
 {
     uint8_t objectiveYear = gScenarioObjectiveYear;
-    int16_t currentMonthYear = gDateMonthsElapsed;
+    int32_t currentMonthYear = gDateMonthsElapsed;
     money32 objectiveParkValue = gScenarioObjectiveCurrency;
     money32 parkValue = gParkValue;
 

--- a/src/openrct2/scripting/ScDate.hpp
+++ b/src/openrct2/scripting/ScDate.hpp
@@ -37,16 +37,16 @@ namespace OpenRCT2::Scripting
         }
 
     private:
-        uint32_t monthsElapsed_get() const
+        int32_t monthsElapsed_get() const
         {
             const auto& date = GetDate();
             return date.GetMonthsElapsed();
         }
 
-        void monthsElapsed_set(uint32_t value)
+        void monthsElapsed_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            gDateMonthsElapsed = value;
+            gDateMonthsElapsed = static_cast<int32_t>(value);
         }
 
         uint32_t monthProgress_get() const

--- a/src/openrct2/scripting/ScRide.hpp
+++ b/src/openrct2/scripting/ScRide.hpp
@@ -546,12 +546,12 @@ namespace OpenRCT2::Scripting
             }
         }
 
-        int16_t buildDate_get() const
+        int32_t buildDate_get() const
         {
             auto ride = GetRide();
             return ride != nullptr ? ride->build_date : 0;
         }
-        void buildDate_set(int16_t value)
+        void buildDate_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
             auto ride = GetRide();

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -258,7 +258,7 @@ static int8_t climate_step_weather_level(int8_t currentWeatherLevel, int8_t next
  */
 static void climate_determine_future_weather(int32_t randomDistribution)
 {
-    int8_t month = date_get_month(gDateMonthsElapsed);
+    int32_t month = date_get_month(gDateMonthsElapsed);
 
     // Generate a random variable with values 0 up to DistributionSize-1 and chose weather from the distribution table
     // accordingly


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/pull/11712/commits/f6fbd272ecfe2aa994690dfcfe8c2bae11809b1a changed the fields to be unsigned, but many rides' ages were set to negative to indicate that they were quite old, so that the `getAge()` function could do `elapsedMonths - (-age)` = `elapsedMonths + Age`. Changing it to be ` = gDateMonthsElapsed`, would just be 0 on some cases. 

There are several ways to fix this, this is one of them, but I'm opening up for discussions