### PR TITLE
Fix #5753: Entertainers make themselves happy instead of the guests

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -154,6 +154,7 @@ The following people are not part of the development team, but have been contrib
 * Arran Ireland (ion232)
 * Ryan Bello (ryan-bello)
 * Simon Jarrett (mwnciau)
+* Richard Fine (richard-fine)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#12712] Add TCP / socket plugin APIs.
 - Feature: [#12840] Add Park.entranceFee to the plugin API.
 - Fix: [#400] Unable to place some saved tracks flush to the ground (original bug).
+- Fix: [#5753]: Entertainers make themselves happy instead of the guests.
 - Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -33,7 +33,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -946,6 +946,8 @@ private:
     bool DoMiscPathFinding();
 
     int32_t HandymanDirectionRandSurface(uint8_t validDirections);
+
+    void EntertainerUpdateNearbyPeeps() const;
 };
 
 static_assert(sizeof(Peep) <= 512);

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1009,19 +1009,19 @@ bool Staff::DoMiscPathFinding()
  *
  *  rct2: 0x006C086D
  */
-static void staff_entertainer_update_nearby_peeps(Peep* peep)
+void Staff::EntertainerUpdateNearbyPeeps() const
 {
     for (auto guest : EntityList<Guest>(EntityListId::Peep))
     {
         if (guest->x == LOCATION_NULL)
             continue;
 
-        int16_t z_dist = abs(peep->z - guest->z);
+        int16_t z_dist = abs(z - guest->z);
         if (z_dist > 48)
             continue;
 
-        int16_t x_dist = abs(peep->x - guest->x);
-        int16_t y_dist = abs(peep->y - guest->y);
+        int16_t x_dist = abs(x - guest->x);
+        int16_t y_dist = abs(y - guest->y);
 
         if (x_dist > 96)
             continue;
@@ -1029,21 +1029,14 @@ static void staff_entertainer_update_nearby_peeps(Peep* peep)
         if (y_dist > 96)
             continue;
 
-        if (peep->State == PEEP_STATE_WALKING)
+        if (guest->State == PEEP_STATE_WALKING)
         {
-            peep->HappinessTarget = std::min(peep->HappinessTarget + 4, PEEP_MAX_HAPPINESS);
+            guest->HappinessTarget = std::min(guest->HappinessTarget + 4, PEEP_MAX_HAPPINESS);
         }
-        else if (peep->State == PEEP_STATE_QUEUING)
+        else if (guest->State == PEEP_STATE_QUEUING)
         {
-            if (peep->TimeInQueue > 200)
-            {
-                peep->TimeInQueue -= 200;
-            }
-            else
-            {
-                peep->TimeInQueue = 0;
-            }
-            peep->HappinessTarget = std::min(peep->HappinessTarget + 3, PEEP_MAX_HAPPINESS);
+            guest->TimeInQueue = std::max(0, guest->TimeInQueue - 200);
+            guest->HappinessTarget = std::min(guest->HappinessTarget + 3, PEEP_MAX_HAPPINESS);
         }
     }
 }
@@ -1061,7 +1054,7 @@ bool Staff::DoEntertainerPathFinding()
         ActionSpriteImageOffset = 0;
 
         UpdateCurrentActionSpriteType();
-        staff_entertainer_update_nearby_peeps(this);
+        EntertainerUpdateNearbyPeeps();
     }
 
     return DoMiscPathFinding();


### PR DESCRIPTION
After identifying guests that are near an entertainer, modify the guest's HappinessTarget and TimeInQueue values instead of the entertainer's own values.