### PR TITLE
Part of #11437: Refactor Win32 RemoveFileAssociations to Platform2

### DIFF
--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -427,7 +427,7 @@ static exitcode_t HandleCommandRegisterShell([[maybe_unused]] CommandLineArgEnum
     }
     else
     {
-        platform_remove_file_associations();
+        Platform::RemoveFileAssociations();
     }
     return EXITCODE_OK;
 }

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -51,6 +51,7 @@ namespace Platform
     bool SetUpFileAssociation(
         const std::string extension, const std::string fileTypeText, const std::string commandText,
         const std::string commandArgs, const uint32_t iconIndex);
+    void RemoveFileAssociations();
 #endif
 
     bool IsRunningInWine();

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -501,58 +501,11 @@ bool platform_process_is_elevated()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// File association setup
+// URI protocol association setup
 ///////////////////////////////////////////////////////////////////////////////
 
 #    define SOFTWARE_CLASSES L"Software\\Classes"
 #    define MUI_CACHE L"Local Settings\\Software\\Microsoft\\Windows\\Shell\\MuiCache"
-
-static std::wstring get_progIdName(const std::string_view& extension)
-{
-    auto progIdName = std::string(OPENRCT2_NAME) + std::string(extension);
-    auto progIdNameW = String::ToWideChar(progIdName);
-    return progIdNameW;
-}
-
-static void windows_remove_file_association(const utf8* extension)
-{
-#    if _WIN32_WINNT >= 0x0600
-    // [HKEY_CURRENT_USER\Software\Classes]
-    HKEY hRootKey;
-    if (RegOpenKeyW(HKEY_CURRENT_USER, SOFTWARE_CLASSES, &hRootKey) == ERROR_SUCCESS)
-    {
-        // [hRootKey\.ext]
-        RegDeleteTreeA(hRootKey, extension);
-
-        // [hRootKey\OpenRCT2.ext]
-        auto progIdName = get_progIdName(extension);
-        RegDeleteTreeW(hRootKey, progIdName.c_str());
-
-        RegCloseKey(hRootKey);
-    }
-#    endif
-}
-
-void platform_remove_file_associations()
-{
-    // Remove file extensions
-    windows_remove_file_association(".sc4");
-    windows_remove_file_association(".sc6");
-    windows_remove_file_association(".sv4");
-    windows_remove_file_association(".sv6");
-    windows_remove_file_association(".sv7");
-    windows_remove_file_association(".td4");
-    windows_remove_file_association(".td6");
-
-    // Refresh explorer
-    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////////////////
-// URI protocol association setup
-///////////////////////////////////////////////////////////////////////////////
 
 bool platform_setup_uri_protocol()
 {

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -149,7 +149,6 @@ void core_init();
 #    undef CreateWindow
 #    undef GetMessage
 
-void platform_remove_file_associations();
 bool platform_setup_uri_protocol();
 // This function cannot be marked as 'static', even though it may seem to be,
 // as it requires external linkage, which 'static' prevents


### PR DESCRIPTION
Additionally fixes missing changes from previous refactor in #12036 that
borked WinNT 5.1 support