### PR TITLE
GitHub CI: Add Flathub Beta job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           path: artifacts
   linux-flathub-beta:
     name: Linux (Flathub beta channel)
-    if: github.event_name == 'push'
+    if: github.repository == 'OpenRCT2/OpenRCT2' && github.ref == 'refs/heads/develop' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Send dispatch event to OpenRCT2 Flathub repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,17 @@ jobs:
         with:
           name: OpenRCT2-AppImage
           path: artifacts
+  linux-flathub-beta:
+    name: Linux (Flathub beta channel)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send dispatch event to OpenRCT2 Flathub repository
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.OPENRCT2_FLATHUB_TOKEN }}
+          repository: flathub/io.openrct2.OpenRCT2
+          event-type: openrct2_develop_push
+          client-payload: '{ "commit": "${{ github.sha }}" }'
   linux-docker:
     name: Linux (docker)
     needs: [check-code-formatting]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
           path: artifacts
   linux-flathub-beta:
     name: Linux (Flathub beta channel)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Send dispatch event to OpenRCT2 Flathub repository


### PR DESCRIPTION
Add a job that will send a `repository_dispatch` event to the [OpenRCT2 Flathub](https://github.com/flathub/io.openrct2.OpenRCT2) repository with the pushed commit. There, it will set the `beta` manifest to this commit and trigger a build on the Flathub Beta channel, which will deliver flatpaks of the development builds to users.

You will need to create a personal access token for that (as the Flathub repository is public, the `public_repo` scope is enough) and store it as a secret as `OPENRCT2_FLATHUB_TOKEN`.

I'm not familiar with GitHub workflows so please tell me if everything looks alright!