### PR TITLE
Move update notification to top-right corner

### DIFF
--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -31,16 +31,13 @@ enum {
     WIDX_NEW_VERSION,
 };
 
-static ScreenRect _filterRect;
 static constexpr ScreenSize MenuButtonDims = { 82, 82 };
-static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
 
 static rct_widget window_title_menu_widgets[] = {
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
-    MakeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WWT_IMGBTN, WindowColour::Tertiary,  SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
-    MakeWidget({0,                       0}, UpdateButtonDims, WWT_EMPTY,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
+    MakeWidget({0, 0}, MenuButtonDims, WWT_IMGBTN, WindowColour::Tertiary, SPR_MENU_NEW_GAME,       STR_START_NEW_GAME_TIP),
+    MakeWidget({0, 0}, MenuButtonDims, WWT_IMGBTN, WindowColour::Tertiary, SPR_MENU_LOAD_GAME,      STR_CONTINUE_SAVED_GAME_TIP),
+    MakeWidget({0, 0}, MenuButtonDims, WWT_IMGBTN, WindowColour::Tertiary, SPR_G2_MENU_MULTIPLAYER, STR_SHOW_MULTIPLAYER_TIP),
+    MakeWidget({0, 0}, MenuButtonDims, WWT_IMGBTN, WindowColour::Tertiary, SPR_MENU_TOOLBOX,        STR_GAME_TOOLS_TIP),
     { WIDGETS_END },
 };
 
@@ -48,7 +45,6 @@ static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex
 static void window_title_menu_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_title_menu_dropdown(rct_window *w, rct_widgetindex widgetIndex, int32_t dropdownIndex);
 static void window_title_menu_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t *cursorId);
