### PR TITLE
Make CONTRIBUTING point to the full tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,7 @@ Translation is managed in a separate repository, [OpenRCT2/Localisation](https:/
 You will find more information there.
 
 # Contributing code
-## Steps
-1. First, ensure you have a GitHub account and [fork](https://help.github.com/articles/fork-a-repo/) the OpenRCT2 repository.
-2. Create a new branch from develop (unless you are contributing to another) and commit your changes to that.
-3. Submit a new [pull request](https://help.github.com/articles/using-pull-requests/).
-4. Wait for other users to test and review your changes.
-
-## Credits
-If you are contributing to OpenRCT2, please add your name to ```./contributors.md``` so that you can be credited for your
-work outside and inside the game.
+Please read [How To Contribute](https://github.com/OpenRCT2/OpenRCT2/wiki/How-To-Contribute)
 
 ## Code hints
 ### Adding new strings


### PR DESCRIPTION
Our contributing section was very shy, the step #1 assumes very little to no familiarity with git/GitHub, but then all other steps do and are maybe (too) concise. So I guess it wasn't useful for newbies, as it was too simple, nor pros, as it explains things they already know.

My proposal is to just link to our wiki tutorial, which is a comprehensive rundown of what to do.