### PR TITLE
Make ci.yml compatible with act to allow local testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Run clang-format
+        shell: sh
         run: scripts/check-code-formatting
   windows:
     name: Windows


### PR DESCRIPTION
I tried running jobs defined in `ci.yml` using [`act`](https://github.com/nektos/act) locally to debug a Linux i686 specific build issue. I'm honestly not 100% sure why but it failed with a
```
[CI/Check code formatting ] ⭐  Run Run clang-format
| OCI runtime exec failed: exec failed: container_linux.go:349: starting container process caused "exec: \"bash\": executable file not found in $PATH": unknown
```
I'm guessing it has something to do with the default shell differentiating.

Either way, after changing `ci.yml` as proposed, I was able to run
```
act -j linux-portable-32
```
successfully – which is pretty cool.