### PR TITLE
Debunch peeps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip")
 set(OBJECTS_SHA1 "4a3c32a0251c3babe014844f2c683fc32138b3f2")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.19/replays.zip")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.20/replays.zip")
 set(REPLAYS_SHA1 "8EAAE223FF9FE4D49949C9F343831977E6DB6CDE")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.18/
 set(OBJECTS_SHA1 "4a3c32a0251c3babe014844f2c683fc32138b3f2")
 
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.20/replays.zip")
-set(REPLAYS_SHA1 "8EAAE223FF9FE4D49949C9F343831977E6DB6CDE")
+set(REPLAYS_SHA1 "65532bcb21c39236cfc1b7301d30297506383b65")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -52,6 +52,7 @@
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
+- Improved: Changed peep movement so that they stay more spread out over the full width of paths.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#13334] Uninitialised variables in CustomTabDesc
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface
+- Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 
 0.3.2 (2020-11-01)
 ------------------------------------------------------------------------
@@ -49,7 +50,6 @@
 - Fix: [#13278] Desync caused by ghost tiles changing the ride mode.
 - Fix: [#13289] Litter and vomit sometimes not loading with RCT1 saved game or scenario
 - Fix: [#13292] Impossible excitement rating requirements with finish building 5 coasters goal
-- Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -52,7 +52,7 @@
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
-- Improved: Changed peep movement so that they stay more spread out over the full width of paths.
+- Improved: Changed peep movement so that they stay more spread out over the full width of single tile paths.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -49,10 +49,10 @@
 - Fix: [#13278] Desync caused by ghost tiles changing the ride mode.
 - Fix: [#13289] Litter and vomit sometimes not loading with RCT1 saved game or scenario
 - Fix: [#13292] Impossible excitement rating requirements with finish building 5 coasters goal
+- Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
-- Improved: Changed peep movement so that they stay more spread out over the full width of single tile paths.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -49,7 +49,7 @@
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip</ObjectsUrl>
     <ObjectsSha1>4a3c32a0251c3babe014844f2c683fc32138b3f2</ObjectsSha1>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.20/replays.zip</ReplaysUrl>
-    <ReplaysSha1>8EAAE223FF9FE4D49949C9F343831977E6DB6CDE</ReplaysSha1>
+    <ReplaysSha1>65532bcb21c39236cfc1b7301d30297506383b65</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,7 +48,7 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip</ObjectsUrl>
     <ObjectsSha1>4a3c32a0251c3babe014844f2c683fc32138b3f2</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.19/replays.zip</ReplaysUrl>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.20/replays.zip</ReplaysUrl>
     <ReplaysSha1>8EAAE223FF9FE4D49949C9F343831977E6DB6CDE</ReplaysSha1>
   </PropertyGroup>
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -137,7 +137,31 @@ static int32_t peep_move_one_tile(Direction direction, Peep* peep)
     peep->DestinationTolerance = 2;
     if (peep->State != PeepState::Queuing)
     {
-        peep->DestinationTolerance = (scenario_rand() & 7) + 2;
+        // When peeps are walking along a path, we would like them to be spread out across the width of the path,
+        // instead of all walking along the exact center line of the path.
+        //
+        // Setting a random DestinationTolerance does not work very well for this. It means that peeps will make
+        // their new pathfinding decision at a random time, and so will distribute a bit when they are turning
+        // corners (which is good); but, as they walk along a straight path, they will - eventually - have had a
+        // low tolerance value which forced them back to the center of the path, where they stay until they turn
+        // a corner.
+        //
+        // What we want instead is to apply that randomness in the direction they are walking ONLY, and keep their
+        // other coordinate constant.
+
+        int8_t offset = (scenario_rand() & 7) - 3;
+        if (direction == 0 || direction == 2)
+        {
+            // Peep is moving along X, so apply the offset to the X position of the destination and keep their current Y
+            peep->DestinationX += offset;
+            peep->DestinationY = peep->y;
+        }
+        else
+        {
+            // Peep is moving along Y, so apply the offset to the Y position of the destination and keep their current X
+            peep->DestinationX = peep->x;
+            peep->DestinationY += offset;
+        }
     }
     return 0;
 }

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -215,13 +215,13 @@ TEST_P(SimplePathfindingTest, CanFindPathFromStartToGoal)
 INSTANTIATE_TEST_CASE_P(
     ForScenario, SimplePathfindingTest,
     ::testing::Values(
-        SimplePathfindingScenario("StraightFlat", { 19, 15, 14 }, 24), SimplePathfindingScenario("SBend", { 15, 12, 14 }, 88),
-        SimplePathfindingScenario("UBend", { 17, 9, 14 }, 86), SimplePathfindingScenario("CBend", { 14, 5, 14 }, 164),
-        SimplePathfindingScenario("TwoEqualRoutes", { 9, 13, 14 }, 87),
-        SimplePathfindingScenario("TwoUnequalRoutes", { 3, 13, 14 }, 87),
+        SimplePathfindingScenario("StraightFlat", { 19, 15, 14 }, 24), SimplePathfindingScenario("SBend", { 15, 12, 14 }, 87),
+        SimplePathfindingScenario("UBend", { 17, 9, 14 }, 87), SimplePathfindingScenario("CBend", { 14, 5, 14 }, 164),
+        SimplePathfindingScenario("TwoEqualRoutes", { 9, 13, 14 }, 89),
+        SimplePathfindingScenario("TwoUnequalRoutes", { 3, 13, 14 }, 89),
         SimplePathfindingScenario("StraightUpBridge", { 12, 15, 14 }, 24),
         SimplePathfindingScenario("StraightUpSlope", { 14, 15, 14 }, 24),
-        SimplePathfindingScenario("SelfCrossingPath", { 6, 5, 14 }, 213)),
+        SimplePathfindingScenario("SelfCrossingPath", { 6, 5, 14 }, 211)),
     SimplePathfindingScenario::ToName);
 
 class ImpossiblePathfindingTest : public PathfindingTestBase, public ::testing::WithParamInterface<SimplePathfindingScenario>


### PR DESCRIPTION
I've changed the logic in `peep_move_one_tile` to better de-bunch peeps. The previous implementation, giving the tile center as a target but using a randomized DestinationTolerance, never actually worked very well - it would spread peeps out every time they reached a path corner, but as they walked along a straight path, they had gradually increasing probability that they'd be given a low-tolerance destination at the center of the tile - after which they would stay on the center line until reaching the next corner. This behaviour also led to this slightly odd 'course correction' behaviour, usually shortly after a peep turns a corner, like this:

![ezgif-1-b5c7a29a7342](https://user-images.githubusercontent.com/588194/93002660-82208680-f506-11ea-8d7b-21662446432a.gif)

I have changed the logic so that instead of randomizing the tolerance, instead we randomize the destination, but only on the axis that the peep is actually travelling. In the other axis, instead of using the tile center, I use their current position. This has the effect that a peep who is offset to one side of the path, will stay on that side of the path until they reach a corner:

![ezgif com-resize](https://user-images.githubusercontent.com/588194/93002832-b9dbfe00-f507-11ea-9a9c-51706c9d3156.gif)

Peeps will still bunch up in other situations where the destination is set up (like exiting rides, or getting up from a bench), but I think this is a still a good start.