### PR TITLE
Restrict lint-commit to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   lint-commit:
     name: Lint Commit Message
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sometimes it happens that the merge commit itself (or the squashed one) violates the commit lint, which is alright because the individual commit messages were ok in the PR.

We rarely push to the repo directly and, if we do, we won't ammend the commit message, so this just restricts the linter to run only on PRs.