### PR TITLE
Make openrct2-win project the default startup project

### DIFF
--- a/openrct2.sln
+++ b/openrct2.sln
@@ -3,14 +3,14 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29411.138
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libopenrct2", "src\openrct2\libopenrct2.vcxproj", "{D24D94F6-2A74-480C-B512-629C306CE92F}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openrct2-win", "src\openrct2-win\openrct2-win.vcxproj", "{7A9A57D5-7006-4208-A290-5491BA3C8808}"
 	ProjectSection(ProjectDependencies) = postProject
 		{B6808F71-30B4-4499-8FF6-0B1C86391842} = {B6808F71-30B4-4499-8FF6-0B1C86391842}
 		{8DD8AB7D-2EA6-44E3-8265-BAF08E832951} = {8DD8AB7D-2EA6-44E3-8265-BAF08E832951}
 		{D24D94F6-2A74-480C-B512-629C306CE92F} = {D24D94F6-2A74-480C-B512-629C306CE92F}
 	EndProjectSection
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libopenrct2", "src\openrct2\libopenrct2.vcxproj", "{D24D94F6-2A74-480C-B512-629C306CE92F}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tests", "test\tests\tests.vcxproj", "{62B020FA-E4FB-4C6E-B32A-DC999470F155}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
? Yes, `project[1]` is always made the default startup project in a solution.