### PR TITLE
Fix #12912: Plugin: selectedCell of CustomListView is being ignored on creation

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -156,6 +156,7 @@ The following people are not part of the development team, but have been contrib
 * Simon Jarrett (mwnciau)
 * Richard Fine (richard-fine)
 * Tom Parsons (tombomp)
+* Stephan Spengler (Sadret)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#12857] Incorrect Peep thoughts in imported RCT1 parks.
 - Fix: [#12881] Guests' favourite rides are not listed in the guest window.
 - Fix: [#12910] Plugin API: getRide sometimes returns null for valid ride IDs.
+- Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Improved: [#12806] Add Esperanto diacritics to the sprite font.
 - Improved: [#12890] Add stroke to lowercase 'L' to differentiate from capital 'I'.

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -110,6 +110,7 @@ namespace OpenRCT2::Ui::Windows
         std::vector<ListViewColumn> ListViewColumns;
         ScrollbarType Scrollbars{};
         int32_t SelectedIndex{};
+        std::optional<RowColumn> SelectedCell;
         bool IsChecked{};
         bool IsDisabled{};
         bool IsPressed{};
@@ -177,6 +178,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 result.ListViewColumns = FromDuk<std::vector<ListViewColumn>>(desc["columns"]);
                 result.ListViewItems = FromDuk<std::vector<ListViewItem>>(desc["items"]);
+                result.SelectedCell = FromDuk<std::optional<RowColumn>>(desc["selectedCell"]);
                 result.ShowColumnHeaders = AsOrDefault(desc["showColumnHeaders"], false);
                 result.IsStriped = AsOrDefault(desc["isStriped"], false);
                 result.OnClick = desc["onClick"];
@@ -1007,6 +1009,7 @@ namespace OpenRCT2::Ui::Windows
                 listView.SetScrollbars(widgetDesc.Scrollbars, true);
                 listView.SetColumns(widgetDesc.ListViewColumns, true);
                 listView.SetItems(widgetDesc.ListViewItems, true);
+                listView.SelectedCell = widgetDesc.SelectedCell;
                 listView.ShowColumnHeaders = widgetDesc.ShowColumnHeaders;
                 listView.IsStriped = widgetDesc.IsStriped;
                 listView.OnClick = widgetDesc.OnClick;


### PR DESCRIPTION
Plugin: selectedCell of CustomListView is being ignored on creation