### PR TITLE
Fix #12845: Cancel marketing campaigns for demolished rides

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#12737] Space Rings draw the same vehicle 4 times.
 - Fix: [#12764] Rides don't start aged anymore.
 - Fix: [#12820] Title menu buttons not invalidating properly
+- Fix: [#12845] Deleting ride with active ad campaign creates incorrect notification.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Technical: The required version of macOS has been lowered to 10.13 (High Sierra).
 

--- a/src/openrct2/actions/RideDemolishAction.hpp
+++ b/src/openrct2/actions/RideDemolishAction.hpp
@@ -240,6 +240,8 @@ private:
             }
         }
 
+        MarketingCancelCampaignsForRide(_rideIndex);
+
         auto res = std::make_unique<GameActionResult>();
         res->Expenditure = ExpenditureType::RideConstruction;
         res->Cost = refundPrice;

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -237,3 +237,18 @@ void marketing_new_campaign(const MarketingCampaign& campaign)
         gMarketingCampaigns.push_back(campaign);
     }
 }
+
+void MarketingCancelCampaignsForRide(const ride_id_t rideId)
+{
+    auto isCampaignForRideFn = [&rideId](MarketingCampaign& campaign) {
+        if (campaign.Type == ADVERTISING_CAMPAIGN_RIDE_FREE || campaign.Type == ADVERTISING_CAMPAIGN_RIDE)
+        {
+            return campaign.RideId == rideId;
+        }
+        return false;
+    };
+
+    auto& v = gMarketingCampaigns;
+    auto removedIt = std::remove_if(v.begin(), v.end(), isCampaignForRideFn);
+    v.erase(removedIt, v.end());
+}

--- a/src/openrct2/management/Marketing.h
+++ b/src/openrct2/management/Marketing.h
@@ -67,3 +67,4 @@ void marketing_set_guest_campaign(Peep* peep, int32_t campaign);
 bool marketing_is_campaign_type_applicable(int32_t campaignType);
 MarketingCampaign* marketing_get_campaign(int32_t campaignType);
 void marketing_new_campaign(const MarketingCampaign& campaign);
+void MarketingCancelCampaignsForRide(const ride_id_t rideId);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Fixes #12845 

![demolish](https://user-images.githubusercontent.com/812086/92047652-84325a80-ed3a-11ea-84dd-c0094b318f9d.gif)
