### PR TITLE
Fix #12818 - ignore ride price in free-rides parks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.
 - Fix: [#12737] Space Rings draw the same vehicle 4 times.
 - Fix: [#12764] Rides don't start aged anymore.
+- Fix: [#12818] Ride price not ignored in free-rides parks.
 - Fix: [#12820] Title menu buttons not invalidating properly
 - Fix: [#12845] Deleting ride with active ad campaign creates incorrect notification.
 - Fix: [#12857] Incorrect Peep thoughts in imported RCT1 parks.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -522,6 +522,7 @@ money32 Park::CalculateCompanyValue() const
 money16 Park::CalculateTotalRideValueForMoney() const
 {
     money16 totalRideValue = 0;
+    bool ridePricesUnlocked = park_ride_prices_unlocked() && !(gParkFlags & PARK_FLAGS_NO_MONEY);
     for (auto& ride : GetRideManager())
     {
         if (ride.status != RIDE_STATUS_OPEN)
@@ -534,7 +535,11 @@ money16 Park::CalculateTotalRideValueForMoney() const
         // Add ride value
         if (ride.value != RIDE_VALUE_UNDEFINED)
         {
-            money16 rideValue = static_cast<money16>(ride.value - ride.price[0]);
+            money16 rideValue = static_cast<money16>(ride.value);
+            if (ridePricesUnlocked)
+            {
+                rideValue -= ride.price[0];
+            }
             if (rideValue > 0)
             {
                 totalRideValue += rideValue * 2;


### PR DESCRIPTION
This change fixes the reason I opened #12818 by ensuring that, when calculating `CalculateTotalRideValueForMoney` (used in determining a fair entrance fee and in some awards), the ride prices are ignored if the park isn't pay-for-rides.

It occurs to me that the code could be made even more efficient by having two separate loops (so that checking whether ride prices should be considered would only be performed once), but I am assuming that copy/pasting the for loop would not be ideal. The for loop already is already in two places (along with a TODO to merge them). I have two ideas on how to improve this, though I don't know enough C++ to do it at the moment:

1. Some sort of accumulator function that receives a function pointer (and my understanding is that this is less efficeint)
2. RideManager could provide a different iterator object that only iterates over open and functioning rides

Or is the TODO just complaining that all these checks are happening 2x when the functions could be merged?

Side note: I find it a bit strange that `park_ride_prices_unlocked()` doesn't check if the park uses money or not. All the other places it's used also perform the NO_MONEY check, except for `marketing_is_campaign_type_applicable` - but this turns out to not matter in practice because there is a check for this in the UI code (though this sounds like the wrong place to check).