### PR TITLE
Fix formatter Implement copy constructors

### DIFF
--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -101,6 +101,27 @@ public:
     {
     }
 
+    Formatter(const Formatter& other)
+    {
+        *this = other;
+    }
+
+    Formatter& operator=(const Formatter& other)
+    {
+        // If using global or not
+        if (other.StartBuf == other.Buffer.data())
+        {
+            std::copy(std::begin(other.Buffer), std::end(other.Buffer), std::begin(Buffer));
+            StartBuf = Buffer.data();
+        }
+        else
+        {
+            StartBuf = other.StartBuf;
+        }
+        CurrentBuf = StartBuf + other.NumBytes();
+        return *this;
+    }
+
     static Formatter Common()
     {
         return Formatter{ gCommonFormatArgs };


### PR DESCRIPTION
Fixes #12968 

I'm not sure I like how this is ending up. This should be really removed when we get rid of the global variable versions (Common and MapTooltip)