### PR TITLE
Create an enum class serializer

### DIFF
--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -182,7 +182,7 @@ public:
 
     template<typename T> void Visit(const std::string_view& name, T& param)
     {
-        static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
+        static_assert(std::is_arithmetic_v<T> || std::is_enum_v<T>, "Not an arithmetic type");
         auto value = static_cast<int32_t>(param);
         Visit(name, value);
         param = static_cast<T>(value);

--- a/src/openrct2/actions/RideSetSetting.hpp
+++ b/src/openrct2/actions/RideSetSetting.hpp
@@ -49,7 +49,7 @@ public:
     void AcceptParameters(GameActionParameterVisitor & visitor) override
     {
         visitor.Visit("ride", _rideIndex);
-        //visitor.Visit("setting", _setting);
+        visitor.Visit("setting", _setting);
         visitor.Visit("value", _value);
     }
 

--- a/src/openrct2/actions/RideSetSetting.hpp
+++ b/src/openrct2/actions/RideSetSetting.hpp
@@ -32,7 +32,7 @@ DEFINE_GAME_ACTION(RideSetSettingAction, GAME_COMMAND_SET_RIDE_SETTING, GameActi
 {
 private:
     NetworkRideId_t _rideIndex{ RideIdNewNull };
-    uint8_t _setting{ 0 };
+    RideSetSetting _setting{ 0 };
     uint8_t _value{ 0 };
 
 public:
@@ -41,7 +41,7 @@ public:
     }
     RideSetSettingAction(ride_id_t rideIndex, RideSetSetting setting, uint8_t value)
         : _rideIndex(rideIndex)
-        , _setting(static_cast<uint8_t>(setting))
+        , _setting(setting)
         , _value(value)
     {
     }
@@ -49,7 +49,7 @@ public:
     void AcceptParameters(GameActionParameterVisitor & visitor) override
     {
         visitor.Visit("ride", _rideIndex);
-        visitor.Visit("setting", _setting);
+        //visitor.Visit("setting", _setting);
         visitor.Visit("value", _value);
     }
 
@@ -74,7 +74,7 @@ public:
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_CHANGE_OPERATING_MODE);
         }
 
-        switch (static_cast<RideSetSetting>(_setting))
+        switch (_setting)
         {
             case RideSetSetting::Mode:
                 if (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
@@ -162,7 +162,7 @@ public:
                 }
                 break;
             default:
-                log_warning("Invalid RideSetSetting: %u", _setting);
+                log_warning("Invalid RideSetSetting: %u", static_cast<uint8_t>(_setting));
                 return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_CHANGE_OPERATING_MODE);
                 break;
         }
@@ -179,7 +179,7 @@ public:
             return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_CANT_CHANGE_OPERATING_MODE);
         }
 
