### PR TITLE
Part of #11195: Refactor TitleSequence to use RAII model

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -155,7 +155,7 @@ public:
                 {
                     if (!SkipToNextLoadCommand() || _position == entryPosition)
                     {
-                        Console::Error::WriteLine("Unable to load any parks from %s.", _sequence->Name);
+                        Console::Error::WriteLine("Unable to load any parks from %s.", _sequence->Name.c_str());
                         return false;
                     }
                 }

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -110,7 +110,7 @@ public:
         }
 
         // Check that position is valid
-        if (_position >= static_cast<int32_t>(_sequence->NumCommands))
+        if (_position >= static_cast<int32_t>(_sequence->NumCommands()))
         {
             _position = 0;
             return false;
@@ -172,7 +172,7 @@ public:
 
     void Seek(int32_t targetPosition) override
     {
-        if (targetPosition < 0 || targetPosition >= static_cast<int32_t>(_sequence->NumCommands))
+        if (targetPosition < 0 || targetPosition >= static_cast<int32_t>(_sequence->NumCommands()))
         {
             throw std::runtime_error("Invalid position.");
         }
@@ -221,7 +221,7 @@ private:
     void IncrementPosition()
     {
         _position++;
-        if (_position >= static_cast<int32_t>(_sequence->NumCommands))
+        if (_position >= static_cast<int32_t>(_sequence->NumCommands()))
         {
             _position = 0;
         }

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -284,9 +284,9 @@ private:
                 }
                 if (!loadSuccess)
                 {
-                    if (_sequence->NumSaves > saveIndex)
+                    if (_sequence->NumSaves() > saveIndex)
                     {
-                        const utf8* path = _sequence->Saves[saveIndex];
+                        const utf8* path = _sequence->Saves[saveIndex].c_str();
                         Console::Error::WriteLine("Failed to load: \"%s\" for the title sequence.", path);
                     }
                     return false;

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -47,7 +47,7 @@ class TitleSequencePlayer final : public ITitleSequencePlayer
 private:
     GameState& _gameState;
 
-    TitleSequence* _sequence = nullptr;
+    std::unique_ptr<TitleSequence> _sequence;
     int32_t _position = 0;
     int32_t _waitCounter = 0;
 
@@ -74,7 +74,6 @@ public:
     void Eject() override
     {
         FreeTitleSequence(_sequence);
-        _sequence = nullptr;
     }
 
     bool Begin(size_t titleSequenceId) override
@@ -93,7 +92,7 @@ public:
         }
 
         Eject();
-        _sequence = sequence;
+        _sequence = std::move(sequence);
 
         Reset();
         return true;
@@ -277,7 +276,7 @@ private:
             {
                 bool loadSuccess = false;
                 uint8_t saveIndex = command->SaveIndex;
-                TitleSequenceParkHandle* parkHandle = TitleSequenceGetParkHandle(_sequence, saveIndex);
+                TitleSequenceParkHandle* parkHandle = TitleSequenceGetParkHandle(_sequence.get(), saveIndex);
                 if (parkHandle != nullptr)
                 {
                     loadSuccess = LoadParkFromStream(static_cast<OpenRCT2::IStream*>(parkHandle->Stream), parkHandle->HintPath);

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -190,7 +190,7 @@ public:
         for (int32_t i = targetPosition; i >= 0; i--)
         {
             const TitleCommand* command = &_sequence->Commands[i];
-            if ((_position == i && _position != targetPosition) || TitleSequenceIsLoadCommand(command))
+            if ((_position == i && _position != targetPosition) || TitleSequence::IsLoadCommand(command))
             {
                 // Break if we have a new load command or if we're already in the range of the correct load command
                 _position = i;
@@ -236,7 +236,7 @@ private:
         {
             IncrementPosition();
             command = &_sequence->Commands[_position];
-        } while (!TitleSequenceIsLoadCommand(command) && _position != entryPosition);
+        } while (!TitleSequence::IsLoadCommand(command) && _position != entryPosition);
         return _position != entryPosition;
     }
 

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -257,7 +257,7 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
     {
         case TITLE_SCRIPT_LOAD:
             if (command.SaveIndex >= _sequence->NumSaves())
-                command.SaveIndex = SAVE_INDEX_INVALID;
+                command.SaveIndex = TitleSequence::SaveIndexInvalid;
             break;
         case TITLE_SCRIPT_LOCATION:
             snprintf(textbox1Buffer, BUF_SIZE, "%d", command.X);
@@ -772,7 +772,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
     }
     else if (command.Type == TITLE_SCRIPT_LOAD)
     {
-        if (command.SaveIndex == SAVE_INDEX_INVALID)
+        if (command.SaveIndex == TitleSequence::SaveIndexInvalid)
         {
             gfx_draw_string_left_clipped(
                 dpi, STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, nullptr, w->colours[1],

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -256,7 +256,7 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
     switch (command.Type)
     {
         case TITLE_SCRIPT_LOAD:
-            if (command.SaveIndex >= _sequence->NumSaves)
+            if (command.SaveIndex >= _sequence->NumSaves())
                 command.SaveIndex = SAVE_INDEX_INVALID;
             break;
         case TITLE_SCRIPT_LOCATION:
@@ -405,11 +405,11 @@ static void window_title_command_editor_mousedown(rct_window* w, rct_widgetindex
             }
             else if (command.Type == TITLE_SCRIPT_LOAD)
             {
-                int32_t numItems = static_cast<int32_t>(_sequence->NumSaves);
+                int32_t numItems = static_cast<int32_t>(_sequence->NumSaves());
                 for (int32_t i = 0; i < numItems; i++)
                 {
                     gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(_sequence->Saves[i]);
+                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(_sequence->Saves[i].c_str());
                 }
 
                 window_dropdown_show_text_custom_width(
@@ -479,7 +479,7 @@ static void window_title_command_editor_dropdown(rct_window* w, rct_widgetindex 
                     break;
                 case TITLE_SCRIPT_LOAD:
                     command.SaveIndex = 0;
-                    if (command.SaveIndex >= _sequence->NumSaves)
+                    if (command.SaveIndex >= _sequence->NumSaves())
                     {
                         command.SaveIndex = 0xFF;
                     }
@@ -782,7 +782,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
         }
         else
         {
-            Formatter::Common().Add<utf8*>(_sequence->Saves[command.SaveIndex]);
+            Formatter::Common().Add<utf8*>(_sequence->Saves[command.SaveIndex].c_str());
             gfx_draw_string_left_clipped(
                 dpi, STR_STRING, gCommonFormatArgs, w->colours[1],
                 { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -352,9 +352,8 @@ static void window_title_command_editor_mouseup(rct_window* w, rct_widgetindex w
             else
             {
                 _sequence->Commands[_window_title_command_editor_index] = command;
-                TitleSequenceSave(_sequence);
             }
-            TitleSequenceSave(_sequence);
+            _sequence->Save();
 
             rct_window* title_editor_w = window_find_by_class(WC_TITLE_EDITOR);
             if (title_editor_w != nullptr)

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -347,13 +347,7 @@ static void window_title_command_editor_mouseup(rct_window* w, rct_widgetindex w
             if (_window_title_command_editor_insert)
             {
                 size_t insertIndex = _window_title_command_editor_index;
-                _sequence->NumCommands++;
-                _sequence->Commands = Memory::ReallocateArray(_sequence->Commands, _sequence->NumCommands);
-                for (size_t i = _sequence->NumCommands - 1; i > insertIndex; i--)
-                {
-                    _sequence->Commands[i] = _sequence->Commands[i - 1];
-                }
-                _sequence->Commands[insertIndex] = command;
+                _sequence->Commands.insert(_sequence->Commands.begin() + insertIndex, command);
             }
             else
             {

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -336,7 +336,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
                 if (w->selected_list_item != -1)
                 {
                     TitleSequenceRemovePark(_editingTitleSequence.get(), w->selected_list_item);
-                    if (w->selected_list_item >= static_cast<int16_t>(_editingTitleSequence->NumSaves))
+                    if (w->selected_list_item >= static_cast<int16_t>(_editingTitleSequence->NumSaves()))
                     {
                         w->selected_list_item--;
                     }
@@ -350,12 +350,12 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
                 {
                     window_text_input_open(
                         w, widgetIndex, STR_FILEBROWSER_RENAME_SAVE_TITLE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SAVE, STR_STRING,
-                        reinterpret_cast<uintptr_t>(_editingTitleSequence->Saves[w->selected_list_item]), 52 - 1);
+                        reinterpret_cast<uintptr_t>(_editingTitleSequence->Saves[w->selected_list_item].c_str()), 52 - 1);
                 }
             }
             break;
         case WIDX_TITLE_EDITOR_LOAD_SAVE:
-            if (w->selected_list_item >= 0 && w->selected_list_item < static_cast<int16_t>(_editingTitleSequence->NumSaves))
+            if (w->selected_list_item >= 0 && w->selected_list_item < static_cast<int16_t>(_editingTitleSequence->NumSaves()))
             {
                 auto handle = TitleSequenceGetParkHandle(_editingTitleSequence.get(), w->selected_list_item);
                 auto stream = static_cast<OpenRCT2::IStream*>(handle->Stream);
@@ -592,7 +592,7 @@ static void window_title_editor_scrollgetsize(rct_window* w, int32_t scrollIndex
 {
     size_t lineCount = 1;
     if (w->selected_tab == WINDOW_TITLE_EDITOR_TAB_SAVES)
-        lineCount = _editingTitleSequence->NumSaves;
+        lineCount = _editingTitleSequence->NumSaves();
     else if (w->selected_tab == WINDOW_TITLE_EDITOR_TAB_SCRIPT)
         lineCount = _editingTitleSequence->NumCommands();
 
@@ -619,7 +619,7 @@ static void window_title_editor_scrollmousedown(rct_window* w, int32_t scrollInd
     switch (w->selected_tab)
     {
         case WINDOW_TITLE_EDITOR_TAB_SAVES:
-            if (index < static_cast<int32_t>(_editingTitleSequence->NumSaves))
+            if (index < static_cast<int32_t>(_editingTitleSequence->NumSaves()))
             {
                 w->selected_list_item = index;
                 widget_invalidate(w, WIDX_TITLE_EDITOR_LIST);
@@ -641,7 +641,7 @@ static void window_title_editor_scrollmouseover(rct_window* w, int32_t scrollInd
     switch (w->selected_tab)
     {
         case WINDOW_TITLE_EDITOR_TAB_SAVES:
-            if (index < static_cast<int32_t>(_editingTitleSequence->NumSaves))
+            if (index < static_cast<int32_t>(_editingTitleSequence->NumSaves()))
                 _window_title_editor_highlighted_index = static_cast<int16_t>(index);
             break;
         case WINDOW_TITLE_EDITOR_TAB_SCRIPT:
@@ -865,7 +865,7 @@ static void window_title_editor_scrollpaint_saves(rct_window* w, rct_drawpixelin
     if (_editingTitleSequence == nullptr)
         return;
 
-    for (int32_t i = 0; i < static_cast<int32_t>(_editingTitleSequence->NumSaves); i++, screenCoords.y += SCROLLABLE_ROW_HEIGHT)
+    for (int32_t i = 0; i < static_cast<int32_t>(_editingTitleSequence->NumSaves()); i++, screenCoords.y += SCROLLABLE_ROW_HEIGHT)
     {
         bool selected = false;
         bool hover = false;
@@ -888,7 +888,7 @@ static void window_title_editor_scrollpaint_saves(rct_window* w, rct_drawpixelin
 
         char buffer[256];
         auto ft = Formatter::Common();
-        ft.Add<const char*>(_editingTitleSequence->Saves[i]);
+        ft.Add<const char*>(_editingTitleSequence->Saves[i].c_str());
         if (selected || hover)
         {
             format_string(buffer, 256, STR_STRING, gCommonFormatArgs);
@@ -952,7 +952,7 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
                 }
                 else
                 {
-                    ft.Add<const char*>(_editingTitleSequence->Saves[command->SaveIndex]);
+                    ft.Add<const char*>(_editingTitleSequence->Saves[command->SaveIndex].c_str());
                 }
                 break;
             case TITLE_SCRIPT_LOCATION:
@@ -1103,9 +1103,9 @@ static bool window_title_editor_check_can_edit()
 static bool save_filename_exists(const utf8* filename)
 {
     auto seq = _editingTitleSequence.get();
-    for (size_t i = 0; i < seq->NumSaves; i++)
+    for (size_t i = 0; i < seq->NumSaves(); i++)
     {
-        const utf8* savePath = seq->Saves[i];
+        const utf8* savePath = seq->Saves[i].c_str();
 
         if (_stricmp(savePath, filename) == 0)
             return true;
@@ -1142,11 +1142,11 @@ static void window_title_editor_rename_park(size_t index, const utf8* name)
         return;
     }
 
-    for (size_t i = 0; i < _editingTitleSequence->NumSaves; i++)
+    for (size_t i = 0; i < _editingTitleSequence->NumSaves(); i++)
     {
         if (i != index)
         {
-            const utf8* savePath = _editingTitleSequence->Saves[i];
+            const utf8* savePath = _editingTitleSequence->Saves[i].c_str();
             if (_strcmpi(savePath, name) == 0)
             {
                 context_show_error(STR_ERROR_EXISTING_NAME, STR_NONE);

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -942,7 +942,7 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
         {
             case TITLE_SCRIPT_LOAD:
                 commandName = STR_TITLE_EDITOR_COMMAND_LOAD_FILE;
-                if (command->SaveIndex == SAVE_INDEX_INVALID)
+                if (command->SaveIndex == TitleSequence::SaveIndexInvalid)
                 {
                     commandName = STR_TITLE_EDITOR_COMMAND_LOAD_NO_SAVE;
                     error = true;

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -37,14 +37,12 @@ static void LegacyScriptGetLine(OpenRCT2::IStream* stream, char* parts);
 static std::vector<uint8_t> ReadScriptFile(const utf8* path);
 static std::string LegacyScriptWrite(TitleSequence* seq);
 
-TitleSequence* CreateTitleSequence()
+std::unique_ptr<TitleSequence> CreateTitleSequence()
 {
-    TitleSequence* seq = Memory::Allocate<TitleSequence>();
-    *seq = {};
-    return seq;
+    return std::make_unique<TitleSequence>();
 }
 
-TitleSequence* LoadTitleSequence(const utf8* path)
+std::unique_ptr<TitleSequence> LoadTitleSequence(const utf8* path)
 {
     std::vector<uint8_t> script;
     std::vector<utf8*> saves;
@@ -90,7 +88,7 @@ TitleSequence* LoadTitleSequence(const utf8* path)
 
     auto commands = LegacyScriptRead(reinterpret_cast<utf8*>(script.data()), script.size(), saves);
 
-    TitleSequence* seq = CreateTitleSequence();
+    auto seq = CreateTitleSequence();
     seq->Name = Path::GetFileNameWithoutExtension(path);
     seq->Path = String::Duplicate(path);
     seq->NumSaves = saves.size();
@@ -101,9 +99,9 @@ TitleSequence* LoadTitleSequence(const utf8* path)
     return seq;
 }
 
-void FreeTitleSequence(TitleSequence* seq)
+void FreeTitleSequence(std::unique_ptr<TitleSequence>& seq)
 {
-    if (seq != nullptr)
+    if (seq)
     {
         Memory::Free(seq->Name);
         Memory::Free(seq->Path);
@@ -113,7 +111,7 @@ void FreeTitleSequence(TitleSequence* seq)
             Memory::Free(seq->Saves[i]);
         }
         Memory::Free(seq->Saves);
-        Memory::Free(seq);
+        seq.reset();
     }
 }
 

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -93,8 +93,7 @@ std::unique_ptr<TitleSequence> LoadTitleSequence(const utf8* path)
     seq->Name = Path::GetFileNameWithoutExtension(seq->Path);
     seq->NumSaves = saves.size();
     seq->Saves = Collections::ToArray(saves);
-    seq->NumCommands = commands.size();
-    seq->Commands = Collections::ToArray(commands);
+    seq->Commands = std::move(commands);
     seq->IsZip = isZip;
     return seq;
 }
@@ -103,7 +102,6 @@ void FreeTitleSequence(std::unique_ptr<TitleSequence>& seq)
 {
     if (seq)
     {
-        Memory::Free(seq->Commands);
         for (size_t i = 0; i < seq->NumSaves; i++)
         {
             Memory::Free(seq->Saves[i]);
@@ -326,7 +324,7 @@ bool TitleSequenceRemovePark(TitleSequence* seq, size_t index)
     seq->NumSaves--;
 
     // Update load commands
-    for (size_t i = 0; i < seq->NumCommands; i++)
+    for (size_t i = 0; i < seq->NumCommands(); i++)
     {
         TitleCommand* command = &seq->Commands[i];
         if (command->Type == TITLE_SCRIPT_LOAD)
@@ -556,7 +554,7 @@ static std::string LegacyScriptWrite(TitleSequence* seq)
     sb.Append("# SCRIPT FOR ");
     sb.Append(seq->Name.c_str());
     sb.Append("\n");
-    for (size_t i = 0; i < seq->NumCommands; i++)
+    for (size_t i = 0; i < seq->NumCommands(); i++)
     {
         const TitleCommand* command = &seq->Commands[i];
         switch (command->Type)

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -40,8 +40,8 @@ struct TitleCommand
 
 struct TitleSequence
 {
-    const utf8* Name;
-    const utf8* Path;
+    std::string Path;
+    std::string Name;
 
     size_t NumCommands;
     TitleCommand* Commands;

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -46,8 +46,8 @@ struct TitleSequence
     std::vector<TitleCommand> Commands;
     size_t NumCommands() const { return Commands.size(); }
 
-    size_t NumSaves;
-    utf8** Saves;
+    std::vector<std::string> Saves;
+    size_t NumSaves() const { return Saves.size(); }
 
     bool IsZip;
 };

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -78,9 +78,9 @@ enum TITLE_SCRIPT
 constexpr const utf8* TITLE_SEQUENCE_EXTENSION = ".parkseq";
 constexpr uint8_t SAVE_INDEX_INVALID = UINT8_MAX;
 
-TitleSequence* CreateTitleSequence();
-TitleSequence* LoadTitleSequence(const utf8* path);
-void FreeTitleSequence(TitleSequence* seq);
+std::unique_ptr<TitleSequence> CreateTitleSequence();
+std::unique_ptr<TitleSequence> LoadTitleSequence(const utf8* path);
+void FreeTitleSequence(std::unique_ptr<TitleSequence>& seq);
 
 TitleSequenceParkHandle* TitleSequenceGetParkHandle(TitleSequence* seq, size_t index);
 

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -61,6 +61,11 @@ struct TitleSequence
     TitleSequenceParkHandle* GetParkHandle(size_t index);
     void CloseParkHandle(TitleSequenceParkHandle* handle);
 
+    static bool IsLoadCommand(const TitleCommand* command);
+
+    static constexpr const utf8* Extension = ".parkseq";
+    static constexpr uint8_t SaveIndexInvalid = std::numeric_limits<uint8_t>::max();
+
     size_t NumSaves() const
     {
         return Saves.size();
@@ -95,8 +100,3 @@ enum TITLE_SCRIPT
     TITLE_SCRIPT_ENDLOOP,
     TITLE_SCRIPT_LOADSC,
 };
-
-constexpr const utf8* TITLE_SEQUENCE_EXTENSION = ".parkseq";
-constexpr uint8_t SAVE_INDEX_INVALID = UINT8_MAX;
-
-bool TitleSequenceIsLoadCommand(const TitleCommand* command);

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -38,24 +38,45 @@ struct TitleCommand
     };
 };
 
-struct TitleSequence
-{
-    std::string Path;
-    std::string Name;
-
-    std::vector<TitleCommand> Commands;
-    size_t NumCommands() const { return Commands.size(); }
-
-    std::vector<std::string> Saves;
-    size_t NumSaves() const { return Saves.size(); }
-
-    bool IsZip;
-};
-
 struct TitleSequenceParkHandle
 {
     const utf8* HintPath;
     void* Stream;
+};
+
+struct TitleSequence
+{
+    explicit TitleSequence(const utf8* path);
+    TitleSequence() = default;
+    ~TitleSequence() = default;
+
+    bool Save();
+    bool AddPark(const utf8*, const utf8* name);
+    bool RenamePark(size_t index, const utf8* name);
+    bool RemovePark(size_t index);
+    std::string LegacyScriptWrite();
+    void SwapConsecutiveCommands(size_t index);
+
+    // TODO: TitleSequenceParkHandle should also be migrated to RAII
+    TitleSequenceParkHandle* GetParkHandle(size_t index);
+    void CloseParkHandle(TitleSequenceParkHandle* handle);
+
+    size_t NumSaves() const
+    {
+        return Saves.size();
+    }
+    size_t NumCommands() const
+    {
+        return Commands.size();
+    }
+
+    std::string Path;
+    std::string Name;
+
+    std::vector<TitleCommand> Commands;
+    std::vector<std::string> Saves;
+
+    bool IsZip = false;
 };
 
 enum TITLE_SCRIPT
@@ -77,21 +98,5 @@ enum TITLE_SCRIPT
 
 constexpr const utf8* TITLE_SEQUENCE_EXTENSION = ".parkseq";
 constexpr uint8_t SAVE_INDEX_INVALID = UINT8_MAX;
-
-std::unique_ptr<TitleSequence> CreateTitleSequence();
-std::unique_ptr<TitleSequence> LoadTitleSequence(const utf8* path);
-void FreeTitleSequence(std::unique_ptr<TitleSequence>& seq);
-
-TitleSequenceParkHandle* TitleSequenceGetParkHandle(TitleSequence* seq, size_t index);
-
-/**
- * Close a title sequence park handle.
- * The pointer to the handle is invalid after calling this function.
- */
-void TitleSequenceCloseParkHandle(TitleSequenceParkHandle* handle);
-bool TitleSequenceSave(TitleSequence* seq);
-bool TitleSequenceAddPark(TitleSequence* seq, const utf8* path, const utf8* name);
-bool TitleSequenceRenamePark(TitleSequence* seq, size_t index, const utf8* name);
-bool TitleSequenceRemovePark(TitleSequence* seq, size_t index);
 
 bool TitleSequenceIsLoadCommand(const TitleCommand* command);

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -43,8 +43,8 @@ struct TitleSequence
     std::string Path;
     std::string Name;
 
-    size_t NumCommands;
-    TitleCommand* Commands;
+    std::vector<TitleCommand> Commands;
+    size_t NumCommands() const { return Commands.size(); }
 
     size_t NumSaves;
     utf8** Saves;

--- a/src/openrct2/title/TitleSequence.h
+++ b/src/openrct2/title/TitleSequence.h
@@ -40,8 +40,8 @@ struct TitleCommand
 
 struct TitleSequenceParkHandle
 {
-    const utf8* HintPath;
-    void* Stream;
+    std::string HintPath;
+    std::unique_ptr<OpenRCT2::IStream> Stream;
 };
 
 struct TitleSequence
@@ -57,9 +57,7 @@ struct TitleSequence
     std::string LegacyScriptWrite();
     void SwapConsecutiveCommands(size_t index);
 
-    // TODO: TitleSequenceParkHandle should also be migrated to RAII
-    TitleSequenceParkHandle* GetParkHandle(size_t index);
-    void CloseParkHandle(TitleSequenceParkHandle* handle);
+    std::unique_ptr<TitleSequenceParkHandle> GetParkHandle(size_t index);
 
     static bool IsLoadCommand(const TitleCommand* command);
 

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -104,7 +104,7 @@ namespace TitleSequenceManager
         Path::Append(newPath, sizeof(newPath), newName);
         if (item->IsZip)
         {
-            String::Append(newPath, sizeof(newPath), TITLE_SEQUENCE_EXTENSION);
+            String::Append(newPath, sizeof(newPath), TitleSequence::Extension);
             platform_file_move(oldPath, newPath);
         }
         else
@@ -164,7 +164,7 @@ namespace TitleSequenceManager
         auto path = Path::Combine(GetUserSequencesPath(), name);
         if (isZip)
         {
-            path += TITLE_SEQUENCE_EXTENSION;
+            path += TitleSequence::Extension;
         }
         return path;
     }

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -140,13 +140,14 @@ namespace TitleSequenceManager
     size_t CreateItem(const utf8* name)
     {
         std::string path = GetNewTitleSequencePath(std::string(name), true);
-        auto seq = CreateTitleSequence();
-        seq->Name = String::Duplicate(name);
-        seq->Path = String::Duplicate(path.c_str());
+        auto seq = std::make_unique<TitleSequence>();
+
+        seq->Name = name;
+        seq->Path = path;
         seq->IsZip = true;
 
-        bool success = TitleSequenceSave(seq.get());
-        FreeTitleSequence(seq);
+        bool success = seq->Save();
+        seq.reset();
 
         size_t index = SIZE_MAX;
         if (success)

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -140,12 +140,12 @@ namespace TitleSequenceManager
     size_t CreateItem(const utf8* name)
     {
         std::string path = GetNewTitleSequencePath(std::string(name), true);
-        TitleSequence* seq = CreateTitleSequence();
+        auto seq = CreateTitleSequence();
         seq->Name = String::Duplicate(name);
         seq->Path = String::Duplicate(path.c_str());
         seq->IsZip = true;
 
-        bool success = TitleSequenceSave(seq);
+        bool success = TitleSequenceSave(seq.get());
         FreeTitleSequence(seq);
 
         size_t index = SIZE_MAX;


### PR DESCRIPTION
This changeset adds a smart pointer to manage TitleSequence's storage.

There is one specific aspect that I'd like an opinion from the reviewers:
The `FreeTitleSequence` function could be implemented in two distinct ways:

1. Receives a non-const reference to the `std::unique_ptr<TitleSequence>`, and it frees the memory calling `::reset()`.
2. Receive a copy of the unique_ptr. Caller should explicitly move it:  `FreeTitleSequence(std::move(_sequence))`.

I arbitrarily chose the first option, but I'm good with both (or even a third one I haven`t envision). Please let me know your thoughts about it.

Thanks a lot.

PS.: Is there any tool (ASAN, Valgrind, etc...) to be sure I'm not messing up with memory management here?