### PR TITLE
Part of #11159: Refactor on StringBuilder.hpp

### DIFF
--- a/src/openrct2/core/StringBuilder.hpp
+++ b/src/openrct2/core/StringBuilder.hpp
@@ -95,44 +95,6 @@ public:
     }
 
     /**
-     * Like Clear, only will guarantee freeing of the underlying buffer.
-     */
-    void Reset()
-    {
-        _length = 0;
-        _capacity = 0;
-        SafeFree(_buffer);
-    }
-
-    /**
-     * Resets the StringBuilder and returns the working buffer (resized to the string size).
-     */
-    utf8* StealString()
-    {
-        utf8* result = _buffer;
-        result = Memory::ReallocateArray<utf8>(result, _length + 1);
-        result[_length] = 0;
-
-        _length = 0;
-        _capacity = 0;
-        _buffer = nullptr;
-
-        return result;
-    }
-
-    /**
-     * Returns the current string buffer as a new fire-and-forget string.
-     */
-    utf8* GetString() const
-    {
-        // If buffer is null, length should be 0 which will create a new one byte memory block containing a null terminator
-        utf8* result = Memory::AllocateArray<utf8>(_length + 1);
-        std::copy_n(_buffer, _length, result);
-        result[_length] = 0;
-        return result;
-    }
-
-    /**
      * Returns the current string buffer as a standard string.
      */
     std::string GetStdString() const
@@ -150,14 +112,6 @@ public:
         if (_buffer == nullptr)
             return "";
         return _buffer;
-    }
-
-    /**
-     * Gets the amount of allocated memory for the string buffer.
-     */
-    size_t GetCapacity() const
-    {
-        return _capacity;
     }
 
     /**

--- a/src/openrct2/core/StringBuilder.hpp
+++ b/src/openrct2/core/StringBuilder.hpp
@@ -10,10 +10,10 @@
 #pragma once
 
 #include "../common.h"
-#include "Memory.hpp"
 #include "String.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <string>
 
 /**
@@ -26,13 +26,10 @@ public:
     StringBuilder() = default;
     explicit StringBuilder(size_t capacity)
     {
-        EnsureCapacity(capacity);
+        _buffer.reserve(capacity);
     }
 
-    ~StringBuilder()
-    {
-        Memory::Free(_buffer);
-    }
+    ~StringBuilder() = default;
 
     void Append(int32_t codepoint)
     {
@@ -45,10 +42,9 @@ public:
     void Append(codepoint_t codepoint)
     {
         size_t codepointLength = String::GetCodepointLength(codepoint);
-        EnsureCapacity(_length + codepointLength + 1);
-        String::WriteCodepoint(_buffer + _length, codepoint);
-        _length += codepointLength;
-        _buffer[_length] = 0;
+        std::basic_string<utf8> data(codepointLength, {});
+        String::WriteCodepoint(data.data(), codepoint);
+        _buffer.insert(_buffer.end(), data.begin(), data.end());
     }
 
     /**
@@ -68,10 +64,7 @@ public:
      */
     void Append(const utf8* text, size_t textLength)
     {
-        EnsureCapacity(_length + textLength + 1);
-        std::copy_n(text, textLength, _buffer + _length);
-        _length += textLength;
-        _buffer[_length] = 0;
+        _buffer.insert(_buffer.end(), text, text + textLength);
     }
 
     /**
@@ -87,11 +80,7 @@ public:
      */
     void Clear()
     {
-        _length = 0;
-        if (_capacity >= 1)
-        {
-            _buffer[_length] = 0;
-        }
+        _buffer.clear();
     }
 
     /**
@@ -99,7 +88,7 @@ public:
      */
     std::string GetStdString() const
     {
-        return std::string(_buffer, _length);
+        return std::string(GetBuffer(), GetLength());
     }
 
     /**
@@ -108,10 +97,10 @@ public:
      */
     const utf8* GetBuffer() const
     {
-        // buffer may be null, so return an immutable empty string
-        if (_buffer == nullptr)
+        // buffer may be empty, so return an immutable empty string
+        if (_buffer.empty())
             return "";
-        return _buffer;
+        return _buffer.c_str();
     }
 
     /**
@@ -119,25 +108,9 @@ public:
      */
     size_t GetLength() const
     {
-        return _length;
+        return _buffer.size();
     }
 
 private:
-    utf8* _buffer = nullptr;
-    size_t _capacity = 0;
-    size_t _length = 0;
-
-    void EnsureCapacity(size_t capacity)
-    {
-        if (_capacity > capacity)
-            return;
-
-        _capacity = std::max(static_cast<size_t>(8), _capacity);
-        while (_capacity < capacity)
-        {
-            _capacity *= 2;
-        }
-
-        _buffer = Memory::ReallocateArray<utf8>(_buffer, _capacity);
-    }
+    std::basic_string<utf8> _buffer;
 };


### PR DESCRIPTION
## Overall Idea
Use RAII to prevent dangerous operations with raw pointers.

## What was done
As far as I understood, `StringBuilder` is a "glorified" `std::stringstream`. At first, I thought it would be possible to directly port to the standard solution, but in a matter of fact, `StringBuilder` does some low-level optimizations that are not made by `std::stringstream`: If a 32bit integer is appended to the builder, it would actually try to break it into (at most 4) 8bit chunks. That said, I just changed how the memory layout of this object looks, using a `std::vector<utf8>`.

### Edit
To handle strings more gently (and also fix some functional issues), I have changed the underlying implementation from `std::vector<utf8>` to `std::basic_string<utf8>` (a.k.a `std::string`).

## For the long term
Check the usage of allocations made by the `Memory::` namespace. Taking a quick look, I was able to find many opportunities to refactor data structures that are allocated using its functions.