### PR TITLE
Allow compilation with nlohmann/json < 3.9.0

### DIFF
--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -32,7 +32,7 @@ namespace Json
 
         try
         {
-            json = json_t::parse(fileData, nullptr, true);
+            json = json_t::parse(fileData);
         }
         catch (const json_t::exception& e)
         {
@@ -58,7 +58,7 @@ namespace Json
 
         try
         {
-            json = json_t::parse(raw, nullptr, true);
+            json = json_t::parse(raw);
         }
         catch (const json_t::exception& e)
         {

--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -32,7 +32,7 @@ namespace Json
 
         try
         {
-            json = json_t::parse(fileData, nullptr, true, true);
+            json = json_t::parse(fileData, nullptr, true);
         }
         catch (const json_t::exception& e)
         {
@@ -58,7 +58,7 @@ namespace Json
 
         try
         {
-            json = json_t::parse(raw, nullptr, true, true);
+            json = json_t::parse(raw, nullptr, true);
         }
         catch (const json_t::exception& e)
         {


### PR DESCRIPTION
According to the [API docs](https://github.com/nlohmann/json/blob/develop/single_include/nlohmann/json.hpp#L23219-L23222). the fourth argument (which allows ignoring comments) was only introduced in version 3.9.0 (released on 27 July 2020), which is not present in Ubuntu 20.04 (it only has 3.7.3-1).

Since comments are not part of the JSON spec, this option is not terribly useful anyway. I have removed it, so that it can now compile on Ubuntu 20.04, and possibly also earlier versions.