-        switch (static_cast<RideSetSetting>(_setting))
+        switch (_setting)
         {
             case RideSetSetting::Mode:
                 invalidate_test_results(ride);

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -258,14 +258,14 @@ template<> struct DataSerializerTraits_t<OpenRCT2::MemoryStream>
 {
     static void encode(OpenRCT2::IStream* stream, const OpenRCT2::MemoryStream& val)
     {
-        DataSerializerTraits_t<uint32_t> s;
+        DataSerializerTraits<uint32_t> s;
         s.encode(stream, val.GetLength());
 
         stream->Write(val.GetData(), val.GetLength());
     }
     static void decode(OpenRCT2::IStream* stream, OpenRCT2::MemoryStream& val)
     {
-        DataSerializerTraits_t<uint32_t> s;
+        DataSerializerTraits<uint32_t> s;
 
         uint32_t length = 0;
         s.decode(stream, length);
@@ -288,7 +288,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
         uint16_t swapped = ByteSwapBE(len);
         stream->Write(&swapped);
 
-        DataSerializerTraits_t<uint8_t> s;
+        DataSerializerTraits<uint8_t> s;
         for (auto&& sub : val)
         {
             s.encode(stream, sub);
@@ -303,7 +303,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
         if (len != _Size)
             throw std::runtime_error("Invalid size, can't decode");
 
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.decode(stream, sub);
@@ -312,7 +312,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
     static void log(OpenRCT2::IStream* stream, const _Ty (&val)[_Size])
     {
         stream->Write("{", 1);
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.log(stream, sub);
@@ -346,7 +346,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits_t<std::array<_T
         uint16_t swapped = ByteSwapBE(len);
         stream->Write(&swapped);
 
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.encode(stream, sub);
@@ -361,7 +361,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits_t<std::array<_T
         if (len != _Size)
             throw std::runtime_error("Invalid size, can't decode");
 
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.decode(stream, sub);
@@ -370,7 +370,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits_t<std::array<_T
     static void log(OpenRCT2::IStream* stream, const std::array<_Ty, _Size>& val)
     {
         stream->Write("{", 1);
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.log(stream, sub);
@@ -388,7 +388,7 @@ template<typename _Ty> struct DataSerializerTraits_t<std::vector<_Ty>>
         uint16_t swapped = ByteSwapBE(len);
         stream->Write(&swapped);
 
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.encode(stream, sub);
@@ -400,7 +400,7 @@ template<typename _Ty> struct DataSerializerTraits_t<std::vector<_Ty>>
         stream->Read(&len);
         len = ByteSwapBE(len);
 
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto i = 0; i < len; ++i)
         {
             _Ty sub;
@@ -411,7 +411,7 @@ template<typename _Ty> struct DataSerializerTraits_t<std::vector<_Ty>>
     static void log(OpenRCT2::IStream* stream, const std::vector<_Ty>& val)
     {
         stream->Write("{", 1);
-        DataSerializerTraits_t<_Ty> s;
+        DataSerializerTraits<_Ty> s;
         for (auto&& sub : val)
         {
             s.log(stream, sub);
@@ -686,7 +686,7 @@ template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
         stream->Write(&val.flags);
         stream->Write(&val.primary_colour);
         stream->Write(&val.secondary_colour);
-        DataSerializerTraits_t<rct_object_entry> s;
+        DataSerializerTraits<rct_object_entry> s;
         s.encode(stream, val.scenery_object);
     }
     static void decode(OpenRCT2::IStream* stream, TrackDesignSceneryElement& val)
@@ -697,7 +697,7 @@ template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
         stream->Read(&val.flags);
         stream->Read(&val.primary_colour);
         stream->Read(&val.secondary_colour);
-        DataSerializerTraits_t<rct_object_entry> s;
+        DataSerializerTraits<rct_object_entry> s;
         s.decode(stream, val.scenery_object);
     }
     static void log(OpenRCT2::IStream* stream, const TrackDesignSceneryElement& val)

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -37,7 +37,6 @@ template<typename T> struct DataSerializerTraits_t
 
 template<typename T> struct DataSerializerTraits_enum
 {
-    using underlying = std::underlying_type_t<T>;
     static void encode(OpenRCT2::IStream* stream, const T& val)
     {
         stream->Write(&val);
@@ -48,6 +47,7 @@ template<typename T> struct DataSerializerTraits_enum
     }
     static void log(OpenRCT2::IStream* stream, const T& val)
     {
+        using underlying = std::underlying_type_t<T>;
         std::stringstream ss;
         ss << std::hex << std::setw(sizeof(underlying) * 2) << std::setfill('0') << static_cast<underlying>(val);
 


### PR DESCRIPTION
As part of the entity refactor there is going to be a need for using enums in the serializer traits so this adds that support.
I'm not sure what I should do with the naming. Ideally I wouldn't have to add a suffix but I can't get the SIFNAE to work otherwise. I believe in C++20 this can be improved to use concepts but as we aren't using that atm it will have to wait.
I still need to think how to change the visitor.