### PR TITLE
Fix #12820: Title menu buttons not invalidating properly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.
 - Fix: [#12737] Space Rings draw the same vehicle 4 times.
 - Fix: [#12764] Rides don't start aged anymore.
+- Fix: [#12820] Title menu buttons not invalidating properly
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Technical: The required version of macOS has been lowered to 10.13 (High Sierra).
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -242,8 +242,8 @@ static void window_title_menu_cursor(
 
 static void window_title_menu_invalidate(rct_window* w)
 {
-    _filterRect = { w->windowPos.x, w->windowPos.y + UpdateButtonDims.width, w->windowPos.x + w->width - 1,
-                    w->windowPos.y + MenuButtonDims.width + UpdateButtonDims.width - 1 };
+    _filterRect = { w->windowPos.x, w->windowPos.y + UpdateButtonDims.height, w->windowPos.x + w->width - 1,
+                    w->windowPos.y + MenuButtonDims.height + UpdateButtonDims.height - 1 };
     if (OpenRCT2::GetContext()->HasNewVersionInfo())
     {
         w->enabled_widgets |= (1ULL << WIDX_NEW_VERSION);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -32,15 +32,18 @@ enum {
 };
 
 static ScreenRect _filterRect;
+static constexpr ScreenSize MenuButtonDims = { 82, 82 };
+static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
 
 static rct_widget window_title_menu_widgets[] = {
-    MakeWidget({0, 28}, {    82, 82}, WWT_IMGBTN, WindowColour::Tertiary , SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
-    MakeWidget({0, 28}, {    82, 82}, WWT_IMGBTN, WindowColour::Tertiary , SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
-    MakeWidget({0, 28}, {    82, 82}, WWT_IMGBTN, WindowColour::Tertiary , SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
-    MakeWidget({0, 28}, {    82, 82}, WWT_IMGBTN, WindowColour::Tertiary , SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
-    MakeWidget({0,  0}, {82 * 4, 28}, WWT_EMPTY,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
+    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
+    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
+    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
+    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
+    MakeWidget({0,                       0}, UpdateButtonDims, WWT_EMPTY,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
     { WIDGETS_END },
 };
+// clang-format on
 
 static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_menu_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
@@ -79,7 +82,6 @@ static rct_window_event_list window_title_menu_events = {
     window_title_menu_paint,
     nullptr
 };
-// clang-format on
 
 /**
  * Creates the window containing the menu buttons on the title screen.
@@ -89,9 +91,11 @@ rct_window* window_title_menu_open()
 {
     rct_window* window;
 
+    const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
     window = window_create(
-        ScreenCoordsXY(0, context_get_height() - 182), 0, 100, &window_title_menu_events, WC_TITLE_MENU,
+        ScreenCoordsXY(0, context_get_height() - 182), 0, windowHeight, &window_title_menu_events, WC_TITLE_MENU,
         WF_STICK_TO_BACK | WF_TRANSPARENT | WF_NO_BACKGROUND);
+
     window->widgets = window_title_menu_widgets;
     window->enabled_widgets
         = ((1 << WIDX_START_NEW_GAME) | (1 << WIDX_CONTINUE_SAVED_GAME) |
@@ -107,9 +111,9 @@ rct_window* window_title_menu_open()
         if (widget_is_enabled(window, i))
         {
             widget->left = x;
-            widget->right = x + 81;
+            widget->right = x + MenuButtonDims.width - 1;
 
-            x += 82;
+            x += MenuButtonDims.width;
         }
         else
         {
@@ -238,7 +242,8 @@ static void window_title_menu_cursor(
 
 static void window_title_menu_invalidate(rct_window* w)
 {
-    _filterRect = { w->windowPos.x, w->windowPos.y + 28, w->windowPos.x + w->width - 1, w->windowPos.y + 82 + 28 - 1 };
+    _filterRect = { w->windowPos.x, w->windowPos.y + UpdateButtonDims.width, w->windowPos.x + w->width - 1,
+                    w->windowPos.y + MenuButtonDims.width + UpdateButtonDims.width - 1 };
     if (OpenRCT2::GetContext()->HasNewVersionInfo())
     {
         w->enabled_widgets |= (1ULL << WIDX_NEW_VERSION);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -43,7 +43,6 @@ static rct_widget window_title_menu_widgets[] = {
     MakeWidget({0,                       0}, UpdateButtonDims, WWT_EMPTY,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
     { WIDGETS_END },
 };
-// clang-format on
 
 static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_menu_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
@@ -82,6 +81,7 @@ static rct_window_event_list window_title_menu_events = {
     window_title_menu_paint,
     nullptr
 };
+// clang-format on
 
 /**
  * Creates the window containing the menu buttons on the title screen.


### PR DESCRIPTION
The title menu buttons are 82x82 pixels. The window height for the menu was set to 100px — a little overkill for the buttons. However, #12347 added an update notification widget to the menu, increasing its height by 28px. Now, 110px are necessary for it to render properly at all times.

I have added constants for the various buttons to ensure this does not happen again.