### PR TITLE
Add Park.entranceFee to the plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.3.0+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#10807] Add 2x and 4x zoom levels (currently limited to OpenGL).
+- Feature: [#12840] Add Park.entranceFee to the plugin API.
 - Fix: [#400] Unable to place some saved tracks flush to the ground (original bug).
 - Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1344,6 +1344,12 @@ declare global {
         rating: number;
         bankLoan: number;
         maxBankLoan: number;
+
+        /**
+         * The current entrance fee for the park.
+         */
+        entranceFee: number;
+
         name: string;
         messages: ParkMessage[];
 

--- a/src/openrct2/scripting/ScPark.hpp
+++ b/src/openrct2/scripting/ScPark.hpp
@@ -280,11 +280,20 @@ namespace OpenRCT2::Scripting
             context_broadcast_intent(&intent);
         }
 
+        money16 entranceFee_get() const
+        {
+            return gParkEntranceFee;
+        }
+        void entranceFee_set(money16 value)
+        {
+            ThrowIfGameStateNotMutable();
+            gParkEntranceFee = value;
+        }
+
         std::string name_get() const
         {
             return GetContext()->GetGameState()->GetPark().Name;
         }
-
         void name_set(std::string value)
         {
             ThrowIfGameStateNotMutable();
@@ -383,6 +392,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScPark::rating_get, &ScPark::rating_set, "rating");
             dukglue_register_property(ctx, &ScPark::bankLoan_get, &ScPark::bankLoan_set, "bankLoan");
             dukglue_register_property(ctx, &ScPark::maxBankLoan_get, &ScPark::maxBankLoan_set, "maxBankLoan");
+            dukglue_register_property(ctx, &ScPark::entranceFee_get, &ScPark::entranceFee_set, "entranceFee");
             dukglue_register_property(ctx, &ScPark::name_get, &ScPark::name_set, "name");
             dukglue_register_property(ctx, &ScPark::messages_get, &ScPark::messages_set, "messages");
             dukglue_register_method(ctx, &ScPark::postMessage, "postMessage");

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -41,7 +41,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 2;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 3;
 
 struct ExpressionStringifier final
 {


### PR DESCRIPTION
## Description

While looking through the code of [openrct2-ride-price-manager](https://github.com/mgovea/openrct2-ride-price-manager) I noticed the plugin has its own setting to determine if the park charges an entrance fee. It seems like it would make sense to just provide this as part of the plugin API instead.

## Test

I tested this by changing the aforementioned plugin to check for `park.entranceFee > 0` instead of [`config.getParkAdmissionEnabled()`](https://github.com/mgovea/openrct2-ride-price-manager/blob/b60aae47775fbc391a6b62a7789a5c982f8ac4b6/src/fixRidePrices.ts#L37). Additionally I tested updating the fee with this simple plugin which seemed to work as expected.

```
var main = function() {
  context.subscribe("interval.day", function () {
    park.entranceFee = date.day * 10;
  });
};

registerPlugin({
    name: 'Set Park Price',
    version: '1.0',
    authors: ['OpenRCT2'],
    type: 'remote',
    main: main
});
```

![entranceFee](https://user-images.githubusercontent.com/812086/91920330-93070780-ec7d-11ea-9e8c-5543e3de5c04.gif)
