### PR TITLE
Fix wrong syntax of std::array in Window.cpp

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -194,7 +194,7 @@ rct_window* window_create_auto_pos(
     auto screenHeight = uiContext->GetHeight();
 
     // Place window in an empty corner of the screen
-    const std::array cornerPositions = {
+    const std::array<ScreenCoordsXY, 4> cornerPositions = {
         ScreenCoordsXY{ 0, 30 },                                          // topLeft
         ScreenCoordsXY{ screenWidth - width, 30 },                        // topRight
         ScreenCoordsXY{ 0, screenHeight - 34 - height },                  // bottomLeft
@@ -212,14 +212,14 @@ rct_window* window_create_auto_pos(
     {
         if (w->flags & WF_STICK_TO_BACK)
             continue;
-        const std::array offsets = { ScreenCoordsXY{ w->width + 2, 0 },
-                                     ScreenCoordsXY{ -w->width - 2, 0 },
-                                     ScreenCoordsXY{ 0, w->height + 2 },
-                                     ScreenCoordsXY{ 0, -w->height - 2 },
-                                     ScreenCoordsXY{ w->width + 2, -w->height - 2 },
-                                     ScreenCoordsXY{ -w->width - 2, -w->height - 2 },
-                                     ScreenCoordsXY{ w->width + 2, w->height + 2 },
-                                     ScreenCoordsXY{ -w->width - 2, w->height + 2 } };
+        const std::array<ScreenCoordsXY, 8> offsets = { ScreenCoordsXY{ w->width + 2, 0 },
+                                                        ScreenCoordsXY{ -w->width - 2, 0 },
+                                                        ScreenCoordsXY{ 0, w->height + 2 },
+                                                        ScreenCoordsXY{ 0, -w->height - 2 },
+                                                        ScreenCoordsXY{ w->width + 2, -w->height - 2 },
+                                                        ScreenCoordsXY{ -w->width - 2, -w->height - 2 },
+                                                        ScreenCoordsXY{ w->width + 2, w->height + 2 },
+                                                        ScreenCoordsXY{ -w->width - 2, w->height + 2 } };
         for (const auto& offset : offsets)
         {
             auto screenPos = w->windowPos + offset;
@@ -236,10 +236,11 @@ rct_window* window_create_auto_pos(
             continue;
 
         // clang-format off
-        const std::array offsets = { ScreenCoordsXY{ w->width + 2, 0 },
-                                     ScreenCoordsXY{ -w->width - 2, 0 },
-                                     ScreenCoordsXY{ 0, w->height + 2 },
-                                     ScreenCoordsXY{ 0, -w->height - 2 } };
+        const std::array<ScreenCoordsXY, 4> offsets = {
+            ScreenCoordsXY{ w->width + 2, 0 },
+            ScreenCoordsXY{ -w->width - 2, 0 },
+            ScreenCoordsXY{ 0, w->height + 2 },
+            ScreenCoordsXY{ 0, -w->height - 2 } };
         // clang-format on
 
         for (const auto& offset : offsets)


### PR DESCRIPTION
Fixed a compilation error on Window.cpp caused by incorrect std::array syntax.