### PR TITLE
Consistently render various height marks when zoomed in

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -340,9 +340,7 @@ void entrance_paint(paint_session* session, uint8_t direction, int32_t height, c
 {
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_LABEL;
 
-    rct_drawpixelinfo* dpi = &session->DPI;
-
-    if (session->ViewFlags & VIEWPORT_FLAG_PATH_HEIGHTS && dpi->zoom_level <= 0)
+    if (PaintShouldShowHeightMarkers(session, VIEWPORT_FLAG_PATH_HEIGHTS))
     {
         if (entrance_get_directions(tile_element) & 0xF)
         {

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -930,7 +930,7 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
         }
     }
 
-    if (session->ViewFlags & VIEWPORT_FLAG_PATH_HEIGHTS)
+    if (PaintShouldShowHeightMarkers(session, VIEWPORT_FLAG_PATH_HEIGHTS))
     {
         uint16_t heightMarkerBaseZ = tile_element->GetBaseZ() + 3;
         if (tile_element->AsPath()->IsSloped())

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1015,7 +1015,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         descriptor.corner_heights.left = baseHeight + ch.left;
     }
 
-    if ((session->ViewFlags & VIEWPORT_FLAG_LAND_HEIGHTS) && (zoomLevel == 0))
+    if (PaintShouldShowHeightMarkers(session, VIEWPORT_FLAG_LAND_HEIGHTS))
     {
         const int16_t x = session->MapPosition.x;
         const int16_t y = session->MapPosition.y;

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -453,3 +453,9 @@ uint16_t paint_util_rotate_segments(uint16_t segments, uint8_t rotation)
 
     return (segments & 0xFF00) | temp;
 }
+
+bool PaintShouldShowHeightMarkers(const paint_session* session, const uint32_t viewportFlag)
+{
+    auto dpi = &session->DPI;
+    return (session->ViewFlags & viewportFlag) && (dpi->zoom_level <= 0);
+}

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -111,4 +111,6 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
 void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t height, const TileElement* tileElement);
 void track_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tileElement);
 
+bool PaintShouldShowHeightMarkers(const paint_session* session, const uint32_t viewportFlag);
+
 #endif

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2143,8 +2143,6 @@ void track_paint(paint_session* session, uint8_t direction, int32_t height, cons
         return;
     }
 
-    rct_drawpixelinfo* dpi = &session->DPI;
-
     if ((!gTrackDesignSaveMode || rideIndex == gTrackDesignSaveRideIndex)
         && !(session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
     {
@@ -2152,7 +2150,7 @@ void track_paint(paint_session* session, uint8_t direction, int32_t height, cons
         int32_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
         int32_t trackColourScheme = tileElement->AsTrack()->GetColourScheme();
 
-        if ((session->ViewFlags & VIEWPORT_FLAG_TRACK_HEIGHTS) && dpi->zoom_level <= 0)
+        if (PaintShouldShowHeightMarkers(session, VIEWPORT_FLAG_TRACK_HEIGHTS))
         {
             session->InteractionType = VIEWPORT_INTERACTION_ITEM_NONE;
             if (TrackHeightMarkerPositions[trackType] & (1 << trackSequence))


### PR DESCRIPTION
This PR adjusts the rendering logic for the various height markers so that they consistently render when zoomed in but not when zoomed out (due to them being hard/impossible to read).