### PR TITLE
Fix #12944. Mistake from refactor meant formatter optimised away

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -468,7 +468,8 @@ static void widget_groupbox_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
 
         utf8 buffer[512] = { 0 };
         format_string(buffer, sizeof(buffer), stringId, formatArgs);
-        auto ft = Formatter().Add<utf8*>(buffer);
+        auto ft = Formatter();
+        ft.Add<utf8*>(buffer);
         gfx_draw_string_left(dpi, STR_STRING, ft.Data(), colour, { l, t });
         textRight = l + gfx_get_string_width(buffer) + 1;
     }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -415,7 +415,8 @@ static void window_staff_list_tooldown(rct_window* w, rct_widgetindex widgetInde
         }
         else
         {
-            auto ft = Formatter().Add<rct_string_id>(StaffNamingConvention[selectedPeepType].plural);
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(StaffNamingConvention[selectedPeepType].plural);
             context_show_error(STR_NO_THING_IN_PARK_YET, STR_NONE, ft);
         }
     }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -672,7 +672,8 @@ namespace OpenRCT2
             catch (const UnsupportedRCTCFlagException& e)
             {
                 auto windowManager = _uiContext->GetWindowManager();
-                auto ft = Formatter().Add<uint16_t>(e.Flag);
+                auto ft = Formatter();
+                ft.Add<uint16_t>(e.Flag);
                 windowManager->ShowError(STR_FAILED_TO_LOAD_IMCOMPATIBLE_RCTC_FLAG, STR_NONE, ft);
             }
             catch (const std::exception& e)

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2443,7 +2443,8 @@ void NetworkBase::Client_Handle_GAMESTATE(NetworkConnection& connection, Network
             {
                 log_info("Wrote desync report to '%s'", outputFile.c_str());
 
-                auto ft = Formatter().Add<char*>(uniqueFileName);
+                auto ft = Formatter();
+                ft.Add<char*>(uniqueFileName);
 
                 char str_desync[1024];
                 format_string(str_desync, sizeof(str_desync), STR_DESYNC_REPORT, ft.Data());


### PR DESCRIPTION
Fix #12944. Mistake from refactor meant formatter optimised away

Not sure why it should get optimised away but this will fix the crashes.