-static void window_title_menu_invalidate(rct_window *w);
 static void window_title_menu_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static rct_window_event_list window_title_menu_events = {
@@ -77,7 +73,7 @@ static rct_window_event_list window_title_menu_events = {
     nullptr,
     window_title_menu_cursor,
     nullptr,
-    window_title_menu_invalidate,
+    nullptr,
     window_title_menu_paint,
     nullptr
 };
@@ -89,11 +85,8 @@ static rct_window_event_list window_title_menu_events = {
  */
 rct_window* window_title_menu_open()
 {
-    rct_window* window;
-
-    const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
-    window = window_create(
-        ScreenCoordsXY(0, context_get_height() - 182), 0, windowHeight, &window_title_menu_events, WC_TITLE_MENU,
+    rct_window* window = window_create(
+        ScreenCoordsXY(0, context_get_height() - 154), 0, MenuButtonDims.height, &window_title_menu_events, WC_TITLE_MENU,
         WF_STICK_TO_BACK | WF_TRANSPARENT | WF_NO_BACKGROUND);
 
     window->widgets = window_title_menu_widgets;
@@ -106,7 +99,7 @@ rct_window* window_title_menu_open()
 
     rct_widgetindex i = 0;
     int32_t x = 0;
-    for (rct_widget* widget = window->widgets; widget != &window->widgets[WIDX_NEW_VERSION]; widget++)
+    for (rct_widget* widget = window->widgets; widget->type != WWT_LAST; widget++)
     {
         if (widget_is_enabled(window, i))
         {
@@ -122,9 +115,7 @@ rct_window* window_title_menu_open()
         i++;
     }
     window->width = x;
-    window->widgets[WIDX_NEW_VERSION].right = window->width;
     window->windowPos.x = (context_get_width() - window->width) / 2;
-    window->colours[1] = TRANSLUCENT(COLOUR_LIGHT_ORANGE);
 
     window_init_scroll_widgets(window);
 
@@ -183,9 +174,6 @@ static void window_title_menu_mouseup(rct_window* w, rct_widgetindex widgetIndex
                 context_open_window(WC_SERVER_LIST);
             }
             break;
-        case WIDX_NEW_VERSION:
-            context_open_window_view(WV_NEW_VERSION_INFO);
-            break;
     }
 }
 
@@ -240,20 +228,8 @@ static void window_title_menu_cursor(
     gTooltipTimeout = 2000;
 }
 
-static void window_title_menu_invalidate(rct_window* w)
-{
-    _filterRect = { w->windowPos.x, w->windowPos.y + UpdateButtonDims.height, w->windowPos.x + w->width - 1,
-                    w->windowPos.y + MenuButtonDims.height + UpdateButtonDims.height - 1 };
-    if (OpenRCT2::GetContext()->HasNewVersionInfo())
-    {
-        w->enabled_widgets |= (1ULL << WIDX_NEW_VERSION);
-        w->widgets[WIDX_NEW_VERSION].type = WWT_BUTTON;
-        _filterRect.Point1.y = w->windowPos.y;
-    }
-}
-
 static void window_title_menu_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    gfx_filter_rect(dpi, _filterRect, PALETTE_51);
+    gfx_filter_rect(dpi, w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width - 1, w->windowPos.y + 82 - 1, PALETTE_51);
     window_draw_widgets(w, dpi);
 }

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -16,15 +16,21 @@
 
 // clang-format off
 enum WINDOW_TITLE_OPTIONS_WIDGET_IDX {
+    WIDX_NEW_VERSION,
     WIDX_OPTIONS,
 };
 
+static constexpr ScreenSize OptionsButtonDims = { 80, 15 };
+static constexpr ScreenSize UpdateButtonDims = { 125, 15 };
+
 static rct_widget window_title_options_widgets[] = {
-    MakeWidget({0, 0}, {80, 15}, WWT_BUTTON, WindowColour::Tertiary, STR_OPTIONS, STR_OPTIONS_TIP),
+    MakeWidget({                     0, 0},  UpdateButtonDims, WWT_EMPTY,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
+    MakeWidget({UpdateButtonDims.width, 0}, OptionsButtonDims, WWT_BUTTON, WindowColour::Tertiary,  STR_OPTIONS, STR_OPTIONS_TIP),
     { WIDGETS_END },
 };
 
 static void window_title_options_mouseup(rct_window *w, rct_widgetindex widgetIndex);
+static void window_title_options_invalidate(rct_window *w);
 static void window_title_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static rct_window_event_list window_title_options_events = {
@@ -53,7 +59,7 @@ static rct_window_event_list window_title_options_events = {
     nullptr,
     nullptr,
     nullptr,
-    nullptr,
+    window_title_options_invalidate,
     window_title_options_paint,
     nullptr
 };
@@ -64,11 +70,14 @@ static rct_window_event_list window_title_options_events = {
  */
 rct_window* window_title_options_open()
 {
+    const uint16_t windowWidth = UpdateButtonDims.width + OptionsButtonDims.width;
+
     rct_window* window = window_create(
-        ScreenCoordsXY(context_get_width() - 80, 0), 80, 15, &window_title_options_events, WC_TITLE_OPTIONS,
-        WF_STICK_TO_BACK | WF_TRANSPARENT);
+        ScreenCoordsXY(context_get_width() - windowWidth, 0), windowWidth, OptionsButtonDims.height,
+        &window_title_options_events, WC_TITLE_OPTIONS, WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_options_widgets;
-    window->enabled_widgets |= (1ULL << WIDX_OPTIONS);
+    window->enabled_widgets = (1ULL << WIDX_OPTIONS);
+    window->colours[1] = TRANSLUCENT(COLOUR_LIGHT_ORANGE);
     window_init_scroll_widgets(window);
 
     return window;
@@ -84,10 +93,37 @@ static void window_title_options_mouseup(rct_window* w, rct_widgetindex widgetIn
         case WIDX_OPTIONS:
             context_open_window(WC_OPTIONS);
             break;
+        case WIDX_NEW_VERSION:
+            context_open_window_view(WV_NEW_VERSION_INFO);
+            break;
     }
+}
+
+static void window_title_options_invalidate(rct_window* w)
+{
+    rct_widget& updateButton = w->widgets[WIDX_NEW_VERSION];
+    rct_widget& optionsButton = w->widgets[WIDX_OPTIONS];
+
+    if (OpenRCT2::GetContext()->HasNewVersionInfo())
+    {
+        w->width = UpdateButtonDims.width + OptionsButtonDims.width;
+        w->enabled_widgets |= (1ULL << WIDX_NEW_VERSION);
+        updateButton.type = WWT_BUTTON;
+        optionsButton.left = UpdateButtonDims.width;
+    }
+    else
+    {
+        w->width = OptionsButtonDims.width;
+        updateButton.type = WWT_EMPTY;
+        optionsButton.left = 0;
+    }
+
+    optionsButton.right = optionsButton.left + OptionsButtonDims.width;
+    w->windowPos.x = context_get_width() - w->width;
 }
 
 static void window_title_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
+    gfx_filter_rect(dpi, { w->windowPos.x, w->windowPos.y, w->windowPos.x + w->width - 1, w->windowPos.y - 1 }, PALETTE_51);
     window_draw_widgets(w, dpi);
 }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1630,7 +1630,7 @@ void window_resize_gui(int32_t width, int32_t height)
     if (titleWind != nullptr)
     {
         titleWind->windowPos.x = (width - titleWind->width) / 2;
-        titleWind->windowPos.y = height - 182;
+        titleWind->windowPos.y = height - 154;
     }
 
     rct_window* exitWind = window_find_by_class(WC_TITLE_EXIT);
@@ -1643,7 +1643,7 @@ void window_resize_gui(int32_t width, int32_t height)
     rct_window* optionsWind = window_find_by_class(WC_TITLE_OPTIONS);
     if (optionsWind != nullptr)
     {
-        optionsWind->windowPos.x = width - 80;
+        optionsWind->windowPos.x = width - 205;
     }
 
     gfx_invalidate_screen();


### PR DESCRIPTION
_Just_ before the last release, in #12347, an update notification mechanism was introduced to OpenRCT2. To draw attention to the notification, it was placed on top of the title menu buttons. However, there has been discussion about whether this is too prominent. In this PR, I therefore propose to move it to the top-right corner, where it can sit next to the 'Options' button.

## Screenshots

### v0.3.0:
![Haunted Harbour 2020-08-30 20-24-56](https://user-images.githubusercontent.com/604665/91666678-f28ad900-eafe-11ea-91b7-65146db50767.png)

### This PR:
![Haunted Harbour 2020-08-30 20-19-45](https://user-images.githubusercontent.com/604665/91666676-f1f24280-eafe-11ea-8e46-86005139f4a9.png)