### PR TITLE
Fix #12434: Refactor ENTERTAINER_COSTUME to use strong enum 

### DIFF
--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -282,7 +282,7 @@ static constexpr const uint32_t window_staff_page_enabled_widgets[] = {
 };
 // clang-format on
 
-static uint8_t _availableCostumes[ENTERTAINER_COSTUME_COUNT];
+static uint8_t _availableCostumes[static_cast<uint8_t>(EntertainerCostume::Count)];
 
 enum class PatrolAreaValue
 {

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -282,7 +282,7 @@ static constexpr const uint32_t window_staff_page_enabled_widgets[] = {
 };
 // clang-format on
 
-static uint8_t _availableCostumes[static_cast<uint8_t>(EntertainerCostume::Count)];
+static EntertainerCostume _availableCostumes[static_cast<uint8_t>(EntertainerCostume::Count)];
 
 enum class PatrolAreaValue
 {
@@ -1472,12 +1472,13 @@ void window_staff_options_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
     int32_t numCostumes = staff_get_available_entertainer_costume_list(_availableCostumes);
     for (int32_t i = 0; i < numCostumes; i++)
     {
-        uint8_t costume = _availableCostumes[i];
-        if (peep->SpriteType == PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + costume)
+        EntertainerCostume costume = _availableCostumes[i];
+        uint8_t costume_value = static_cast<uint8_t>(costume);
+        if (peep->SpriteType == PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + costume_value)
         {
             checkedIndex = i;
         }
-        gDropdownItemsArgs[i] = StaffCostumeNames[costume];
+        gDropdownItemsArgs[i] = StaffCostumeNames[costume_value];
         gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
     }
 
@@ -1510,7 +1511,7 @@ void window_staff_options_dropdown(rct_window* w, rct_widgetindex widgetIndex, i
     if (dropdownIndex == -1)
         return;
 
-    uint8_t costume = _availableCostumes[dropdownIndex];
+    EntertainerCostume costume = _availableCostumes[dropdownIndex];
     auto staffSetCostumeAction = StaffSetCostumeAction(w->number, costume);
     GameActions::Execute(&staffSetCostumeAction);
 }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1473,12 +1473,11 @@ void window_staff_options_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
     for (int32_t i = 0; i < numCostumes; i++)
     {
         EntertainerCostume costume = _availableCostumes[i];
-        uint8_t costumeValue = static_cast<uint8_t>(costume);
-        if (peep->SpriteType == PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + costumeValue)
+        if (peep->SpriteType == EntertainerCostumeToSprite(costume))
         {
             checkedIndex = i;
         }
-        gDropdownItemsArgs[i] = StaffCostumeNames[costumeValue];
+        gDropdownItemsArgs[i] = StaffCostumeNames[static_cast<uint8_t>(costume)];
         gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
     }
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1473,12 +1473,12 @@ void window_staff_options_mousedown(rct_window* w, rct_widgetindex widgetIndex, 
     for (int32_t i = 0; i < numCostumes; i++)
     {
         EntertainerCostume costume = _availableCostumes[i];
-        uint8_t costume_value = static_cast<uint8_t>(costume);
-        if (peep->SpriteType == PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + costume_value)
+        uint8_t costumeValue = static_cast<uint8_t>(costume);
+        if (peep->SpriteType == PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + costumeValue)
         {
             checkedIndex = i;
         }
-        gDropdownItemsArgs[i] = StaffCostumeNames[costume_value];
+        gDropdownItemsArgs[i] = StaffCostumeNames[costumeValue];
         gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
     }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -129,7 +129,7 @@ static rct_widget window_staff_list_widgets[] = {
 static int32_t _windowStaffListHighlightedIndex;
 static int32_t _windowStaffListSelectedTab = WINDOW_STAFF_LIST_TAB_HANDYMEN;
 
-static uint8_t window_staff_list_get_random_entertainer_costume();
+static EntertainerCostume window_staff_list_get_random_entertainer_costume();
 
 struct staff_naming_convention
 {
@@ -231,10 +231,10 @@ static void window_staff_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_STAFF_LIST_HIRE_BUTTON:
         {
             StaffType staffType = static_cast<StaffType>(_windowStaffListSelectedTab);
-            EntertainerCostume costume = EntertainerCostume::Count;
+            auto costume = EntertainerCostume::Count;
             if (staffType == StaffType::Entertainer)
             {
-                costume = static_cast<EntertainerCostume>(window_staff_list_get_random_entertainer_costume());
+                costume = window_staff_list_get_random_entertainer_costume();
             }
             staff_hire_new_member(staffType, costume);
             break;
@@ -756,10 +756,10 @@ void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
     }
 }
 
-static uint8_t window_staff_list_get_random_entertainer_costume()
+static EntertainerCostume window_staff_list_get_random_entertainer_costume()
 {
-    uint8_t result = static_cast<uint8_t>(EntertainerCostume::Panda);
-    uint8_t costumeList[static_cast<uint8_t>(EntertainerCostume::Count)];
+    auto result = EntertainerCostume::Panda;
+    EntertainerCostume costumeList[static_cast<uint8_t>(EntertainerCostume::Count)];
     int32_t numCostumes = staff_get_available_entertainer_costume_list(costumeList);
     if (numCostumes > 0)
     {

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -231,10 +231,10 @@ static void window_staff_list_mouseup(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_STAFF_LIST_HIRE_BUTTON:
         {
             StaffType staffType = static_cast<StaffType>(_windowStaffListSelectedTab);
-            ENTERTAINER_COSTUME costume = ENTERTAINER_COSTUME_COUNT;
+            EntertainerCostume costume = EntertainerCostume::Count;
             if (staffType == StaffType::Entertainer)
             {
-                costume = static_cast<ENTERTAINER_COSTUME>(window_staff_list_get_random_entertainer_costume());
+                costume = static_cast<EntertainerCostume>(window_staff_list_get_random_entertainer_costume());
             }
             staff_hire_new_member(staffType, costume);
             break;
@@ -758,8 +758,8 @@ void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
 
 static uint8_t window_staff_list_get_random_entertainer_costume()
 {
-    uint8_t result = ENTERTAINER_COSTUME_PANDA;
-    uint8_t costumeList[ENTERTAINER_COSTUME_COUNT];
+    uint8_t result = static_cast<uint8_t>(EntertainerCostume::Panda);
+    uint8_t costumeList[static_cast<uint8_t>(EntertainerCostume::Count)];
     int32_t numCostumes = staff_get_available_entertainer_costume_list(costumeList);
     if (numCostumes > 0)
     {

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -55,7 +55,7 @@ DEFINE_GAME_ACTION(StaffHireNewAction, GAME_COMMAND_HIRE_NEW_STAFF_MEMBER, Staff
 private:
     bool _autoPosition = false;
     uint8_t _staffType = static_cast<uint8_t>(StaffType::Count);
-    uint8_t _entertainerType = static_cast<uint8_t>(EntertainerCostume::Count);
+    EntertainerCostume _entertainerType = EntertainerCostume::Count;
     uint32_t _staffOrders = 0;
 
 public:
@@ -63,7 +63,7 @@ public:
     StaffHireNewAction(bool autoPosition, StaffType staffType, EntertainerCostume entertainerType, uint32_t staffOrders)
         : _autoPosition(autoPosition)
         , _staffType(static_cast<uint8_t>(staffType))
-        , _entertainerType(static_cast<uint8_t>(entertainerType))
+        , _entertainerType(entertainerType)
         , _staffOrders(staffOrders)
     {
     }
@@ -112,7 +112,7 @@ private:
 
         if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
         {
-            if (_entertainerType >= static_cast<uint8_t>(EntertainerCostume::Count))
+            if (static_cast<uint8_t>(_entertainerType) >= static_cast<uint8_t>(EntertainerCostume::Count))
             {
                 // Invalid entertainer costume
                 log_error("Tried to use invalid entertainer type: %u", static_cast<uint32_t>(_entertainerType));
@@ -121,7 +121,7 @@ private:
             }
 
             uint32_t availableCostumes = staff_get_available_entertainer_costumes();
-            if (!(availableCostumes & (1 << _entertainerType)))
+            if (!(availableCostumes & (1 << static_cast<uint8_t>(_entertainerType))))
             {
                 // Entertainer costume unavailable
                 log_error("Tried to use unavailable entertainer type: %u", static_cast<uint32_t>(_entertainerType));
@@ -204,7 +204,7 @@ private:
             PeepSpriteType spriteType = spriteTypes[_staffType];
             if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
             {
-                spriteType = static_cast<PeepSpriteType>(PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + _entertainerType);
+                spriteType = static_cast<PeepSpriteType>(PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + static_cast<uint8_t>(_entertainerType));
             }
             newPeep->Name = nullptr;
             newPeep->SpriteType = spriteType;

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -204,7 +204,8 @@ private:
             PeepSpriteType spriteType = spriteTypes[_staffType];
             if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
             {
-                spriteType = static_cast<PeepSpriteType>(PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + static_cast<uint8_t>(_entertainerType));
+                spriteType = static_cast<PeepSpriteType>(
+                    PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + static_cast<uint8_t>(_entertainerType));
             }
             newPeep->Name = nullptr;
             newPeep->SpriteType = spriteType;

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -55,15 +55,15 @@ DEFINE_GAME_ACTION(StaffHireNewAction, GAME_COMMAND_HIRE_NEW_STAFF_MEMBER, Staff
 private:
     bool _autoPosition = false;
     uint8_t _staffType = static_cast<uint8_t>(StaffType::Count);
-    uint8_t _entertainerType = ENTERTAINER_COSTUME::ENTERTAINER_COSTUME_COUNT;
+    uint8_t _entertainerType = static_cast<uint8_t>(EntertainerCostume::Count);
     uint32_t _staffOrders = 0;
 
 public:
     StaffHireNewAction() = default;
-    StaffHireNewAction(bool autoPosition, StaffType staffType, ENTERTAINER_COSTUME entertainerType, uint32_t staffOrders)
+    StaffHireNewAction(bool autoPosition, StaffType staffType, EntertainerCostume entertainerType, uint32_t staffOrders)
         : _autoPosition(autoPosition)
         , _staffType(static_cast<uint8_t>(staffType))
-        , _entertainerType(entertainerType)
+        , _entertainerType(static_cast<uint8_t>(entertainerType))
         , _staffOrders(staffOrders)
     {
     }
@@ -112,7 +112,7 @@ private:
 
         if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
         {
-            if (_entertainerType >= ENTERTAINER_COSTUME_COUNT)
+            if (_entertainerType >= static_cast<uint8_t>(EntertainerCostume::Count))
             {
                 // Invalid entertainer costume
                 log_error("Tried to use invalid entertainer type: %u", static_cast<uint32_t>(_entertainerType));

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -204,7 +204,7 @@ private:
             PeepSpriteType spriteType = spriteTypes[_staffType];
             if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
             {
-                spriteType = map_costume_to_sprite(_entertainerType);
+                spriteType = EntertainerCostumeToSprite(_entertainerType);
             }
             newPeep->Name = nullptr;
             newPeep->SpriteType = spriteType;

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -204,8 +204,7 @@ private:
             PeepSpriteType spriteType = spriteTypes[_staffType];
             if (_staffType == static_cast<uint8_t>(StaffType::Entertainer))
             {
-                spriteType = static_cast<PeepSpriteType>(
-                    PEEP_SPRITE_TYPE_ENTERTAINER_PANDA + static_cast<uint8_t>(_entertainerType));
+                spriteType = map_costume_to_sprite(_entertainerType);
             }
             newPeep->Name = nullptr;
             newPeep->SpriteType = spriteType;

--- a/src/openrct2/actions/StaffSetCostumeAction.hpp
+++ b/src/openrct2/actions/StaffSetCostumeAction.hpp
@@ -42,13 +42,13 @@ DEFINE_GAME_ACTION(StaffSetCostumeAction, GAME_COMMAND_SET_STAFF_COSTUME, GameAc
 {
 private:
     uint16_t _spriteIndex;
-    uint8_t _costume;
+    EntertainerCostume _costume;
 
 public:
     StaffSetCostumeAction()
     {
     }
-    StaffSetCostumeAction(uint16_t spriteIndex, uint8_t costume)
+    StaffSetCostumeAction(uint16_t spriteIndex, EntertainerCostume costume)
         : _spriteIndex(spriteIndex)
         , _costume(costume)
     {
@@ -80,7 +80,7 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
         }
 
-        auto spriteType = static_cast<PeepSpriteType>(_costume + 4);
+        auto spriteType = EntertainerCostumeToSprite(_costume);
         if (spriteType > std::size(peep_slow_walking_types))
         {
             log_warning("Invalid game command for sprite %u", _spriteIndex);
@@ -98,7 +98,7 @@ public:
             return std::make_unique<GameActionResult>(GA_ERROR::INVALID_PARAMETERS, STR_NONE);
         }
 
-        auto spriteType = static_cast<PeepSpriteType>(_costume + 4);
+        auto spriteType = EntertainerCostumeToSprite(_costume);
         staff->SpriteType = spriteType;
         staff->PeepFlags &= ~PEEP_FLAGS_SLOW_WALK;
         if (peep_slow_walking_types[spriteType])

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -449,7 +449,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
             {
                 console.WriteFormatLine("staff set energy <staff id> <value 0-255>");
                 console.WriteFormatLine("staff set costume <staff id> <costume id>");
-                for (int32_t i = 0; i < ENTERTAINER_COSTUME_COUNT; i++)
+                for (int32_t i = 0; i < static_cast<uint8_t>(EntertainerCostume::Count); i++)
                 {
                     char costume_name[128] = { 0 };
                     rct_string_id costume = StaffCostumeNames[i];
@@ -499,7 +499,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
                     console.WriteLineError("Specified staff is not entertainer");
                     return 1;
                 }
-                if (!int_valid[1] || int_val[1] < 0 || int_val[1] >= ENTERTAINER_COSTUME_COUNT)
+                if (!int_valid[1] || int_val[1] < 0 || int_val[1] >= static_cast<uint8_t>(EntertainerCostume::Count))
                 {
                     console.WriteLineError("Invalid costume ID");
                     return 1;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -505,7 +505,7 @@ static int32_t cc_staff(InteractiveConsole& console, const arguments_t& argv)
                     return 1;
                 }
 
-                uint8_t costume = int_val[1];
+                EntertainerCostume costume = static_cast<EntertainerCostume>(int_val[1]);
                 auto staffSetCostumeAction = StaffSetCostumeAction(int_val[0], costume);
                 GameActions::Execute(&staffSetCostumeAction);
             }

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -139,7 +139,7 @@ uint32_t SceneryGroupObject::ReadJsonEntertainerCostumes(const json_t* jCostumes
     for (const auto& szCostume : szCostumes)
     {
         auto entertainer = ParseEntertainerCostume(szCostume);
-        auto peepSprite  = EntertainerCostumeToSprite(entertainer);
+        auto peepSprite = EntertainerCostumeToSprite(entertainer);
         costumes |= 1 << (static_cast<uint8_t>(peepSprite));
     }
     return costumes;

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -142,36 +142,36 @@ uint32_t SceneryGroupObject::ReadJsonEntertainerCostumes(const json_t* jCostumes
 
         // For some reason the flags are +4 from the actual costume IDs
         // See staff_get_available_entertainer_costumes
-        costumes |= 1 << (entertainer + 4);
+        costumes |= 1 << (static_cast<uint8_t>(entertainer) + 4);
     }
     return costumes;
 }
 
-uint32_t SceneryGroupObject::ParseEntertainerCostume(const std::string& s)
+EntertainerCostume SceneryGroupObject::ParseEntertainerCostume(const std::string& s)
 {
     if (s == "panda")
-        return static_cast<uint32_t>(EntertainerCostume::Panda);
+        return EntertainerCostume::Panda;
     if (s == "tiger")
-        return static_cast<uint32_t>(EntertainerCostume::Tiger);
+        return EntertainerCostume::Tiger;
     if (s == "elephant")
-        return static_cast<uint32_t>(EntertainerCostume::Elephant);
+        return EntertainerCostume::Elephant;
     if (s == "roman")
-        return static_cast<uint32_t>(EntertainerCostume::Roman);
+        return EntertainerCostume::Roman;
     if (s == "gorilla")
-        return static_cast<uint32_t>(EntertainerCostume::Gorilla);
+        return EntertainerCostume::Gorilla;
     if (s == "snowman")
-        return static_cast<uint32_t>(EntertainerCostume::Snowman);
+        return EntertainerCostume::Snowman;
     if (s == "knight")
-        return static_cast<uint32_t>(EntertainerCostume::Knight);
+        return EntertainerCostume::Knight;
     if (s == "astronaut")
-        return static_cast<uint32_t>(EntertainerCostume::Astronaut);
+        return EntertainerCostume::Astronaut;
     if (s == "bandit")
-        return static_cast<uint32_t>(EntertainerCostume::Bandit);
+        return EntertainerCostume::Bandit;
     if (s == "sheriff")
-        return static_cast<uint32_t>(EntertainerCostume::Sheriff);
+        return EntertainerCostume::Sheriff;
     if (s == "pirate")
-        return static_cast<uint32_t>(EntertainerCostume::Pirate);
-    return static_cast<uint32_t>(EntertainerCostume::Panda);
+        return EntertainerCostume::Pirate;
+    return EntertainerCostume::Panda;
 }
 
 std::vector<rct_object_entry> SceneryGroupObject::ReadJsonEntries(const json_t* jEntries)

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -115,7 +115,7 @@ void SceneryGroupObject::ReadJson(IReadObjectContext* context, const json_t* roo
     auto properties = json_object_get(root, "properties");
     _legacyType.priority = json_integer_value(json_object_get(properties, "priority"));
 
-    // Entertainer cosumes
+    // Entertainer costumes
     auto jCostumes = json_object_get(properties, "entertainerCostumes");
     if (jCostumes != nullptr)
     {
@@ -150,28 +150,28 @@ uint32_t SceneryGroupObject::ReadJsonEntertainerCostumes(const json_t* jCostumes
 uint32_t SceneryGroupObject::ParseEntertainerCostume(const std::string& s)
 {
     if (s == "panda")
-        return ENTERTAINER_COSTUME_PANDA;
+        return static_cast<uint32_t>(EntertainerCostume::Panda);
     if (s == "tiger")
-        return ENTERTAINER_COSTUME_TIGER;
+        return static_cast<uint32_t>(EntertainerCostume::Tiger);
     if (s == "elephant")
-        return ENTERTAINER_COSTUME_ELEPHANT;
+        return static_cast<uint32_t>(EntertainerCostume::Elephant);
     if (s == "roman")
-        return ENTERTAINER_COSTUME_ROMAN;
+        return static_cast<uint32_t>(EntertainerCostume::Roman);
     if (s == "gorilla")
-        return ENTERTAINER_COSTUME_GORILLA;
+        return static_cast<uint32_t>(EntertainerCostume::Gorilla);
     if (s == "snowman")
-        return ENTERTAINER_COSTUME_SNOWMAN;
+        return static_cast<uint32_t>(EntertainerCostume::Snowman);
     if (s == "knight")
-        return ENTERTAINER_COSTUME_KNIGHT;
+        return static_cast<uint32_t>(EntertainerCostume::Knight);
     if (s == "astronaut")
-        return ENTERTAINER_COSTUME_ASTRONAUT;
+        return static_cast<uint32_t>(EntertainerCostume::Astronaut);
     if (s == "bandit")
-        return ENTERTAINER_COSTUME_BANDIT;
+        return static_cast<uint32_t>(EntertainerCostume::Bandit);
     if (s == "sheriff")
-        return ENTERTAINER_COSTUME_SHERIFF;
+        return static_cast<uint32_t>(EntertainerCostume::Sheriff);
     if (s == "pirate")
-        return ENTERTAINER_COSTUME_PIRATE;
-    return ENTERTAINER_COSTUME_PANDA;
+        return static_cast<uint32_t>(EntertainerCostume::Pirate);
+    return static_cast<uint32_t>(EntertainerCostume::Panda);
 }
 
 std::vector<rct_object_entry> SceneryGroupObject::ReadJsonEntries(const json_t* jEntries)

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -139,10 +139,8 @@ uint32_t SceneryGroupObject::ReadJsonEntertainerCostumes(const json_t* jCostumes
     for (const auto& szCostume : szCostumes)
     {
         auto entertainer = ParseEntertainerCostume(szCostume);
-
-        // For some reason the flags are +4 from the actual costume IDs
-        // See staff_get_available_entertainer_costumes
-        costumes |= 1 << (static_cast<uint8_t>(entertainer) + 4);
+        auto peepSprite  = EntertainerCostumeToSprite(entertainer);
+        costumes |= 1 << (static_cast<uint8_t>(peepSprite));
     }
     return costumes;
 }

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../peep/Staff.h"
 #include "../world/Scenery.h"
 #include "Object.h"
 
@@ -46,6 +47,6 @@ public:
 private:
     static std::vector<rct_object_entry> ReadItems(OpenRCT2::IStream* stream);
     static uint32_t ReadJsonEntertainerCostumes(const json_t* jCostumes);
-    static uint32_t ParseEntertainerCostume(const std::string& s);
+    static EntertainerCostume ParseEntertainerCostume(const std::string& s);
     static std::vector<rct_object_entry> ReadJsonEntries(const json_t* jEntries);
 };

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -9,13 +9,14 @@
 
 #pragma once
 
-#include "../peep/Staff.h"
 #include "../world/Scenery.h"
 #include "Object.h"
 
 #include <vector>
 
 struct ObjectRepositoryItem;
+
+enum class EntertainerCostume : uint8_t;
 
 class SceneryGroupObject final : public Object
 {

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1097,7 +1097,8 @@ uint8_t Staff::GetCostume() const
 
 void Staff::SetCostume(uint8_t value)
 {
-    SpriteType = static_cast<PeepSpriteType>(value + PEEP_SPRITE_TYPE_ENTERTAINER_PANDA);
+    auto costume = static_cast<EntertainerCostume>(value);
+    SpriteType = EntertainerCostumeToSprite(costume);
 }
 
 PeepSpriteType EntertainerCostumeToSprite(EntertainerCostume entertainerType)

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -103,7 +103,7 @@ void staff_reset_modes()
 /**
  * Hires a new staff member of the given type.
  */
-bool staff_hire_new_member(StaffType staffType, ENTERTAINER_COSTUME entertainerType)
+bool staff_hire_new_member(StaffType staffType, EntertainerCostume entertainerType)
 {
     bool autoPosition = gConfigGeneral.auto_staff_placement;
     if (gInputPlaceObjectModifier & PLACE_OBJECT_MODIFIER_SHIFT_Z)
@@ -1153,8 +1153,8 @@ uint32_t staff_get_available_entertainer_costumes()
     entertainerCostumes >>= 4;
 
     // Fix #6593: force enable the default costumes, which normally get enabled through the default scenery groups.
-    entertainerCostumes |= (1 << ENTERTAINER_COSTUME_PANDA) | (1 << ENTERTAINER_COSTUME_TIGER)
-        | (1 << ENTERTAINER_COSTUME_ELEPHANT);
+    entertainerCostumes |= (1 << static_cast<uint8_t>(EntertainerCostume::Panda))
+        | (1 << static_cast<uint8_t>(EntertainerCostume::Tiger)) | (1 << static_cast<uint8_t>(EntertainerCostume::Elephant));
 
     return entertainerCostumes;
 }
@@ -1163,7 +1163,7 @@ int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList)
 {
     uint32_t availableCostumes = staff_get_available_entertainer_costumes();
     int32_t numCostumes = 0;
-    for (uint8_t i = 0; i < ENTERTAINER_COSTUME_COUNT; i++)
+    for (uint8_t i = 0; i < static_cast<uint8_t>(EntertainerCostume::Count); i++)
     {
         if (availableCostumes & (1 << i))
         {

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1100,6 +1100,13 @@ void Staff::SetCostume(uint8_t value)
     SpriteType = static_cast<PeepSpriteType>(value + PEEP_SPRITE_TYPE_ENTERTAINER_PANDA);
 }
 
+PeepSpriteType map_costume_to_sprite(EntertainerCostume entertainerType)
+{
+    uint8_t value = static_cast<uint8_t>(entertainerType);
+    PeepSpriteType newSpriteType = static_cast<PeepSpriteType>(value + PEEP_SPRITE_TYPE_ENTERTAINER_PANDA);
+    return newSpriteType;
+}
+
 colour_t staff_get_colour(StaffType staffType)
 {
     switch (staffType)

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1100,7 +1100,7 @@ void Staff::SetCostume(uint8_t value)
     SpriteType = static_cast<PeepSpriteType>(value + PEEP_SPRITE_TYPE_ENTERTAINER_PANDA);
 }
 
-PeepSpriteType map_costume_to_sprite(EntertainerCostume entertainerType)
+PeepSpriteType EntertainerCostumeToSprite(EntertainerCostume entertainerType)
 {
     uint8_t value = static_cast<uint8_t>(entertainerType);
     PeepSpriteType newSpriteType = static_cast<PeepSpriteType>(value + PEEP_SPRITE_TYPE_ENTERTAINER_PANDA);

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1166,7 +1166,7 @@ uint32_t staff_get_available_entertainer_costumes()
     return entertainerCostumes;
 }
 
-int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList)
+int32_t staff_get_available_entertainer_costume_list(EntertainerCostume* costumeList)
 {
     uint32_t availableCostumes = staff_get_available_entertainer_costumes();
     int32_t numCostumes = 0;
@@ -1174,7 +1174,7 @@ int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList)
     {
         if (availableCostumes & (1 << i))
         {
-            costumeList[numCostumes++] = i;
+            costumeList[numCostumes++] = static_cast<EntertainerCostume>(i);
         }
     }
     return numCostumes;

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -76,7 +76,7 @@ void staff_toggle_patrol_area(int32_t staffIndex, const CoordsXY& coords);
 colour_t staff_get_colour(StaffType staffType);
 bool staff_set_colour(StaffType staffType, colour_t value);
 uint32_t staff_get_available_entertainer_costumes();
-int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList);
+int32_t staff_get_available_entertainer_costume_list(EntertainerCostume* costumeList);
 
 PeepSpriteType EntertainerCostumeToSprite(EntertainerCostume entertainerType);
 

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -78,6 +78,6 @@ bool staff_set_colour(StaffType staffType, colour_t value);
 uint32_t staff_get_available_entertainer_costumes();
 int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList);
 
-PeepSpriteType map_costume_to_sprite(EntertainerCostume entertainerType);
+PeepSpriteType EntertainerCostumeToSprite(EntertainerCostume entertainerType);
 
 #endif

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -78,4 +78,6 @@ bool staff_set_colour(StaffType staffType, colour_t value);
 uint32_t staff_get_available_entertainer_costumes();
 int32_t staff_get_available_entertainer_costume_list(uint8_t* costumeList);
 
+PeepSpriteType map_costume_to_sprite(EntertainerCostume entertainerType);
+
 #endif

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -35,26 +35,26 @@ enum STAFF_ORDERS
     STAFF_ORDERS_FIX_RIDES = (1 << 1)
 };
 
-enum ENTERTAINER_COSTUME : uint8_t
+enum class EntertainerCostume : uint8_t
 {
-    ENTERTAINER_COSTUME_PANDA,
-    ENTERTAINER_COSTUME_TIGER,
-    ENTERTAINER_COSTUME_ELEPHANT,
-    ENTERTAINER_COSTUME_ROMAN,
-    ENTERTAINER_COSTUME_GORILLA,
-    ENTERTAINER_COSTUME_SNOWMAN,
-    ENTERTAINER_COSTUME_KNIGHT,
-    ENTERTAINER_COSTUME_ASTRONAUT,
-    ENTERTAINER_COSTUME_BANDIT,
-    ENTERTAINER_COSTUME_SHERIFF,
-    ENTERTAINER_COSTUME_PIRATE,
+    Panda,
+    Tiger,
+    Elephant,
+    Roman,
+    Gorilla,
+    Snowman,
+    Knight,
+    Astronaut,
+    Bandit,
+    Sheriff,
+    Pirate,
 
-    ENTERTAINER_COSTUME_COUNT
+    Count
 };
 
 extern const money32 gStaffWageTable[static_cast<uint8_t>(StaffType::Count)];
 
-extern const rct_string_id StaffCostumeNames[ENTERTAINER_COSTUME_COUNT];
+extern const rct_string_id StaffCostumeNames[static_cast<uint8_t>(EntertainerCostume::Count)];
 
 extern uint32_t gStaffPatrolAreas[(STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)) * STAFF_PATROL_AREA_SIZE];
 extern StaffMode gStaffModes[STAFF_MAX_COUNT + static_cast<uint8_t>(StaffType::Count)];
@@ -65,7 +65,7 @@ extern colour_t gStaffSecurityColour;
 
 void staff_reset_modes();
 void staff_set_name(uint16_t spriteIndex, const char* name);
-bool staff_hire_new_member(StaffType staffType, ENTERTAINER_COSTUME entertainerType);
+bool staff_hire_new_member(StaffType staffType, EntertainerCostume entertainerType);
 void staff_update_greyed_patrol_areas();
 bool staff_is_location_on_patrol_edge(Peep* mechanic, const CoordsXY& loc);
 bool staff_can_ignore_wide_flag(Peep* mechanic, const CoordsXYZ& staffPos, TileElement* path);


### PR DESCRIPTION
This is a pretty straightforward translation, following the example https://github.com/OpenRCT2/OpenRCT2/pull/12386.
There's some places to improve brevity, like returning EntertainerCostumes rather than converting back and forth to uint_8.