### PR TITLE
Refactor NETWORK_SERVER_STATE to use strong enum

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -782,16 +782,16 @@ bool NetworkBase::CheckSRAND(uint32_t tick, uint32_t srand0)
 
 bool NetworkBase::IsDesynchronised()
 {
-    return _serverState.state == NETWORK_SERVER_STATE_DESYNCED;
+    return _serverState.state == NetworkServerState::Desynced;
 }
 
 bool NetworkBase::CheckDesynchronizaton()
 {
     // Check synchronisation
-    if (GetMode() == NETWORK_MODE_CLIENT && _serverState.state != NETWORK_SERVER_STATE_DESYNCED
+    if (GetMode() == NETWORK_MODE_CLIENT && _serverState.state != NetworkServerState::Desynced
         && !CheckSRAND(gCurrentTicks, scenario_rand_state().s0))
     {
-        _serverState.state = NETWORK_SERVER_STATE_DESYNCED;
+        _serverState.state = NetworkServerState::Desynced;
         _serverState.desyncTick = gCurrentTicks;
 
         char str_desync[256];
@@ -2697,7 +2697,7 @@ void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connecti
             game_load_scripts();
             _serverState.tick = gCurrentTicks;
             // window_network_status_open("Loaded new map from network");
-            _serverState.state = NETWORK_SERVER_STATE_OK;
+            _serverState.state = NetworkServerState::Ok;
             _clientMapLoaded = true;
             gFirstTimeSaving = true;
 

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -88,15 +88,15 @@ enum class NetworkCommand : uint32_t
 
 static_assert(NetworkCommand::GameInfo == static_cast<NetworkCommand>(9), "Master server expects this to be 9");
 
-enum NETWORK_SERVER_STATE
+enum class NetworkServerState
 {
-    NETWORK_SERVER_STATE_OK,
-    NETWORK_SERVER_STATE_DESYNCED,
+    Ok,
+    Desynced
 };
 
 struct NetworkServerState_t
 {
-    NETWORK_SERVER_STATE state = NETWORK_SERVER_STATE_OK;
+    NetworkServerState state = NetworkServerState::Ok;
     uint32_t desyncTick = 0;
     uint32_t tick = 0;
     uint32_t srand0 = 0;


### PR DESCRIPTION
#12423
Replacing enum NETWORK_SERVER_STATE with enum class NetworkServerState.