### PR TITLE
Add Ride.totalProfit to the plugin API

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -805,6 +805,11 @@ declare global {
         runningCost: number;
 
         /**
+         * The total profit of the ride over the course of its lifetime.
+         */
+        totalProfit: number;
+
+        /**
          * How often the ride should be inspected by a mechanic.
          */
         inspectionInterval: number;

--- a/src/openrct2/scripting/ScRide.hpp
+++ b/src/openrct2/scripting/ScRide.hpp
@@ -582,6 +582,21 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        int32_t totalProfit_get() const
+        {
+            auto ride = GetRide();
+            return ride != nullptr ? ride->total_profit : 0;
+        }
+        void totalProfit_set(int32_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            auto ride = GetRide();
+            if (ride != nullptr)
+            {
+                ride->total_profit = value;
+            }
+        }
+
         uint8_t inspectionInterval_get() const
         {
             auto ride = GetRide();
@@ -660,6 +675,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScRide::buildDate_get, &ScRide::buildDate_set, "buildDate");
             dukglue_register_property(ctx, &ScRide::age_get, nullptr, "age");
             dukglue_register_property(ctx, &ScRide::runningCost_get, &ScRide::runningCost_set, "runningCost");
+            dukglue_register_property(ctx, &ScRide::totalProfit_get, &ScRide::totalProfit_set, "totalProfit");
             dukglue_register_property(
                 ctx, &ScRide::inspectionInterval_get, &ScRide::inspectionInterval_set, "inspectionInterval");
             dukglue_register_property(ctx, &ScRide::value_get, &ScRide::value_set, "value");

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -41,7 +41,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 1;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 2;
 
 struct ExpressionStringifier final
 {


### PR DESCRIPTION
Simple addition to the plugin API that allows for querying the total profit of a ride.