### PR TITLE
Fix #12881: Guests' favourite rides not listed in the guest window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,7 +16,7 @@
 - Fix: [#12820] Title menu buttons not invalidating properly
 - Fix: [#12845] Deleting ride with active ad campaign creates incorrect notification.
 - Fix: [#12857] Incorrect Peep thoughts in imported RCT1 parks.
-- Fix: [#12881] Guests have no favorite ride.
+- Fix: [#12881] Guests' favourite rides are not listed in the guest window.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Technical: The required version of macOS has been lowered to 10.13 (High Sierra).
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#12820] Title menu buttons not invalidating properly
 - Fix: [#12845] Deleting ride with active ad campaign creates incorrect notification.
 - Fix: [#12857] Incorrect Peep thoughts in imported RCT1 parks.
+- Fix: [#12881] Guests have no favorite ride.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Technical: The required version of macOS has been lowered to 10.13 (High Sierra).
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1765,22 +1765,16 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenCoords.y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
     auto ft = Formatter::Common();
-    if (peep->FavouriteRide != RIDE_ID_NULL)
+    auto ride = get_ride(peep->FavouriteRide);
+    if (ride != nullptr)
     {
-        auto ride = get_ride(peep->FavouriteRide);
-        if (ride != nullptr)
-        {
-            ride->FormatNameTo(ft);
-        }
-        else
-        {
-            ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
-        }
+        ride->FormatNameTo(ft);
     }
     else
     {
         ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
     }
+
     DrawTextEllipsised(dpi, screenCoords, w->width - 14, STR_FAVOURITE_RIDE, ft, COLOUR_BLACK);
 }
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1765,7 +1765,6 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenCoords.y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
     auto ft = Formatter::Common();
-    ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
     if (peep->FavouriteRide != RIDE_ID_NULL)
     {
         auto ride = get_ride(peep->FavouriteRide);
@@ -1773,6 +1772,14 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             ride->FormatNameTo(ft);
         }
+        else
+        {
+            ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
+        }
+    }
+    else
+    {
+        ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
     }
     DrawTextEllipsised(dpi, screenCoords, w->width - 14, STR_FAVOURITE_RIDE, ft, COLOUR_BLACK);
 }


### PR DESCRIPTION
I scoured #12041 and this seems to be the only actual bug that slipped (reusing a formatter but without resetting it back to "0")