### PR TITLE
Compact syntax for event lists

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -64,34 +64,21 @@ namespace OpenRCT2::Ui::Windows
     static void window_custom_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
     static void window_custom_update_viewport(rct_window* w);
 
-    static rct_window_event_list window_custom_events = { window_custom_close,
-                                                          window_custom_mouseup,
-                                                          window_custom_resize,
-                                                          window_custom_mousedown,
-                                                          window_custom_dropdown,
-                                                          nullptr,
-                                                          window_custom_update,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          window_custom_scrollgetsize,
-                                                          window_custom_scrollmousedown,
-                                                          window_custom_scrollmousedrag,
-                                                          window_custom_scrollmouseover,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          window_custom_invalidate,
-                                                          window_custom_paint,
-                                                          window_custom_scrollpaint };
+    static rct_window_event_list window_custom_events([](auto& events) {
+        events.close = &window_custom_close;
+        events.mouse_up = &window_custom_mouseup;
+        events.resize = &window_custom_resize;
+        events.mouse_down = &window_custom_mousedown;
+        events.dropdown = &window_custom_dropdown;
+        events.update = &window_custom_update;
+        events.get_scroll_size = &window_custom_scrollgetsize;
+        events.scroll_mousedown = &window_custom_scrollmousedown;
+        events.scroll_mousedrag = &window_custom_scrollmousedrag;
+        events.scroll_mouseover = &window_custom_scrollmouseover;
+        events.invalidate = &window_custom_invalidate;
+        events.paint = &window_custom_paint;
+        events.scroll_paint = &window_custom_scrollpaint;
+    });
 
     struct CustomWidgetDesc
     {

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -89,32 +89,18 @@ static void window_about_rct2_mouseup(rct_window *w, rct_widgetindex widgetIndex
 static void window_about_rct2_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_about_openrct2_common_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_about_openrct2_events = {};
-
-static void window_about_openrct2_events_init()
+static rct_window_event_list window_about_openrct2_events([](auto& events)
 {
-    auto& events = window_about_openrct2_events;
+    events.mouse_up = &window_about_openrct2_mouseup;
+    events.invalidate = &window_about_openrct2_invalidate;
+    events.paint = &window_about_openrct2_paint;
+});
 
-    events.mouse_up = window_about_openrct2_mouseup;
-    events.invalidate = window_about_openrct2_invalidate;
-    events.paint = window_about_openrct2_paint;
-}
-
-static rct_window_event_list window_about_rct2_events = {};
-
-static void window_about_rct2_events_init()
+static rct_window_event_list window_about_rct2_events([](auto& events)
 {
-    auto& events = window_about_rct2_events;
-
-    events.mouse_up = window_about_rct2_mouseup;
-    events.paint = window_about_rct2_paint;
-}
-
-static void window_about_events_init_all()
-{
-    window_about_openrct2_events_init();
-    window_about_rct2_events_init();
-}
+    events.mouse_up = &window_about_rct2_mouseup;
+    events.paint = &window_about_rct2_paint;
+});
 
 static rct_window_event_list *window_about_page_events[] = {
     &window_about_openrct2_events,
@@ -137,7 +123,6 @@ rct_window* window_about_open()
     if (window != nullptr)
         return window;
 
-    window_about_events_init_all();
     window = window_create_centred(WW, WH, window_about_page_events[WINDOW_ABOUT_PAGE_OPENRCT2], WC_ABOUT, 0);
 
     window_about_set_page(window, WINDOW_ABOUT_PAGE_OPENRCT2);

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -89,67 +89,32 @@ static void window_about_rct2_mouseup(rct_window *w, rct_widgetindex widgetIndex
 static void window_about_rct2_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_about_openrct2_common_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_about_openrct2_events = {
-    nullptr,
-    window_about_openrct2_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_about_openrct2_invalidate,
-    window_about_openrct2_paint,
-    nullptr
-};
+static rct_window_event_list window_about_openrct2_events = {};
 
-static rct_window_event_list window_about_rct2_events = {
-    nullptr,
-    window_about_rct2_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_about_rct2_paint,
-    nullptr
-};
+static void window_about_openrct2_events_init()
+{
+    auto& events = window_about_openrct2_events;
+
+    events.mouse_up = window_about_openrct2_mouseup;
+    events.invalidate = window_about_openrct2_invalidate;
+    events.paint = window_about_openrct2_paint;
+}
+
+static rct_window_event_list window_about_rct2_events = {};
+
+static void window_about_rct2_events_init()
+{
+    auto& events = window_about_rct2_events;
+
+    events.mouse_up = window_about_rct2_mouseup;
+    events.paint = window_about_rct2_paint;
+}
+
+static void window_about_events_init_all()
+{
+    window_about_openrct2_events_init();
+    window_about_rct2_events_init();
+}
 
 static rct_window_event_list *window_about_page_events[] = {
     &window_about_openrct2_events,
@@ -172,6 +137,7 @@ rct_window* window_about_open()
     if (window != nullptr)
         return window;
 
+    window_about_events_init_all();
     window = window_create_centred(WW, WH, window_about_page_events[WINDOW_ABOUT_PAGE_OPENRCT2], WC_ABOUT, 0);
 
     window_about_set_page(window, WINDOW_ABOUT_PAGE_OPENRCT2);

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -77,20 +77,16 @@ static void window_banner_viewport_rotate(rct_window *w);
 static void window_banner_invalidate(rct_window *w);
 static void window_banner_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_banner_events = {};
-
-static void window_banner_events_init()
+static rct_window_event_list window_banner_events([](auto& events)
 {
-    auto& events = window_banner_events;
-
-    events.mouse_up = window_banner_mouseup;
-    events.mouse_down = window_banner_mousedown;
-    events.dropdown = window_banner_dropdown;
-    events.text_input = window_banner_textinput;
-    events.viewport_rotate = window_banner_viewport_rotate;
-    events.invalidate = window_banner_invalidate;
-    events.paint = window_banner_paint;
-}
+    events.mouse_up = &window_banner_mouseup;
+    events.mouse_down = &window_banner_mousedown;
+    events.dropdown = &window_banner_dropdown;
+    events.text_input = &window_banner_textinput;
+    events.viewport_rotate = &window_banner_viewport_rotate;
+    events.invalidate = &window_banner_invalidate;
+    events.paint = &window_banner_paint;
+});
 // clang-format on
 
 /**
@@ -107,7 +103,6 @@ rct_window* window_banner_open(rct_windownumber number)
     if (w != nullptr)
         return w;
 
-    window_banner_events_init();
     w = window_create_auto_pos(WW, WH, &window_banner_events, WC_BANNER, WF_NO_SCROLLING);
     w->widgets = window_banner_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_BANNER_TEXT) | (1 << WIDX_BANNER_NO_ENTRY) | (1 << WIDX_BANNER_DEMOLISH)

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -77,36 +77,20 @@ static void window_banner_viewport_rotate(rct_window *w);
 static void window_banner_invalidate(rct_window *w);
 static void window_banner_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_banner_events = {
-    nullptr,
-    window_banner_mouseup,
-    nullptr,
-    window_banner_mousedown,
-    window_banner_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_banner_textinput,
-    window_banner_viewport_rotate,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_banner_invalidate,
-    window_banner_paint,
-    nullptr
-};
+static rct_window_event_list window_banner_events = {};
+
+static void window_banner_events_init()
+{
+    auto& events = window_banner_events;
+
+    events.mouse_up = window_banner_mouseup;
+    events.mouse_down = window_banner_mousedown;
+    events.dropdown = window_banner_dropdown;
+    events.text_input = window_banner_textinput;
+    events.viewport_rotate = window_banner_viewport_rotate;
+    events.invalidate = window_banner_invalidate;
+    events.paint = window_banner_paint;
+}
 // clang-format on
 
 /**
@@ -123,6 +107,7 @@ rct_window* window_banner_open(rct_windownumber number)
     if (w != nullptr)
         return w;
 
+    window_banner_events_init();
     w = window_create_auto_pos(WW, WH, &window_banner_events, WC_BANNER, WF_NO_SCROLLING);
     w->widgets = window_banner_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_BANNER_TEXT) | (1 << WIDX_BANNER_NO_ENTRY) | (1 << WIDX_BANNER_DEMOLISH)

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -57,36 +57,20 @@ static void window_changelog_invalidate(rct_window *w);
 static void window_changelog_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_changelog_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_changelog_events = {
-    window_changelog_close,
-    window_changelog_mouseup,
-    window_changelog_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_changelog_scrollgetsize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_changelog_invalidate,
-    window_changelog_paint,
-    window_changelog_scrollpaint
-};
+static rct_window_event_list window_changelog_events = {};
+
+static void window_changelog_events_init()
+{
+    auto& events = window_changelog_events;
+
+    events.close = window_changelog_close;
+    events.mouse_up = window_changelog_mouseup;
+    events.resize = window_changelog_resize;
+    events.get_scroll_size = window_changelog_scrollgetsize;
+    events.invalidate = window_changelog_invalidate;
+    events.paint = window_changelog_paint;
+    events.scroll_paint = window_changelog_scrollpaint;
+}
 // clang-format on
 
 static void window_new_version_process_info();
@@ -143,6 +127,7 @@ rct_window* window_changelog_open(int personality)
     int32_t screenWidth = context_get_width();
     int32_t screenHeight = context_get_height();
 
+    window_changelog_events_init();
     window = window_create_centred(
         screenWidth * 4 / 5, screenHeight * 4 / 5, &window_changelog_events, WC_CHANGELOG, WF_RESIZABLE);
     window->widgets = window_changelog_widgets;

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -57,20 +57,16 @@ static void window_changelog_invalidate(rct_window *w);
 static void window_changelog_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_changelog_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_changelog_events = {};
-
-static void window_changelog_events_init()
+static rct_window_event_list window_changelog_events([](auto& events)
 {
-    auto& events = window_changelog_events;
-
-    events.close = window_changelog_close;
-    events.mouse_up = window_changelog_mouseup;
-    events.resize = window_changelog_resize;
-    events.get_scroll_size = window_changelog_scrollgetsize;
-    events.invalidate = window_changelog_invalidate;
-    events.paint = window_changelog_paint;
-    events.scroll_paint = window_changelog_scrollpaint;
-}
+    events.close = &window_changelog_close;
+    events.mouse_up = &window_changelog_mouseup;
+    events.resize = &window_changelog_resize;
+    events.get_scroll_size = &window_changelog_scrollgetsize;
+    events.invalidate = &window_changelog_invalidate;
+    events.paint = &window_changelog_paint;
+    events.scroll_paint = &window_changelog_scrollpaint;
+});
 // clang-format on
 
 static void window_new_version_process_info();
@@ -127,7 +123,6 @@ rct_window* window_changelog_open(int personality)
     int32_t screenWidth = context_get_width();
     int32_t screenHeight = context_get_height();
 
-    window_changelog_events_init();
     window = window_create_centred(
         screenWidth * 4 / 5, screenHeight * 4 / 5, &window_changelog_events, WC_CHANGELOG, WF_RESIZABLE);
     window->widgets = window_changelog_widgets;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -333,65 +333,41 @@ static void window_cheats_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_cheats_set_page(rct_window *w, int32_t page);
 static void window_cheats_text_input(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_cheats_money_events = {};
-
-static void window_cheats_money_events_init()
+static rct_window_event_list window_cheats_money_events([](auto& events)
 {
-    auto& events = window_cheats_money_events;
+    events.mouse_up = &window_cheats_money_mouseup;
+    events.mouse_down = &window_cheats_money_mousedown;
+    events.update = &window_cheats_update;
+    events.text_input = &window_cheats_text_input;
+    events.invalidate = &window_cheats_invalidate;
+    events.paint = &window_cheats_paint;
+});
 
-    events.mouse_up = window_cheats_money_mouseup;
-    events.mouse_down = window_cheats_money_mousedown;
-    events.update = window_cheats_update;
-    events.text_input = window_cheats_text_input;
-    events.invalidate = window_cheats_invalidate;
-    events.paint = window_cheats_paint;
-}
-
-static rct_window_event_list window_cheats_guests_events = {};
-
-static void window_cheats_guests_events_init()
+static rct_window_event_list window_cheats_guests_events([](auto& events)
 {
-    auto& events = window_cheats_guests_events;
+    events.mouse_up = &window_cheats_guests_mouseup;
+    events.update = &window_cheats_update;
+    events.invalidate = &window_cheats_invalidate;
+    events.paint = &window_cheats_paint;
+});
 
-    events.mouse_up = window_cheats_guests_mouseup;
-    events.update = window_cheats_update;
-    events.invalidate = window_cheats_invalidate;
-    events.paint = window_cheats_paint;
-}
-
-static rct_window_event_list window_cheats_misc_events = {};
-
-static void window_cheats_misc_events_init()
+static rct_window_event_list window_cheats_misc_events([](auto& events)
 {
-    auto& events = window_cheats_misc_events;
+    events.mouse_up = &window_cheats_misc_mouseup;
+    events.mouse_down = &window_cheats_misc_mousedown;
+    events.dropdown = &window_cheats_misc_dropdown;
+    events.update = &window_cheats_update;
+    events.invalidate = &window_cheats_invalidate;
+    events.paint = &window_cheats_paint;
+});
 
-    events.mouse_up = window_cheats_misc_mouseup;
-    events.mouse_down = window_cheats_misc_mousedown;
-    events.dropdown = window_cheats_misc_dropdown;
-    events.update = window_cheats_update;
-    events.invalidate = window_cheats_invalidate;
-    events.paint = window_cheats_paint;
-}
-
-static rct_window_event_list window_cheats_rides_events = {};
-
-static void window_cheats_rides_events_init()
+static rct_window_event_list window_cheats_rides_events([](auto& events)
 {
-    auto& events = window_cheats_rides_events;
-
-    events.mouse_up = window_cheats_rides_mouseup;
-    events.update = window_cheats_update;
-    events.invalidate = window_cheats_invalidate;
-    events.paint = window_cheats_paint;
-}
-
-static void window_cheats_events_init_all()
-{
-    window_cheats_money_events_init();
-    window_cheats_guests_events_init();
-    window_cheats_misc_events_init();
-    window_cheats_rides_events_init();
-}
+    events.mouse_up = &window_cheats_rides_mouseup;
+    events.update = &window_cheats_update;
+    events.invalidate = &window_cheats_invalidate;
+    events.paint = &window_cheats_paint;
+});
 
 
 static rct_window_event_list *window_cheats_page_events[] =
@@ -541,7 +517,6 @@ rct_window* window_cheats_open()
     if (window != nullptr)
         return window;
 
-    window_cheats_events_init_all();
     window = window_create(ScreenCoordsXY(32, 32), WW, WH, &window_cheats_money_events, WC_CHEATS, 0);
     window->widgets = window_cheats_money_widgets;
     window->enabled_widgets = window_cheats_page_enabled_widgets[0];

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -333,133 +333,65 @@ static void window_cheats_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_cheats_set_page(rct_window *w, int32_t page);
 static void window_cheats_text_input(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_cheats_money_events =
-{
-    nullptr,
-    window_cheats_money_mouseup,
-    nullptr,
-    window_cheats_money_mousedown,
-    nullptr,
-    nullptr,
-    window_cheats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_text_input,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_invalidate,
-    window_cheats_paint,
-    nullptr
-};
+static rct_window_event_list window_cheats_money_events = {};
 
-static rct_window_event_list window_cheats_guests_events =
+static void window_cheats_money_events_init()
 {
-    nullptr,
-    window_cheats_guests_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_invalidate,
-    window_cheats_paint,
-    nullptr
-};
+    auto& events = window_cheats_money_events;
 
-static rct_window_event_list window_cheats_misc_events =
-{
-    nullptr,
-    window_cheats_misc_mouseup,
-    nullptr,
-    window_cheats_misc_mousedown,
-    window_cheats_misc_dropdown,
-    nullptr,
-    window_cheats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_invalidate,
-    window_cheats_paint,
-    nullptr
-};
+    events.mouse_up = window_cheats_money_mouseup;
+    events.mouse_down = window_cheats_money_mousedown;
+    events.update = window_cheats_update;
+    events.text_input = window_cheats_text_input;
+    events.invalidate = window_cheats_invalidate;
+    events.paint = window_cheats_paint;
+}
 
-static rct_window_event_list window_cheats_rides_events =
+static rct_window_event_list window_cheats_guests_events = {};
+
+static void window_cheats_guests_events_init()
 {
-    nullptr,
-    window_cheats_rides_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_cheats_invalidate,
-    window_cheats_paint,
-    nullptr
-};
+    auto& events = window_cheats_guests_events;
+
+    events.mouse_up = window_cheats_guests_mouseup;
+    events.update = window_cheats_update;
+    events.invalidate = window_cheats_invalidate;
+    events.paint = window_cheats_paint;
+}
+
+static rct_window_event_list window_cheats_misc_events = {};
+
+static void window_cheats_misc_events_init()
+{
+    auto& events = window_cheats_misc_events;
+
+    events.mouse_up = window_cheats_misc_mouseup;
+    events.mouse_down = window_cheats_misc_mousedown;
+    events.dropdown = window_cheats_misc_dropdown;
+    events.update = window_cheats_update;
+    events.invalidate = window_cheats_invalidate;
+    events.paint = window_cheats_paint;
+}
+
+static rct_window_event_list window_cheats_rides_events = {};
+
+static void window_cheats_rides_events_init()
+{
+    auto& events = window_cheats_rides_events;
+
+    events.mouse_up = window_cheats_rides_mouseup;
+    events.update = window_cheats_update;
+    events.invalidate = window_cheats_invalidate;
+    events.paint = window_cheats_paint;
+}
+
+static void window_cheats_events_init_all()
+{
+    window_cheats_money_events_init();
+    window_cheats_guests_events_init();
+    window_cheats_misc_events_init();
+    window_cheats_rides_events_init();
+}
 
 
 static rct_window_event_list *window_cheats_page_events[] =
@@ -609,6 +541,7 @@ rct_window* window_cheats_open()
     if (window != nullptr)
         return window;
 
+    window_cheats_events_init_all();
     window = window_create(ScreenCoordsXY(32, 32), WW, WH, &window_cheats_money_events, WC_CHEATS, 0);
     window->widgets = window_cheats_money_widgets;
     window->enabled_widgets = window_cheats_page_enabled_widgets[0];

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -53,20 +53,16 @@ static void window_clear_scenery_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_clear_scenery_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_clear_scenery_inputsize(rct_window *w);
 
-static rct_window_event_list window_clear_scenery_events = {};
-
-static void window_clear_scenery_events_init()
+static rct_window_event_list window_clear_scenery_events([](auto& events)
 {
-    auto& events = window_clear_scenery_events;
-
-    events.close = window_clear_scenery_close;
-    events.mouse_up = window_clear_scenery_mouseup;
-    events.mouse_down = window_clear_scenery_mousedown;
-    events.update = window_clear_scenery_update;
-    events.text_input = window_clear_scenery_textinput;
-    events.invalidate = window_clear_scenery_invalidate;
-    events.paint = window_clear_scenery_paint;
-}
+    events.close = &window_clear_scenery_close;
+    events.mouse_up = &window_clear_scenery_mouseup;
+    events.mouse_down = &window_clear_scenery_mousedown;
+    events.update = &window_clear_scenery_update;
+    events.text_input = &window_clear_scenery_textinput;
+    events.invalidate = &window_clear_scenery_invalidate;
+    events.paint = &window_clear_scenery_paint;
+});
 // clang-format on
 
 /**
@@ -82,7 +78,6 @@ rct_window* window_clear_scenery_open()
     if (window != nullptr)
         return window;
 
-    window_clear_scenery_events_init();
     window = window_create(
         ScreenCoordsXY(context_get_width() - WW, 29), WW, WH, &window_clear_scenery_events, WC_CLEAR_SCENERY, 0);
     window->widgets = window_clear_scenery_widgets;

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -53,36 +53,20 @@ static void window_clear_scenery_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_clear_scenery_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_clear_scenery_inputsize(rct_window *w);
 
-static rct_window_event_list window_clear_scenery_events = {
-    window_clear_scenery_close,
-    window_clear_scenery_mouseup,
-    nullptr,
-    window_clear_scenery_mousedown,
-    nullptr,
-    nullptr,
-    window_clear_scenery_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_clear_scenery_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_clear_scenery_invalidate,
-    window_clear_scenery_paint,
-    nullptr
-};
+static rct_window_event_list window_clear_scenery_events = {};
+
+static void window_clear_scenery_events_init()
+{
+    auto& events = window_clear_scenery_events;
+
+    events.close = window_clear_scenery_close;
+    events.mouse_up = window_clear_scenery_mouseup;
+    events.mouse_down = window_clear_scenery_mousedown;
+    events.update = window_clear_scenery_update;
+    events.text_input = window_clear_scenery_textinput;
+    events.invalidate = window_clear_scenery_invalidate;
+    events.paint = window_clear_scenery_paint;
+}
 // clang-format on
 
 /**
@@ -98,6 +82,7 @@ rct_window* window_clear_scenery_open()
     if (window != nullptr)
         return window;
 
+    window_clear_scenery_events_init();
     window = window_create(
         ScreenCoordsXY(context_get_width() - WW, 29), WW, WH, &window_clear_scenery_events, WC_CLEAR_SCENERY, 0);
     window->widgets = window_clear_scenery_widgets;

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -50,18 +50,14 @@ static void custom_currency_window_text_input(struct rct_window *w, rct_widgetin
 static void custom_currency_window_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 
-static rct_window_event_list _windowCustomCurrencyEvents = {};
-
-static void _windowCustomCurrencyEvents_init()
+static rct_window_event_list _windowCustomCurrencyEvents([](auto& events)
 {
-    auto& events = _windowCustomCurrencyEvents;
-
-    events.mouse_up = custom_currency_window_mouseup;
-    events.mouse_down = custom_currency_window_mousedown;
-    events.dropdown = custom_currency_window_dropdown;
-    events.text_input = custom_currency_window_text_input;
-    events.paint = custom_currency_window_paint;
-}
+    events.mouse_up = &custom_currency_window_mouseup;
+    events.mouse_down = &custom_currency_window_mousedown;
+    events.dropdown = &custom_currency_window_dropdown;
+    events.text_input = &custom_currency_window_text_input;
+    events.paint = &custom_currency_window_paint;
+});
 // clang-format on
 
 rct_window* custom_currency_window_open()
@@ -73,7 +69,6 @@ rct_window* custom_currency_window_open()
     if (window != nullptr)
         return window;
 
-    _windowCustomCurrencyEvents_init();
     window = window_create_centred(400, 100, &_windowCustomCurrencyEvents, WC_CUSTOM_CURRENCY_CONFIG, 0);
     window->widgets = window_custom_currency_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_RATE) | (1 << WIDX_RATE_UP) | (1 << WIDX_RATE_DOWN)

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -50,36 +50,18 @@ static void custom_currency_window_text_input(struct rct_window *w, rct_widgetin
 static void custom_currency_window_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 
-static rct_window_event_list _windowCustomCurrencyEvents = {
-    nullptr,
-    custom_currency_window_mouseup,
-    nullptr,
-    custom_currency_window_mousedown,
-    custom_currency_window_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    custom_currency_window_text_input,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    custom_currency_window_paint,
-    nullptr
-};
+static rct_window_event_list _windowCustomCurrencyEvents = {};
+
+static void _windowCustomCurrencyEvents_init()
+{
+    auto& events = _windowCustomCurrencyEvents;
+
+    events.mouse_up = custom_currency_window_mouseup;
+    events.mouse_down = custom_currency_window_mousedown;
+    events.dropdown = custom_currency_window_dropdown;
+    events.text_input = custom_currency_window_text_input;
+    events.paint = custom_currency_window_paint;
+}
 // clang-format on
 
 rct_window* custom_currency_window_open()
@@ -91,6 +73,7 @@ rct_window* custom_currency_window_open()
     if (window != nullptr)
         return window;
 
+    _windowCustomCurrencyEvents_init();
     window = window_create_centred(400, 100, &_windowCustomCurrencyEvents, WC_CUSTOM_CURRENCY_CONFIG, 0);
     window->widgets = window_custom_currency_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_RATE) | (1 << WIDX_RATE_UP) | (1 << WIDX_RATE_DOWN)

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -49,36 +49,16 @@ static void window_debug_paint_mouseup(rct_window * w, rct_widgetindex widgetInd
 static void window_debug_paint_invalidate(rct_window * w);
 static void window_debug_paint_paint(rct_window * w, rct_drawpixelinfo * dpi);
 
-static rct_window_event_list window_debug_paint_events = {
-    nullptr,
-    window_debug_paint_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_debug_paint_invalidate,
-    window_debug_paint_paint,
-    nullptr
-};
+static rct_window_event_list window_debug_paint_events = {};
+
+static void window_debug_paint_events_init()
+{
+    auto& events = window_debug_paint_events;
+
+    events.mouse_up = window_debug_paint_mouseup;
+    events.invalidate = window_debug_paint_invalidate;
+    events.paint = window_debug_paint_paint;
+}
 // clang-format on
 
 rct_window* window_debug_paint_open()
@@ -90,6 +70,7 @@ rct_window* window_debug_paint_open()
     if (window != nullptr)
         return window;
 
+    window_debug_paint_events_init();
     window = window_create(
         ScreenCoordsXY(16, context_get_height() - 16 - 33 - WINDOW_HEIGHT), WINDOW_WIDTH, WINDOW_HEIGHT,
         &window_debug_paint_events, WC_DEBUG_PAINT, WF_STICK_TO_FRONT | WF_TRANSPARENT);

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -49,16 +49,12 @@ static void window_debug_paint_mouseup(rct_window * w, rct_widgetindex widgetInd
 static void window_debug_paint_invalidate(rct_window * w);
 static void window_debug_paint_paint(rct_window * w, rct_drawpixelinfo * dpi);
 
-static rct_window_event_list window_debug_paint_events = {};
-
-static void window_debug_paint_events_init()
+static rct_window_event_list window_debug_paint_events([](auto& events)
 {
-    auto& events = window_debug_paint_events;
-
-    events.mouse_up = window_debug_paint_mouseup;
-    events.invalidate = window_debug_paint_invalidate;
-    events.paint = window_debug_paint_paint;
-}
+    events.mouse_up = &window_debug_paint_mouseup;
+    events.invalidate = &window_debug_paint_invalidate;
+    events.paint = &window_debug_paint_paint;
+});
 // clang-format on
 
 rct_window* window_debug_paint_open()
@@ -70,7 +66,6 @@ rct_window* window_debug_paint_open()
     if (window != nullptr)
         return window;
 
-    window_debug_paint_events_init();
     window = window_create(
         ScreenCoordsXY(16, context_get_height() - 16 - 33 - WINDOW_HEIGHT), WINDOW_WIDTH, WINDOW_HEIGHT,
         &window_debug_paint_events, WC_DEBUG_PAINT, WF_STICK_TO_FRONT | WF_TRANSPARENT);

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -52,68 +52,32 @@ static void window_ride_refurbish_mouseup(rct_window *w, rct_widgetindex widgetI
 static void window_ride_refurbish_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 //0x0098E2E4
-static rct_window_event_list window_ride_demolish_events = {
-    nullptr,
-    window_ride_demolish_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_demolish_paint,
-    nullptr,
-};
+static rct_window_event_list window_ride_demolish_events = {};
+
+static void window_ride_demolish_events_init()
+{
+    auto& events = window_ride_demolish_events;
+
+    events.mouse_up = window_ride_demolish_mouseup;
+    events.paint = window_ride_demolish_paint;
+}
 // clang-format on
 
-static rct_window_event_list window_ride_refurbish_events = {
-    nullptr,
-    window_ride_refurbish_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_refurbish_paint,
-    nullptr,
-};
+static rct_window_event_list window_ride_refurbish_events = {};
+
+static void window_ride_refurbish_events_init()
+{
+    auto& events = window_ride_refurbish_events;
+
+    events.mouse_up = window_ride_refurbish_mouseup;
+    events.paint = window_ride_refurbish_paint;
+}
+
+static void window_demolish_ride_prompt_events_init_all()
+{
+    window_ride_demolish_events_init();
+    window_ride_refurbish_events_init();
+}
 
 /** Based off of rct2: 0x006B486A */
 rct_window* window_ride_demolish_prompt_open(Ride* ride)
@@ -125,10 +89,12 @@ rct_window* window_ride_demolish_prompt_open(Ride* ride)
     {
         auto windowPos = w->windowPos;
         window_close(w);
+        window_demolish_ride_prompt_events_init_all();
         w = window_create(windowPos, WW, WH, &window_ride_demolish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
     else
     {
+        window_demolish_ride_prompt_events_init_all();
         w = window_create_centred(WW, WH, &window_ride_demolish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
 
@@ -150,10 +116,12 @@ rct_window* window_ride_refurbish_prompt_open(Ride* ride)
     {
         auto windowPos = w->windowPos;
         window_close(w);
+        window_demolish_ride_prompt_events_init_all();
         w = window_create(windowPos, WW, WH, &window_ride_refurbish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
     else
     {
+        window_demolish_ride_prompt_events_init_all();
         w = window_create_centred(WW, WH, &window_ride_refurbish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
 

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -52,32 +52,17 @@ static void window_ride_refurbish_mouseup(rct_window *w, rct_widgetindex widgetI
 static void window_ride_refurbish_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 //0x0098E2E4
-static rct_window_event_list window_ride_demolish_events = {};
-
-static void window_ride_demolish_events_init()
+static rct_window_event_list window_ride_demolish_events([](auto& events)
 {
-    auto& events = window_ride_demolish_events;
-
-    events.mouse_up = window_ride_demolish_mouseup;
-    events.paint = window_ride_demolish_paint;
-}
+    events.mouse_up = &window_ride_demolish_mouseup;
+    events.paint = &window_ride_demolish_paint;
+});
 // clang-format on
 
-static rct_window_event_list window_ride_refurbish_events = {};
-
-static void window_ride_refurbish_events_init()
-{
-    auto& events = window_ride_refurbish_events;
-
-    events.mouse_up = window_ride_refurbish_mouseup;
-    events.paint = window_ride_refurbish_paint;
-}
-
-static void window_demolish_ride_prompt_events_init_all()
-{
-    window_ride_demolish_events_init();
-    window_ride_refurbish_events_init();
-}
+static rct_window_event_list window_ride_refurbish_events([](auto& events) {
+    events.mouse_up = &window_ride_refurbish_mouseup;
+    events.paint = &window_ride_refurbish_paint;
+});
 
 /** Based off of rct2: 0x006B486A */
 rct_window* window_ride_demolish_prompt_open(Ride* ride)
@@ -89,12 +74,10 @@ rct_window* window_ride_demolish_prompt_open(Ride* ride)
     {
         auto windowPos = w->windowPos;
         window_close(w);
-        window_demolish_ride_prompt_events_init_all();
         w = window_create(windowPos, WW, WH, &window_ride_demolish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
     else
     {
-        window_demolish_ride_prompt_events_init_all();
         w = window_create_centred(WW, WH, &window_ride_demolish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
 
@@ -116,12 +99,10 @@ rct_window* window_ride_refurbish_prompt_open(Ride* ride)
     {
         auto windowPos = w->windowPos;
         window_close(w);
-        window_demolish_ride_prompt_events_init_all();
         w = window_create(windowPos, WW, WH, &window_ride_refurbish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
     else
     {
-        window_demolish_ride_prompt_events_init_all();
         w = window_create_centred(WW, WH, &window_ride_refurbish_events, WC_DEMOLISH_RIDE_PROMPT, WF_TRANSPARENT);
     }
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -91,14 +91,10 @@ void dropdown_set_disabled(int32_t index, bool value)
 static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
 // clang-format off
-static rct_window_event_list window_dropdown_events = {};
-
-static void window_dropdown_events_init()
+static rct_window_event_list window_dropdown_events([](auto& events)
 {
-    auto& events = window_dropdown_events;
-
-    events.paint = window_dropdown_paint;
-}
+    events.paint = &window_dropdown_paint;
+});
 // clang-format on
 
 /**
@@ -187,7 +183,6 @@ void window_dropdown_show_text_custom_width(
     window_dropdown_widgets[WIDX_BACKGROUND].bottom = height;
 
     // Create the window
-    window_dropdown_events_init();
     w = window_create(
         boundedScreenPos + ScreenCoordsXY{ 0, extray }, window_dropdown_widgets[WIDX_BACKGROUND].right + 1,
         window_dropdown_widgets[WIDX_BACKGROUND].bottom + 1, &window_dropdown_events, WC_DROPDOWN, WF_STICK_TO_FRONT);
@@ -268,7 +263,6 @@ void window_dropdown_show_image(
     window_dropdown_widgets[WIDX_BACKGROUND].bottom = height;
 
     // Create the window
-    window_dropdown_events_init();
     w = window_create(
         ScreenCoordsXY(x, y + extray), window_dropdown_widgets[WIDX_BACKGROUND].right + 1,
         window_dropdown_widgets[WIDX_BACKGROUND].bottom + 1, &window_dropdown_events, WC_DROPDOWN, WF_STICK_TO_FRONT);

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -91,36 +91,14 @@ void dropdown_set_disabled(int32_t index, bool value)
 static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
 // clang-format off
-static rct_window_event_list window_dropdown_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_dropdown_paint,
-    nullptr
-};
+static rct_window_event_list window_dropdown_events = {};
+
+static void window_dropdown_events_init()
+{
+    auto& events = window_dropdown_events;
+
+    events.paint = window_dropdown_paint;
+}
 // clang-format on
 
 /**
@@ -209,6 +187,7 @@ void window_dropdown_show_text_custom_width(
     window_dropdown_widgets[WIDX_BACKGROUND].bottom = height;
 
     // Create the window
+    window_dropdown_events_init();
     w = window_create(
         boundedScreenPos + ScreenCoordsXY{ 0, extray }, window_dropdown_widgets[WIDX_BACKGROUND].right + 1,
         window_dropdown_widgets[WIDX_BACKGROUND].bottom + 1, &window_dropdown_events, WC_DROPDOWN, WF_STICK_TO_FRONT);
@@ -289,6 +268,7 @@ void window_dropdown_show_image(
     window_dropdown_widgets[WIDX_BACKGROUND].bottom = height;
 
     // Create the window
+    window_dropdown_events_init();
     w = window_create(
         ScreenCoordsXY(x, y + extray), window_dropdown_widgets[WIDX_BACKGROUND].right + 1,
         window_dropdown_widgets[WIDX_BACKGROUND].bottom + 1, &window_dropdown_events, WC_DROPDOWN, WF_STICK_TO_FRONT);

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -58,16 +58,12 @@ static void window_editor_bottom_toolbar_jump_forward_to_options_selection();
 static void window_editor_bottom_toolbar_jump_forward_to_objective_selection();
 static void window_editor_bottom_toolbar_jump_forward_to_save_scenario();
 
-static rct_window_event_list window_editor_bottom_toolbar_events = {};
-
-static void window_editor_bottom_toolbar_events_init()
+static rct_window_event_list window_editor_bottom_toolbar_events([](auto& events)
 {
-    auto& events = window_editor_bottom_toolbar_events;
-
-    events.mouse_up = window_editor_bottom_toolbar_mouseup;
-    events.invalidate = window_editor_bottom_toolbar_invalidate;
-    events.paint = window_editor_bottom_toolbar_paint;
-}
+    events.mouse_up = &window_editor_bottom_toolbar_mouseup;
+    events.invalidate = &window_editor_bottom_toolbar_invalidate;
+    events.paint = &window_editor_bottom_toolbar_paint;
+});
 
 static EMPTY_ARGS_VOID_POINTER *previous_button_mouseup_events[] = {
     nullptr,
@@ -109,7 +105,6 @@ static constexpr const rct_string_id EditorStepNames[] = {
  */
 rct_window* window_editor_bottom_toolbar_open()
 {
-    window_editor_bottom_toolbar_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, context_get_height() - 32), context_get_width(), 32, &window_editor_bottom_toolbar_events,
         WC_BOTTOM_TOOLBAR, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -60,7 +60,7 @@ static void window_editor_bottom_toolbar_jump_forward_to_save_scenario();
 
 static rct_window_event_list window_editor_bottom_toolbar_events = {
     nullptr,
-    window_editor_bottom_toolbar_mouseup, // 0x0066f5ae,
+    window_editor_bottom_toolbar_mouseup,
     nullptr,
     nullptr,
     nullptr,
@@ -84,8 +84,8 @@ static rct_window_event_list window_editor_bottom_toolbar_events = {
     nullptr,
     nullptr,
     nullptr,
-    window_editor_bottom_toolbar_invalidate, // 0x0066f1c9,
-    window_editor_bottom_toolbar_paint, // 0x0066f25c,
+    window_editor_bottom_toolbar_invalidate,
+    window_editor_bottom_toolbar_paint,
     nullptr
 };
 

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -58,36 +58,16 @@ static void window_editor_bottom_toolbar_jump_forward_to_options_selection();
 static void window_editor_bottom_toolbar_jump_forward_to_objective_selection();
 static void window_editor_bottom_toolbar_jump_forward_to_save_scenario();
 
-static rct_window_event_list window_editor_bottom_toolbar_events = {
-    nullptr,
-    window_editor_bottom_toolbar_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_bottom_toolbar_invalidate,
-    window_editor_bottom_toolbar_paint,
-    nullptr
-};
+static rct_window_event_list window_editor_bottom_toolbar_events = {};
+
+static void window_editor_bottom_toolbar_events_init()
+{
+    auto& events = window_editor_bottom_toolbar_events;
+
+    events.mouse_up = window_editor_bottom_toolbar_mouseup;
+    events.invalidate = window_editor_bottom_toolbar_invalidate;
+    events.paint = window_editor_bottom_toolbar_paint;
+}
 
 static EMPTY_ARGS_VOID_POINTER *previous_button_mouseup_events[] = {
     nullptr,
@@ -129,6 +109,7 @@ static constexpr const rct_string_id EditorStepNames[] = {
  */
 rct_window* window_editor_bottom_toolbar_open()
 {
+    window_editor_bottom_toolbar_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, context_get_height() - 32), context_get_width(), 32, &window_editor_bottom_toolbar_events,
         WC_BOTTOM_TOOLBAR, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -86,68 +86,42 @@ static void window_editor_inventions_list_drag_paint(rct_window *w, rct_drawpixe
 static std::pair<rct_string_id, Formatter> window_editor_inventions_list_prepare_name(const ResearchItem * researchItem, bool withGap);
 
 // 0x0098177C
-static rct_window_event_list window_editor_inventions_list_events = {
-    window_editor_inventions_list_close,
-    window_editor_inventions_list_mouseup,
-    window_editor_inventions_list_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_inventions_list_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_inventions_list_scrollgetheight,
-    window_editor_inventions_list_scrollmousedown,
-    nullptr,
-    window_editor_inventions_list_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_inventions_list_cursor,
-    nullptr,
-    window_editor_inventions_list_invalidate,
-    window_editor_inventions_list_paint,
-    window_editor_inventions_list_scrollpaint
-};
+static rct_window_event_list window_editor_inventions_list_events = {};
+
+static void window_editor_inventions_list_events_init()
+{
+    auto& events = window_editor_inventions_list_events;
+
+    events.close = window_editor_inventions_list_close;
+    events.mouse_up = window_editor_inventions_list_mouseup;
+    events.resize = window_editor_inventions_list_resize;
+    events.update = window_editor_inventions_list_update;
+    events.get_scroll_size = window_editor_inventions_list_scrollgetheight;
+    events.scroll_mousedown = window_editor_inventions_list_scrollmousedown;
+    events.scroll_mouseover = window_editor_inventions_list_scrollmouseover;
+    events.cursor = window_editor_inventions_list_cursor;
+    events.invalidate = window_editor_inventions_list_invalidate;
+    events.paint = window_editor_inventions_list_paint;
+    events.scroll_paint = window_editor_inventions_list_scrollpaint;
+}
 
 // 0x009817EC
-static rct_window_event_list window_editor_inventions_list_drag_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_inventions_list_drag_cursor,
-    window_editor_inventions_list_drag_moved,
-    nullptr,
-    window_editor_inventions_list_drag_paint,
-    nullptr
-};
+static rct_window_event_list window_editor_inventions_list_drag_events = {};
+
+static void window_editor_inventions_list_drag_events_init()
+{
+    auto& events = window_editor_inventions_list_drag_events;
+
+    events.cursor = window_editor_inventions_list_drag_cursor;
+    events.moved = window_editor_inventions_list_drag_moved;
+    events.paint = window_editor_inventions_list_drag_paint;
+}
+
+static void window_editor_inventions_list_events_init_all()
+{
+    window_editor_inventions_list_events_init();
+    window_editor_inventions_list_drag_events_init();
+}
 
 #pragma endregion
 
@@ -302,6 +276,7 @@ rct_window* window_editor_inventions_list_open()
 
     research_rides_setup();
 
+    window_editor_inventions_list_events_init_all();
     w = window_create_centred(
         WW, WH, &window_editor_inventions_list_events, WC_EDITOR_INVENTION_LIST, WF_NO_SCROLLING | WF_RESIZABLE);
     w->widgets = window_editor_inventions_list_widgets;
@@ -753,6 +728,7 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
     stringWidth = gfx_get_string_width(buffer);
     window_editor_inventions_list_drag_widgets[0].right = stringWidth;
 
+    window_editor_inventions_list_events_init_all();
     w = window_create(
         ScreenCoordsXY(gTooltipCursorX - (stringWidth / 2), gTooltipCursorY - 7), stringWidth, 14,
         &window_editor_inventions_list_drag_events, WC_EDITOR_INVENTION_LIST_DRAG,

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -86,42 +86,28 @@ static void window_editor_inventions_list_drag_paint(rct_window *w, rct_drawpixe
 static std::pair<rct_string_id, Formatter> window_editor_inventions_list_prepare_name(const ResearchItem * researchItem, bool withGap);
 
 // 0x0098177C
-static rct_window_event_list window_editor_inventions_list_events = {};
-
-static void window_editor_inventions_list_events_init()
+static rct_window_event_list window_editor_inventions_list_events([](auto& events)
 {
-    auto& events = window_editor_inventions_list_events;
-
-    events.close = window_editor_inventions_list_close;
-    events.mouse_up = window_editor_inventions_list_mouseup;
-    events.resize = window_editor_inventions_list_resize;
-    events.update = window_editor_inventions_list_update;
-    events.get_scroll_size = window_editor_inventions_list_scrollgetheight;
-    events.scroll_mousedown = window_editor_inventions_list_scrollmousedown;
-    events.scroll_mouseover = window_editor_inventions_list_scrollmouseover;
-    events.cursor = window_editor_inventions_list_cursor;
-    events.invalidate = window_editor_inventions_list_invalidate;
-    events.paint = window_editor_inventions_list_paint;
-    events.scroll_paint = window_editor_inventions_list_scrollpaint;
-}
+    events.close = &window_editor_inventions_list_close;
+    events.mouse_up = &window_editor_inventions_list_mouseup;
+    events.resize = &window_editor_inventions_list_resize;
+    events.update = &window_editor_inventions_list_update;
+    events.get_scroll_size = &window_editor_inventions_list_scrollgetheight;
+    events.scroll_mousedown = &window_editor_inventions_list_scrollmousedown;
+    events.scroll_mouseover = &window_editor_inventions_list_scrollmouseover;
+    events.cursor = &window_editor_inventions_list_cursor;
+    events.invalidate = &window_editor_inventions_list_invalidate;
+    events.paint = &window_editor_inventions_list_paint;
+    events.scroll_paint = &window_editor_inventions_list_scrollpaint;
+});
 
 // 0x009817EC
-static rct_window_event_list window_editor_inventions_list_drag_events = {};
-
-static void window_editor_inventions_list_drag_events_init()
+static rct_window_event_list window_editor_inventions_list_drag_events([](auto& events)
 {
-    auto& events = window_editor_inventions_list_drag_events;
-
-    events.cursor = window_editor_inventions_list_drag_cursor;
-    events.moved = window_editor_inventions_list_drag_moved;
-    events.paint = window_editor_inventions_list_drag_paint;
-}
-
-static void window_editor_inventions_list_events_init_all()
-{
-    window_editor_inventions_list_events_init();
-    window_editor_inventions_list_drag_events_init();
-}
+    events.cursor = &window_editor_inventions_list_drag_cursor;
+    events.moved = &window_editor_inventions_list_drag_moved;
+    events.paint = &window_editor_inventions_list_drag_paint;
+});
 
 #pragma endregion
 
@@ -276,7 +262,6 @@ rct_window* window_editor_inventions_list_open()
 
     research_rides_setup();
 
-    window_editor_inventions_list_events_init_all();
     w = window_create_centred(
         WW, WH, &window_editor_inventions_list_events, WC_EDITOR_INVENTION_LIST, WF_NO_SCROLLING | WF_RESIZABLE);
     w->widgets = window_editor_inventions_list_widgets;
@@ -728,7 +713,6 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
     stringWidth = gfx_get_string_width(buffer);
     window_editor_inventions_list_drag_widgets[0].right = stringWidth;
 
-    window_editor_inventions_list_events_init_all();
     w = window_create(
         ScreenCoordsXY(gTooltipCursorX - (stringWidth / 2), gTooltipCursorY - 7), stringWidth, 14,
         &window_editor_inventions_list_drag_events, WC_EDITOR_INVENTION_LIST_DRAG,

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -17,7 +17,11 @@
 
 static void window_editor_main_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_editor_main_events([](auto& events) { events.paint = &window_editor_main_paint; });
+// clang-format off
+static rct_window_event_list window_editor_main_events([](auto& events) {
+    events.paint = &window_editor_main_paint;
+});
+// clang-format on
 
 static rct_widget window_editor_main_widgets[] = {
     MakeWidget({ 0, 0 }, { 0, 0 }, WWT_VIEWPORT, WindowColour::Primary, STR_VIEWPORT),

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -17,36 +17,14 @@
 
 static void window_editor_main_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_editor_main_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_main_paint,
-    nullptr,
-};
+static rct_window_event_list window_editor_main_events = {};
+
+static void window_editor_main_events_init()
+{
+    auto& events = window_editor_main_events;
+
+    events.paint = window_editor_main_paint;
+}
 
 static rct_widget window_editor_main_widgets[] = {
     MakeWidget({ 0, 0 }, { 0, 0 }, WWT_VIEWPORT, WindowColour::Primary, STR_VIEWPORT),
@@ -61,6 +39,7 @@ rct_window* window_editor_main_open()
 {
     window_editor_main_widgets[0].right = context_get_width();
     window_editor_main_widgets[0].bottom = context_get_height();
+    window_editor_main_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), window_editor_main_widgets[0].right, window_editor_main_widgets[0].bottom,
         &window_editor_main_events, WC_MAIN_WINDOW, WF_STICK_TO_BACK);

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -44,7 +44,7 @@ static rct_window_event_list window_editor_main_events = {
     nullptr,
     nullptr,
     nullptr,
-    window_editor_main_paint, // 0x0066FC97, // window_editor_main_paint,
+    window_editor_main_paint,
     nullptr,
 };
 

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -17,14 +17,7 @@
 
 static void window_editor_main_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_editor_main_events = {};
-
-static void window_editor_main_events_init()
-{
-    auto& events = window_editor_main_events;
-
-    events.paint = window_editor_main_paint;
-}
+static rct_window_event_list window_editor_main_events([](auto& events) { events.paint = &window_editor_main_paint; });
 
 static rct_widget window_editor_main_widgets[] = {
     MakeWidget({ 0, 0 }, { 0, 0 }, WWT_VIEWPORT, WindowColour::Primary, STR_VIEWPORT),
@@ -39,7 +32,6 @@ rct_window* window_editor_main_open()
 {
     window_editor_main_widgets[0].right = context_get_width();
     window_editor_main_widgets[0].bottom = context_get_height();
-    window_editor_main_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), window_editor_main_widgets[0].right, window_editor_main_widgets[0].bottom,
         &window_editor_main_events, WC_MAIN_WINDOW, WF_STICK_TO_BACK);

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -186,27 +186,23 @@ static void window_editor_object_selection_paint(rct_window *w, rct_drawpixelinf
 static void window_editor_object_selection_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 static void window_editor_object_selection_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_editor_object_selection_events = {};
-
-static void window_editor_object_selection_events_init()
+static rct_window_event_list window_editor_object_selection_events([](auto& events)
 {
-    auto& events = window_editor_object_selection_events;
-
-    events.close = window_editor_object_selection_close;
-    events.mouse_up = window_editor_object_selection_mouseup;
-    events.resize = window_editor_object_selection_resize;
-    events.mouse_down = window_editor_object_selection_mousedown;
-    events.dropdown = window_editor_object_selection_dropdown;
-    events.update = window_editor_object_selection_update;
-    events.get_scroll_size = window_editor_object_selection_scrollgetsize;
-    events.scroll_mousedown = window_editor_object_selection_scroll_mousedown;
-    events.scroll_mouseover = window_editor_object_selection_scroll_mouseover;
-    events.text_input = window_editor_object_selection_textinput;
-    events.tooltip = window_editor_object_selection_tooltip;
-    events.invalidate = window_editor_object_selection_invalidate;
-    events.paint = window_editor_object_selection_paint;
-    events.scroll_paint = window_editor_object_selection_scrollpaint;
-}
+    events.close = &window_editor_object_selection_close;
+    events.mouse_up = &window_editor_object_selection_mouseup;
+    events.resize = &window_editor_object_selection_resize;
+    events.mouse_down = &window_editor_object_selection_mousedown;
+    events.dropdown = &window_editor_object_selection_dropdown;
+    events.update = &window_editor_object_selection_update;
+    events.get_scroll_size = &window_editor_object_selection_scrollgetsize;
+    events.scroll_mousedown = &window_editor_object_selection_scroll_mousedown;
+    events.scroll_mouseover = &window_editor_object_selection_scroll_mouseover;
+    events.text_input = &window_editor_object_selection_textinput;
+    events.tooltip = &window_editor_object_selection_tooltip;
+    events.invalidate = &window_editor_object_selection_invalidate;
+    events.paint = &window_editor_object_selection_paint;
+    events.scroll_paint = &window_editor_object_selection_scrollpaint;
+});
 // clang-format on
 
 #pragma endregion
@@ -377,7 +373,6 @@ rct_window* window_editor_object_selection_open()
     sub_6AB211();
     reset_selected_object_count_and_size();
 
-    window_editor_object_selection_events_init();
     window = window_create_centred(
         600, 400, &window_editor_object_selection_events, WC_EDITOR_OBJECT_SELECTION, WF_10 | WF_RESIZABLE);
     window->widgets = _window_editor_object_selection_widgets.data();

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -186,36 +186,27 @@ static void window_editor_object_selection_paint(rct_window *w, rct_drawpixelinf
 static void window_editor_object_selection_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 static void window_editor_object_selection_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_editor_object_selection_events = {
-    window_editor_object_selection_close,
-    window_editor_object_selection_mouseup,
-    window_editor_object_selection_resize,
-    window_editor_object_selection_mousedown,
-    window_editor_object_selection_dropdown,
-    nullptr,
-    window_editor_object_selection_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_object_selection_scrollgetsize,
-    window_editor_object_selection_scroll_mousedown,
-    nullptr,
-    window_editor_object_selection_scroll_mouseover,
-    window_editor_object_selection_textinput,
-    nullptr,
-    nullptr,
-    window_editor_object_selection_tooltip,
-    nullptr,
-    nullptr,
-    window_editor_object_selection_invalidate,
-    window_editor_object_selection_paint,
-    window_editor_object_selection_scrollpaint
-};
+static rct_window_event_list window_editor_object_selection_events = {};
+
+static void window_editor_object_selection_events_init()
+{
+    auto& events = window_editor_object_selection_events;
+
+    events.close = window_editor_object_selection_close;
+    events.mouse_up = window_editor_object_selection_mouseup;
+    events.resize = window_editor_object_selection_resize;
+    events.mouse_down = window_editor_object_selection_mousedown;
+    events.dropdown = window_editor_object_selection_dropdown;
+    events.update = window_editor_object_selection_update;
+    events.get_scroll_size = window_editor_object_selection_scrollgetsize;
+    events.scroll_mousedown = window_editor_object_selection_scroll_mousedown;
+    events.scroll_mouseover = window_editor_object_selection_scroll_mouseover;
+    events.text_input = window_editor_object_selection_textinput;
+    events.tooltip = window_editor_object_selection_tooltip;
+    events.invalidate = window_editor_object_selection_invalidate;
+    events.paint = window_editor_object_selection_paint;
+    events.scroll_paint = window_editor_object_selection_scrollpaint;
+}
 // clang-format on
 
 #pragma endregion
@@ -386,6 +377,7 @@ rct_window* window_editor_object_selection_open()
     sub_6AB211();
     reset_selected_object_count_and_size();
 
+    window_editor_object_selection_events_init();
     window = window_create_centred(
         600, 400, &window_editor_object_selection_events, WC_EDITOR_OBJECT_SELECTION, WF_10 | WF_RESIZABLE);
     window->widgets = _window_editor_object_selection_widgets.data();

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -140,45 +140,31 @@ static void window_editor_objective_options_rides_paint(rct_window *w, rct_drawp
 static void window_editor_objective_options_rides_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
 // 0x009A9DF4
-static rct_window_event_list window_objective_options_main_events = {};
-
-static void window_objective_options_main_events_init()
+static rct_window_event_list window_objective_options_main_events([](auto& events)
 {
-    auto& events = window_objective_options_main_events;
-
-    events.mouse_up = window_editor_objective_options_main_mouseup;
-    events.resize = window_editor_objective_options_main_resize;
-    events.mouse_down = window_editor_objective_options_main_mousedown;
-    events.dropdown = window_editor_objective_options_main_dropdown;
-    events.update = window_editor_objective_options_main_update;
-    events.text_input = window_editor_objective_options_main_textinput;
-    events.invalidate = window_editor_objective_options_main_invalidate;
-    events.paint = window_editor_objective_options_main_paint;
-}
+    events.mouse_up = &window_editor_objective_options_main_mouseup;
+    events.resize = &window_editor_objective_options_main_resize;
+    events.mouse_down = &window_editor_objective_options_main_mousedown;
+    events.dropdown = &window_editor_objective_options_main_dropdown;
+    events.update = &window_editor_objective_options_main_update;
+    events.text_input = &window_editor_objective_options_main_textinput;
+    events.invalidate = &window_editor_objective_options_main_invalidate;
+    events.paint = &window_editor_objective_options_main_paint;
+});
 
 // 0x009A9F58
-static rct_window_event_list window_objective_options_rides_events = {};
-
-static void window_objective_options_rides_events_init()
+static rct_window_event_list window_objective_options_rides_events([](auto& events)
 {
-    auto& events = window_objective_options_rides_events;
-
-    events.mouse_up = window_editor_objective_options_rides_mouseup;
-    events.resize = window_editor_objective_options_rides_resize;
-    events.update = window_editor_objective_options_rides_update;
-    events.get_scroll_size = window_editor_objective_options_rides_scrollgetheight;
-    events.scroll_mousedown = window_editor_objective_options_rides_scrollmousedown;
-    events.scroll_mouseover = window_editor_objective_options_rides_scrollmouseover;
-    events.invalidate = window_editor_objective_options_rides_invalidate;
-    events.paint = window_editor_objective_options_rides_paint;
-    events.scroll_paint = window_editor_objective_options_rides_scrollpaint;
-}
-
-static void window_editor_objective_options_events_init_all()
-{
-    window_objective_options_main_events_init();
-    window_objective_options_rides_events_init();
-}
+    events.mouse_up = &window_editor_objective_options_rides_mouseup;
+    events.resize = &window_editor_objective_options_rides_resize;
+    events.update = &window_editor_objective_options_rides_update;
+    events.get_scroll_size = &window_editor_objective_options_rides_scrollgetheight;
+    events.scroll_mousedown = &window_editor_objective_options_rides_scrollmousedown;
+    events.scroll_mouseover = &window_editor_objective_options_rides_scrollmouseover;
+    events.invalidate = &window_editor_objective_options_rides_invalidate;
+    events.paint = &window_editor_objective_options_rides_paint;
+    events.scroll_paint = &window_editor_objective_options_rides_scrollpaint;
+});
 
 static rct_window_event_list *window_editor_objective_options_page_events[] = {
     &window_objective_options_main_events,
@@ -236,7 +222,6 @@ rct_window* window_editor_objective_options_open()
     if (w != nullptr)
         return w;
 
-    window_editor_objective_options_events_init_all();
     w = window_create_centred(450, 228, &window_objective_options_main_events, WC_EDTIOR_OBJECTIVE_OPTIONS, WF_10);
     w->widgets = window_editor_objective_options_main_widgets;
     w->enabled_widgets = window_editor_objective_options_page_enabled_widgets[WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN];

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -140,68 +140,45 @@ static void window_editor_objective_options_rides_paint(rct_window *w, rct_drawp
 static void window_editor_objective_options_rides_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
 // 0x009A9DF4
-static rct_window_event_list window_objective_options_main_events = {
-    nullptr,
-    window_editor_objective_options_main_mouseup,
-    window_editor_objective_options_main_resize,
-    window_editor_objective_options_main_mousedown,
-    window_editor_objective_options_main_dropdown,
-    nullptr,
-    window_editor_objective_options_main_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_objective_options_main_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_objective_options_main_invalidate,
-    window_editor_objective_options_main_paint,
-    nullptr
-};
+static rct_window_event_list window_objective_options_main_events = {};
+
+static void window_objective_options_main_events_init()
+{
+    auto& events = window_objective_options_main_events;
+
+    events.mouse_up = window_editor_objective_options_main_mouseup;
+    events.resize = window_editor_objective_options_main_resize;
+    events.mouse_down = window_editor_objective_options_main_mousedown;
+    events.dropdown = window_editor_objective_options_main_dropdown;
+    events.update = window_editor_objective_options_main_update;
+    events.text_input = window_editor_objective_options_main_textinput;
+    events.invalidate = window_editor_objective_options_main_invalidate;
+    events.paint = window_editor_objective_options_main_paint;
+}
 
 // 0x009A9F58
-static rct_window_event_list window_objective_options_rides_events = {
-    nullptr,
-    window_editor_objective_options_rides_mouseup,
-    window_editor_objective_options_rides_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_objective_options_rides_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_objective_options_rides_scrollgetheight,
-    window_editor_objective_options_rides_scrollmousedown,
-    nullptr,
-    window_editor_objective_options_rides_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_objective_options_rides_invalidate,
-    window_editor_objective_options_rides_paint,
-    window_editor_objective_options_rides_scrollpaint
-};
+static rct_window_event_list window_objective_options_rides_events = {};
+
+static void window_objective_options_rides_events_init()
+{
+    auto& events = window_objective_options_rides_events;
+
+    events.mouse_up = window_editor_objective_options_rides_mouseup;
+    events.resize = window_editor_objective_options_rides_resize;
+    events.update = window_editor_objective_options_rides_update;
+    events.get_scroll_size = window_editor_objective_options_rides_scrollgetheight;
+    events.scroll_mousedown = window_editor_objective_options_rides_scrollmousedown;
+    events.scroll_mouseover = window_editor_objective_options_rides_scrollmouseover;
+    events.invalidate = window_editor_objective_options_rides_invalidate;
+    events.paint = window_editor_objective_options_rides_paint;
+    events.scroll_paint = window_editor_objective_options_rides_scrollpaint;
+}
+
+static void window_editor_objective_options_events_init_all()
+{
+    window_objective_options_main_events_init();
+    window_objective_options_rides_events_init();
+}
 
 static rct_window_event_list *window_editor_objective_options_page_events[] = {
     &window_objective_options_main_events,
@@ -259,6 +236,7 @@ rct_window* window_editor_objective_options_open()
     if (w != nullptr)
         return w;
 
+    window_editor_objective_options_events_init_all();
     w = window_create_centred(450, 228, &window_objective_options_main_events, WC_EDTIOR_OBJECTIVE_OPTIONS, WF_10);
     w->widgets = window_editor_objective_options_main_widgets;
     w->enabled_widgets = window_editor_objective_options_page_enabled_widgets[WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN];

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -201,100 +201,57 @@ static void window_editor_scenario_options_park_invalidate(rct_window *w);
 static void window_editor_scenario_options_park_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x0097EB60
-static rct_window_event_list window_scenario_options_financial_events = {
-    nullptr,
-    window_editor_scenario_options_financial_mouseup,
-    window_editor_scenario_options_financial_resize,
-    window_editor_scenario_options_financial_mousedown,
-    nullptr,
-    nullptr,
-    window_editor_scenario_options_financial_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_scenario_options_financial_invalidate,
-    window_editor_scenario_options_financial_paint,
-    nullptr
-};
+static rct_window_event_list window_scenario_options_financial_events = {};
+
+static void window_scenario_options_financial_events_init()
+{
+    auto& events = window_scenario_options_financial_events;
+
+    events.mouse_up = window_editor_scenario_options_financial_mouseup;
+    events.resize = window_editor_scenario_options_financial_resize;
+    events.mouse_down = window_editor_scenario_options_financial_mousedown;
+    events.update = window_editor_scenario_options_financial_update;
+    events.invalidate = window_editor_scenario_options_financial_invalidate;
+    events.paint = window_editor_scenario_options_financial_paint;
+}
 
 // 0x0097EBD0
-static rct_window_event_list window_scenario_options_guests_events = {
-    nullptr,
-    window_editor_scenario_options_guests_mouseup,
-    window_editor_scenario_options_guests_resize,
-    window_editor_scenario_options_guests_mousedown,
-    nullptr,
-    nullptr,
-    window_editor_scenario_options_guests_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_scenario_options_guests_invalidate,
-    window_editor_scenario_options_guests_paint,
-    nullptr
-};
+static rct_window_event_list window_scenario_options_guests_events = {};
+
+static void window_scenario_options_guests_events_init()
+{
+    auto& events = window_scenario_options_guests_events;
+
+    events.mouse_up = window_editor_scenario_options_guests_mouseup;
+    events.resize = window_editor_scenario_options_guests_resize;
+    events.mouse_down = window_editor_scenario_options_guests_mousedown;
+    events.update = window_editor_scenario_options_guests_update;
+    events.invalidate = window_editor_scenario_options_guests_invalidate;
+    events.paint = window_editor_scenario_options_guests_paint;
+}
 
 // 0x0097EC40
-static rct_window_event_list window_scenario_options_park_events = {
-    nullptr,
-    window_editor_scenario_options_park_mouseup,
-    window_editor_scenario_options_park_resize,
-    window_editor_scenario_options_park_mousedown,
-    window_editor_scenario_options_park_dropdown,
-    nullptr,
-    window_editor_scenario_options_park_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_editor_scenario_options_park_invalidate,
-    window_editor_scenario_options_park_paint,
-    nullptr
-};
+static rct_window_event_list window_scenario_options_park_events = {};
+
+static void window_scenario_options_park_events_init()
+{
+    auto& events = window_scenario_options_park_events;
+
+    events.mouse_up = window_editor_scenario_options_park_mouseup;
+    events.resize = window_editor_scenario_options_park_resize;
+    events.mouse_down = window_editor_scenario_options_park_mousedown;
+    events.dropdown = window_editor_scenario_options_park_dropdown;
+    events.update = window_editor_scenario_options_park_update;
+    events.invalidate = window_editor_scenario_options_park_invalidate;
+    events.paint = window_editor_scenario_options_park_paint;
+}
+
+static void window_editor_scenario_options_events_init_all()
+{
+    window_scenario_options_financial_events_init();
+    window_scenario_options_guests_events_init();
+    window_scenario_options_park_events_init();
+}
 
 static rct_window_event_list *window_editor_scenario_options_page_events[] = {
     &window_scenario_options_financial_events,
@@ -393,6 +350,7 @@ rct_window* window_editor_scenario_options_open()
     if (w != nullptr)
         return w;
 
+    window_editor_scenario_options_events_init_all();
     w = window_create_centred(
         280, 148, window_editor_scenario_options_page_events[0], WC_EDITOR_SCENARIO_OPTIONS, WF_NO_SCROLLING);
     w->widgets = window_editor_scenario_options_widgets[0];

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -201,57 +201,38 @@ static void window_editor_scenario_options_park_invalidate(rct_window *w);
 static void window_editor_scenario_options_park_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x0097EB60
-static rct_window_event_list window_scenario_options_financial_events = {};
-
-static void window_scenario_options_financial_events_init()
+static rct_window_event_list window_scenario_options_financial_events([](auto& events)
 {
-    auto& events = window_scenario_options_financial_events;
-
-    events.mouse_up = window_editor_scenario_options_financial_mouseup;
-    events.resize = window_editor_scenario_options_financial_resize;
-    events.mouse_down = window_editor_scenario_options_financial_mousedown;
-    events.update = window_editor_scenario_options_financial_update;
-    events.invalidate = window_editor_scenario_options_financial_invalidate;
-    events.paint = window_editor_scenario_options_financial_paint;
-}
+    events.mouse_up = &window_editor_scenario_options_financial_mouseup;
+    events.resize = &window_editor_scenario_options_financial_resize;
+    events.mouse_down = &window_editor_scenario_options_financial_mousedown;
+    events.update = &window_editor_scenario_options_financial_update;
+    events.invalidate = &window_editor_scenario_options_financial_invalidate;
+    events.paint = &window_editor_scenario_options_financial_paint;
+});
 
 // 0x0097EBD0
-static rct_window_event_list window_scenario_options_guests_events = {};
-
-static void window_scenario_options_guests_events_init()
+static rct_window_event_list window_scenario_options_guests_events([](auto& events)
 {
-    auto& events = window_scenario_options_guests_events;
-
-    events.mouse_up = window_editor_scenario_options_guests_mouseup;
-    events.resize = window_editor_scenario_options_guests_resize;
-    events.mouse_down = window_editor_scenario_options_guests_mousedown;
-    events.update = window_editor_scenario_options_guests_update;
-    events.invalidate = window_editor_scenario_options_guests_invalidate;
-    events.paint = window_editor_scenario_options_guests_paint;
-}
+    events.mouse_up = &window_editor_scenario_options_guests_mouseup;
+    events.resize = &window_editor_scenario_options_guests_resize;
+    events.mouse_down = &window_editor_scenario_options_guests_mousedown;
+    events.update = &window_editor_scenario_options_guests_update;
+    events.invalidate = &window_editor_scenario_options_guests_invalidate;
+    events.paint = &window_editor_scenario_options_guests_paint;
+});
 
 // 0x0097EC40
-static rct_window_event_list window_scenario_options_park_events = {};
-
-static void window_scenario_options_park_events_init()
+static rct_window_event_list window_scenario_options_park_events([](auto& events)
 {
-    auto& events = window_scenario_options_park_events;
-
-    events.mouse_up = window_editor_scenario_options_park_mouseup;
-    events.resize = window_editor_scenario_options_park_resize;
-    events.mouse_down = window_editor_scenario_options_park_mousedown;
-    events.dropdown = window_editor_scenario_options_park_dropdown;
-    events.update = window_editor_scenario_options_park_update;
-    events.invalidate = window_editor_scenario_options_park_invalidate;
-    events.paint = window_editor_scenario_options_park_paint;
-}
-
-static void window_editor_scenario_options_events_init_all()
-{
-    window_scenario_options_financial_events_init();
-    window_scenario_options_guests_events_init();
-    window_scenario_options_park_events_init();
-}
+    events.mouse_up = &window_editor_scenario_options_park_mouseup;
+    events.resize = &window_editor_scenario_options_park_resize;
+    events.mouse_down = &window_editor_scenario_options_park_mousedown;
+    events.dropdown = &window_editor_scenario_options_park_dropdown;
+    events.update = &window_editor_scenario_options_park_update;
+    events.invalidate = &window_editor_scenario_options_park_invalidate;
+    events.paint = &window_editor_scenario_options_park_paint;
+});
 
 static rct_window_event_list *window_editor_scenario_options_page_events[] = {
     &window_scenario_options_financial_events,
@@ -350,7 +331,6 @@ rct_window* window_editor_scenario_options_open()
     if (w != nullptr)
         return w;
 
-    window_editor_scenario_options_events_init_all();
     w = window_create_centred(
         280, 148, window_editor_scenario_options_page_events[0], WC_EDITOR_SCENARIO_OPTIONS, WF_NO_SCROLLING);
     w->widgets = window_editor_scenario_options_widgets[0];

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -30,15 +30,11 @@ static rct_widget window_error_widgets[] = {
 static void window_error_unknown5(rct_window *w);
 static void window_error_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_error_events = {};
-
-static void window_error_events_init()
+static rct_window_event_list window_error_events([](auto& events)
 {
-    auto& events = window_error_events;
-
-    events.unknown_05 = window_error_unknown5;
-    events.paint = window_error_paint;
-}
+    events.unknown_05 = &window_error_unknown5;
+    events.paint = &window_error_paint;
+});
 // clang-format on
 
 static std::string _window_error_text;
@@ -122,7 +118,6 @@ rct_window* window_error_open(const std::string_view& title, const std::string_v
         windowPosition.y = std::min(windowPosition.y - height - 40, maxY);
     }
 
-    window_error_events_init();
     w = window_create(
         windowPosition, width, height, &window_error_events, WC_ERROR, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_RESIZABLE);
     w->widgets = window_error_widgets;

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -30,36 +30,15 @@ static rct_widget window_error_widgets[] = {
 static void window_error_unknown5(rct_window *w);
 static void window_error_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_error_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_error_unknown5,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_error_paint,
-    nullptr
-};
+static rct_window_event_list window_error_events = {};
+
+static void window_error_events_init()
+{
+    auto& events = window_error_events;
+
+    events.unknown_05 = window_error_unknown5;
+    events.paint = window_error_paint;
+}
 // clang-format on
 
 static std::string _window_error_text;
@@ -143,6 +122,7 @@ rct_window* window_error_open(const std::string_view& title, const std::string_v
         windowPosition.y = std::min(windowPosition.y - height - 40, maxY);
     }
 
+    window_error_events_init();
     w = window_create(
         windowPosition, width, height, &window_error_events, WC_ERROR, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_RESIZABLE);
     w->widgets = window_error_widgets;

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -213,202 +213,97 @@ static void window_finances_research_invalidate(rct_window *w);
 static void window_finances_research_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x00988EB8
-static rct_window_event_list _windowFinancesSummaryEvents =
+static rct_window_event_list _windowFinancesSummaryEvents = {};
+
+static void _windowFinancesSummaryEvents_init()
 {
-    nullptr,
-    window_finances_summary_mouseup,
-    nullptr,
-    window_finances_summary_mousedown,
-    nullptr,
-    nullptr,
-    window_finances_summary_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_summary_scrollgetsize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_summary_invalidate,
-    window_finances_summary_paint,
-    window_finances_summary_scrollpaint
-};
+    auto& events = _windowFinancesSummaryEvents;
+
+    events.mouse_up = window_finances_summary_mouseup;
+    events.mouse_down = window_finances_summary_mousedown;
+    events.update = window_finances_summary_update;
+    events.get_scroll_size = window_finances_summary_scrollgetsize;
+    events.invalidate = window_finances_summary_invalidate;
+    events.paint = window_finances_summary_paint;
+    events.scroll_paint = window_finances_summary_scrollpaint;
+}
 
 // 0x00988F28
-static rct_window_event_list _windowFinancesFinancialGraphEvents =
+static rct_window_event_list _windowFinancesFinancialGraphEvents = {};
+
+static void _windowFinancesFinancialGraphEvents_init()
 {
-    nullptr,
-    window_finances_financial_graph_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_financial_graph_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_financial_graph_invalidate,
-    window_finances_financial_graph_paint,
-    nullptr
-};
+    auto& events = _windowFinancesFinancialGraphEvents;
+
+    events.mouse_up = window_finances_financial_graph_mouseup;
+    events.update = window_finances_financial_graph_update;
+    events.invalidate = window_finances_financial_graph_invalidate;
+    events.paint = window_finances_financial_graph_paint;
+}
 
 // 0x00988F98
-static rct_window_event_list _windowFinancesValueGraphEvents =
+static rct_window_event_list _windowFinancesValueGraphEvents = {};
+
+static void _windowFinancesValueGraphEvents_init()
 {
-    nullptr,
-    window_finances_park_value_graph_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_park_value_graph_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_park_value_graph_invalidate,
-    window_finances_park_value_graph_paint,
-    nullptr
-};
+    auto& events = _windowFinancesValueGraphEvents;
+
+    events.mouse_up = window_finances_park_value_graph_mouseup;
+    events.update = window_finances_park_value_graph_update;
+    events.invalidate = window_finances_park_value_graph_invalidate;
+    events.paint = window_finances_park_value_graph_paint;
+}
 
 // 0x00989008
-static rct_window_event_list _windowFinancesProfitGraphEvents =
+static rct_window_event_list _windowFinancesProfitGraphEvents = {};
+
+static void _windowFinancesProfitGraphEvents_init()
 {
-    nullptr,
-    window_finances_profit_graph_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_profit_graph_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_profit_graph_invalidate,
-    window_finances_profit_graph_paint,
-    nullptr
-};
+    auto& events = _windowFinancesProfitGraphEvents;
+
+    events.mouse_up = window_finances_profit_graph_mouseup;
+    events.update = window_finances_profit_graph_update;
+    events.invalidate = window_finances_profit_graph_invalidate;
+    events.paint = window_finances_profit_graph_paint;
+}
 
 // 0x00989078
-static rct_window_event_list _windowFinancesMarketingEvents =
+static rct_window_event_list _windowFinancesMarketingEvents = {};
+
+static void _windowFinancesMarketingEvents_init()
 {
-    nullptr,
-    window_finances_marketing_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_marketing_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_marketing_invalidate,
-    window_finances_marketing_paint,
-    nullptr
-};
+    auto& events = _windowFinancesMarketingEvents;
+
+    events.mouse_up = window_finances_marketing_mouseup;
+    events.update = window_finances_marketing_update;
+    events.invalidate = window_finances_marketing_invalidate;
+    events.paint = window_finances_marketing_paint;
+}
 
 // 0x009890E8
-static rct_window_event_list _windowFinancesResearchEvents =
+static rct_window_event_list _windowFinancesResearchEvents = {};
+
+static void _windowFinancesResearchEvents_init()
 {
-    nullptr,
-    window_finances_research_mouseup,
-    nullptr,
-    window_finances_research_mousedown,
-    window_finances_research_dropdown,
-    nullptr,
-    window_finances_research_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_finances_research_invalidate,
-    window_finances_research_paint,
-    nullptr
-};
+    auto& events = _windowFinancesResearchEvents;
+
+    events.mouse_up = window_finances_research_mouseup;
+    events.mouse_down = window_finances_research_mousedown;
+    events.dropdown = window_finances_research_dropdown;
+    events.update = window_finances_research_update;
+    events.invalidate = window_finances_research_invalidate;
+    events.paint = window_finances_research_paint;
+}
+
+static void window_finances_events_init_all()
+{
+    _windowFinancesSummaryEvents_init();
+    _windowFinancesFinancialGraphEvents_init();
+    _windowFinancesValueGraphEvents_init();
+    _windowFinancesProfitGraphEvents_init();
+    _windowFinancesMarketingEvents_init();
+    _windowFinancesResearchEvents_init();
+}
 
 static rct_window_event_list *const _windowFinancesPageEvents[] =
 {
@@ -522,6 +417,7 @@ rct_window* window_finances_open()
     w = window_bring_to_front_by_class(WC_FINANCES);
     if (w == nullptr)
     {
+        window_finances_events_init_all();
         w = window_create_auto_pos(WW_OTHER_TABS, WH_SUMMARY, _windowFinancesPageEvents[0], WC_FINANCES, WF_10);
         w->number = 0;
         w->frame_no = 0;

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -213,97 +213,63 @@ static void window_finances_research_invalidate(rct_window *w);
 static void window_finances_research_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x00988EB8
-static rct_window_event_list _windowFinancesSummaryEvents = {};
-
-static void _windowFinancesSummaryEvents_init()
+static rct_window_event_list _windowFinancesSummaryEvents([](auto& events)
 {
-    auto& events = _windowFinancesSummaryEvents;
-
-    events.mouse_up = window_finances_summary_mouseup;
-    events.mouse_down = window_finances_summary_mousedown;
-    events.update = window_finances_summary_update;
-    events.get_scroll_size = window_finances_summary_scrollgetsize;
-    events.invalidate = window_finances_summary_invalidate;
-    events.paint = window_finances_summary_paint;
-    events.scroll_paint = window_finances_summary_scrollpaint;
-}
+    events.mouse_up = &window_finances_summary_mouseup;
+    events.mouse_down = &window_finances_summary_mousedown;
+    events.update = &window_finances_summary_update;
+    events.get_scroll_size = &window_finances_summary_scrollgetsize;
+    events.invalidate = &window_finances_summary_invalidate;
+    events.paint = &window_finances_summary_paint;
+    events.scroll_paint = &window_finances_summary_scrollpaint;
+});
 
 // 0x00988F28
-static rct_window_event_list _windowFinancesFinancialGraphEvents = {};
-
-static void _windowFinancesFinancialGraphEvents_init()
+static rct_window_event_list _windowFinancesFinancialGraphEvents([](auto& events)
 {
-    auto& events = _windowFinancesFinancialGraphEvents;
-
-    events.mouse_up = window_finances_financial_graph_mouseup;
-    events.update = window_finances_financial_graph_update;
-    events.invalidate = window_finances_financial_graph_invalidate;
-    events.paint = window_finances_financial_graph_paint;
-}
+    events.mouse_up = &window_finances_financial_graph_mouseup;
+    events.update = &window_finances_financial_graph_update;
+    events.invalidate = &window_finances_financial_graph_invalidate;
+    events.paint = &window_finances_financial_graph_paint;
+});
 
 // 0x00988F98
-static rct_window_event_list _windowFinancesValueGraphEvents = {};
-
-static void _windowFinancesValueGraphEvents_init()
+static rct_window_event_list _windowFinancesValueGraphEvents([](auto& events)
 {
-    auto& events = _windowFinancesValueGraphEvents;
-
-    events.mouse_up = window_finances_park_value_graph_mouseup;
-    events.update = window_finances_park_value_graph_update;
-    events.invalidate = window_finances_park_value_graph_invalidate;
-    events.paint = window_finances_park_value_graph_paint;
-}
+    events.mouse_up = &window_finances_park_value_graph_mouseup;
+    events.update = &window_finances_park_value_graph_update;
+    events.invalidate = &window_finances_park_value_graph_invalidate;
+    events.paint = &window_finances_park_value_graph_paint;
+});
 
 // 0x00989008
-static rct_window_event_list _windowFinancesProfitGraphEvents = {};
-
-static void _windowFinancesProfitGraphEvents_init()
+static rct_window_event_list _windowFinancesProfitGraphEvents([](auto& events)
 {
-    auto& events = _windowFinancesProfitGraphEvents;
-
-    events.mouse_up = window_finances_profit_graph_mouseup;
-    events.update = window_finances_profit_graph_update;
-    events.invalidate = window_finances_profit_graph_invalidate;
-    events.paint = window_finances_profit_graph_paint;
-}
+    events.mouse_up = &window_finances_profit_graph_mouseup;
+    events.update = &window_finances_profit_graph_update;
+    events.invalidate = &window_finances_profit_graph_invalidate;
+    events.paint = &window_finances_profit_graph_paint;
+});
 
 // 0x00989078
-static rct_window_event_list _windowFinancesMarketingEvents = {};
-
-static void _windowFinancesMarketingEvents_init()
+static rct_window_event_list _windowFinancesMarketingEvents([](auto& events)
 {
-    auto& events = _windowFinancesMarketingEvents;
-
-    events.mouse_up = window_finances_marketing_mouseup;
-    events.update = window_finances_marketing_update;
-    events.invalidate = window_finances_marketing_invalidate;
-    events.paint = window_finances_marketing_paint;
-}
+    events.mouse_up = &window_finances_marketing_mouseup;
+    events.update = &window_finances_marketing_update;
+    events.invalidate = &window_finances_marketing_invalidate;
+    events.paint = &window_finances_marketing_paint;
+});
 
 // 0x009890E8
-static rct_window_event_list _windowFinancesResearchEvents = {};
-
-static void _windowFinancesResearchEvents_init()
+static rct_window_event_list _windowFinancesResearchEvents([](auto& events)
 {
-    auto& events = _windowFinancesResearchEvents;
-
-    events.mouse_up = window_finances_research_mouseup;
-    events.mouse_down = window_finances_research_mousedown;
-    events.dropdown = window_finances_research_dropdown;
-    events.update = window_finances_research_update;
-    events.invalidate = window_finances_research_invalidate;
-    events.paint = window_finances_research_paint;
-}
-
-static void window_finances_events_init_all()
-{
-    _windowFinancesSummaryEvents_init();
-    _windowFinancesFinancialGraphEvents_init();
-    _windowFinancesValueGraphEvents_init();
-    _windowFinancesProfitGraphEvents_init();
-    _windowFinancesMarketingEvents_init();
-    _windowFinancesResearchEvents_init();
-}
+    events.mouse_up = &window_finances_research_mouseup;
+    events.mouse_down = &window_finances_research_mousedown;
+    events.dropdown = &window_finances_research_dropdown;
+    events.update = &window_finances_research_update;
+    events.invalidate = &window_finances_research_invalidate;
+    events.paint = &window_finances_research_paint;
+});
 
 static rct_window_event_list *const _windowFinancesPageEvents[] =
 {
@@ -417,7 +383,6 @@ rct_window* window_finances_open()
     w = window_bring_to_front_by_class(WC_FINANCES);
     if (w == nullptr)
     {
-        window_finances_events_init_all();
         w = window_create_auto_pos(WW_OTHER_TABS, WH_SUMMARY, _windowFinancesPageEvents[0], WC_FINANCES, WF_10);
         w->number = 0;
         w->frame_no = 0;

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -112,24 +112,20 @@ static void window_footpath_toolup(rct_window * w, rct_widgetindex widgetIndex, 
 static void window_footpath_invalidate(rct_window * w);
 static void window_footpath_paint(rct_window * w, rct_drawpixelinfo * dpi);
 
-static rct_window_event_list window_footpath_events = {};
-
-static void window_footpath_events_init()
+static rct_window_event_list window_footpath_events([](auto& events)
 {
-    auto& events = window_footpath_events;
-
-    events.close = window_footpath_close;
-    events.mouse_up = window_footpath_mouseup;
-    events.mouse_down = window_footpath_mousedown;
-    events.dropdown = window_footpath_dropdown;
-    events.update = window_footpath_update;
-    events.tool_update = window_footpath_toolupdate;
-    events.tool_down = window_footpath_tooldown;
-    events.tool_drag = window_footpath_tooldrag;
-    events.tool_up = window_footpath_toolup;
-    events.invalidate = window_footpath_invalidate;
-    events.paint = window_footpath_paint;
-}
+    events.close = &window_footpath_close;
+    events.mouse_up = &window_footpath_mouseup;
+    events.mouse_down = &window_footpath_mousedown;
+    events.dropdown = &window_footpath_dropdown;
+    events.update = &window_footpath_update;
+    events.tool_update = &window_footpath_toolupdate;
+    events.tool_down = &window_footpath_tooldown;
+    events.tool_drag = &window_footpath_tooldrag;
+    events.tool_up = &window_footpath_toolup;
+    events.invalidate = &window_footpath_invalidate;
+    events.paint = &window_footpath_paint;
+});
 // clang-format on
 
 static money32 _window_footpath_cost;
@@ -207,7 +203,6 @@ rct_window* window_footpath_open()
         return window;
     }
 
-    window_footpath_events_init();
     window = window_create(ScreenCoordsXY(0, 29), 106, 381, &window_footpath_events, WC_FOOTPATH, 0);
     window->widgets = window_footpath_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_FOOTPATH_TYPE) | (1 << WIDX_QUEUELINE_TYPE)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -112,36 +112,24 @@ static void window_footpath_toolup(rct_window * w, rct_widgetindex widgetIndex, 
 static void window_footpath_invalidate(rct_window * w);
 static void window_footpath_paint(rct_window * w, rct_drawpixelinfo * dpi);
 
-static rct_window_event_list window_footpath_events = {
-    window_footpath_close,
-    window_footpath_mouseup,
-    nullptr,
-    window_footpath_mousedown,
-    window_footpath_dropdown,
-    nullptr,
-    window_footpath_update,
-    nullptr,
-    nullptr,
-    window_footpath_toolupdate,
-    window_footpath_tooldown,
-    window_footpath_tooldrag,
-    window_footpath_toolup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_footpath_invalidate,
-    window_footpath_paint,
-    nullptr
-};
+static rct_window_event_list window_footpath_events = {};
+
+static void window_footpath_events_init()
+{
+    auto& events = window_footpath_events;
+
+    events.close = window_footpath_close;
+    events.mouse_up = window_footpath_mouseup;
+    events.mouse_down = window_footpath_mousedown;
+    events.dropdown = window_footpath_dropdown;
+    events.update = window_footpath_update;
+    events.tool_update = window_footpath_toolupdate;
+    events.tool_down = window_footpath_tooldown;
+    events.tool_drag = window_footpath_tooldrag;
+    events.tool_up = window_footpath_toolup;
+    events.invalidate = window_footpath_invalidate;
+    events.paint = window_footpath_paint;
+}
 // clang-format on
 
 static money32 _window_footpath_cost;
@@ -219,6 +207,7 @@ rct_window* window_footpath_open()
         return window;
     }
 
+    window_footpath_events_init();
     window = window_create(ScreenCoordsXY(0, 29), 106, 381, &window_footpath_events, WC_FOOTPATH, 0);
     window->widgets = window_footpath_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_FOOTPATH_TYPE) | (1 << WIDX_QUEUELINE_TYPE)

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -85,20 +85,16 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo *dpi,
  *
  *  rct2: 0x0097BFDC
  */
-static rct_window_event_list window_game_bottom_toolbar_events = {};
-
-static void window_game_bottom_toolbar_events_init()
+static rct_window_event_list window_game_bottom_toolbar_events([](auto& events)
 {
-    auto& events = window_game_bottom_toolbar_events;
-
-    events.mouse_up = window_game_bottom_toolbar_mouseup;
-    events.unknown_05 = window_game_bottom_toolbar_unknown05;
-    events.update = window_game_bottom_toolbar_update;
-    events.tooltip = window_game_bottom_toolbar_tooltip;
-    events.cursor = window_game_bottom_toolbar_cursor;
-    events.invalidate = window_game_bottom_toolbar_invalidate;
-    events.paint = window_game_bottom_toolbar_paint;
-}
+    events.mouse_up = &window_game_bottom_toolbar_mouseup;
+    events.unknown_05 = &window_game_bottom_toolbar_unknown05;
+    events.update = &window_game_bottom_toolbar_update;
+    events.tooltip = &window_game_bottom_toolbar_tooltip;
+    events.cursor = &window_game_bottom_toolbar_cursor;
+    events.invalidate = &window_game_bottom_toolbar_invalidate;
+    events.paint = &window_game_bottom_toolbar_paint;
+});
 // clang-format on
 
 static void window_game_bottom_toolbar_invalidate_dirty_widgets(rct_window* w);
@@ -116,7 +112,6 @@ rct_window* window_game_bottom_toolbar_open()
     uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
     uint32_t toolbar_height = line_height * 2 + 12;
 
-    window_game_bottom_toolbar_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, screenHeight - toolbar_height), screenWidth, toolbar_height, &window_game_bottom_toolbar_events,
         WC_BOTTOM_TOOLBAR, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -85,37 +85,20 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo *dpi,
  *
  *  rct2: 0x0097BFDC
  */
-static rct_window_event_list window_game_bottom_toolbar_events =
+static rct_window_event_list window_game_bottom_toolbar_events = {};
+
+static void window_game_bottom_toolbar_events_init()
 {
-    nullptr,
-    window_game_bottom_toolbar_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_game_bottom_toolbar_unknown05,
-    window_game_bottom_toolbar_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_game_bottom_toolbar_tooltip,
-    window_game_bottom_toolbar_cursor,
-    nullptr,
-    window_game_bottom_toolbar_invalidate,
-    window_game_bottom_toolbar_paint,
-    nullptr
-};
+    auto& events = window_game_bottom_toolbar_events;
+
+    events.mouse_up = window_game_bottom_toolbar_mouseup;
+    events.unknown_05 = window_game_bottom_toolbar_unknown05;
+    events.update = window_game_bottom_toolbar_update;
+    events.tooltip = window_game_bottom_toolbar_tooltip;
+    events.cursor = window_game_bottom_toolbar_cursor;
+    events.invalidate = window_game_bottom_toolbar_invalidate;
+    events.paint = window_game_bottom_toolbar_paint;
+}
 // clang-format on
 
 static void window_game_bottom_toolbar_invalidate_dirty_widgets(rct_window* w);
@@ -133,6 +116,7 @@ rct_window* window_game_bottom_toolbar_open()
     uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
     uint32_t toolbar_height = line_height * 2 + 12;
 
+    window_game_bottom_toolbar_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, screenHeight - toolbar_height), screenWidth, toolbar_height, &window_game_bottom_toolbar_events,
         WC_BOTTOM_TOOLBAR, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -182,222 +182,117 @@ static void window_guest_inventory_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_guest_debug_update(rct_window *w);
 static void window_guest_debug_paint(rct_window *w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_guest_overview_events = {
-    window_guest_overview_close,
-    window_guest_overview_mouse_up,
-    window_guest_overview_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_overview_update,
-    nullptr,
-    nullptr,
-    window_guest_overview_tool_update,
-    window_guest_overview_tool_down,
-    nullptr,
-    nullptr,
-    window_guest_overview_tool_abort,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_overview_text_input,
-    window_guest_overview_viewport_rotate,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_overview_invalidate,
-    window_guest_overview_paint,
-    nullptr
-};
+static rct_window_event_list window_guest_overview_events = {};
 
-static rct_window_event_list window_guest_stats_events = {
-    nullptr,
-    window_guest_mouse_up,
-    window_guest_common_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_stats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_common_invalidate,
-    window_guest_stats_paint,
-    nullptr
-};
+static void window_guest_overview_events_init()
+{
+    auto& events = window_guest_overview_events;
 
-static rct_window_event_list window_guest_rides_events = {
-    nullptr,
-    window_guest_mouse_up,
-    window_guest_common_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_rides_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_rides_scroll_get_size,
-    window_guest_rides_scroll_mouse_down,
-    nullptr,
-    window_guest_rides_scroll_mouse_over,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_rides_invalidate,
-    window_guest_rides_paint,
-    window_guest_rides_scroll_paint
-};
+    events.close = window_guest_overview_close;
+    events.mouse_up = window_guest_overview_mouse_up;
+    events.resize = window_guest_overview_resize;
+    events.update = window_guest_overview_update;
+    events.tool_update = window_guest_overview_tool_update;
+    events.tool_down = window_guest_overview_tool_down;
+    events.tool_abort = window_guest_overview_tool_abort;
+    events.text_input = window_guest_overview_text_input;
+    events.viewport_rotate = window_guest_overview_viewport_rotate;
+    events.invalidate = window_guest_overview_invalidate;
+    events.paint = window_guest_overview_paint;
+}
 
-static rct_window_event_list window_guest_finance_events = {
-    nullptr,
-    window_guest_mouse_up,
-    window_guest_common_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_finance_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_common_invalidate,
-    window_guest_finance_paint,
-    nullptr
-};
+static rct_window_event_list window_guest_stats_events = {};
 
-static rct_window_event_list window_guest_thoughts_events = {
-    nullptr,
-    window_guest_mouse_up,
-    window_guest_common_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_thoughts_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_common_invalidate,
-    window_guest_thoughts_paint,
-    nullptr
-};
+static void window_guest_stats_events_init()
+{
+    auto& events = window_guest_stats_events;
 
-static rct_window_event_list window_guest_inventory_events = {
-    nullptr,
-    window_guest_mouse_up,
-    window_guest_common_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_inventory_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_common_invalidate,
-    window_guest_inventory_paint,
-    nullptr
-};
+    events.mouse_up = window_guest_mouse_up;
+    events.resize = window_guest_common_resize;
+    events.update = window_guest_stats_update;
+    events.invalidate = window_guest_common_invalidate;
+    events.paint = window_guest_stats_paint;
+}
 
-static rct_window_event_list window_guest_debug_events = {
-    nullptr,
-    window_guest_mouse_up,
-    window_guest_common_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_debug_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_common_invalidate,
-    window_guest_debug_paint,
-    nullptr
-};
+static rct_window_event_list window_guest_rides_events = {};
+
+static void window_guest_rides_events_init()
+{
+    auto& events = window_guest_rides_events;
+
+    events.mouse_up = window_guest_mouse_up;
+    events.resize = window_guest_common_resize;
+    events.update = window_guest_rides_update;
+    events.get_scroll_size = window_guest_rides_scroll_get_size;
+    events.scroll_mousedown = window_guest_rides_scroll_mouse_down;
+    events.scroll_mouseover = window_guest_rides_scroll_mouse_over;
+    events.invalidate = window_guest_rides_invalidate;
+    events.paint = window_guest_rides_paint;
+    events.scroll_paint = window_guest_rides_scroll_paint;
+}
+
+static rct_window_event_list window_guest_finance_events = {};
+
+static void window_guest_finance_events_init()
+{
+    auto& events = window_guest_finance_events;
+
+    events.mouse_up = window_guest_mouse_up;
+    events.resize = window_guest_common_resize;
+    events.update = window_guest_finance_update;
+    events.invalidate = window_guest_common_invalidate;
+    events.paint = window_guest_finance_paint;
+}
+
+static rct_window_event_list window_guest_thoughts_events = {};
+
+static void window_guest_thoughts_events_init()
+{
+    auto& events = window_guest_thoughts_events;
+
+    events.mouse_up = window_guest_mouse_up;
+    events.resize = window_guest_common_resize;
+    events.update = window_guest_thoughts_update;
+    events.invalidate = window_guest_common_invalidate;
+    events.paint = window_guest_thoughts_paint;
+}
+
+static rct_window_event_list window_guest_inventory_events = {};
+
+static void window_guest_inventory_events_init()
+{
+    auto& events = window_guest_inventory_events;
+
+    events.mouse_up = window_guest_mouse_up;
+    events.resize = window_guest_common_resize;
+    events.update = window_guest_inventory_update;
+    events.invalidate = window_guest_common_invalidate;
+    events.paint = window_guest_inventory_paint;
+}
+
+static rct_window_event_list window_guest_debug_events = {};
+
+static void window_guest_debug_events_init()
+{
+    auto& events = window_guest_debug_events;
+
+    events.mouse_up = window_guest_mouse_up;
+    events.resize = window_guest_common_resize;
+    events.update = window_guest_debug_update;
+    events.invalidate = window_guest_common_invalidate;
+    events.paint = window_guest_debug_paint;
+}
+
+static void window_guest_events_init_all()
+{
+    window_guest_overview_events_init();
+    window_guest_stats_events_init();
+    window_guest_rides_events_init();
+    window_guest_finance_events_init();
+    window_guest_thoughts_events_init();
+    window_guest_inventory_events_init();
+    window_guest_debug_events_init();
+}
 
 // 0x981D24
 static rct_window_event_list *window_guest_page_events[] = {
@@ -530,6 +425,7 @@ rct_window* window_guest_open(Peep* peep)
         if (gConfigGeneral.debugging_tools)
             windowWidth += TabWidth;
 
+        window_guest_events_init_all();
         window = window_create_auto_pos(windowWidth, 157, &window_guest_overview_events, WC_PEEP, WF_RESIZABLE);
         window->widgets = window_guest_overview_widgets;
         window->enabled_widgets = window_guest_page_enabled_widgets[0];

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -182,117 +182,78 @@ static void window_guest_inventory_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_guest_debug_update(rct_window *w);
 static void window_guest_debug_paint(rct_window *w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_guest_overview_events = {};
-
-static void window_guest_overview_events_init()
+static rct_window_event_list window_guest_overview_events([](auto& events)
 {
-    auto& events = window_guest_overview_events;
+    events.close = &window_guest_overview_close;
+    events.mouse_up = &window_guest_overview_mouse_up;
+    events.resize = &window_guest_overview_resize;
+    events.update = &window_guest_overview_update;
+    events.tool_update = &window_guest_overview_tool_update;
+    events.tool_down = &window_guest_overview_tool_down;
+    events.tool_abort = &window_guest_overview_tool_abort;
+    events.text_input = &window_guest_overview_text_input;
+    events.viewport_rotate = &window_guest_overview_viewport_rotate;
+    events.invalidate = &window_guest_overview_invalidate;
+    events.paint = &window_guest_overview_paint;
+});
 
-    events.close = window_guest_overview_close;
-    events.mouse_up = window_guest_overview_mouse_up;
-    events.resize = window_guest_overview_resize;
-    events.update = window_guest_overview_update;
-    events.tool_update = window_guest_overview_tool_update;
-    events.tool_down = window_guest_overview_tool_down;
-    events.tool_abort = window_guest_overview_tool_abort;
-    events.text_input = window_guest_overview_text_input;
-    events.viewport_rotate = window_guest_overview_viewport_rotate;
-    events.invalidate = window_guest_overview_invalidate;
-    events.paint = window_guest_overview_paint;
-}
-
-static rct_window_event_list window_guest_stats_events = {};
-
-static void window_guest_stats_events_init()
+static rct_window_event_list window_guest_stats_events([](auto& events)
 {
-    auto& events = window_guest_stats_events;
+    events.mouse_up = &window_guest_mouse_up;
+    events.resize = &window_guest_common_resize;
+    events.update = &window_guest_stats_update;
+    events.invalidate = &window_guest_common_invalidate;
+    events.paint = &window_guest_stats_paint;
+});
 
-    events.mouse_up = window_guest_mouse_up;
-    events.resize = window_guest_common_resize;
-    events.update = window_guest_stats_update;
-    events.invalidate = window_guest_common_invalidate;
-    events.paint = window_guest_stats_paint;
-}
-
-static rct_window_event_list window_guest_rides_events = {};
-
-static void window_guest_rides_events_init()
+static rct_window_event_list window_guest_rides_events([](auto& events)
 {
-    auto& events = window_guest_rides_events;
+    events.mouse_up = &window_guest_mouse_up;
+    events.resize = &window_guest_common_resize;
+    events.update = &window_guest_rides_update;
+    events.get_scroll_size = &window_guest_rides_scroll_get_size;
+    events.scroll_mousedown = &window_guest_rides_scroll_mouse_down;
+    events.scroll_mouseover = &window_guest_rides_scroll_mouse_over;
+    events.invalidate = &window_guest_rides_invalidate;
+    events.paint = &window_guest_rides_paint;
+    events.scroll_paint = &window_guest_rides_scroll_paint;
+});
 
-    events.mouse_up = window_guest_mouse_up;
-    events.resize = window_guest_common_resize;
-    events.update = window_guest_rides_update;
-    events.get_scroll_size = window_guest_rides_scroll_get_size;
-    events.scroll_mousedown = window_guest_rides_scroll_mouse_down;
-    events.scroll_mouseover = window_guest_rides_scroll_mouse_over;
-    events.invalidate = window_guest_rides_invalidate;
-    events.paint = window_guest_rides_paint;
-    events.scroll_paint = window_guest_rides_scroll_paint;
-}
-
-static rct_window_event_list window_guest_finance_events = {};
-
-static void window_guest_finance_events_init()
+static rct_window_event_list window_guest_finance_events([](auto& events)
 {
-    auto& events = window_guest_finance_events;
+    events.mouse_up = &window_guest_mouse_up;
+    events.resize = &window_guest_common_resize;
+    events.update = &window_guest_finance_update;
+    events.invalidate = &window_guest_common_invalidate;
+    events.paint = &window_guest_finance_paint;
+});
 
-    events.mouse_up = window_guest_mouse_up;
-    events.resize = window_guest_common_resize;
-    events.update = window_guest_finance_update;
-    events.invalidate = window_guest_common_invalidate;
-    events.paint = window_guest_finance_paint;
-}
-
-static rct_window_event_list window_guest_thoughts_events = {};
-
-static void window_guest_thoughts_events_init()
+static rct_window_event_list window_guest_thoughts_events([](auto& events)
 {
-    auto& events = window_guest_thoughts_events;
+    events.mouse_up = &window_guest_mouse_up;
+    events.resize = &window_guest_common_resize;
+    events.update = &window_guest_thoughts_update;
+    events.invalidate = &window_guest_common_invalidate;
+    events.paint = &window_guest_thoughts_paint;
+});
 
-    events.mouse_up = window_guest_mouse_up;
-    events.resize = window_guest_common_resize;
-    events.update = window_guest_thoughts_update;
-    events.invalidate = window_guest_common_invalidate;
-    events.paint = window_guest_thoughts_paint;
-}
-
-static rct_window_event_list window_guest_inventory_events = {};
-
-static void window_guest_inventory_events_init()
+static rct_window_event_list window_guest_inventory_events([](auto& events)
 {
-    auto& events = window_guest_inventory_events;
+    events.mouse_up = &window_guest_mouse_up;
+    events.resize = &window_guest_common_resize;
+    events.update = &window_guest_inventory_update;
+    events.invalidate = &window_guest_common_invalidate;
+    events.paint = &window_guest_inventory_paint;
+});
 
-    events.mouse_up = window_guest_mouse_up;
-    events.resize = window_guest_common_resize;
-    events.update = window_guest_inventory_update;
-    events.invalidate = window_guest_common_invalidate;
-    events.paint = window_guest_inventory_paint;
-}
-
-static rct_window_event_list window_guest_debug_events = {};
-
-static void window_guest_debug_events_init()
+static rct_window_event_list window_guest_debug_events([](auto& events)
 {
-    auto& events = window_guest_debug_events;
-
-    events.mouse_up = window_guest_mouse_up;
-    events.resize = window_guest_common_resize;
-    events.update = window_guest_debug_update;
-    events.invalidate = window_guest_common_invalidate;
-    events.paint = window_guest_debug_paint;
-}
-
-static void window_guest_events_init_all()
-{
-    window_guest_overview_events_init();
-    window_guest_stats_events_init();
-    window_guest_rides_events_init();
-    window_guest_finance_events_init();
-    window_guest_thoughts_events_init();
-    window_guest_inventory_events_init();
-    window_guest_debug_events_init();
-}
+    events.mouse_up = &window_guest_mouse_up;
+    events.resize = &window_guest_common_resize;
+    events.update = &window_guest_debug_update;
+    events.invalidate = &window_guest_common_invalidate;
+    events.paint = &window_guest_debug_paint;
+});
 
 // 0x981D24
 static rct_window_event_list *window_guest_page_events[] = {
@@ -425,7 +386,6 @@ rct_window* window_guest_open(Peep* peep)
         if (gConfigGeneral.debugging_tools)
             windowWidth += TabWidth;
 
-        window_guest_events_init_all();
         window = window_create_auto_pos(windowWidth, 157, &window_guest_overview_events, WC_PEEP, WF_RESIZABLE);
         window->widgets = window_guest_overview_widgets;
         window->enabled_widgets = window_guest_page_enabled_widgets[0];

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -102,25 +102,21 @@ static void window_guest_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 static void window_guest_list_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_guest_list_events = {};
-
-static void window_guest_list_events_init()
+static rct_window_event_list window_guest_list_events([](auto& events)
 {
-    auto& events = window_guest_list_events;
-
-    events.mouse_up = window_guest_list_mouseup;
-    events.resize = window_guest_list_resize;
-    events.mouse_down = window_guest_list_mousedown;
-    events.dropdown = window_guest_list_dropdown;
-    events.update = window_guest_list_update;
-    events.get_scroll_size = window_guest_list_scrollgetsize;
-    events.scroll_mousedown = window_guest_list_scrollmousedown;
-    events.scroll_mouseover = window_guest_list_scrollmouseover;
-    events.text_input = window_guest_list_textinput;
-    events.invalidate = window_guest_list_invalidate;
-    events.paint = window_guest_list_paint;
-    events.scroll_paint = window_guest_list_scrollpaint;
-}
+    events.mouse_up = &window_guest_list_mouseup;
+    events.resize = &window_guest_list_resize;
+    events.mouse_down = &window_guest_list_mousedown;
+    events.dropdown = &window_guest_list_dropdown;
+    events.update = &window_guest_list_update;
+    events.get_scroll_size = &window_guest_list_scrollgetsize;
+    events.scroll_mousedown = &window_guest_list_scrollmousedown;
+    events.scroll_mouseover = &window_guest_list_scrollmouseover;
+    events.text_input = &window_guest_list_textinput;
+    events.invalidate = &window_guest_list_invalidate;
+    events.paint = &window_guest_list_paint;
+    events.scroll_paint = &window_guest_list_scrollpaint;
+});
 // clang-format on
 
 struct FilterArguments
@@ -193,7 +189,6 @@ rct_window* window_guest_list_open()
     if (window != nullptr)
         return window;
 
-    window_guest_list_events_init();
     window = window_create_auto_pos(350, 330, &window_guest_list_events, WC_GUEST_LIST, WF_10 | WF_RESIZABLE);
     window->widgets = window_guest_list_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_PAGE_DROPDOWN) | (1 << WIDX_PAGE_DROPDOWN_BUTTON)

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -102,36 +102,25 @@ static void window_guest_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_guest_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 static void window_guest_list_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_guest_list_events = {
-    nullptr,
-    window_guest_list_mouseup,
-    window_guest_list_resize,
-    window_guest_list_mousedown,
-    window_guest_list_dropdown,
-    nullptr,
-    window_guest_list_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_list_scrollgetsize,
-    window_guest_list_scrollmousedown,
-    nullptr,
-    window_guest_list_scrollmouseover,
-    window_guest_list_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_guest_list_invalidate,
-    window_guest_list_paint,
-    window_guest_list_scrollpaint
-};
+static rct_window_event_list window_guest_list_events = {};
+
+static void window_guest_list_events_init()
+{
+    auto& events = window_guest_list_events;
+
+    events.mouse_up = window_guest_list_mouseup;
+    events.resize = window_guest_list_resize;
+    events.mouse_down = window_guest_list_mousedown;
+    events.dropdown = window_guest_list_dropdown;
+    events.update = window_guest_list_update;
+    events.get_scroll_size = window_guest_list_scrollgetsize;
+    events.scroll_mousedown = window_guest_list_scrollmousedown;
+    events.scroll_mouseover = window_guest_list_scrollmouseover;
+    events.text_input = window_guest_list_textinput;
+    events.invalidate = window_guest_list_invalidate;
+    events.paint = window_guest_list_paint;
+    events.scroll_paint = window_guest_list_scrollpaint;
+}
 // clang-format on
 
 struct FilterArguments
@@ -204,6 +193,7 @@ rct_window* window_guest_list_open()
     if (window != nullptr)
         return window;
 
+    window_guest_list_events_init();
     window = window_create_auto_pos(350, 330, &window_guest_list_events, WC_GUEST_LIST, WF_10 | WF_RESIZABLE);
     window->widgets = window_guest_list_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_PAGE_DROPDOWN) | (1 << WIDX_PAGE_DROPDOWN_BUTTON)

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -57,36 +57,18 @@ static void window_install_track_invalidate(rct_window *w);
 static void window_install_track_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_install_track_text_input(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_install_track_events = {
-    window_install_track_close,
-    window_install_track_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_install_track_text_input,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_install_track_invalidate,
-    window_install_track_paint,
-    nullptr
-};
+static rct_window_event_list window_install_track_events = {};
+
+static void window_install_track_events_init()
+{
+    auto& events = window_install_track_events;
+
+    events.close = window_install_track_close;
+    events.mouse_up = window_install_track_mouseup;
+    events.text_input = window_install_track_text_input;
+    events.invalidate = window_install_track_invalidate;
+    events.paint = window_install_track_paint;
+}
 // clang-format on
 
 static std::unique_ptr<TrackDesign> _trackDesign;
@@ -133,6 +115,7 @@ rct_window* window_install_track_open(const utf8* path)
     int32_t x = screenWidth / 2 - 201;
     int32_t y = std::max(TOP_TOOLBAR_HEIGHT + 1, screenHeight / 2 - 200);
 
+    window_install_track_events_init();
     rct_window* w = window_create(ScreenCoordsXY(x, y), WW, WH, &window_install_track_events, WC_INSTALL_TRACK, 0);
     w->widgets = window_install_track_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_ROTATE) | (1 << WIDX_TOGGLE_SCENERY) | (1 << WIDX_INSTALL)

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -57,18 +57,14 @@ static void window_install_track_invalidate(rct_window *w);
 static void window_install_track_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_install_track_text_input(rct_window *w, rct_widgetindex widgetIndex, char *text);
 
-static rct_window_event_list window_install_track_events = {};
-
-static void window_install_track_events_init()
+static rct_window_event_list window_install_track_events([](auto& events)
 {
-    auto& events = window_install_track_events;
-
-    events.close = window_install_track_close;
-    events.mouse_up = window_install_track_mouseup;
-    events.text_input = window_install_track_text_input;
-    events.invalidate = window_install_track_invalidate;
-    events.paint = window_install_track_paint;
-}
+    events.close = &window_install_track_close;
+    events.mouse_up = &window_install_track_mouseup;
+    events.text_input = &window_install_track_text_input;
+    events.invalidate = &window_install_track_invalidate;
+    events.paint = &window_install_track_paint;
+});
 // clang-format on
 
 static std::unique_ptr<TrackDesign> _trackDesign;
@@ -115,7 +111,6 @@ rct_window* window_install_track_open(const utf8* path)
     int32_t x = screenWidth / 2 - 201;
     int32_t y = std::max(TOP_TOOLBAR_HEIGHT + 1, screenHeight / 2 - 200);
 
-    window_install_track_events_init();
     rct_window* w = window_create(ScreenCoordsXY(x, y), WW, WH, &window_install_track_events, WC_INSTALL_TRACK, 0);
     w->widgets = window_install_track_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_ROTATE) | (1 << WIDX_TOGGLE_SCENERY) | (1 << WIDX_INSTALL)

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -63,21 +63,17 @@ static void window_land_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_land_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_land_inputsize(rct_window *w);
 
-static rct_window_event_list window_land_events = {};
-
-static void window_land_events_init()
+static rct_window_event_list window_land_events([](auto& events)
 {
-    auto& events = window_land_events;
-
-    events.close = window_land_close;
-    events.mouse_up = window_land_mouseup;
-    events.mouse_down = window_land_mousedown;
-    events.dropdown = window_land_dropdown;
-    events.update = window_land_update;
-    events.text_input = window_land_textinput;
-    events.invalidate = window_land_invalidate;
-    events.paint = window_land_paint;
-}
+    events.close = &window_land_close;
+    events.mouse_up = &window_land_mouseup;
+    events.mouse_down = &window_land_mousedown;
+    events.dropdown = &window_land_dropdown;
+    events.update = &window_land_update;
+    events.text_input = &window_land_textinput;
+    events.invalidate = &window_land_invalidate;
+    events.paint = &window_land_paint;
+});
 // clang-format on
 
 static int32_t _selectedFloorTexture;
@@ -96,7 +92,6 @@ rct_window* window_land_open()
     if (window != nullptr)
         return window;
 
-    window_land_events_init();
     window = window_create(ScreenCoordsXY(context_get_width() - 98, 29), 98, 160, &window_land_events, WC_LAND, 0);
     window->widgets = window_land_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_FLOOR)

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -63,36 +63,21 @@ static void window_land_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_land_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_land_inputsize(rct_window *w);
 
-static rct_window_event_list window_land_events = {
-    window_land_close,
-    window_land_mouseup,
-    nullptr,
-    window_land_mousedown,
-    window_land_dropdown,
-    nullptr,
-    window_land_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_land_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_land_invalidate,
-    window_land_paint,
-    nullptr
-};
+static rct_window_event_list window_land_events = {};
+
+static void window_land_events_init()
+{
+    auto& events = window_land_events;
+
+    events.close = window_land_close;
+    events.mouse_up = window_land_mouseup;
+    events.mouse_down = window_land_mousedown;
+    events.dropdown = window_land_dropdown;
+    events.update = window_land_update;
+    events.text_input = window_land_textinput;
+    events.invalidate = window_land_invalidate;
+    events.paint = window_land_paint;
+}
 // clang-format on
 
 static int32_t _selectedFloorTexture;
@@ -111,6 +96,7 @@ rct_window* window_land_open()
     if (window != nullptr)
         return window;
 
+    window_land_events_init();
     window = window_create(ScreenCoordsXY(context_get_width() - 98, 29), 98, 160, &window_land_events, WC_LAND, 0);
     window->widgets = window_land_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_FLOOR)

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -61,24 +61,20 @@ static void window_land_rights_toolabort(rct_window *w, rct_widgetindex widgetIn
 static bool land_rights_tool_is_active();
 
 
-static rct_window_event_list window_land_rights_events = {};
-
-static void window_land_rights_events_init()
+static rct_window_event_list window_land_rights_events([](auto& events)
 {
-    auto& events = window_land_rights_events;
-
-    events.close = window_land_rights_close;
-    events.mouse_up = window_land_rights_mouseup;
-    events.mouse_down = window_land_rights_mousedown;
-    events.update = window_land_rights_update;
-    events.tool_update = window_land_rights_toolupdate;
-    events.tool_down = window_land_rights_tooldown;
-    events.tool_drag = window_land_rights_tooldrag;
-    events.tool_abort = window_land_rights_toolabort;
-    events.text_input = window_land_rights_textinput;
-    events.invalidate = window_land_rights_invalidate;
-    events.paint = window_land_rights_paint;
-}
+    events.close = &window_land_rights_close;
+    events.mouse_up = &window_land_rights_mouseup;
+    events.mouse_down = &window_land_rights_mousedown;
+    events.update = &window_land_rights_update;
+    events.tool_update = &window_land_rights_toolupdate;
+    events.tool_down = &window_land_rights_tooldown;
+    events.tool_drag = &window_land_rights_tooldrag;
+    events.tool_abort = &window_land_rights_toolabort;
+    events.text_input = &window_land_rights_textinput;
+    events.invalidate = &window_land_rights_invalidate;
+    events.paint = &window_land_rights_paint;
+});
 // clang-format on
 
 constexpr uint8_t LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS = 0;
@@ -96,7 +92,6 @@ rct_window* window_land_rights_open()
     if (window != nullptr)
         return window;
 
-    window_land_rights_events_init();
     window = window_create(ScreenCoordsXY(context_get_width() - 98, 29), 98, 94, &window_land_rights_events, WC_LAND_RIGHTS, 0);
     window->widgets = window_land_rights_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_PREVIEW)

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -61,36 +61,24 @@ static void window_land_rights_toolabort(rct_window *w, rct_widgetindex widgetIn
 static bool land_rights_tool_is_active();
 
 
-static rct_window_event_list window_land_rights_events = {
-    window_land_rights_close,
-    window_land_rights_mouseup,
-    nullptr,
-    window_land_rights_mousedown,
-    nullptr,
-    nullptr,
-    window_land_rights_update,
-    nullptr,
-    nullptr,
-    window_land_rights_toolupdate,
-    window_land_rights_tooldown,
-    window_land_rights_tooldrag,
-    nullptr,
-    window_land_rights_toolabort,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_land_rights_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_land_rights_invalidate,
-    window_land_rights_paint,
-    nullptr
-};
+static rct_window_event_list window_land_rights_events = {};
+
+static void window_land_rights_events_init()
+{
+    auto& events = window_land_rights_events;
+
+    events.close = window_land_rights_close;
+    events.mouse_up = window_land_rights_mouseup;
+    events.mouse_down = window_land_rights_mousedown;
+    events.update = window_land_rights_update;
+    events.tool_update = window_land_rights_toolupdate;
+    events.tool_down = window_land_rights_tooldown;
+    events.tool_drag = window_land_rights_tooldrag;
+    events.tool_abort = window_land_rights_toolabort;
+    events.text_input = window_land_rights_textinput;
+    events.invalidate = window_land_rights_invalidate;
+    events.paint = window_land_rights_paint;
+}
 // clang-format on
 
 constexpr uint8_t LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS = 0;
@@ -108,6 +96,7 @@ rct_window* window_land_rights_open()
     if (window != nullptr)
         return window;
 
+    window_land_rights_events_init();
     window = window_create(ScreenCoordsXY(context_get_width() - 98, 29), 98, 94, &window_land_rights_events, WC_LAND_RIGHTS, 0);
     window->widgets = window_land_rights_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_PREVIEW)

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -91,37 +91,23 @@ static void window_loadsave_invalidate(rct_window *w);
 static void window_loadsave_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_loadsave_events =
+static rct_window_event_list window_loadsave_events = {};
+
+static void window_loadsave_events_init()
 {
-    window_loadsave_close,
-    window_loadsave_mouseup,
-    window_loadsave_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_loadsave_scrollgetsize,
-    window_loadsave_scrollmousedown,
-    nullptr,
-    window_loadsave_scrollmouseover,
-    window_loadsave_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_loadsave_invalidate,
-    window_loadsave_paint,
-    window_loadsave_scrollpaint
-};
+    auto& events = window_loadsave_events;
+
+    events.close = window_loadsave_close;
+    events.mouse_up = window_loadsave_mouseup;
+    events.resize = window_loadsave_resize;
+    events.get_scroll_size = window_loadsave_scrollgetsize;
+    events.scroll_mousedown = window_loadsave_scrollmousedown;
+    events.scroll_mouseover = window_loadsave_scrollmouseover;
+    events.text_input = window_loadsave_textinput;
+    events.invalidate = window_loadsave_invalidate;
+    events.paint = window_loadsave_paint;
+    events.scroll_paint = window_loadsave_scrollpaint;
+}
 // clang-format on
 
 #pragma endregion
@@ -282,6 +268,7 @@ rct_window* window_loadsave_open(int32_t type, const char* defaultName, loadsave
     rct_window* w = window_bring_to_front_by_class(WC_LOADSAVE);
     if (w == nullptr)
     {
+        window_loadsave_events_init();
         w = window_create_centred(WW, WH, &window_loadsave_events, WC_LOADSAVE, WF_STICK_TO_FRONT | WF_RESIZABLE);
         w->widgets = window_loadsave_widgets;
         w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_UP) | (1 << WIDX_NEW_FOLDER) | (1 << WIDX_NEW_FILE)
@@ -1159,36 +1146,15 @@ static rct_widget window_overwrite_prompt_widgets[] = {
 static void window_overwrite_prompt_mouseup(rct_window* w, rct_widgetindex widgetIndex);
 static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_overwrite_prompt_events = {
-    nullptr,
-    window_overwrite_prompt_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_overwrite_prompt_paint,
-    nullptr,
-};
+static rct_window_event_list window_overwrite_prompt_events = {};
+
+static void window_overwrite_prompt_events_init()
+{
+    auto& events = window_overwrite_prompt_events;
+
+    events.mouse_up = window_overwrite_prompt_mouseup;
+    events.paint = window_overwrite_prompt_paint;
+}
 
 static char _window_overwrite_prompt_name[256];
 static char _window_overwrite_prompt_path[MAX_PATH];
@@ -1199,6 +1165,7 @@ static rct_window* window_overwrite_prompt_open(const char* name, const char* pa
 
     window_close_by_class(WC_LOADSAVE_OVERWRITE_PROMPT);
 
+    window_overwrite_prompt_events_init();
     w = window_create_centred(
         OVERWRITE_WW, OVERWRITE_WH, &window_overwrite_prompt_events, WC_LOADSAVE_OVERWRITE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_overwrite_prompt_widgets;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -91,23 +91,19 @@ static void window_loadsave_invalidate(rct_window *w);
 static void window_loadsave_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_loadsave_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_loadsave_events = {};
-
-static void window_loadsave_events_init()
+static rct_window_event_list window_loadsave_events([](auto& events)
 {
-    auto& events = window_loadsave_events;
-
-    events.close = window_loadsave_close;
-    events.mouse_up = window_loadsave_mouseup;
-    events.resize = window_loadsave_resize;
-    events.get_scroll_size = window_loadsave_scrollgetsize;
-    events.scroll_mousedown = window_loadsave_scrollmousedown;
-    events.scroll_mouseover = window_loadsave_scrollmouseover;
-    events.text_input = window_loadsave_textinput;
-    events.invalidate = window_loadsave_invalidate;
-    events.paint = window_loadsave_paint;
-    events.scroll_paint = window_loadsave_scrollpaint;
-}
+    events.close = &window_loadsave_close;
+    events.mouse_up = &window_loadsave_mouseup;
+    events.resize = &window_loadsave_resize;
+    events.get_scroll_size = &window_loadsave_scrollgetsize;
+    events.scroll_mousedown = &window_loadsave_scrollmousedown;
+    events.scroll_mouseover = &window_loadsave_scrollmouseover;
+    events.text_input = &window_loadsave_textinput;
+    events.invalidate = &window_loadsave_invalidate;
+    events.paint = &window_loadsave_paint;
+    events.scroll_paint = &window_loadsave_scrollpaint;
+});
 // clang-format on
 
 #pragma endregion
@@ -268,7 +264,6 @@ rct_window* window_loadsave_open(int32_t type, const char* defaultName, loadsave
     rct_window* w = window_bring_to_front_by_class(WC_LOADSAVE);
     if (w == nullptr)
     {
-        window_loadsave_events_init();
         w = window_create_centred(WW, WH, &window_loadsave_events, WC_LOADSAVE, WF_STICK_TO_FRONT | WF_RESIZABLE);
         w->widgets = window_loadsave_widgets;
         w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_UP) | (1 << WIDX_NEW_FOLDER) | (1 << WIDX_NEW_FILE)
@@ -1146,15 +1141,10 @@ static rct_widget window_overwrite_prompt_widgets[] = {
 static void window_overwrite_prompt_mouseup(rct_window* w, rct_widgetindex widgetIndex);
 static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
-static rct_window_event_list window_overwrite_prompt_events = {};
-
-static void window_overwrite_prompt_events_init()
-{
-    auto& events = window_overwrite_prompt_events;
-
-    events.mouse_up = window_overwrite_prompt_mouseup;
-    events.paint = window_overwrite_prompt_paint;
-}
+static rct_window_event_list window_overwrite_prompt_events([](auto& events) {
+    events.mouse_up = &window_overwrite_prompt_mouseup;
+    events.paint = &window_overwrite_prompt_paint;
+});
 
 static char _window_overwrite_prompt_name[256];
 static char _window_overwrite_prompt_path[MAX_PATH];
@@ -1165,7 +1155,6 @@ static rct_window* window_overwrite_prompt_open(const char* name, const char* pa
 
     window_close_by_class(WC_LOADSAVE_OVERWRITE_PROMPT);
 
-    window_overwrite_prompt_events_init();
     w = window_create_centred(
         OVERWRITE_WW, OVERWRITE_WH, &window_overwrite_prompt_events, WC_LOADSAVE_OVERWRITE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_overwrite_prompt_widgets;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -23,14 +23,10 @@ static rct_widget window_main_widgets[] = {
 
 void window_main_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_main_events = {};
-
-static void window_main_events_init()
+static rct_window_event_list window_main_events([](auto& events)
 {
-    auto& events = window_main_events;
-
-    events.paint = window_main_paint;
-}
+    events.paint = &window_main_paint;
+});
 // clang-format on
 
 /**
@@ -41,7 +37,6 @@ rct_window* window_main_open()
 {
     window_main_widgets[0].right = context_get_width();
     window_main_widgets[0].bottom = context_get_height();
-    window_main_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), window_main_widgets[0].right, window_main_widgets[0].bottom, &window_main_events, WC_MAIN_WINDOW,
         WF_STICK_TO_BACK);

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -23,36 +23,14 @@ static rct_widget window_main_widgets[] = {
 
 void window_main_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_main_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_main_paint,
-    nullptr
-};
+static rct_window_event_list window_main_events = {};
+
+static void window_main_events_init()
+{
+    auto& events = window_main_events;
+
+    events.paint = window_main_paint;
+}
 // clang-format on
 
 /**
@@ -63,6 +41,7 @@ rct_window* window_main_open()
 {
     window_main_widgets[0].right = context_get_width();
     window_main_widgets[0].bottom = context_get_height();
+    window_main_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), window_main_widgets[0].right, window_main_widgets[0].bottom, &window_main_events, WC_MAIN_WINDOW,
         WF_STICK_TO_BACK);

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -138,29 +138,25 @@ static void window_map_invalidate(rct_window *w);
 static void window_map_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_map_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_map_events = {};
-
-static void window_map_events_init()
+static rct_window_event_list window_map_events([](auto& events)
 {
-    auto& events = window_map_events;
-
-    events.close = window_map_close;
-    events.mouse_up = window_map_mouseup;
-    events.resize = window_map_resize;
-    events.mouse_down = window_map_mousedown;
-    events.update = window_map_update;
-    events.tool_update = window_map_toolupdate;
-    events.tool_down = window_map_tooldown;
-    events.tool_drag = window_map_tooldrag;
-    events.tool_abort = window_map_toolabort;
-    events.get_scroll_size = window_map_scrollgetsize;
-    events.scroll_mousedown = window_map_scrollmousedown;
-    events.scroll_mousedrag = window_map_scrollmousedown;
-    events.text_input = window_map_textinput;
-    events.invalidate = window_map_invalidate;
-    events.paint = window_map_paint;
-    events.scroll_paint = window_map_scrollpaint;
-}
+    events.close = &window_map_close;
+    events.mouse_up = &window_map_mouseup;
+    events.resize = &window_map_resize;
+    events.mouse_down = &window_map_mousedown;
+    events.update = &window_map_update;
+    events.tool_update = &window_map_toolupdate;
+    events.tool_down = &window_map_tooldown;
+    events.tool_drag = &window_map_tooldrag;
+    events.tool_abort = &window_map_toolabort;
+    events.get_scroll_size = &window_map_scrollgetsize;
+    events.scroll_mousedown = &window_map_scrollmousedown;
+    events.scroll_mousedrag = &window_map_scrollmousedown;
+    events.text_input = &window_map_textinput;
+    events.invalidate = &window_map_invalidate;
+    events.paint = &window_map_paint;
+    events.scroll_paint = &window_map_scrollpaint;
+});
 // clang-format on
 
 /** rct2: 0x00F1AD61 */
@@ -221,7 +217,6 @@ rct_window* window_map_open()
         return nullptr;
     }
 
-    window_map_events_init();
     w = window_create_auto_pos(245, 259, &window_map_events, WC_MAP, WF_10);
     w->widgets = window_map_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_PEOPLE_TAB) | (1 << WIDX_RIDES_TAB) | (1 << WIDX_MAP_SIZE_SPINNER)

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -138,36 +138,29 @@ static void window_map_invalidate(rct_window *w);
 static void window_map_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_map_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_map_events = {
-    window_map_close,
-    window_map_mouseup,
-    window_map_resize,
-    window_map_mousedown,
-    nullptr,
-    nullptr,
-    window_map_update,
-    nullptr,
-    nullptr,
-    window_map_toolupdate,
-    window_map_tooldown,
-    window_map_tooldrag,
-    nullptr,
-    window_map_toolabort,
-    nullptr,
-    window_map_scrollgetsize,
-    window_map_scrollmousedown,
-    window_map_scrollmousedown,
-    nullptr,
-    window_map_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_map_invalidate,
-    window_map_paint,
-    window_map_scrollpaint
-};
+static rct_window_event_list window_map_events = {};
+
+static void window_map_events_init()
+{
+    auto& events = window_map_events;
+
+    events.close = window_map_close;
+    events.mouse_up = window_map_mouseup;
+    events.resize = window_map_resize;
+    events.mouse_down = window_map_mousedown;
+    events.update = window_map_update;
+    events.tool_update = window_map_toolupdate;
+    events.tool_down = window_map_tooldown;
+    events.tool_drag = window_map_tooldrag;
+    events.tool_abort = window_map_toolabort;
+    events.get_scroll_size = window_map_scrollgetsize;
+    events.scroll_mousedown = window_map_scrollmousedown;
+    events.scroll_mousedrag = window_map_scrollmousedown;
+    events.text_input = window_map_textinput;
+    events.invalidate = window_map_invalidate;
+    events.paint = window_map_paint;
+    events.scroll_paint = window_map_scrollpaint;
+}
 // clang-format on
 
 /** rct2: 0x00F1AD61 */
@@ -228,6 +221,7 @@ rct_window* window_map_open()
         return nullptr;
     }
 
+    window_map_events_init();
     w = window_create_auto_pos(245, 259, &window_map_events, WC_MAP, WF_10);
     w->widgets = window_map_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_PEOPLE_TAB) | (1 << WIDX_RIDES_TAB) | (1 << WIDX_MAP_SIZE_SPINNER)

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -211,129 +211,72 @@ static void window_mapgen_heightmap_mousedown(rct_window *w, rct_widgetindex wid
 static void window_mapgen_heightmap_invalidate(rct_window *w);
 static void window_mapgen_heightmap_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list BaseEvents = {
-    window_mapgen_shared_close,
-    window_mapgen_base_mouseup,
-    nullptr,
-    window_mapgen_base_mousedown,
-    window_mapgen_base_dropdown,
-    nullptr,
-    window_mapgen_base_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_mapgen_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_mapgen_base_invalidate,
-    window_mapgen_base_paint,
-    nullptr
-};
+static rct_window_event_list BaseEvents = {};
 
-static rct_window_event_list RandomEvents = {
-    window_mapgen_shared_close,
-    window_mapgen_random_mouseup,
-    nullptr,
-    window_mapgen_random_mousedown,
-    nullptr,
-    nullptr,
-    window_mapgen_random_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_mapgen_random_invalidate,
-    window_mapgen_random_paint,
-    nullptr
-};
+static void BaseEvents_init()
+{
+    auto& events = BaseEvents;
 
-static rct_window_event_list SimplexEvents = {
-    window_mapgen_shared_close,
-    window_mapgen_simplex_mouseup,
-    nullptr,
-    window_mapgen_simplex_mousedown,
-    window_mapgen_simplex_dropdown,
-    nullptr,
-    window_mapgen_simplex_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_mapgen_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_mapgen_simplex_invalidate,
-    window_mapgen_simplex_paint,
-    nullptr
-};
+    events.close = window_mapgen_shared_close;
+    events.mouse_up = window_mapgen_base_mouseup;
+    events.mouse_down = window_mapgen_base_mousedown;
+    events.dropdown = window_mapgen_base_dropdown;
+    events.update = window_mapgen_base_update;
+    events.text_input = window_mapgen_textinput;
+    events.invalidate = window_mapgen_base_invalidate;
+    events.paint = window_mapgen_base_paint;
+}
 
-static rct_window_event_list HeightmapEvents = {
-    window_mapgen_shared_close,
-    window_mapgen_heightmap_mouseup,
-    nullptr,
-    window_mapgen_heightmap_mousedown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_mapgen_heightmap_invalidate,
-    window_mapgen_heightmap_paint,
-    nullptr
-};
+static rct_window_event_list RandomEvents = {};
+
+static void RandomEvents_init()
+{
+    auto& events = RandomEvents;
+
+    events.close = window_mapgen_shared_close;
+    events.mouse_up = window_mapgen_random_mouseup;
+    events.mouse_down = window_mapgen_random_mousedown;
+    events.update = window_mapgen_random_update;
+    events.invalidate = window_mapgen_random_invalidate;
+    events.paint = window_mapgen_random_paint;
+}
+
+static rct_window_event_list SimplexEvents = {};
+
+static void SimplexEvents_init()
+{
+    auto& events = SimplexEvents;
+
+    events.close = window_mapgen_shared_close;
+    events.mouse_up = window_mapgen_simplex_mouseup;
+    events.mouse_down = window_mapgen_simplex_mousedown;
+    events.dropdown = window_mapgen_simplex_dropdown;
+    events.update = window_mapgen_simplex_update;
+    events.text_input = window_mapgen_textinput;
+    events.invalidate = window_mapgen_simplex_invalidate;
+    events.paint = window_mapgen_simplex_paint;
+}
+
+static rct_window_event_list HeightmapEvents = {};
+
+static void HeightmapEvents_init()
+{
+    auto& events = HeightmapEvents;
+
+    events.close = window_mapgen_shared_close;
+    events.mouse_up = window_mapgen_heightmap_mouseup;
+    events.mouse_down = window_mapgen_heightmap_mousedown;
+    events.invalidate = window_mapgen_heightmap_invalidate;
+    events.paint = window_mapgen_heightmap_paint;
+}
+
+static void window_mapgen_events_init_all()
+{
+    BaseEvents_init();
+    RandomEvents_init();
+    SimplexEvents_init();
+    HeightmapEvents_init();
+}
 
 static rct_window_event_list *PageEvents[] = {
     &BaseEvents,
@@ -528,6 +471,7 @@ rct_window* window_mapgen_open()
         return w;
     }
 
+    window_mapgen_events_init_all();
     w = window_create_centred(WW, WH, PageEvents[WINDOW_MAPGEN_PAGE_BASE], WC_MAPGEN, WF_10);
     w->number = 0;
     w->frame_no = 0;

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -211,72 +211,48 @@ static void window_mapgen_heightmap_mousedown(rct_window *w, rct_widgetindex wid
 static void window_mapgen_heightmap_invalidate(rct_window *w);
 static void window_mapgen_heightmap_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list BaseEvents = {};
-
-static void BaseEvents_init()
+static rct_window_event_list BaseEvents([](auto& events)
 {
-    auto& events = BaseEvents;
+    events.close = &window_mapgen_shared_close;
+    events.mouse_up = &window_mapgen_base_mouseup;
+    events.mouse_down = &window_mapgen_base_mousedown;
+    events.dropdown = &window_mapgen_base_dropdown;
+    events.update = &window_mapgen_base_update;
+    events.text_input = &window_mapgen_textinput;
+    events.invalidate = &window_mapgen_base_invalidate;
+    events.paint = &window_mapgen_base_paint;
+});
 
-    events.close = window_mapgen_shared_close;
-    events.mouse_up = window_mapgen_base_mouseup;
-    events.mouse_down = window_mapgen_base_mousedown;
-    events.dropdown = window_mapgen_base_dropdown;
-    events.update = window_mapgen_base_update;
-    events.text_input = window_mapgen_textinput;
-    events.invalidate = window_mapgen_base_invalidate;
-    events.paint = window_mapgen_base_paint;
-}
-
-static rct_window_event_list RandomEvents = {};
-
-static void RandomEvents_init()
+static rct_window_event_list RandomEvents([](auto& events)
 {
-    auto& events = RandomEvents;
+    events.close = &window_mapgen_shared_close;
+    events.mouse_up = &window_mapgen_random_mouseup;
+    events.mouse_down = &window_mapgen_random_mousedown;
+    events.update = &window_mapgen_random_update;
+    events.invalidate = &window_mapgen_random_invalidate;
+    events.paint = &window_mapgen_random_paint;
+});
 
-    events.close = window_mapgen_shared_close;
-    events.mouse_up = window_mapgen_random_mouseup;
-    events.mouse_down = window_mapgen_random_mousedown;
-    events.update = window_mapgen_random_update;
-    events.invalidate = window_mapgen_random_invalidate;
-    events.paint = window_mapgen_random_paint;
-}
-
-static rct_window_event_list SimplexEvents = {};
-
-static void SimplexEvents_init()
+static rct_window_event_list SimplexEvents([](auto& events)
 {
-    auto& events = SimplexEvents;
+    events.close = &window_mapgen_shared_close;
+    events.mouse_up = &window_mapgen_simplex_mouseup;
+    events.mouse_down = &window_mapgen_simplex_mousedown;
+    events.dropdown = &window_mapgen_simplex_dropdown;
+    events.update = &window_mapgen_simplex_update;
+    events.text_input = &window_mapgen_textinput;
+    events.invalidate = &window_mapgen_simplex_invalidate;
+    events.paint = &window_mapgen_simplex_paint;
+});
 
-    events.close = window_mapgen_shared_close;
-    events.mouse_up = window_mapgen_simplex_mouseup;
-    events.mouse_down = window_mapgen_simplex_mousedown;
-    events.dropdown = window_mapgen_simplex_dropdown;
-    events.update = window_mapgen_simplex_update;
-    events.text_input = window_mapgen_textinput;
-    events.invalidate = window_mapgen_simplex_invalidate;
-    events.paint = window_mapgen_simplex_paint;
-}
-
-static rct_window_event_list HeightmapEvents = {};
-
-static void HeightmapEvents_init()
+static rct_window_event_list HeightmapEvents([](auto& events)
 {
-    auto& events = HeightmapEvents;
-
-    events.close = window_mapgen_shared_close;
-    events.mouse_up = window_mapgen_heightmap_mouseup;
-    events.mouse_down = window_mapgen_heightmap_mousedown;
-    events.invalidate = window_mapgen_heightmap_invalidate;
-    events.paint = window_mapgen_heightmap_paint;
-}
-
-static void window_mapgen_events_init_all()
-{
-    BaseEvents_init();
-    RandomEvents_init();
-    SimplexEvents_init();
-    HeightmapEvents_init();
-}
+    events.close = &window_mapgen_shared_close;
+    events.mouse_up = &window_mapgen_heightmap_mouseup;
+    events.mouse_down = &window_mapgen_heightmap_mousedown;
+    events.invalidate = &window_mapgen_heightmap_invalidate;
+    events.paint = &window_mapgen_heightmap_paint;
+});
 
 static rct_window_event_list *PageEvents[] = {
     &BaseEvents,
@@ -471,7 +447,6 @@ rct_window* window_mapgen_open()
         return w;
     }
 
-    window_mapgen_events_init_all();
     w = window_create_centred(WW, WH, PageEvents[WINDOW_MAPGEN_PAGE_BASE], WC_MAPGEN, WF_10);
     w->number = 0;
     w->frame_no = 0;

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -25,15 +25,11 @@ static rct_widget window_map_tooltip_widgets[] = {
 static void window_map_tooltip_update(rct_window *w);
 static void window_map_tooltip_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_map_tooltip_events = {};
-
-static void window_map_tooltip_events_init()
+static rct_window_event_list window_map_tooltip_events([](auto& events)
 {
-    auto& events = window_map_tooltip_events;
-
-    events.update = window_map_tooltip_update;
-    events.paint = window_map_tooltip_paint;
-}
+    events.update = &window_map_tooltip_update;
+    events.paint = &window_map_tooltip_paint;
+});
 // clang-format on
 
 #define MAP_TOOLTIP_ARGS
@@ -100,7 +96,6 @@ static void window_map_tooltip_open()
     w = window_find_by_class(WC_MAP_TOOLTIP);
     if (w == nullptr)
     {
-        window_map_tooltip_events_init();
         w = window_create(
             pos, width, height, &window_map_tooltip_events, WC_MAP_TOOLTIP,
             WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -25,36 +25,15 @@ static rct_widget window_map_tooltip_widgets[] = {
 static void window_map_tooltip_update(rct_window *w);
 static void window_map_tooltip_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_map_tooltip_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_map_tooltip_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_map_tooltip_paint,
-    nullptr
-};
+static rct_window_event_list window_map_tooltip_events = {};
+
+static void window_map_tooltip_events_init()
+{
+    auto& events = window_map_tooltip_events;
+
+    events.update = window_map_tooltip_update;
+    events.paint = window_map_tooltip_paint;
+}
 // clang-format on
 
 #define MAP_TOOLTIP_ARGS
@@ -121,6 +100,7 @@ static void window_map_tooltip_open()
     w = window_find_by_class(WC_MAP_TOOLTIP);
     if (w == nullptr)
     {
+        window_map_tooltip_events_init();
         w = window_create(
             pos, width, height, &window_map_tooltip_events, WC_MAP_TOOLTIP,
             WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -96,36 +96,22 @@ static void window_maze_construction_invalidate(rct_window *w);
 static void window_maze_construction_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x993F6C
-static rct_window_event_list window_maze_construction_events = {
-    window_maze_construction_close,
-    window_maze_construction_mouseup,
-    window_maze_construction_resize,
-    window_maze_construction_mousedown,
-    nullptr,
-    nullptr,
-    window_maze_construction_update,
-    nullptr,
-    nullptr,
-    window_maze_construction_toolupdate,
-    window_maze_construction_tooldown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_maze_construction_invalidate,
-    window_maze_construction_paint,
-    nullptr
-};
+static rct_window_event_list window_maze_construction_events = {};
+
+static void window_maze_construction_events_init()
+{
+    auto& events = window_maze_construction_events;
+
+    events.close = window_maze_construction_close;
+    events.mouse_up = window_maze_construction_mouseup;
+    events.resize = window_maze_construction_resize;
+    events.mouse_down = window_maze_construction_mousedown;
+    events.update = window_maze_construction_update;
+    events.tool_update = window_maze_construction_toolupdate;
+    events.tool_down = window_maze_construction_tooldown;
+    events.invalidate = window_maze_construction_invalidate;
+    events.paint = window_maze_construction_paint;
+}
 // clang-format on
 
 #pragma endregion
@@ -138,6 +124,7 @@ static void window_maze_construction_construct(int32_t direction);
  */
 rct_window* window_maze_construction_open()
 {
+    window_maze_construction_events_init();
     rct_window* w = window_create(
         ScreenCoordsXY(0, 29), 166, 200, &window_maze_construction_events, WC_RIDE_CONSTRUCTION, WF_NO_AUTO_CLOSE);
     w->widgets = window_maze_construction_widgets;

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -96,22 +96,18 @@ static void window_maze_construction_invalidate(rct_window *w);
 static void window_maze_construction_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x993F6C
-static rct_window_event_list window_maze_construction_events = {};
-
-static void window_maze_construction_events_init()
+static rct_window_event_list window_maze_construction_events([](auto& events)
 {
-    auto& events = window_maze_construction_events;
-
-    events.close = window_maze_construction_close;
-    events.mouse_up = window_maze_construction_mouseup;
-    events.resize = window_maze_construction_resize;
-    events.mouse_down = window_maze_construction_mousedown;
-    events.update = window_maze_construction_update;
-    events.tool_update = window_maze_construction_toolupdate;
-    events.tool_down = window_maze_construction_tooldown;
-    events.invalidate = window_maze_construction_invalidate;
-    events.paint = window_maze_construction_paint;
-}
+    events.close = &window_maze_construction_close;
+    events.mouse_up = &window_maze_construction_mouseup;
+    events.resize = &window_maze_construction_resize;
+    events.mouse_down = &window_maze_construction_mousedown;
+    events.update = &window_maze_construction_update;
+    events.tool_update = &window_maze_construction_toolupdate;
+    events.tool_down = &window_maze_construction_tooldown;
+    events.invalidate = &window_maze_construction_invalidate;
+    events.paint = &window_maze_construction_paint;
+});
 // clang-format on
 
 #pragma endregion
@@ -124,7 +120,6 @@ static void window_maze_construction_construct(int32_t direction);
  */
 rct_window* window_maze_construction_open()
 {
-    window_maze_construction_events_init();
     rct_window* w = window_create(
         ScreenCoordsXY(0, 29), 166, 200, &window_maze_construction_events, WC_RIDE_CONSTRUCTION, WF_NO_AUTO_CLOSE);
     w->widgets = window_maze_construction_widgets;

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -161,129 +161,76 @@ static void window_multiplayer_options_update(rct_window *w);
 static void window_multiplayer_options_invalidate(rct_window *w);
 static void window_multiplayer_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_multiplayer_information_events = {
-    nullptr,
-    window_multiplayer_information_mouseup,
-    window_multiplayer_information_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_information_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_information_invalidate,
-    window_multiplayer_information_paint,
-    nullptr
-};
+static rct_window_event_list window_multiplayer_information_events = {};
 
-static rct_window_event_list window_multiplayer_players_events = {
-    nullptr,
-    window_multiplayer_players_mouseup,
-    window_multiplayer_players_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_players_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_players_scrollgetsize,
-    window_multiplayer_players_scrollmousedown,
-    nullptr,
-    window_multiplayer_players_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_players_invalidate,
-    window_multiplayer_players_paint,
-    window_multiplayer_players_scrollpaint
-};
+static void window_multiplayer_information_events_init()
+{
+    auto& events = window_multiplayer_information_events;
 
-static rct_window_event_list window_multiplayer_groups_events = {
-    nullptr,
-    window_multiplayer_groups_mouseup,
-    window_multiplayer_groups_resize,
-    window_multiplayer_groups_mousedown,
-    window_multiplayer_groups_dropdown,
-    nullptr,
-    window_multiplayer_groups_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_groups_scrollgetsize,
-    window_multiplayer_groups_scrollmousedown,
-    nullptr,
-    window_multiplayer_groups_scrollmouseover,
-    window_multiplayer_groups_text_input,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_groups_invalidate,
-    window_multiplayer_groups_paint,
-    window_multiplayer_groups_scrollpaint
-};
+    events.mouse_up = window_multiplayer_information_mouseup;
+    events.resize = window_multiplayer_information_resize;
+    events.update = window_multiplayer_information_update;
+    events.invalidate = window_multiplayer_information_invalidate;
+    events.paint = window_multiplayer_information_paint;
+}
 
-static rct_window_event_list window_multiplayer_options_events = {
-    nullptr,
-    window_multiplayer_options_mouseup,
-    window_multiplayer_options_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_options_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_multiplayer_options_invalidate,
-    window_multiplayer_options_paint,
-    nullptr
-};
+static rct_window_event_list window_multiplayer_players_events = {};
+
+static void window_multiplayer_players_events_init()
+{
+    auto& events = window_multiplayer_players_events;
+
+    events.mouse_up = window_multiplayer_players_mouseup;
+    events.resize = window_multiplayer_players_resize;
+    events.update = window_multiplayer_players_update;
+    events.get_scroll_size = window_multiplayer_players_scrollgetsize;
+    events.scroll_mousedown = window_multiplayer_players_scrollmousedown;
+    events.scroll_mouseover = window_multiplayer_players_scrollmouseover;
+    events.invalidate = window_multiplayer_players_invalidate;
+    events.paint = window_multiplayer_players_paint;
+    events.scroll_paint = window_multiplayer_players_scrollpaint;
+}
+
+static rct_window_event_list window_multiplayer_groups_events = {};
+
+static void window_multiplayer_groups_events_init()
+{
+    auto& events = window_multiplayer_groups_events;
+
+    events.mouse_up = window_multiplayer_groups_mouseup;
+    events.resize = window_multiplayer_groups_resize;
+    events.mouse_down = window_multiplayer_groups_mousedown;
+    events.dropdown = window_multiplayer_groups_dropdown;
+    events.update = window_multiplayer_groups_update;
+    events.get_scroll_size = window_multiplayer_groups_scrollgetsize;
+    events.scroll_mousedown = window_multiplayer_groups_scrollmousedown;
+    events.scroll_mouseover = window_multiplayer_groups_scrollmouseover;
+    events.text_input = window_multiplayer_groups_text_input;
+    events.invalidate = window_multiplayer_groups_invalidate;
+    events.paint = window_multiplayer_groups_paint;
+    events.scroll_paint = window_multiplayer_groups_scrollpaint;
+}
+
+static rct_window_event_list window_multiplayer_options_events = {};
+
+static void window_multiplayer_options_events_init()
+{
+    auto& events = window_multiplayer_options_events;
+
+    events.mouse_up = window_multiplayer_options_mouseup;
+    events.resize = window_multiplayer_options_resize;
+    events.update = window_multiplayer_options_update;
+    events.invalidate = window_multiplayer_options_invalidate;
+    events.paint = window_multiplayer_options_paint;
+}
+
+static void window_multiplayer_events_init_all()
+{
+    window_multiplayer_information_events_init();
+    window_multiplayer_players_events_init();
+    window_multiplayer_groups_events_init();
+    window_multiplayer_options_events_init();
+}
 
 static rct_window_event_list *window_multiplayer_page_events[] = {
     &window_multiplayer_information_events,
@@ -308,6 +255,7 @@ rct_window* window_multiplayer_open()
     rct_window* window = window_bring_to_front_by_class(WC_MULTIPLAYER);
     if (window == nullptr)
     {
+        window_multiplayer_events_init_all();
         window = window_create_auto_pos(320, 144, &window_multiplayer_players_events, WC_MULTIPLAYER, WF_10 | WF_RESIZABLE);
         window_multiplayer_set_page(window, WINDOW_MULTIPLAYER_PAGE_INFORMATION);
     }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -161,76 +161,52 @@ static void window_multiplayer_options_update(rct_window *w);
 static void window_multiplayer_options_invalidate(rct_window *w);
 static void window_multiplayer_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_multiplayer_information_events = {};
-
-static void window_multiplayer_information_events_init()
+static rct_window_event_list window_multiplayer_information_events([](auto& events)
 {
-    auto& events = window_multiplayer_information_events;
+    events.mouse_up = &window_multiplayer_information_mouseup;
+    events.resize = &window_multiplayer_information_resize;
+    events.update = &window_multiplayer_information_update;
+    events.invalidate = &window_multiplayer_information_invalidate;
+    events.paint = &window_multiplayer_information_paint;
+});
 
-    events.mouse_up = window_multiplayer_information_mouseup;
-    events.resize = window_multiplayer_information_resize;
-    events.update = window_multiplayer_information_update;
-    events.invalidate = window_multiplayer_information_invalidate;
-    events.paint = window_multiplayer_information_paint;
-}
-
-static rct_window_event_list window_multiplayer_players_events = {};
-
-static void window_multiplayer_players_events_init()
+static rct_window_event_list window_multiplayer_players_events([](auto& events)
 {
-    auto& events = window_multiplayer_players_events;
+    events.mouse_up = &window_multiplayer_players_mouseup;
+    events.resize = &window_multiplayer_players_resize;
+    events.update = &window_multiplayer_players_update;
+    events.get_scroll_size = &window_multiplayer_players_scrollgetsize;
+    events.scroll_mousedown = &window_multiplayer_players_scrollmousedown;
+    events.scroll_mouseover = &window_multiplayer_players_scrollmouseover;
+    events.invalidate = &window_multiplayer_players_invalidate;
+    events.paint = &window_multiplayer_players_paint;
+    events.scroll_paint = &window_multiplayer_players_scrollpaint;
+});
 
-    events.mouse_up = window_multiplayer_players_mouseup;
-    events.resize = window_multiplayer_players_resize;
-    events.update = window_multiplayer_players_update;
-    events.get_scroll_size = window_multiplayer_players_scrollgetsize;
-    events.scroll_mousedown = window_multiplayer_players_scrollmousedown;
-    events.scroll_mouseover = window_multiplayer_players_scrollmouseover;
-    events.invalidate = window_multiplayer_players_invalidate;
-    events.paint = window_multiplayer_players_paint;
-    events.scroll_paint = window_multiplayer_players_scrollpaint;
-}
-
-static rct_window_event_list window_multiplayer_groups_events = {};
-
-static void window_multiplayer_groups_events_init()
+static rct_window_event_list window_multiplayer_groups_events([](auto& events)
 {
-    auto& events = window_multiplayer_groups_events;
+    events.mouse_up = &window_multiplayer_groups_mouseup;
+    events.resize = &window_multiplayer_groups_resize;
+    events.mouse_down = &window_multiplayer_groups_mousedown;
+    events.dropdown = &window_multiplayer_groups_dropdown;
+    events.update = &window_multiplayer_groups_update;
+    events.get_scroll_size = &window_multiplayer_groups_scrollgetsize;
+    events.scroll_mousedown = &window_multiplayer_groups_scrollmousedown;
+    events.scroll_mouseover = &window_multiplayer_groups_scrollmouseover;
+    events.text_input = &window_multiplayer_groups_text_input;
+    events.invalidate = &window_multiplayer_groups_invalidate;
+    events.paint = &window_multiplayer_groups_paint;
+    events.scroll_paint = &window_multiplayer_groups_scrollpaint;
+});
 
-    events.mouse_up = window_multiplayer_groups_mouseup;
-    events.resize = window_multiplayer_groups_resize;
-    events.mouse_down = window_multiplayer_groups_mousedown;
-    events.dropdown = window_multiplayer_groups_dropdown;
-    events.update = window_multiplayer_groups_update;
-    events.get_scroll_size = window_multiplayer_groups_scrollgetsize;
-    events.scroll_mousedown = window_multiplayer_groups_scrollmousedown;
-    events.scroll_mouseover = window_multiplayer_groups_scrollmouseover;
-    events.text_input = window_multiplayer_groups_text_input;
-    events.invalidate = window_multiplayer_groups_invalidate;
-    events.paint = window_multiplayer_groups_paint;
-    events.scroll_paint = window_multiplayer_groups_scrollpaint;
-}
-
-static rct_window_event_list window_multiplayer_options_events = {};
-
-static void window_multiplayer_options_events_init()
+static rct_window_event_list window_multiplayer_options_events([](auto& events)
 {
-    auto& events = window_multiplayer_options_events;
-
-    events.mouse_up = window_multiplayer_options_mouseup;
-    events.resize = window_multiplayer_options_resize;
-    events.update = window_multiplayer_options_update;
-    events.invalidate = window_multiplayer_options_invalidate;
-    events.paint = window_multiplayer_options_paint;
-}
-
-static void window_multiplayer_events_init_all()
-{
-    window_multiplayer_information_events_init();
-    window_multiplayer_players_events_init();
-    window_multiplayer_groups_events_init();
-    window_multiplayer_options_events_init();
-}
+    events.mouse_up = &window_multiplayer_options_mouseup;
+    events.resize = &window_multiplayer_options_resize;
+    events.update = &window_multiplayer_options_update;
+    events.invalidate = &window_multiplayer_options_invalidate;
+    events.paint = &window_multiplayer_options_paint;
+});
 
 static rct_window_event_list *window_multiplayer_page_events[] = {
     &window_multiplayer_information_events,
@@ -255,7 +231,6 @@ rct_window* window_multiplayer_open()
     rct_window* window = window_bring_to_front_by_class(WC_MULTIPLAYER);
     if (window == nullptr)
     {
-        window_multiplayer_events_init_all();
         window = window_create_auto_pos(320, 144, &window_multiplayer_players_events, WC_MULTIPLAYER, WF_10 | WF_RESIZABLE);
         window_multiplayer_set_page(window, WINDOW_MULTIPLAYER_PAGE_INFORMATION);
     }

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -84,36 +84,17 @@ static void window_music_credits_scrollgetsize(rct_window *w, int32_t scrollInde
 static void window_music_credits_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_music_credits_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_music_credits_events = {
-    nullptr,
-    window_music_credits_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_music_credits_scrollgetsize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_music_credits_paint,
-    window_music_credits_scrollpaint
-};
+static rct_window_event_list window_music_credits_events = {};
+
+static void window_music_credits_events_init()
+{
+    auto& events = window_music_credits_events;
+
+    events.mouse_up = window_music_credits_mouseup;
+    events.get_scroll_size = window_music_credits_scrollgetsize;
+    events.paint = window_music_credits_paint;
+    events.scroll_paint = window_music_credits_scrollpaint;
+}
 // clang-format on
 
 /**
@@ -129,6 +110,7 @@ rct_window* window_music_credits_open()
     if (window != nullptr)
         return window;
 
+    window_music_credits_events_init();
     window = window_create_centred(510, 314, &window_music_credits_events, WC_MUSIC_CREDITS, 0);
 
     window->widgets = window_music_credits_widgets;

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -84,17 +84,13 @@ static void window_music_credits_scrollgetsize(rct_window *w, int32_t scrollInde
 static void window_music_credits_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_music_credits_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_music_credits_events = {};
-
-static void window_music_credits_events_init()
+static rct_window_event_list window_music_credits_events([](auto& events)
 {
-    auto& events = window_music_credits_events;
-
-    events.mouse_up = window_music_credits_mouseup;
-    events.get_scroll_size = window_music_credits_scrollgetsize;
-    events.paint = window_music_credits_paint;
-    events.scroll_paint = window_music_credits_scrollpaint;
-}
+    events.mouse_up = &window_music_credits_mouseup;
+    events.get_scroll_size = &window_music_credits_scrollgetsize;
+    events.paint = &window_music_credits_paint;
+    events.scroll_paint = &window_music_credits_scrollpaint;
+});
 // clang-format on
 
 /**
@@ -110,7 +106,6 @@ rct_window* window_music_credits_open()
     if (window != nullptr)
         return window;
 
-    window_music_credits_events_init();
     window = window_create_centred(510, 314, &window_music_credits_events, WC_MUSIC_CREDITS, 0);
 
     window->widgets = window_music_credits_widgets;

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -99,36 +99,18 @@ static constexpr int32_t NetworkTrafficGroupNames[NETWORK_STATISTICS_GROUP_MAX] 
     STR_NETWORK_LEGEND_MAPDATA,
 };
 
-static rct_window_event_list window_network_information_events = {
-    nullptr,
-    window_network_information_mouseup,
-    window_network_information_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_network_information_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_network_information_invalidate,
-    window_network_information_paint,
-    nullptr
-};
+static rct_window_event_list window_network_information_events = {};
+
+static void window_network_information_events_init()
+{
+    auto& events = window_network_information_events;
+
+    events.mouse_up = window_network_information_mouseup;
+    events.resize = window_network_information_resize;
+    events.update = window_network_information_update;
+    events.invalidate = window_network_information_invalidate;
+    events.paint = window_network_information_paint;
+}
 
 static rct_window_event_list *window_network_page_events[] = {
     &window_network_information_events,
@@ -147,6 +129,7 @@ rct_window* window_network_open()
     rct_window* window = window_bring_to_front_by_class(WC_NETWORK);
     if (window == nullptr)
     {
+        window_network_information_events_init();
         window = window_create_auto_pos(320, 144, &window_network_information_events, WC_NETWORK, WF_10 | WF_RESIZABLE);
         window_network_set_page(window, WINDOW_NETWORK_PAGE_INFORMATION);
 

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -99,18 +99,14 @@ static constexpr int32_t NetworkTrafficGroupNames[NETWORK_STATISTICS_GROUP_MAX] 
     STR_NETWORK_LEGEND_MAPDATA,
 };
 
-static rct_window_event_list window_network_information_events = {};
-
-static void window_network_information_events_init()
+static rct_window_event_list window_network_information_events([](auto& events)
 {
-    auto& events = window_network_information_events;
-
-    events.mouse_up = window_network_information_mouseup;
-    events.resize = window_network_information_resize;
-    events.update = window_network_information_update;
-    events.invalidate = window_network_information_invalidate;
-    events.paint = window_network_information_paint;
-}
+    events.mouse_up = &window_network_information_mouseup;
+    events.resize = &window_network_information_resize;
+    events.update = &window_network_information_update;
+    events.invalidate = &window_network_information_invalidate;
+    events.paint = &window_network_information_paint;
+});
 
 static rct_window_event_list *window_network_page_events[] = {
     &window_network_information_events,
@@ -129,7 +125,6 @@ rct_window* window_network_open()
     rct_window* window = window_bring_to_front_by_class(WC_NETWORK);
     if (window == nullptr)
     {
-        window_network_information_events_init();
         window = window_create_auto_pos(320, 144, &window_network_information_events, WC_NETWORK, WF_10 | WF_RESIZABLE);
         window_network_set_page(window, WINDOW_NETWORK_PAGE_INFORMATION);
 

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -40,19 +40,15 @@ static void window_network_status_textinput(rct_window *w, rct_widgetindex widge
 static void window_network_status_invalidate(rct_window *w);
 static void window_network_status_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_network_status_events = {};
-
-static void window_network_status_events_init()
+static rct_window_event_list window_network_status_events([](auto& events)
 {
-    auto& events = window_network_status_events;
-
-    events.close = window_network_status_onclose;
-    events.mouse_up = window_network_status_mouseup;
-    events.update = window_network_status_update;
-    events.text_input = window_network_status_textinput;
-    events.invalidate = window_network_status_invalidate;
-    events.paint = window_network_status_paint;
-}
+    events.close = &window_network_status_onclose;
+    events.mouse_up = &window_network_status_mouseup;
+    events.update = &window_network_status_update;
+    events.text_input = &window_network_status_textinput;
+    events.invalidate = &window_network_status_invalidate;
+    events.paint = &window_network_status_paint;
+});
 // clang-format on
 
 static close_callback _onClose = nullptr;
@@ -67,7 +63,6 @@ rct_window* window_network_status_open(const char* text, close_callback onClose)
     if (window != nullptr)
         return window;
 
-    window_network_status_events_init();
     window = window_create_centred(420, 90, &window_network_status_events, WC_NETWORK_STATUS, WF_10 | WF_TRANSPARENT);
 
     window->widgets = window_network_status_widgets;

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -40,36 +40,19 @@ static void window_network_status_textinput(rct_window *w, rct_widgetindex widge
 static void window_network_status_invalidate(rct_window *w);
 static void window_network_status_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_network_status_events = {
-    window_network_status_onclose,
-    window_network_status_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_network_status_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_network_status_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_network_status_invalidate,
-    window_network_status_paint,
-    nullptr
-};
+static rct_window_event_list window_network_status_events = {};
+
+static void window_network_status_events_init()
+{
+    auto& events = window_network_status_events;
+
+    events.close = window_network_status_onclose;
+    events.mouse_up = window_network_status_mouseup;
+    events.update = window_network_status_update;
+    events.text_input = window_network_status_textinput;
+    events.invalidate = window_network_status_invalidate;
+    events.paint = window_network_status_paint;
+}
 // clang-format on
 
 static close_callback _onClose = nullptr;
@@ -84,6 +67,7 @@ rct_window* window_network_status_open(const char* text, close_callback onClose)
     if (window != nullptr)
         return window;
 
+    window_network_status_events_init();
     window = window_create_centred(420, 90, &window_network_status_events, WC_NETWORK_STATUS, WF_10 | WF_TRANSPARENT);
 
     window->widgets = window_network_status_widgets;

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -58,36 +58,18 @@ static void window_new_campaign_dropdown(rct_window *w, rct_widgetindex widgetIn
 static void window_new_campaign_invalidate(rct_window *w);
 static void window_new_campaign_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_new_campaign_events = {
-    nullptr,
-    window_new_campaign_mouseup,
-    nullptr,
-    window_new_campaign_mousedown,
-    window_new_campaign_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_new_campaign_invalidate,
-    window_new_campaign_paint,
-    nullptr
-};
+static rct_window_event_list window_new_campaign_events = {};
+
+static void window_new_campaign_events_init()
+{
+    auto& events = window_new_campaign_events;
+
+    events.mouse_up = window_new_campaign_mouseup;
+    events.mouse_down = window_new_campaign_mousedown;
+    events.dropdown = window_new_campaign_dropdown;
+    events.invalidate = window_new_campaign_invalidate;
+    events.paint = window_new_campaign_paint;
+}
 // clang-format on
 
 static std::vector<ride_id_t> window_new_campaign_rides;
@@ -138,6 +120,7 @@ rct_window* window_new_campaign_open(int16_t campaignType)
         window_close(w);
     }
 
+    window_new_campaign_events_init();
     w = window_create_auto_pos(WW, WH, &window_new_campaign_events, WC_NEW_CAMPAIGN, 0);
     w->widgets = window_new_campaign_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_RIDE_DROPDOWN) | (1 << WIDX_RIDE_DROPDOWN_BUTTON)

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -58,18 +58,14 @@ static void window_new_campaign_dropdown(rct_window *w, rct_widgetindex widgetIn
 static void window_new_campaign_invalidate(rct_window *w);
 static void window_new_campaign_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_new_campaign_events = {};
-
-static void window_new_campaign_events_init()
+static rct_window_event_list window_new_campaign_events([](auto& events)
 {
-    auto& events = window_new_campaign_events;
-
-    events.mouse_up = window_new_campaign_mouseup;
-    events.mouse_down = window_new_campaign_mousedown;
-    events.dropdown = window_new_campaign_dropdown;
-    events.invalidate = window_new_campaign_invalidate;
-    events.paint = window_new_campaign_paint;
-}
+    events.mouse_up = &window_new_campaign_mouseup;
+    events.mouse_down = &window_new_campaign_mousedown;
+    events.dropdown = &window_new_campaign_dropdown;
+    events.invalidate = &window_new_campaign_invalidate;
+    events.paint = &window_new_campaign_paint;
+});
 // clang-format on
 
 static std::vector<ride_id_t> window_new_campaign_rides;
@@ -120,7 +116,6 @@ rct_window* window_new_campaign_open(int16_t campaignType)
         window_close(w);
     }
 
-    window_new_campaign_events_init();
     w = window_create_auto_pos(WW, WH, &window_new_campaign_events, WC_NEW_CAMPAIGN, 0);
     w->widgets = window_new_campaign_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_RIDE_DROPDOWN) | (1 << WIDX_RIDE_DROPDOWN_BUTTON)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -219,22 +219,18 @@ static void window_new_ride_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, i
 static void window_new_ride_list_vehicles_for(uint8_t rideType, const rct_ride_entry* rideEntry, char* buffer, size_t bufferLen);
 
 // 0x0098E354
-static rct_window_event_list window_new_ride_events = {};
-
-static void window_new_ride_events_init()
+static rct_window_event_list window_new_ride_events([](auto& events)
 {
-    auto& events = window_new_ride_events;
-
-    events.mouse_up = window_new_ride_mouseup;
-    events.mouse_down = window_new_ride_mousedown;
-    events.update = window_new_ride_update;
-    events.get_scroll_size = window_new_ride_scrollgetsize;
-    events.scroll_mousedown = window_new_ride_scrollmousedown;
-    events.scroll_mouseover = window_new_ride_scrollmouseover;
-    events.invalidate = window_new_ride_invalidate;
-    events.paint = window_new_ride_paint;
-    events.scroll_paint = window_new_ride_scrollpaint;
-}
+    events.mouse_up = &window_new_ride_mouseup;
+    events.mouse_down = &window_new_ride_mousedown;
+    events.update = &window_new_ride_update;
+    events.get_scroll_size = &window_new_ride_scrollgetsize;
+    events.scroll_mousedown = &window_new_ride_scrollmousedown;
+    events.scroll_mouseover = &window_new_ride_scrollmouseover;
+    events.invalidate = &window_new_ride_invalidate;
+    events.paint = &window_new_ride_paint;
+    events.scroll_paint = &window_new_ride_scrollpaint;
+});
 
 #pragma endregion
 
@@ -429,7 +425,6 @@ rct_window* window_new_ride_open()
     window_close_by_class(WC_TRACK_DESIGN_LIST);
     window_close_by_class(WC_TRACK_DESIGN_PLACE);
 
-    window_new_ride_events_init();
     w = window_create_auto_pos(WW, WH, &window_new_ride_events, WC_CONSTRUCT_RIDE, WF_10);
     w->widgets = window_new_ride_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -219,36 +219,22 @@ static void window_new_ride_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, i
 static void window_new_ride_list_vehicles_for(uint8_t rideType, const rct_ride_entry* rideEntry, char* buffer, size_t bufferLen);
 
 // 0x0098E354
-static rct_window_event_list window_new_ride_events = {
-    nullptr,
-    window_new_ride_mouseup,
-    nullptr,
-    window_new_ride_mousedown,
-    nullptr,
-    nullptr,
-    window_new_ride_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_new_ride_scrollgetsize,
-    window_new_ride_scrollmousedown,
-    nullptr,
-    window_new_ride_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_new_ride_invalidate,
-    window_new_ride_paint,
-    window_new_ride_scrollpaint
-};
+static rct_window_event_list window_new_ride_events = {};
+
+static void window_new_ride_events_init()
+{
+    auto& events = window_new_ride_events;
+
+    events.mouse_up = window_new_ride_mouseup;
+    events.mouse_down = window_new_ride_mousedown;
+    events.update = window_new_ride_update;
+    events.get_scroll_size = window_new_ride_scrollgetsize;
+    events.scroll_mousedown = window_new_ride_scrollmousedown;
+    events.scroll_mouseover = window_new_ride_scrollmouseover;
+    events.invalidate = window_new_ride_invalidate;
+    events.paint = window_new_ride_paint;
+    events.scroll_paint = window_new_ride_scrollpaint;
+}
 
 #pragma endregion
 
@@ -443,6 +429,7 @@ rct_window* window_new_ride_open()
     window_close_by_class(WC_TRACK_DESIGN_LIST);
     window_close_by_class(WC_TRACK_DESIGN_PLACE);
 
+    window_new_ride_events_init();
     w = window_create_auto_pos(WW, WH, &window_new_ride_events, WC_CONSTRUCT_RIDE, WF_10);
     w->widgets = window_new_ride_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4)

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -46,19 +46,15 @@ static void window_news_scrollmousedown(rct_window *w, int32_t scrollIndex, cons
 static void window_news_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_news_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_news_events = {};
-
-static void window_news_events_init()
+static rct_window_event_list window_news_events([](auto& events)
 {
-    auto& events = window_news_events;
-
-    events.mouse_up = window_news_mouseup;
-    events.update = window_news_update;
-    events.get_scroll_size = window_news_scrollgetsize;
-    events.scroll_mousedown = window_news_scrollmousedown;
-    events.paint = window_news_paint;
-    events.scroll_paint = window_news_scrollpaint;
-}
+    events.mouse_up = &window_news_mouseup;
+    events.update = &window_news_update;
+    events.get_scroll_size = &window_news_scrollgetsize;
+    events.scroll_mousedown = &window_news_scrollmousedown;
+    events.paint = &window_news_paint;
+    events.scroll_paint = &window_news_scrollpaint;
+});
 // clang-format on
 
 /**
@@ -73,7 +69,6 @@ rct_window* window_news_open()
     window = window_bring_to_front_by_class(WC_RECENT_NEWS);
     if (window == nullptr)
     {
-        window_news_events_init();
         window = window_create_auto_pos(400, 300, &window_news_events, WC_RECENT_NEWS, 0);
         window->widgets = window_news_widgets;
         window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_SETTINGS);

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -46,36 +46,19 @@ static void window_news_scrollmousedown(rct_window *w, int32_t scrollIndex, cons
 static void window_news_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_news_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_news_events = {
-    nullptr,
-    window_news_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_news_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_news_scrollgetsize,
-    window_news_scrollmousedown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_news_paint,
-    window_news_scrollpaint
-};
+static rct_window_event_list window_news_events = {};
+
+static void window_news_events_init()
+{
+    auto& events = window_news_events;
+
+    events.mouse_up = window_news_mouseup;
+    events.update = window_news_update;
+    events.get_scroll_size = window_news_scrollgetsize;
+    events.scroll_mousedown = window_news_scrollmousedown;
+    events.paint = window_news_paint;
+    events.scroll_paint = window_news_scrollpaint;
+}
 // clang-format on
 
 /**
@@ -90,6 +73,7 @@ rct_window* window_news_open()
     window = window_bring_to_front_by_class(WC_RECENT_NEWS);
     if (window == nullptr)
     {
+        window_news_events_init();
         window = window_create_auto_pos(400, 300, &window_news_events, WC_RECENT_NEWS, 0);
         window->widgets = window_news_widgets;
         window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_SETTINGS);

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -88,17 +88,13 @@ static void window_news_options_update(rct_window *w);
 static void window_news_options_invalidate(rct_window *w);
 static void window_news_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_news_options_events = {};
-
-static void window_news_options_events_init()
+static rct_window_event_list window_news_options_events([](auto& events)
 {
-    auto& events = window_news_options_events;
-
-    events.mouse_up = window_news_options_mouseup;
-    events.update = window_news_options_update;
-    events.invalidate = window_news_options_invalidate;
-    events.paint = window_news_options_paint;
-}
+    events.mouse_up = &window_news_options_mouseup;
+    events.update = &window_news_options_update;
+    events.invalidate = &window_news_options_invalidate;
+    events.paint = &window_news_options_paint;
+});
 // clang-format on
 
 static void window_news_options_set_page(rct_window* w, int32_t page);
@@ -113,7 +109,6 @@ rct_window* window_news_options_open()
     window = window_bring_to_front_by_class(WC_NOTIFICATION_OPTIONS);
     if (window == nullptr)
     {
-        window_news_options_events_init();
         window = window_create_centred(400, 300, &window_news_options_events, WC_NOTIFICATION_OPTIONS, 0);
         window->widgets = window_news_options_widgets;
         window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_TAB_PARK) | (1 << WIDX_TAB_RIDE) | (1 << WIDX_TAB_GUEST);

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -88,36 +88,17 @@ static void window_news_options_update(rct_window *w);
 static void window_news_options_invalidate(rct_window *w);
 static void window_news_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_news_options_events = {
-    nullptr,
-    window_news_options_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_news_options_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_news_options_invalidate,
-    window_news_options_paint,
-    nullptr
-};
+static rct_window_event_list window_news_options_events = {};
+
+static void window_news_options_events_init()
+{
+    auto& events = window_news_options_events;
+
+    events.mouse_up = window_news_options_mouseup;
+    events.update = window_news_options_update;
+    events.invalidate = window_news_options_invalidate;
+    events.paint = window_news_options_paint;
+}
 // clang-format on
 
 static void window_news_options_set_page(rct_window* w, int32_t page);
@@ -132,6 +113,7 @@ rct_window* window_news_options_open()
     window = window_bring_to_front_by_class(WC_NOTIFICATION_OPTIONS);
     if (window == nullptr)
     {
+        window_news_options_events_init();
         window = window_create_centred(400, 300, &window_news_options_events, WC_NOTIFICATION_OPTIONS, 0);
         window->widgets = window_news_options_widgets;
         window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_TAB_PARK) | (1 << WIDX_TAB_RIDE) | (1 << WIDX_TAB_GUEST);

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -295,36 +295,21 @@ static void window_object_load_error_download_all(rct_window* w);
 static void window_object_load_error_update_list(rct_window* w);
 #endif
 
-static rct_window_event_list window_object_load_error_events = {
-    window_object_load_error_close,
-    window_object_load_error_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_object_load_error_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_object_load_error_scrollgetsize,
-    window_object_load_error_scrollmousedown,
-    nullptr,
-    window_object_load_error_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_object_load_error_paint,
-    window_object_load_error_scrollpaint
-};
+static rct_window_event_list window_object_load_error_events = {};
+
+static void window_object_load_error_events_init()
+{
+    auto& events = window_object_load_error_events;
+
+    events.close = window_object_load_error_close;
+    events.mouse_up = window_object_load_error_mouseup;
+    events.update = window_object_load_error_update;
+    events.get_scroll_size = window_object_load_error_scrollgetsize;
+    events.scroll_mousedown = window_object_load_error_scrollmousedown;
+    events.scroll_mouseover = window_object_load_error_scrollmouseover;
+    events.paint = window_object_load_error_paint;
+    events.scroll_paint = window_object_load_error_scrollpaint;
+}
 // clang-format on
 
 static std::vector<rct_object_entry> _invalid_entries;
@@ -426,6 +411,7 @@ rct_window* window_object_load_error_open(utf8* path, size_t numMissingObjects, 
     rct_window* window = window_bring_to_front_by_class(WC_OBJECT_LOAD_ERROR);
     if (window == nullptr)
     {
+        window_object_load_error_events_init();
         window = window_create_centred(WW, WH, &window_object_load_error_events, WC_OBJECT_LOAD_ERROR, 0);
 
         window->widgets = window_object_load_error_widgets;

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -295,21 +295,17 @@ static void window_object_load_error_download_all(rct_window* w);
 static void window_object_load_error_update_list(rct_window* w);
 #endif
 
-static rct_window_event_list window_object_load_error_events = {};
-
-static void window_object_load_error_events_init()
+static rct_window_event_list window_object_load_error_events([](auto& events)
 {
-    auto& events = window_object_load_error_events;
-
-    events.close = window_object_load_error_close;
-    events.mouse_up = window_object_load_error_mouseup;
-    events.update = window_object_load_error_update;
-    events.get_scroll_size = window_object_load_error_scrollgetsize;
-    events.scroll_mousedown = window_object_load_error_scrollmousedown;
-    events.scroll_mouseover = window_object_load_error_scrollmouseover;
-    events.paint = window_object_load_error_paint;
-    events.scroll_paint = window_object_load_error_scrollpaint;
-}
+    events.close = &window_object_load_error_close;
+    events.mouse_up = &window_object_load_error_mouseup;
+    events.update = &window_object_load_error_update;
+    events.get_scroll_size = &window_object_load_error_scrollgetsize;
+    events.scroll_mousedown = &window_object_load_error_scrollmousedown;
+    events.scroll_mouseover = &window_object_load_error_scrollmouseover;
+    events.paint = &window_object_load_error_paint;
+    events.scroll_paint = &window_object_load_error_scrollpaint;
+});
 // clang-format on
 
 static std::vector<rct_object_entry> _invalid_entries;
@@ -411,7 +407,6 @@ rct_window* window_object_load_error_open(utf8* path, size_t numMissingObjects, 
     rct_window* window = window_bring_to_front_by_class(WC_OBJECT_LOAD_ERROR);
     if (window == nullptr)
     {
-        window_object_load_error_events_init();
         window = window_create_centred(WW, WH, &window_object_load_error_events, WC_OBJECT_LOAD_ERROR, 0);
 
         window->widgets = window_object_load_error_widgets;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -434,21 +434,17 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_options_scrollgetsize(rct_window *w, int32_t scrollIndex, int32_t *width, int32_t *height);
 static void window_options_tooltip(rct_window *w, rct_widgetindex widgetIndex, rct_string_id *stringid);
 
-static rct_window_event_list window_options_events = {};
-
-static void window_options_events_init()
+static rct_window_event_list window_options_events([](auto& events)
 {
-    auto& events = window_options_events;
-
-    events.mouse_up = window_options_mouseup;
-    events.mouse_down = window_options_mousedown;
-    events.dropdown = window_options_dropdown;
-    events.update = window_options_update;
-    events.get_scroll_size = window_options_scrollgetsize;
-    events.tooltip = window_options_tooltip;
-    events.invalidate = window_options_invalidate;
-    events.paint = window_options_paint;
-}
+    events.mouse_up = &window_options_mouseup;
+    events.mouse_down = &window_options_mousedown;
+    events.dropdown = &window_options_dropdown;
+    events.update = &window_options_update;
+    events.get_scroll_size = &window_options_scrollgetsize;
+    events.tooltip = &window_options_tooltip;
+    events.invalidate = &window_options_invalidate;
+    events.paint = &window_options_paint;
+});
 
 #pragma endregion
 
@@ -585,7 +581,6 @@ rct_window* window_options_open()
     if (w != nullptr)
         return w;
 
-    window_options_events_init();
     w = window_create_centred(WW, WH, &window_options_events, WC_OPTIONS, 0);
     w->widgets = window_options_display_widgets;
     w->enabled_widgets = window_options_page_enabled_widgets[WINDOW_OPTIONS_PAGE_DISPLAY];

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -434,36 +434,21 @@ static void window_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_options_scrollgetsize(rct_window *w, int32_t scrollIndex, int32_t *width, int32_t *height);
 static void window_options_tooltip(rct_window *w, rct_widgetindex widgetIndex, rct_string_id *stringid);
 
-static rct_window_event_list window_options_events = {
-    nullptr,
-    window_options_mouseup,
-    nullptr,
-    window_options_mousedown,
-    window_options_dropdown,
-    nullptr,
-    window_options_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_options_scrollgetsize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_options_tooltip,
-    nullptr,
-    nullptr,
-    window_options_invalidate,
-    window_options_paint,
-    nullptr
-};
+static rct_window_event_list window_options_events = {};
+
+static void window_options_events_init()
+{
+    auto& events = window_options_events;
+
+    events.mouse_up = window_options_mouseup;
+    events.mouse_down = window_options_mousedown;
+    events.dropdown = window_options_dropdown;
+    events.update = window_options_update;
+    events.get_scroll_size = window_options_scrollgetsize;
+    events.tooltip = window_options_tooltip;
+    events.invalidate = window_options_invalidate;
+    events.paint = window_options_paint;
+}
 
 #pragma endregion
 
@@ -600,6 +585,7 @@ rct_window* window_options_open()
     if (w != nullptr)
         return w;
 
+    window_options_events_init();
     w = window_create_centred(WW, WH, &window_options_events, WC_OPTIONS, 0);
     w->widgets = window_options_display_widgets;
     w->enabled_widgets = window_options_page_enabled_widgets[WINDOW_OPTIONS_PAGE_DISPLAY];

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -197,113 +197,74 @@ static void window_park_awards_update(rct_window *w);
 static void window_park_awards_invalidate(rct_window *w);
 static void window_park_awards_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_park_entrance_events = {};
-
-static void window_park_entrance_events_init()
+static rct_window_event_list window_park_entrance_events([](auto& events)
 {
-    auto& events = window_park_entrance_events;
+    events.close = &window_park_entrance_close;
+    events.mouse_up = &window_park_entrance_mouseup;
+    events.resize = &window_park_entrance_resize;
+    events.mouse_down = &window_park_entrance_mousedown;
+    events.dropdown = &window_park_entrance_dropdown;
+    events.update = &window_park_entrance_update;
+    events.text_input = &window_park_entrance_textinput;
+    events.invalidate = &window_park_entrance_invalidate;
+    events.paint = &window_park_entrance_paint;
+});
 
-    events.close = window_park_entrance_close;
-    events.mouse_up = window_park_entrance_mouseup;
-    events.resize = window_park_entrance_resize;
-    events.mouse_down = window_park_entrance_mousedown;
-    events.dropdown = window_park_entrance_dropdown;
-    events.update = window_park_entrance_update;
-    events.text_input = window_park_entrance_textinput;
-    events.invalidate = window_park_entrance_invalidate;
-    events.paint = window_park_entrance_paint;
-}
-
-static rct_window_event_list window_park_rating_events = {};
-
-static void window_park_rating_events_init()
+static rct_window_event_list window_park_rating_events([](auto& events)
 {
-    auto& events = window_park_rating_events;
+    events.mouse_up = &window_park_rating_mouseup;
+    events.resize = &window_park_rating_resize;
+    events.update = &window_park_rating_update;
+    events.invalidate = &window_park_rating_invalidate;
+    events.paint = &window_park_rating_paint;
+});
 
-    events.mouse_up = window_park_rating_mouseup;
-    events.resize = window_park_rating_resize;
-    events.update = window_park_rating_update;
-    events.invalidate = window_park_rating_invalidate;
-    events.paint = window_park_rating_paint;
-}
-
-static rct_window_event_list window_park_guests_events = {};
-
-static void window_park_guests_events_init()
+static rct_window_event_list window_park_guests_events([](auto& events)
 {
-    auto& events = window_park_guests_events;
+    events.mouse_up = &window_park_guests_mouseup;
+    events.resize = &window_park_guests_resize;
+    events.update = &window_park_guests_update;
+    events.invalidate = &window_park_guests_invalidate;
+    events.paint = &window_park_guests_paint;
+});
 
-    events.mouse_up = window_park_guests_mouseup;
-    events.resize = window_park_guests_resize;
-    events.update = window_park_guests_update;
-    events.invalidate = window_park_guests_invalidate;
-    events.paint = window_park_guests_paint;
-}
-
-static rct_window_event_list window_park_price_events = {};
-
-static void window_park_price_events_init()
+static rct_window_event_list window_park_price_events([](auto& events)
 {
-    auto& events = window_park_price_events;
+    events.mouse_up = &window_park_price_mouseup;
+    events.resize = &window_park_price_resize;
+    events.mouse_down = &window_park_price_mousedown;
+    events.update = &window_park_price_update;
+    events.invalidate = &window_park_price_invalidate;
+    events.paint = &window_park_price_paint;
+});
 
-    events.mouse_up = window_park_price_mouseup;
-    events.resize = window_park_price_resize;
-    events.mouse_down = window_park_price_mousedown;
-    events.update = window_park_price_update;
-    events.invalidate = window_park_price_invalidate;
-    events.paint = window_park_price_paint;
-}
-
-static rct_window_event_list window_park_stats_events = {};
-
-static void window_park_stats_events_init()
+static rct_window_event_list window_park_stats_events([](auto& events)
 {
-    auto& events = window_park_stats_events;
+    events.mouse_up = &window_park_stats_mouseup;
+    events.resize = &window_park_stats_resize;
+    events.update = &window_park_stats_update;
+    events.invalidate = &window_park_stats_invalidate;
+    events.paint = &window_park_stats_paint;
+});
 
-    events.mouse_up = window_park_stats_mouseup;
-    events.resize = window_park_stats_resize;
-    events.update = window_park_stats_update;
-    events.invalidate = window_park_stats_invalidate;
-    events.paint = window_park_stats_paint;
-}
-
-static rct_window_event_list window_park_objective_events = {};
-
-static void window_park_objective_events_init()
+static rct_window_event_list window_park_objective_events([](auto& events)
 {
-    auto& events = window_park_objective_events;
+    events.mouse_up = &window_park_objective_mouseup;
+    events.resize = &window_park_objective_resize;
+    events.update = &window_park_objective_update;
+    events.text_input = &window_park_objective_textinput;
+    events.invalidate = &window_park_objective_invalidate;
+    events.paint = &window_park_objective_paint;
+});
 
-    events.mouse_up = window_park_objective_mouseup;
-    events.resize = window_park_objective_resize;
-    events.update = window_park_objective_update;
-    events.text_input = window_park_objective_textinput;
-    events.invalidate = window_park_objective_invalidate;
-    events.paint = window_park_objective_paint;
-}
-
-static rct_window_event_list window_park_awards_events = {};
-
-static void window_park_awards_events_init()
+static rct_window_event_list window_park_awards_events([](auto& events)
 {
-    auto& events = window_park_awards_events;
-
-    events.mouse_up = window_park_awards_mouseup;
-    events.resize = window_park_awards_resize;
-    events.update = window_park_awards_update;
-    events.invalidate = window_park_awards_invalidate;
-    events.paint = window_park_awards_paint;
-}
-
-static void window_park_events_init_all()
-{
-    window_park_entrance_events_init();
-    window_park_rating_events_init();
-    window_park_guests_events_init();
-    window_park_price_events_init();
-    window_park_stats_events_init();
-    window_park_objective_events_init();
-    window_park_awards_events_init();
-}
+    events.mouse_up = &window_park_awards_mouseup;
+    events.resize = &window_park_awards_resize;
+    events.update = &window_park_awards_update;
+    events.invalidate = &window_park_awards_invalidate;
+    events.paint = &window_park_awards_paint;
+});
 
 static rct_window_event_list *window_park_page_events[] = {
     &window_park_entrance_events,
@@ -449,7 +410,6 @@ static rct_window* window_park_open()
 {
     rct_window* w;
 
-    window_park_events_init_all();
     w = window_create_auto_pos(230, 174 + 9, &window_park_entrance_events, WC_PARK_INFORMATION, WF_10);
     w->widgets = window_park_entrance_widgets;
     w->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_ENTRANCE];

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -197,222 +197,113 @@ static void window_park_awards_update(rct_window *w);
 static void window_park_awards_invalidate(rct_window *w);
 static void window_park_awards_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_park_entrance_events = {
-    window_park_entrance_close,
-    window_park_entrance_mouseup,
-    window_park_entrance_resize,
-    window_park_entrance_mousedown,
-    window_park_entrance_dropdown,
-    nullptr,
-    window_park_entrance_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_entrance_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_entrance_invalidate,
-    window_park_entrance_paint,
-    nullptr
-};
+static rct_window_event_list window_park_entrance_events = {};
 
-static rct_window_event_list window_park_rating_events = {
-    nullptr,
-    window_park_rating_mouseup,
-    window_park_rating_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_rating_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_rating_invalidate,
-    window_park_rating_paint,
-    nullptr
-};
+static void window_park_entrance_events_init()
+{
+    auto& events = window_park_entrance_events;
 
-static rct_window_event_list window_park_guests_events = {
-    nullptr,
-    window_park_guests_mouseup,
-    window_park_guests_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_guests_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_guests_invalidate,
-    window_park_guests_paint,
-    nullptr
-};
+    events.close = window_park_entrance_close;
+    events.mouse_up = window_park_entrance_mouseup;
+    events.resize = window_park_entrance_resize;
+    events.mouse_down = window_park_entrance_mousedown;
+    events.dropdown = window_park_entrance_dropdown;
+    events.update = window_park_entrance_update;
+    events.text_input = window_park_entrance_textinput;
+    events.invalidate = window_park_entrance_invalidate;
+    events.paint = window_park_entrance_paint;
+}
 
-static rct_window_event_list window_park_price_events = {
-    nullptr,
-    window_park_price_mouseup,
-    window_park_price_resize,
-    window_park_price_mousedown,
-    nullptr,
-    nullptr,
-    window_park_price_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_price_invalidate,
-    window_park_price_paint,
-    nullptr
-};
+static rct_window_event_list window_park_rating_events = {};
 
-static rct_window_event_list window_park_stats_events = {
-    nullptr,
-    window_park_stats_mouseup,
-    window_park_stats_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_stats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_stats_invalidate,
-    window_park_stats_paint,
-    nullptr
-};
+static void window_park_rating_events_init()
+{
+    auto& events = window_park_rating_events;
 
-static rct_window_event_list window_park_objective_events = {
-    nullptr,
-    window_park_objective_mouseup,
-    window_park_objective_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_objective_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_objective_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_objective_invalidate,
-    window_park_objective_paint,
-    nullptr
-};
+    events.mouse_up = window_park_rating_mouseup;
+    events.resize = window_park_rating_resize;
+    events.update = window_park_rating_update;
+    events.invalidate = window_park_rating_invalidate;
+    events.paint = window_park_rating_paint;
+}
 
-static rct_window_event_list window_park_awards_events = {
-    nullptr,
-    window_park_awards_mouseup,
-    window_park_awards_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_awards_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_park_awards_invalidate,
-    window_park_awards_paint,
-    nullptr
-};
+static rct_window_event_list window_park_guests_events = {};
+
+static void window_park_guests_events_init()
+{
+    auto& events = window_park_guests_events;
+
+    events.mouse_up = window_park_guests_mouseup;
+    events.resize = window_park_guests_resize;
+    events.update = window_park_guests_update;
+    events.invalidate = window_park_guests_invalidate;
+    events.paint = window_park_guests_paint;
+}
+
+static rct_window_event_list window_park_price_events = {};
+
+static void window_park_price_events_init()
+{
+    auto& events = window_park_price_events;
+
+    events.mouse_up = window_park_price_mouseup;
+    events.resize = window_park_price_resize;
+    events.mouse_down = window_park_price_mousedown;
+    events.update = window_park_price_update;
+    events.invalidate = window_park_price_invalidate;
+    events.paint = window_park_price_paint;
+}
+
+static rct_window_event_list window_park_stats_events = {};
+
+static void window_park_stats_events_init()
+{
+    auto& events = window_park_stats_events;
+
+    events.mouse_up = window_park_stats_mouseup;
+    events.resize = window_park_stats_resize;
+    events.update = window_park_stats_update;
+    events.invalidate = window_park_stats_invalidate;
+    events.paint = window_park_stats_paint;
+}
+
+static rct_window_event_list window_park_objective_events = {};
+
+static void window_park_objective_events_init()
+{
+    auto& events = window_park_objective_events;
+
+    events.mouse_up = window_park_objective_mouseup;
+    events.resize = window_park_objective_resize;
+    events.update = window_park_objective_update;
+    events.text_input = window_park_objective_textinput;
+    events.invalidate = window_park_objective_invalidate;
+    events.paint = window_park_objective_paint;
+}
+
+static rct_window_event_list window_park_awards_events = {};
+
+static void window_park_awards_events_init()
+{
+    auto& events = window_park_awards_events;
+
+    events.mouse_up = window_park_awards_mouseup;
+    events.resize = window_park_awards_resize;
+    events.update = window_park_awards_update;
+    events.invalidate = window_park_awards_invalidate;
+    events.paint = window_park_awards_paint;
+}
+
+static void window_park_events_init_all()
+{
+    window_park_entrance_events_init();
+    window_park_rating_events_init();
+    window_park_guests_events_init();
+    window_park_price_events_init();
+    window_park_stats_events_init();
+    window_park_objective_events_init();
+    window_park_awards_events_init();
+}
 
 static rct_window_event_list *window_park_page_events[] = {
     &window_park_entrance_events,
@@ -558,6 +449,7 @@ static rct_window* window_park_open()
 {
     rct_window* w;
 
+    window_park_events_init_all();
     w = window_create_auto_pos(230, 174 + 9, &window_park_entrance_events, WC_PARK_INFORMATION, WF_10);
     w->widgets = window_park_entrance_widgets;
     w->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_ENTRANCE];

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -88,21 +88,17 @@ static void window_player_overview_update(rct_window* w);
 static void window_player_overview_invalidate(rct_window *w);
 static void window_player_overview_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_player_overview_events = {};
-
-static void window_player_overview_events_init()
+static rct_window_event_list window_player_overview_events([](auto& events)
 {
-    auto& events = window_player_overview_events;
-
-    events.close = window_player_overview_close;
-    events.mouse_up = window_player_overview_mouse_up;
-    events.resize = window_player_overview_resize;
-    events.mouse_down = window_player_overview_mouse_down;
-    events.dropdown = window_player_overview_dropdown;
-    events.update = window_player_overview_update;
-    events.invalidate = window_player_overview_invalidate;
-    events.paint = window_player_overview_paint;
-}
+    events.close = &window_player_overview_close;
+    events.mouse_up = &window_player_overview_mouse_up;
+    events.resize = &window_player_overview_resize;
+    events.mouse_down = &window_player_overview_mouse_down;
+    events.dropdown = &window_player_overview_dropdown;
+    events.update = &window_player_overview_update;
+    events.invalidate = &window_player_overview_invalidate;
+    events.paint = &window_player_overview_paint;
+});
 
 static void window_player_statistics_close(rct_window *w);
 static void window_player_statistics_mouse_up(rct_window *w, rct_widgetindex widgetIndex);
@@ -111,25 +107,15 @@ static void window_player_statistics_update(rct_window* w);
 static void window_player_statistics_invalidate(rct_window *w);
 static void window_player_statistics_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_player_statistics_events = {};
-
-static void window_player_statistics_events_init()
+static rct_window_event_list window_player_statistics_events([](auto& events)
 {
-    auto& events = window_player_statistics_events;
-
-    events.close = window_player_statistics_close;
-    events.mouse_up = window_player_statistics_mouse_up;
-    events.resize = window_player_statistics_resize;
-    events.update = window_player_statistics_update;
-    events.invalidate = window_player_statistics_invalidate;
-    events.paint = window_player_statistics_paint;
-}
-
-static void window_player_events_init_all()
-{
-    window_player_overview_events_init();
-    window_player_statistics_events_init();
-}
+    events.close = &window_player_statistics_close;
+    events.mouse_up = &window_player_statistics_mouse_up;
+    events.resize = &window_player_statistics_resize;
+    events.update = &window_player_statistics_update;
+    events.invalidate = &window_player_statistics_invalidate;
+    events.paint = &window_player_statistics_paint;
+});
 
 static rct_window_event_list *window_player_page_events[] = {
     &window_player_overview_events,
@@ -165,7 +151,6 @@ rct_window* window_player_open(uint8_t id)
     window = window_bring_to_front_by_number(WC_PLAYER, id);
     if (window == nullptr)
     {
-        window_player_events_init_all();
         window = window_create_auto_pos(240, 170, &window_player_overview_events, WC_PLAYER, WF_RESIZABLE);
         window->number = id;
         window->page = 0;

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -88,36 +88,21 @@ static void window_player_overview_update(rct_window* w);
 static void window_player_overview_invalidate(rct_window *w);
 static void window_player_overview_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_player_overview_events = {
-    window_player_overview_close,
-    window_player_overview_mouse_up,
-    window_player_overview_resize,
-    window_player_overview_mouse_down,
-    window_player_overview_dropdown,
-    nullptr,
-    window_player_overview_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_player_overview_invalidate,
-    window_player_overview_paint,
-    nullptr
-};
+static rct_window_event_list window_player_overview_events = {};
+
+static void window_player_overview_events_init()
+{
+    auto& events = window_player_overview_events;
+
+    events.close = window_player_overview_close;
+    events.mouse_up = window_player_overview_mouse_up;
+    events.resize = window_player_overview_resize;
+    events.mouse_down = window_player_overview_mouse_down;
+    events.dropdown = window_player_overview_dropdown;
+    events.update = window_player_overview_update;
+    events.invalidate = window_player_overview_invalidate;
+    events.paint = window_player_overview_paint;
+}
 
 static void window_player_statistics_close(rct_window *w);
 static void window_player_statistics_mouse_up(rct_window *w, rct_widgetindex widgetIndex);
@@ -126,36 +111,25 @@ static void window_player_statistics_update(rct_window* w);
 static void window_player_statistics_invalidate(rct_window *w);
 static void window_player_statistics_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_player_statistics_events = {
-    window_player_statistics_close,
-    window_player_statistics_mouse_up,
-    window_player_statistics_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_player_statistics_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_player_statistics_invalidate,
-    window_player_statistics_paint,
-    nullptr
-};
+static rct_window_event_list window_player_statistics_events = {};
+
+static void window_player_statistics_events_init()
+{
+    auto& events = window_player_statistics_events;
+
+    events.close = window_player_statistics_close;
+    events.mouse_up = window_player_statistics_mouse_up;
+    events.resize = window_player_statistics_resize;
+    events.update = window_player_statistics_update;
+    events.invalidate = window_player_statistics_invalidate;
+    events.paint = window_player_statistics_paint;
+}
+
+static void window_player_events_init_all()
+{
+    window_player_overview_events_init();
+    window_player_statistics_events_init();
+}
 
 static rct_window_event_list *window_player_page_events[] = {
     &window_player_overview_events,
@@ -191,6 +165,7 @@ rct_window* window_player_open(uint8_t id)
     window = window_bring_to_front_by_number(WC_PLAYER, id);
     if (window == nullptr)
     {
+        window_player_events_init_all();
         window = window_create_auto_pos(240, 170, &window_player_overview_events, WC_PLAYER, WF_RESIZABLE);
         window->number = id;
         window->page = 0;

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -112,68 +112,38 @@ static void window_research_funding_invalidate(rct_window *w);
 static void window_research_funding_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 //
-static rct_window_event_list window_research_development_events = {
-    nullptr,
-    window_research_development_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_research_development_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_research_development_invalidate,
-    window_research_development_paint,
-    nullptr
-};
+static rct_window_event_list window_research_development_events = {};
+
+static void window_research_development_events_init()
+{
+    auto& events = window_research_development_events;
+
+    events.mouse_up = window_research_development_mouseup;
+    events.update = window_research_development_update;
+    events.invalidate = window_research_development_invalidate;
+    events.paint = window_research_development_paint;
+}
 
 // 0x009890E8
-static rct_window_event_list window_research_funding_events = {
-    nullptr,
-    window_research_funding_mouseup,
-    nullptr,
-    window_research_funding_mousedown,
-    window_research_funding_dropdown,
-    nullptr,
-    window_research_funding_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_research_funding_invalidate,
-    window_research_funding_paint,
-    nullptr
-};
+static rct_window_event_list window_research_funding_events = {};
+
+static void window_research_funding_events_init()
+{
+    auto& events = window_research_funding_events;
+
+    events.mouse_up = window_research_funding_mouseup;
+    events.mouse_down = window_research_funding_mousedown;
+    events.dropdown = window_research_funding_dropdown;
+    events.update = window_research_funding_update;
+    events.invalidate = window_research_funding_invalidate;
+    events.paint = window_research_funding_paint;
+}
+
+static void window_research_events_init_all()
+{
+    window_research_development_events_init();
+    window_research_funding_events_init();
+}
 
 static rct_window_event_list *window_research_page_events[] = {
     &window_research_development_events,
@@ -237,6 +207,7 @@ rct_window* window_research_open()
     w = window_bring_to_front_by_class(WC_RESEARCH);
     if (w == nullptr)
     {
+        window_research_events_init_all();
         w = window_create_auto_pos(WW_FUNDING, WH_FUNDING, window_research_page_events[0], WC_RESEARCH, WF_10);
         w->widgets = window_research_page_widgets[0];
         w->enabled_widgets = window_research_page_enabled_widgets[0];

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -112,38 +112,24 @@ static void window_research_funding_invalidate(rct_window *w);
 static void window_research_funding_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 //
-static rct_window_event_list window_research_development_events = {};
-
-static void window_research_development_events_init()
+static rct_window_event_list window_research_development_events([](auto& events)
 {
-    auto& events = window_research_development_events;
-
-    events.mouse_up = window_research_development_mouseup;
-    events.update = window_research_development_update;
-    events.invalidate = window_research_development_invalidate;
-    events.paint = window_research_development_paint;
-}
+    events.mouse_up = &window_research_development_mouseup;
+    events.update = &window_research_development_update;
+    events.invalidate = &window_research_development_invalidate;
+    events.paint = &window_research_development_paint;
+});
 
 // 0x009890E8
-static rct_window_event_list window_research_funding_events = {};
-
-static void window_research_funding_events_init()
+static rct_window_event_list window_research_funding_events([](auto& events)
 {
-    auto& events = window_research_funding_events;
-
-    events.mouse_up = window_research_funding_mouseup;
-    events.mouse_down = window_research_funding_mousedown;
-    events.dropdown = window_research_funding_dropdown;
-    events.update = window_research_funding_update;
-    events.invalidate = window_research_funding_invalidate;
-    events.paint = window_research_funding_paint;
-}
-
-static void window_research_events_init_all()
-{
-    window_research_development_events_init();
-    window_research_funding_events_init();
-}
+    events.mouse_up = &window_research_funding_mouseup;
+    events.mouse_down = &window_research_funding_mousedown;
+    events.dropdown = &window_research_funding_dropdown;
+    events.update = &window_research_funding_update;
+    events.invalidate = &window_research_funding_invalidate;
+    events.paint = &window_research_funding_paint;
+});
 
 static rct_window_event_list *window_research_page_events[] = {
     &window_research_development_events,
@@ -207,7 +193,6 @@ rct_window* window_research_open()
     w = window_bring_to_front_by_class(WC_RESEARCH);
     if (w == nullptr)
     {
-        window_research_events_init_all();
         w = window_create_auto_pos(WW_FUNDING, WH_FUNDING, window_research_page_events[0], WC_RESEARCH, WF_10);
         w->widgets = window_research_page_widgets[0];
         w->enabled_widgets = window_research_page_enabled_widgets[0];

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -615,324 +615,190 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_ride_set_page(rct_window *w, int32_t page);
 
 // 0x0098DFD4
-static rct_window_event_list window_ride_main_events = {
-    nullptr,
-    window_ride_main_mouseup,
-    window_ride_main_resize,
-    window_ride_main_mousedown,
-    window_ride_main_dropdown,
-    nullptr,
-    window_ride_main_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_main_textinput,
-    window_ride_main_viewport_rotate,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_main_invalidate,
-    window_ride_main_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_main_events = {};
+
+static void window_ride_main_events_init()
+{
+    auto& events = window_ride_main_events;
+
+    events.mouse_up = window_ride_main_mouseup;
+    events.resize = window_ride_main_resize;
+    events.mouse_down = window_ride_main_mousedown;
+    events.dropdown = window_ride_main_dropdown;
+    events.update = window_ride_main_update;
+    events.text_input = window_ride_main_textinput;
+    events.viewport_rotate = window_ride_main_viewport_rotate;
+    events.invalidate = window_ride_main_invalidate;
+    events.paint = window_ride_main_paint;
+}
 
 // 0x0098E204
-static rct_window_event_list window_ride_vehicle_events = {
-    nullptr,
-    window_ride_vehicle_mouseup,
-    window_ride_vehicle_resize,
-    window_ride_vehicle_mousedown,
-    window_ride_vehicle_dropdown,
-    nullptr,
-    window_ride_vehicle_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_vehicle_invalidate,
-    window_ride_vehicle_paint,
-    window_ride_vehicle_scrollpaint
-};
+static rct_window_event_list window_ride_vehicle_events = {};
+
+static void window_ride_vehicle_events_init()
+{
+    auto& events = window_ride_vehicle_events;
+
+    events.mouse_up = window_ride_vehicle_mouseup;
+    events.resize = window_ride_vehicle_resize;
+    events.mouse_down = window_ride_vehicle_mousedown;
+    events.dropdown = window_ride_vehicle_dropdown;
+    events.update = window_ride_vehicle_update;
+    events.invalidate = window_ride_vehicle_invalidate;
+    events.paint = window_ride_vehicle_paint;
+    events.scroll_paint = window_ride_vehicle_scrollpaint;
+}
 
 // 0x0098E0B4
-static rct_window_event_list window_ride_operating_events = {
-    nullptr,
-    window_ride_operating_mouseup,
-    window_ride_operating_resize,
-    window_ride_operating_mousedown,
-    window_ride_operating_dropdown,
-    nullptr,
-    window_ride_operating_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_operating_invalidate,
-    window_ride_operating_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_operating_events = {};
+
+static void window_ride_operating_events_init()
+{
+    auto& events = window_ride_operating_events;
+
+    events.mouse_up = window_ride_operating_mouseup;
+    events.resize = window_ride_operating_resize;
+    events.mouse_down = window_ride_operating_mousedown;
+    events.dropdown = window_ride_operating_dropdown;
+    events.update = window_ride_operating_update;
+    events.invalidate = window_ride_operating_invalidate;
+    events.paint = window_ride_operating_paint;
+}
 
 // 0x0098E124
-static rct_window_event_list window_ride_maintenance_events = {
-    nullptr,
-    window_ride_maintenance_mouseup,
-    window_ride_maintenance_resize,
-    window_ride_maintenance_mousedown,
-    window_ride_maintenance_dropdown,
-    nullptr,
-    window_ride_maintenance_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_maintenance_invalidate,
-    window_ride_maintenance_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_maintenance_events = {};
+
+static void window_ride_maintenance_events_init()
+{
+    auto& events = window_ride_maintenance_events;
+
+    events.mouse_up = window_ride_maintenance_mouseup;
+    events.resize = window_ride_maintenance_resize;
+    events.mouse_down = window_ride_maintenance_mousedown;
+    events.dropdown = window_ride_maintenance_dropdown;
+    events.update = window_ride_maintenance_update;
+    events.invalidate = window_ride_maintenance_invalidate;
+    events.paint = window_ride_maintenance_paint;
+}
 
 // 0x0098E044
-static rct_window_event_list window_ride_colour_events = {
-    window_ride_colour_close,
-    window_ride_colour_mouseup,
-    window_ride_colour_resize,
-    window_ride_colour_mousedown,
-    window_ride_colour_dropdown,
-    nullptr,
-    window_ride_colour_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_colour_tooldown,
-    window_ride_colour_tooldrag,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_colour_invalidate,
-    window_ride_colour_paint,
-    window_ride_colour_scrollpaint
-};
+static rct_window_event_list window_ride_colour_events = {};
+
+static void window_ride_colour_events_init()
+{
+    auto& events = window_ride_colour_events;
+
+    events.close = window_ride_colour_close;
+    events.mouse_up = window_ride_colour_mouseup;
+    events.resize = window_ride_colour_resize;
+    events.mouse_down = window_ride_colour_mousedown;
+    events.dropdown = window_ride_colour_dropdown;
+    events.update = window_ride_colour_update;
+    events.tool_down = window_ride_colour_tooldown;
+    events.tool_drag = window_ride_colour_tooldrag;
+    events.invalidate = window_ride_colour_invalidate;
+    events.paint = window_ride_colour_paint;
+    events.scroll_paint = window_ride_colour_scrollpaint;
+}
 
 // 0x0098E194
-static rct_window_event_list window_ride_music_events = {
-    nullptr,
-    window_ride_music_mouseup,
-    window_ride_music_resize,
-    window_ride_music_mousedown,
-    window_ride_music_dropdown,
-    nullptr,
-    window_ride_music_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_music_invalidate,
-    window_ride_music_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_music_events = {};
+
+static void window_ride_music_events_init()
+{
+    auto& events = window_ride_music_events;
+
+    events.mouse_up = window_ride_music_mouseup;
+    events.resize = window_ride_music_resize;
+    events.mouse_down = window_ride_music_mousedown;
+    events.dropdown = window_ride_music_dropdown;
+    events.update = window_ride_music_update;
+    events.invalidate = window_ride_music_invalidate;
+    events.paint = window_ride_music_paint;
+}
 
 // 0x0098DE14
-static rct_window_event_list window_ride_measurements_events = {
-    window_ride_measurements_close,
-    window_ride_measurements_mouseup,
-    window_ride_measurements_resize,
-    window_ride_measurements_mousedown,
-    window_ride_measurements_dropdown,
-    nullptr,
-    window_ride_measurements_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_measurements_tooldown,
-    window_ride_measurements_tooldrag,
-    nullptr,
-    window_ride_measurements_toolabort,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_measurements_invalidate,
-    window_ride_measurements_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_measurements_events = {};
+
+static void window_ride_measurements_events_init()
+{
+    auto& events = window_ride_measurements_events;
+
+    events.close = window_ride_measurements_close;
+    events.mouse_up = window_ride_measurements_mouseup;
+    events.resize = window_ride_measurements_resize;
+    events.mouse_down = window_ride_measurements_mousedown;
+    events.dropdown = window_ride_measurements_dropdown;
+    events.update = window_ride_measurements_update;
+    events.tool_down = window_ride_measurements_tooldown;
+    events.tool_drag = window_ride_measurements_tooldrag;
+    events.tool_abort = window_ride_measurements_toolabort;
+    events.invalidate = window_ride_measurements_invalidate;
+    events.paint = window_ride_measurements_paint;
+}
 
 // 0x0098DF64
-static rct_window_event_list window_ride_graphs_events = {
-    nullptr,
-    window_ride_graphs_mouseup,
-    window_ride_graphs_resize,
-    window_ride_graphs_mousedown,
-    nullptr,
-    nullptr,
-    window_ride_graphs_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_graphs_scrollgetheight,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_graphs_15,
-    window_ride_graphs_tooltip,
-    nullptr,
-    nullptr,
-    window_ride_graphs_invalidate,
-    window_ride_graphs_paint,
-    window_ride_graphs_scrollpaint
-};
+static rct_window_event_list window_ride_graphs_events = {};
+
+static void window_ride_graphs_events_init()
+{
+    auto& events = window_ride_graphs_events;
+
+    events.mouse_up = window_ride_graphs_mouseup;
+    events.resize = window_ride_graphs_resize;
+    events.mouse_down = window_ride_graphs_mousedown;
+    events.update = window_ride_graphs_update;
+    events.get_scroll_size = window_ride_graphs_scrollgetheight;
+    events.unknown_15 = window_ride_graphs_15;
+    events.tooltip = window_ride_graphs_tooltip;
+    events.invalidate = window_ride_graphs_invalidate;
+    events.paint = window_ride_graphs_paint;
+    events.scroll_paint = window_ride_graphs_scrollpaint;
+}
 
 // 0x0098DEF4
-static rct_window_event_list window_ride_income_events = {
-    nullptr,
-    window_ride_income_mouseup,
-    window_ride_income_resize,
-    window_ride_income_mousedown,
-    nullptr,
-    nullptr,
-    window_ride_income_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_income_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_income_invalidate,
-    window_ride_income_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_income_events = {};
+
+static void window_ride_income_events_init()
+{
+    auto& events = window_ride_income_events;
+
+    events.mouse_up = window_ride_income_mouseup;
+    events.resize = window_ride_income_resize;
+    events.mouse_down = window_ride_income_mousedown;
+    events.update = window_ride_income_update;
+    events.text_input = window_ride_income_textinput;
+    events.invalidate = window_ride_income_invalidate;
+    events.paint = window_ride_income_paint;
+}
 
 // 0x0098DE84
-static rct_window_event_list window_ride_customer_events = {
-    nullptr,
-    window_ride_customer_mouseup,
-    window_ride_customer_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_customer_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_customer_invalidate,
-    window_ride_customer_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_customer_events = {};
+
+static void window_ride_customer_events_init()
+{
+    auto& events = window_ride_customer_events;
+
+    events.mouse_up = window_ride_customer_mouseup;
+    events.resize = window_ride_customer_resize;
+    events.update = window_ride_customer_update;
+    events.invalidate = window_ride_customer_invalidate;
+    events.paint = window_ride_customer_paint;
+}
+
+static void window_ride_events_init_all()
+{
+    window_ride_main_events_init();
+    window_ride_vehicle_events_init();
+    window_ride_operating_events_init();
+    window_ride_maintenance_events_init();
+    window_ride_colour_events_init();
+    window_ride_music_events_init();
+    window_ride_measurements_events_init();
+    window_ride_graphs_events_init();
+    window_ride_income_events_init();
+    window_ride_customer_events_init();
+}
 
 static rct_window_event_list *window_ride_page_events[] = {
     &window_ride_main_events,
@@ -1443,6 +1309,7 @@ static rct_window* window_ride_open(Ride* ride)
 {
     rct_window* w;
 
+    window_ride_events_init_all();
     w = window_create_auto_pos(316, 207, window_ride_page_events[0], WC_RIDE, WF_10 | WF_RESIZABLE);
     w->widgets = window_ride_page_widgets[WINDOW_RIDE_PAGE_MAIN];
     w->enabled_widgets = window_ride_page_enabled_widgets[WINDOW_RIDE_PAGE_MAIN];

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -615,190 +615,136 @@ static void window_ride_customer_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_ride_set_page(rct_window *w, int32_t page);
 
 // 0x0098DFD4
-static rct_window_event_list window_ride_main_events = {};
-
-static void window_ride_main_events_init()
+static rct_window_event_list window_ride_main_events([](auto& events)
 {
-    auto& events = window_ride_main_events;
-
-    events.mouse_up = window_ride_main_mouseup;
-    events.resize = window_ride_main_resize;
-    events.mouse_down = window_ride_main_mousedown;
-    events.dropdown = window_ride_main_dropdown;
-    events.update = window_ride_main_update;
-    events.text_input = window_ride_main_textinput;
-    events.viewport_rotate = window_ride_main_viewport_rotate;
-    events.invalidate = window_ride_main_invalidate;
-    events.paint = window_ride_main_paint;
-}
+    events.mouse_up = &window_ride_main_mouseup;
+    events.resize = &window_ride_main_resize;
+    events.mouse_down = &window_ride_main_mousedown;
+    events.dropdown = &window_ride_main_dropdown;
+    events.update = &window_ride_main_update;
+    events.text_input = &window_ride_main_textinput;
+    events.viewport_rotate = &window_ride_main_viewport_rotate;
+    events.invalidate = &window_ride_main_invalidate;
+    events.paint = &window_ride_main_paint;
+});
 
 // 0x0098E204
-static rct_window_event_list window_ride_vehicle_events = {};
-
-static void window_ride_vehicle_events_init()
+static rct_window_event_list window_ride_vehicle_events([](auto& events)
 {
-    auto& events = window_ride_vehicle_events;
-
-    events.mouse_up = window_ride_vehicle_mouseup;
-    events.resize = window_ride_vehicle_resize;
-    events.mouse_down = window_ride_vehicle_mousedown;
-    events.dropdown = window_ride_vehicle_dropdown;
-    events.update = window_ride_vehicle_update;
-    events.invalidate = window_ride_vehicle_invalidate;
-    events.paint = window_ride_vehicle_paint;
-    events.scroll_paint = window_ride_vehicle_scrollpaint;
-}
+    events.mouse_up = &window_ride_vehicle_mouseup;
+    events.resize = &window_ride_vehicle_resize;
+    events.mouse_down = &window_ride_vehicle_mousedown;
+    events.dropdown = &window_ride_vehicle_dropdown;
+    events.update = &window_ride_vehicle_update;
+    events.invalidate = &window_ride_vehicle_invalidate;
+    events.paint = &window_ride_vehicle_paint;
+    events.scroll_paint = &window_ride_vehicle_scrollpaint;
+});
 
 // 0x0098E0B4
-static rct_window_event_list window_ride_operating_events = {};
-
-static void window_ride_operating_events_init()
+static rct_window_event_list window_ride_operating_events([](auto& events)
 {
-    auto& events = window_ride_operating_events;
-
-    events.mouse_up = window_ride_operating_mouseup;
-    events.resize = window_ride_operating_resize;
-    events.mouse_down = window_ride_operating_mousedown;
-    events.dropdown = window_ride_operating_dropdown;
-    events.update = window_ride_operating_update;
-    events.invalidate = window_ride_operating_invalidate;
-    events.paint = window_ride_operating_paint;
-}
+    events.mouse_up = &window_ride_operating_mouseup;
+    events.resize = &window_ride_operating_resize;
+    events.mouse_down = &window_ride_operating_mousedown;
+    events.dropdown = &window_ride_operating_dropdown;
+    events.update = &window_ride_operating_update;
+    events.invalidate = &window_ride_operating_invalidate;
+    events.paint = &window_ride_operating_paint;
+});
 
 // 0x0098E124
-static rct_window_event_list window_ride_maintenance_events = {};
-
-static void window_ride_maintenance_events_init()
+static rct_window_event_list window_ride_maintenance_events([](auto& events)
 {
-    auto& events = window_ride_maintenance_events;
-
-    events.mouse_up = window_ride_maintenance_mouseup;
-    events.resize = window_ride_maintenance_resize;
-    events.mouse_down = window_ride_maintenance_mousedown;
-    events.dropdown = window_ride_maintenance_dropdown;
-    events.update = window_ride_maintenance_update;
-    events.invalidate = window_ride_maintenance_invalidate;
-    events.paint = window_ride_maintenance_paint;
-}
+    events.mouse_up = &window_ride_maintenance_mouseup;
+    events.resize = &window_ride_maintenance_resize;
+    events.mouse_down = &window_ride_maintenance_mousedown;
+    events.dropdown = &window_ride_maintenance_dropdown;
+    events.update = &window_ride_maintenance_update;
+    events.invalidate = &window_ride_maintenance_invalidate;
+    events.paint = &window_ride_maintenance_paint;
+});
 
 // 0x0098E044
-static rct_window_event_list window_ride_colour_events = {};
-
-static void window_ride_colour_events_init()
+static rct_window_event_list window_ride_colour_events([](auto& events)
 {
-    auto& events = window_ride_colour_events;
-
-    events.close = window_ride_colour_close;
-    events.mouse_up = window_ride_colour_mouseup;
-    events.resize = window_ride_colour_resize;
-    events.mouse_down = window_ride_colour_mousedown;
-    events.dropdown = window_ride_colour_dropdown;
-    events.update = window_ride_colour_update;
-    events.tool_down = window_ride_colour_tooldown;
-    events.tool_drag = window_ride_colour_tooldrag;
-    events.invalidate = window_ride_colour_invalidate;
-    events.paint = window_ride_colour_paint;
-    events.scroll_paint = window_ride_colour_scrollpaint;
-}
+    events.close = &window_ride_colour_close;
+    events.mouse_up = &window_ride_colour_mouseup;
+    events.resize = &window_ride_colour_resize;
+    events.mouse_down = &window_ride_colour_mousedown;
+    events.dropdown = &window_ride_colour_dropdown;
+    events.update = &window_ride_colour_update;
+    events.tool_down = &window_ride_colour_tooldown;
+    events.tool_drag = &window_ride_colour_tooldrag;
+    events.invalidate = &window_ride_colour_invalidate;
+    events.paint = &window_ride_colour_paint;
+    events.scroll_paint = &window_ride_colour_scrollpaint;
+});
 
 // 0x0098E194
-static rct_window_event_list window_ride_music_events = {};
-
-static void window_ride_music_events_init()
+static rct_window_event_list window_ride_music_events([](auto& events)
 {
-    auto& events = window_ride_music_events;
-
-    events.mouse_up = window_ride_music_mouseup;
-    events.resize = window_ride_music_resize;
-    events.mouse_down = window_ride_music_mousedown;
-    events.dropdown = window_ride_music_dropdown;
-    events.update = window_ride_music_update;
-    events.invalidate = window_ride_music_invalidate;
-    events.paint = window_ride_music_paint;
-}
+    events.mouse_up = &window_ride_music_mouseup;
+    events.resize = &window_ride_music_resize;
+    events.mouse_down = &window_ride_music_mousedown;
+    events.dropdown = &window_ride_music_dropdown;
+    events.update = &window_ride_music_update;
+    events.invalidate = &window_ride_music_invalidate;
+    events.paint = &window_ride_music_paint;
+});
 
 // 0x0098DE14
-static rct_window_event_list window_ride_measurements_events = {};
-
-static void window_ride_measurements_events_init()
+static rct_window_event_list window_ride_measurements_events([](auto& events)
 {
-    auto& events = window_ride_measurements_events;
-
-    events.close = window_ride_measurements_close;
-    events.mouse_up = window_ride_measurements_mouseup;
-    events.resize = window_ride_measurements_resize;
-    events.mouse_down = window_ride_measurements_mousedown;
-    events.dropdown = window_ride_measurements_dropdown;
-    events.update = window_ride_measurements_update;
-    events.tool_down = window_ride_measurements_tooldown;
-    events.tool_drag = window_ride_measurements_tooldrag;
-    events.tool_abort = window_ride_measurements_toolabort;
-    events.invalidate = window_ride_measurements_invalidate;
-    events.paint = window_ride_measurements_paint;
-}
+    events.close = &window_ride_measurements_close;
+    events.mouse_up = &window_ride_measurements_mouseup;
+    events.resize = &window_ride_measurements_resize;
+    events.mouse_down = &window_ride_measurements_mousedown;
+    events.dropdown = &window_ride_measurements_dropdown;
+    events.update = &window_ride_measurements_update;
+    events.tool_down = &window_ride_measurements_tooldown;
+    events.tool_drag = &window_ride_measurements_tooldrag;
+    events.tool_abort = &window_ride_measurements_toolabort;
+    events.invalidate = &window_ride_measurements_invalidate;
+    events.paint = &window_ride_measurements_paint;
+});
 
 // 0x0098DF64
-static rct_window_event_list window_ride_graphs_events = {};
-
-static void window_ride_graphs_events_init()
+static rct_window_event_list window_ride_graphs_events([](auto& events)
 {
-    auto& events = window_ride_graphs_events;
-
-    events.mouse_up = window_ride_graphs_mouseup;
-    events.resize = window_ride_graphs_resize;
-    events.mouse_down = window_ride_graphs_mousedown;
-    events.update = window_ride_graphs_update;
-    events.get_scroll_size = window_ride_graphs_scrollgetheight;
-    events.unknown_15 = window_ride_graphs_15;
-    events.tooltip = window_ride_graphs_tooltip;
-    events.invalidate = window_ride_graphs_invalidate;
-    events.paint = window_ride_graphs_paint;
-    events.scroll_paint = window_ride_graphs_scrollpaint;
-}
+    events.mouse_up = &window_ride_graphs_mouseup;
+    events.resize = &window_ride_graphs_resize;
+    events.mouse_down = &window_ride_graphs_mousedown;
+    events.update = &window_ride_graphs_update;
+    events.get_scroll_size = &window_ride_graphs_scrollgetheight;
+    events.unknown_15 = &window_ride_graphs_15;
+    events.tooltip = &window_ride_graphs_tooltip;
+    events.invalidate = &window_ride_graphs_invalidate;
+    events.paint = &window_ride_graphs_paint;
+    events.scroll_paint = &window_ride_graphs_scrollpaint;
+});
 
 // 0x0098DEF4
-static rct_window_event_list window_ride_income_events = {};
-
-static void window_ride_income_events_init()
+static rct_window_event_list window_ride_income_events([](auto& events)
 {
-    auto& events = window_ride_income_events;
-
-    events.mouse_up = window_ride_income_mouseup;
-    events.resize = window_ride_income_resize;
-    events.mouse_down = window_ride_income_mousedown;
-    events.update = window_ride_income_update;
-    events.text_input = window_ride_income_textinput;
-    events.invalidate = window_ride_income_invalidate;
-    events.paint = window_ride_income_paint;
-}
+    events.mouse_up = &window_ride_income_mouseup;
+    events.resize = &window_ride_income_resize;
+    events.mouse_down = &window_ride_income_mousedown;
+    events.update = &window_ride_income_update;
+    events.text_input = &window_ride_income_textinput;
+    events.invalidate = &window_ride_income_invalidate;
+    events.paint = &window_ride_income_paint;
+});
 
 // 0x0098DE84
-static rct_window_event_list window_ride_customer_events = {};
-
-static void window_ride_customer_events_init()
+static rct_window_event_list window_ride_customer_events([](auto& events)
 {
-    auto& events = window_ride_customer_events;
-
-    events.mouse_up = window_ride_customer_mouseup;
-    events.resize = window_ride_customer_resize;
-    events.update = window_ride_customer_update;
-    events.invalidate = window_ride_customer_invalidate;
-    events.paint = window_ride_customer_paint;
-}
-
-static void window_ride_events_init_all()
-{
-    window_ride_main_events_init();
-    window_ride_vehicle_events_init();
-    window_ride_operating_events_init();
-    window_ride_maintenance_events_init();
-    window_ride_colour_events_init();
-    window_ride_music_events_init();
-    window_ride_measurements_events_init();
-    window_ride_graphs_events_init();
-    window_ride_income_events_init();
-    window_ride_customer_events_init();
-}
+    events.mouse_up = &window_ride_customer_mouseup;
+    events.resize = &window_ride_customer_resize;
+    events.update = &window_ride_customer_update;
+    events.invalidate = &window_ride_customer_invalidate;
+    events.paint = &window_ride_customer_paint;
+});
 
 static rct_window_event_list *window_ride_page_events[] = {
     &window_ride_main_events,
@@ -1309,7 +1255,6 @@ static rct_window* window_ride_open(Ride* ride)
 {
     rct_window* w;
 
-    window_ride_events_init_all();
     w = window_create_auto_pos(316, 207, window_ride_page_events[0], WC_RIDE, WF_10 | WF_RESIZABLE);
     w->widgets = window_ride_page_widgets[WINDOW_RIDE_PAGE_MAIN];
     w->enabled_widgets = window_ride_page_enabled_widgets[WINDOW_RIDE_PAGE_MAIN];

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -147,23 +147,19 @@ static void window_ride_construction_paint(rct_window *w, rct_drawpixelinfo *dpi
 static bool track_piece_direction_is_diagonal(const uint8_t direction);
 
 //0x993EEC
-static rct_window_event_list window_ride_construction_events = {};
-
-static void window_ride_construction_events_init()
+static rct_window_event_list window_ride_construction_events([](auto& events)
 {
-    auto& events = window_ride_construction_events;
-
-    events.close = window_ride_construction_close;
-    events.mouse_up = window_ride_construction_mouseup;
-    events.resize = window_ride_construction_resize;
-    events.mouse_down = window_ride_construction_mousedown;
-    events.dropdown = window_ride_construction_dropdown;
-    events.update = window_ride_construction_update;
-    events.tool_update = window_ride_construction_toolupdate;
-    events.tool_down = window_ride_construction_tooldown;
-    events.invalidate = window_ride_construction_invalidate;
-    events.paint = window_ride_construction_paint;
-}
+    events.close = &window_ride_construction_close;
+    events.mouse_up = &window_ride_construction_mouseup;
+    events.resize = &window_ride_construction_resize;
+    events.mouse_down = &window_ride_construction_mousedown;
+    events.dropdown = &window_ride_construction_dropdown;
+    events.update = &window_ride_construction_update;
+    events.tool_update = &window_ride_construction_toolupdate;
+    events.tool_down = &window_ride_construction_tooldown;
+    events.invalidate = &window_ride_construction_invalidate;
+    events.paint = &window_ride_construction_paint;
+});
 
 #pragma endregion
 
@@ -522,7 +518,6 @@ rct_window* window_ride_construction_open()
         return context_open_window_view(WV_MAZE_CONSTRUCTION);
     }
 
-    window_ride_construction_events_init();
     auto w = window_create(
         ScreenCoordsXY(0, 29), 166, 394, &window_ride_construction_events, WC_RIDE_CONSTRUCTION, WF_NO_AUTO_CLOSE);
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -147,36 +147,23 @@ static void window_ride_construction_paint(rct_window *w, rct_drawpixelinfo *dpi
 static bool track_piece_direction_is_diagonal(const uint8_t direction);
 
 //0x993EEC
-static rct_window_event_list window_ride_construction_events = {
-    window_ride_construction_close,
-    window_ride_construction_mouseup,
-    window_ride_construction_resize,
-    window_ride_construction_mousedown,
-    window_ride_construction_dropdown,
-    nullptr,
-    window_ride_construction_update,
-    nullptr,
-    nullptr,
-    window_ride_construction_toolupdate,
-    window_ride_construction_tooldown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_construction_invalidate,
-    window_ride_construction_paint,
-    nullptr
-};
+static rct_window_event_list window_ride_construction_events = {};
+
+static void window_ride_construction_events_init()
+{
+    auto& events = window_ride_construction_events;
+
+    events.close = window_ride_construction_close;
+    events.mouse_up = window_ride_construction_mouseup;
+    events.resize = window_ride_construction_resize;
+    events.mouse_down = window_ride_construction_mousedown;
+    events.dropdown = window_ride_construction_dropdown;
+    events.update = window_ride_construction_update;
+    events.tool_update = window_ride_construction_toolupdate;
+    events.tool_down = window_ride_construction_tooldown;
+    events.invalidate = window_ride_construction_invalidate;
+    events.paint = window_ride_construction_paint;
+}
 
 #pragma endregion
 
@@ -535,6 +522,7 @@ rct_window* window_ride_construction_open()
         return context_open_window_view(WV_MAZE_CONSTRUCTION);
     }
 
+    window_ride_construction_events_init();
     auto w = window_create(
         ScreenCoordsXY(0, 29), 166, 394, &window_ride_construction_events, WC_RIDE_CONSTRUCTION, WF_NO_AUTO_CLOSE);
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -86,24 +86,20 @@ static void window_ride_list_invalidate(rct_window *w);
 static void window_ride_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_ride_list_events = {};
-
-static void window_ride_list_events_init()
+static rct_window_event_list window_ride_list_events([](auto& events)
 {
-    auto& events = window_ride_list_events;
-
-    events.mouse_up = window_ride_list_mouseup;
-    events.resize = window_ride_list_resize;
-    events.mouse_down = window_ride_list_mousedown;
-    events.dropdown = window_ride_list_dropdown;
-    events.update = window_ride_list_update;
-    events.get_scroll_size = window_ride_list_scrollgetsize;
-    events.scroll_mousedown = window_ride_list_scrollmousedown;
-    events.scroll_mouseover = window_ride_list_scrollmouseover;
-    events.invalidate = window_ride_list_invalidate;
-    events.paint = window_ride_list_paint;
-    events.scroll_paint = window_ride_list_scrollpaint;
-}
+    events.mouse_up = &window_ride_list_mouseup;
+    events.resize = &window_ride_list_resize;
+    events.mouse_down = &window_ride_list_mousedown;
+    events.dropdown = &window_ride_list_dropdown;
+    events.update = &window_ride_list_update;
+    events.get_scroll_size = &window_ride_list_scrollgetsize;
+    events.scroll_mousedown = &window_ride_list_scrollmousedown;
+    events.scroll_mouseover = &window_ride_list_scrollmouseover;
+    events.invalidate = &window_ride_list_invalidate;
+    events.paint = &window_ride_list_paint;
+    events.scroll_paint = &window_ride_list_scrollpaint;
+});
 
 enum {
     INFORMATION_TYPE_STATUS,
@@ -191,7 +187,6 @@ rct_window* window_ride_list_open()
     window = window_bring_to_front_by_class(WC_RIDE_LIST);
     if (window == nullptr)
     {
-        window_ride_list_events_init();
         window = window_create_auto_pos(340, 240, &window_ride_list_events, WC_RIDE_LIST, WF_10 | WF_RESIZABLE);
         window->widgets = window_ride_list_widgets;
         window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_OPEN_CLOSE_ALL) | (1 << WIDX_CURRENT_INFORMATION_TYPE)

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -86,36 +86,24 @@ static void window_ride_list_invalidate(rct_window *w);
 static void window_ride_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_ride_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_ride_list_events = {
-    nullptr,
-    window_ride_list_mouseup,
-    window_ride_list_resize,
-    window_ride_list_mousedown,
-    window_ride_list_dropdown,
-    nullptr,
-    window_ride_list_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_list_scrollgetsize,
-    window_ride_list_scrollmousedown,
-    nullptr,
-    window_ride_list_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_ride_list_invalidate,
-    window_ride_list_paint,
-    window_ride_list_scrollpaint
-};
+static rct_window_event_list window_ride_list_events = {};
+
+static void window_ride_list_events_init()
+{
+    auto& events = window_ride_list_events;
+
+    events.mouse_up = window_ride_list_mouseup;
+    events.resize = window_ride_list_resize;
+    events.mouse_down = window_ride_list_mousedown;
+    events.dropdown = window_ride_list_dropdown;
+    events.update = window_ride_list_update;
+    events.get_scroll_size = window_ride_list_scrollgetsize;
+    events.scroll_mousedown = window_ride_list_scrollmousedown;
+    events.scroll_mouseover = window_ride_list_scrollmouseover;
+    events.invalidate = window_ride_list_invalidate;
+    events.paint = window_ride_list_paint;
+    events.scroll_paint = window_ride_list_scrollpaint;
+}
 
 enum {
     INFORMATION_TYPE_STATUS,
@@ -203,6 +191,7 @@ rct_window* window_ride_list_open()
     window = window_bring_to_front_by_class(WC_RIDE_LIST);
     if (window == nullptr)
     {
+        window_ride_list_events_init();
         window = window_create_auto_pos(340, 240, &window_ride_list_events, WC_RIDE_LIST, WF_10 | WF_RESIZABLE);
         window->widgets = window_ride_list_widgets;
         window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_OPEN_CLOSE_ALL) | (1 << WIDX_CURRENT_INFORMATION_TYPE)

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -72,36 +72,16 @@ static void window_save_prompt_mouseup(rct_window *w, rct_widgetindex widgetInde
 static void window_save_prompt_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_save_prompt_callback(int32_t result, const utf8 * path);
 
-static rct_window_event_list window_save_prompt_events = {
-    window_save_prompt_close,
-    window_save_prompt_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_save_prompt_paint,
-    nullptr
-};
+static rct_window_event_list window_save_prompt_events = {};
+
+static void window_save_prompt_events_init()
+{
+    auto& events = window_save_prompt_events;
+
+    events.close = window_save_prompt_close;
+    events.mouse_up = window_save_prompt_mouseup;
+    events.paint = window_save_prompt_paint;
+}
 // clang-format on
 
 /**
@@ -170,6 +150,7 @@ rct_window* window_save_prompt_open()
         log_warning("Invalid save prompt mode %u", prompt_mode);
         return nullptr;
     }
+    window_save_prompt_events_init();
     window = window_create_centred(
         width, height, &window_save_prompt_events, WC_SAVE_PROMPT, WF_TRANSPARENT | WF_STICK_TO_FRONT);
 

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -72,16 +72,12 @@ static void window_save_prompt_mouseup(rct_window *w, rct_widgetindex widgetInde
 static void window_save_prompt_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_save_prompt_callback(int32_t result, const utf8 * path);
 
-static rct_window_event_list window_save_prompt_events = {};
-
-static void window_save_prompt_events_init()
+static rct_window_event_list window_save_prompt_events([](auto& events)
 {
-    auto& events = window_save_prompt_events;
-
-    events.close = window_save_prompt_close;
-    events.mouse_up = window_save_prompt_mouseup;
-    events.paint = window_save_prompt_paint;
-}
+    events.close = &window_save_prompt_close;
+    events.mouse_up = &window_save_prompt_mouseup;
+    events.paint = &window_save_prompt_paint;
+});
 // clang-format on
 
 /**
@@ -150,7 +146,6 @@ rct_window* window_save_prompt_open()
         log_warning("Invalid save prompt mode %u", prompt_mode);
         return nullptr;
     }
-    window_save_prompt_events_init();
     window = window_create_centred(
         width, height, &window_save_prompt_events, WC_SAVE_PROMPT, WF_TRANSPARENT | WF_STICK_TO_FRONT);
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -110,36 +110,22 @@ static void window_scenarioselect_invalidate(rct_window *w);
 static void window_scenarioselect_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_scenarioselect_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_scenarioselect_events = {
-    window_scenarioselect_close,
-    window_scenarioselect_mouseup,
-    nullptr,
-    window_scenarioselect_mousedown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_scenarioselect_scrollgetsize,
-    window_scenarioselect_scrollmousedown,
-    nullptr,
-    window_scenarioselect_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_scenarioselect_invalidate,
-    window_scenarioselect_paint,
-    window_scenarioselect_scrollpaint
-};
+static rct_window_event_list window_scenarioselect_events = {};
+
+static void window_scenarioselect_events_init()
+{
+    auto& events = window_scenarioselect_events;
+
+    events.close = window_scenarioselect_close;
+    events.mouse_up = window_scenarioselect_mouseup;
+    events.mouse_down = window_scenarioselect_mousedown;
+    events.get_scroll_size = window_scenarioselect_scrollgetsize;
+    events.scroll_mousedown = window_scenarioselect_scrollmousedown;
+    events.scroll_mouseover = window_scenarioselect_scrollmouseover;
+    events.invalidate = window_scenarioselect_invalidate;
+    events.paint = window_scenarioselect_paint;
+    events.scroll_paint = window_scenarioselect_scrollpaint;
+}
 // clang-format on
 
 static void draw_category_heading(
@@ -183,6 +169,7 @@ rct_window* window_scenarioselect_open(scenarioselect_callback callback, bool ti
     else
         windowWidth = 733;
 
+    window_scenarioselect_events_init();
     window = window_create_centred(
         windowWidth, windowHeight, &window_scenarioselect_events, WC_SCENARIO_SELECT,
         WF_10 | (titleEditor ? WF_STICK_TO_FRONT : 0));

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -110,22 +110,18 @@ static void window_scenarioselect_invalidate(rct_window *w);
 static void window_scenarioselect_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_scenarioselect_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_scenarioselect_events = {};
-
-static void window_scenarioselect_events_init()
+static rct_window_event_list window_scenarioselect_events([](auto& events)
 {
-    auto& events = window_scenarioselect_events;
-
-    events.close = window_scenarioselect_close;
-    events.mouse_up = window_scenarioselect_mouseup;
-    events.mouse_down = window_scenarioselect_mousedown;
-    events.get_scroll_size = window_scenarioselect_scrollgetsize;
-    events.scroll_mousedown = window_scenarioselect_scrollmousedown;
-    events.scroll_mouseover = window_scenarioselect_scrollmouseover;
-    events.invalidate = window_scenarioselect_invalidate;
-    events.paint = window_scenarioselect_paint;
-    events.scroll_paint = window_scenarioselect_scrollpaint;
-}
+    events.close = &window_scenarioselect_close;
+    events.mouse_up = &window_scenarioselect_mouseup;
+    events.mouse_down = &window_scenarioselect_mousedown;
+    events.get_scroll_size = &window_scenarioselect_scrollgetsize;
+    events.scroll_mousedown = &window_scenarioselect_scrollmousedown;
+    events.scroll_mouseover = &window_scenarioselect_scrollmouseover;
+    events.invalidate = &window_scenarioselect_invalidate;
+    events.paint = &window_scenarioselect_paint;
+    events.scroll_paint = &window_scenarioselect_scrollpaint;
+});
 // clang-format on
 
 static void draw_category_heading(
@@ -169,7 +165,6 @@ rct_window* window_scenarioselect_open(scenarioselect_callback callback, bool ti
     else
         windowWidth = 733;
 
-    window_scenarioselect_events_init();
     window = window_create_centred(
         windowWidth, windowHeight, &window_scenarioselect_events, WC_SCENARIO_SELECT,
         WF_10 | (titleEditor ? WF_STICK_TO_FRONT : 0));

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -82,27 +82,23 @@ static void window_scenery_invalidate(rct_window *w);
 static void window_scenery_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_scenery_events = {};
-
-static void window_scenery_events_init()
+static rct_window_event_list window_scenery_events([](auto& events)
 {
-    auto& events = window_scenery_events;
-
-    events.close = window_scenery_close;
-    events.mouse_up = window_scenery_mouseup;
-    events.resize = window_scenery_resize;
-    events.mouse_down = window_scenery_mousedown;
-    events.dropdown = window_scenery_dropdown;
-    events.update = window_scenery_update;
-    events.periodic_update = window_scenery_periodic_update;
-    events.get_scroll_size = window_scenery_scrollgetsize;
-    events.scroll_mousedown = window_scenery_scrollmousedown;
-    events.scroll_mouseover = window_scenery_scrollmouseover;
-    events.tooltip = window_scenery_tooltip;
-    events.invalidate = window_scenery_invalidate;
-    events.paint = window_scenery_paint;
-    events.scroll_paint = window_scenery_scrollpaint;
-}
+    events.close = &window_scenery_close;
+    events.mouse_up = &window_scenery_mouseup;
+    events.resize = &window_scenery_resize;
+    events.mouse_down = &window_scenery_mousedown;
+    events.dropdown = &window_scenery_dropdown;
+    events.update = &window_scenery_update;
+    events.periodic_update = &window_scenery_periodic_update;
+    events.get_scroll_size = &window_scenery_scrollgetsize;
+    events.scroll_mousedown = &window_scenery_scrollmousedown;
+    events.scroll_mouseover = &window_scenery_scrollmouseover;
+    events.tooltip = &window_scenery_tooltip;
+    events.invalidate = &window_scenery_invalidate;
+    events.paint = &window_scenery_paint;
+    events.scroll_paint = &window_scenery_scrollpaint;
+});
 
 
 enum WINDOW_SCENERY_LIST_WIDGET_IDX {
@@ -440,7 +436,6 @@ rct_window* window_scenery_open()
 
     window_scenery_init();
 
-    window_scenery_events_init();
     window = window_create(
         ScreenCoordsXY(context_get_width() - WINDOW_SCENERY_WIDTH, 0x1D), WINDOW_SCENERY_WIDTH, WINDOW_SCENERY_HEIGHT,
         &window_scenery_events, WC_SCENERY, WF_NO_SCROLLING);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -82,36 +82,27 @@ static void window_scenery_invalidate(rct_window *w);
 static void window_scenery_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_scenery_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_scenery_events = {
-    window_scenery_close,
-    window_scenery_mouseup,
-    window_scenery_resize,
-    window_scenery_mousedown,
-    window_scenery_dropdown,
-    nullptr,
-    window_scenery_update,
-    window_scenery_periodic_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_scenery_scrollgetsize,
-    window_scenery_scrollmousedown,
-    nullptr,
-    window_scenery_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_scenery_tooltip,
-    nullptr,
-    nullptr,
-    window_scenery_invalidate,
-    window_scenery_paint,
-    window_scenery_scrollpaint,
-};
+static rct_window_event_list window_scenery_events = {};
+
+static void window_scenery_events_init()
+{
+    auto& events = window_scenery_events;
+
+    events.close = window_scenery_close;
+    events.mouse_up = window_scenery_mouseup;
+    events.resize = window_scenery_resize;
+    events.mouse_down = window_scenery_mousedown;
+    events.dropdown = window_scenery_dropdown;
+    events.update = window_scenery_update;
+    events.periodic_update = window_scenery_periodic_update;
+    events.get_scroll_size = window_scenery_scrollgetsize;
+    events.scroll_mousedown = window_scenery_scrollmousedown;
+    events.scroll_mouseover = window_scenery_scrollmouseover;
+    events.tooltip = window_scenery_tooltip;
+    events.invalidate = window_scenery_invalidate;
+    events.paint = window_scenery_paint;
+    events.scroll_paint = window_scenery_scrollpaint;
+}
 
 
 enum WINDOW_SCENERY_LIST_WIDGET_IDX {
@@ -449,6 +440,7 @@ rct_window* window_scenery_open()
 
     window_scenery_init();
 
+    window_scenery_events_init();
     window = window_create(
         ScreenCoordsXY(context_get_width() - WINDOW_SCENERY_WIDTH, 0x1D), WINDOW_SCENERY_WIDTH, WINDOW_SCENERY_HEIGHT,
         &window_scenery_events, WC_SCENERY, WF_NO_SCROLLING);

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -60,19 +60,15 @@ static void window_scenery_scatter_textinput(rct_window* w, rct_widgetindex widg
 static void window_scenery_scatter_inputsize(rct_window* w, rct_widgetindex widgetindex);
 
 // clang-format off
-static rct_window_event_list window_clear_scenery_events = {};
-
-static void window_clear_scenery_events_init()
+static rct_window_event_list window_clear_scenery_events([](auto& events)
 {
-    auto& events = window_clear_scenery_events;
-
-    events.close = window_scenery_scatter_close;
-    events.mouse_up = window_scenery_scatter_mouseup;
-    events.mouse_down = window_scenery_scatter_mousedown;
-    events.text_input = window_scenery_scatter_textinput;
-    events.invalidate = window_scenery_scatter_invalidate;
-    events.paint = window_scenery_scatter_paint;
-}
+    events.close = &window_scenery_scatter_close;
+    events.mouse_up = &window_scenery_scatter_mouseup;
+    events.mouse_down = &window_scenery_scatter_mousedown;
+    events.text_input = &window_scenery_scatter_textinput;
+    events.invalidate = &window_scenery_scatter_invalidate;
+    events.paint = &window_scenery_scatter_paint;
+});
 // clang-format on
 
 rct_window* window_scenery_scatter_open()
@@ -84,7 +80,6 @@ rct_window* window_scenery_scatter_open()
     if (window != nullptr)
         return window;
 
-    window_clear_scenery_events_init();
     window = window_create_auto_pos(86, 100, &window_clear_scenery_events, WC_SCENERY_SCATTER, 0);
 
     window->widgets = window_scenery_scatter_widgets;

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -60,36 +60,19 @@ static void window_scenery_scatter_textinput(rct_window* w, rct_widgetindex widg
 static void window_scenery_scatter_inputsize(rct_window* w, rct_widgetindex widgetindex);
 
 // clang-format off
-static rct_window_event_list window_clear_scenery_events = {
-    window_scenery_scatter_close,
-    window_scenery_scatter_mouseup,
-    nullptr,
-    window_scenery_scatter_mousedown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_scenery_scatter_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_scenery_scatter_invalidate,
-    window_scenery_scatter_paint,
-    nullptr
-};
+static rct_window_event_list window_clear_scenery_events = {};
+
+static void window_clear_scenery_events_init()
+{
+    auto& events = window_clear_scenery_events;
+
+    events.close = window_scenery_scatter_close;
+    events.mouse_up = window_scenery_scatter_mouseup;
+    events.mouse_down = window_scenery_scatter_mousedown;
+    events.text_input = window_scenery_scatter_textinput;
+    events.invalidate = window_scenery_scatter_invalidate;
+    events.paint = window_scenery_scatter_paint;
+}
 // clang-format on
 
 rct_window* window_scenery_scatter_open()
@@ -101,6 +84,7 @@ rct_window* window_scenery_scatter_open()
     if (window != nullptr)
         return window;
 
+    window_clear_scenery_events_init();
     window = window_create_auto_pos(86, 100, &window_clear_scenery_events, WC_SCENERY_SCATTER, 0);
 
     window->widgets = window_scenery_scatter_widgets;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -82,25 +82,21 @@ static void window_server_list_invalidate(rct_window *w);
 static void window_server_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_server_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_server_list_events = {};
-
-static void window_server_list_events_init()
+static rct_window_event_list window_server_list_events([](auto& events)
 {
-    auto& events = window_server_list_events;
-
-    events.close = window_server_list_close;
-    events.mouse_up = window_server_list_mouseup;
-    events.resize = window_server_list_resize;
-    events.dropdown = window_server_list_dropdown;
-    events.update = window_server_list_update;
-    events.get_scroll_size = window_server_list_scroll_getsize;
-    events.scroll_mousedown = window_server_list_scroll_mousedown;
-    events.scroll_mouseover = window_server_list_scroll_mouseover;
-    events.text_input = window_server_list_textinput;
-    events.invalidate = window_server_list_invalidate;
-    events.paint = window_server_list_paint;
-    events.scroll_paint = window_server_list_scrollpaint;
-}
+    events.close = &window_server_list_close;
+    events.mouse_up = &window_server_list_mouseup;
+    events.resize = &window_server_list_resize;
+    events.dropdown = &window_server_list_dropdown;
+    events.update = &window_server_list_update;
+    events.get_scroll_size = &window_server_list_scroll_getsize;
+    events.scroll_mousedown = &window_server_list_scroll_mousedown;
+    events.scroll_mouseover = &window_server_list_scroll_mouseover;
+    events.text_input = &window_server_list_textinput;
+    events.invalidate = &window_server_list_invalidate;
+    events.paint = &window_server_list_paint;
+    events.scroll_paint = &window_server_list_scrollpaint;
+});
 // clang-format on
 
 enum
@@ -126,7 +122,6 @@ rct_window* window_server_list_open()
     if (window != nullptr)
         return window;
 
-    window_server_list_events_init();
     window = window_create_centred(WWIDTH_MIN, WHEIGHT_MIN, &window_server_list_events, WC_SERVER_LIST, WF_10 | WF_RESIZABLE);
 
     window_server_list_widgets[WIDX_PLAYER_NAME_INPUT].string = _playerName;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -82,36 +82,25 @@ static void window_server_list_invalidate(rct_window *w);
 static void window_server_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_server_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_server_list_events = {
-    window_server_list_close,
-    window_server_list_mouseup,
-    window_server_list_resize,
-    nullptr,
-    window_server_list_dropdown,
-    nullptr,
-    window_server_list_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_server_list_scroll_getsize,
-    window_server_list_scroll_mousedown,
-    nullptr,
-    window_server_list_scroll_mouseover,
-    window_server_list_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_server_list_invalidate,
-    window_server_list_paint,
-    window_server_list_scrollpaint
-};
+static rct_window_event_list window_server_list_events = {};
+
+static void window_server_list_events_init()
+{
+    auto& events = window_server_list_events;
+
+    events.close = window_server_list_close;
+    events.mouse_up = window_server_list_mouseup;
+    events.resize = window_server_list_resize;
+    events.dropdown = window_server_list_dropdown;
+    events.update = window_server_list_update;
+    events.get_scroll_size = window_server_list_scroll_getsize;
+    events.scroll_mousedown = window_server_list_scroll_mousedown;
+    events.scroll_mouseover = window_server_list_scroll_mouseover;
+    events.text_input = window_server_list_textinput;
+    events.invalidate = window_server_list_invalidate;
+    events.paint = window_server_list_paint;
+    events.scroll_paint = window_server_list_scrollpaint;
+}
 // clang-format on
 
 enum
@@ -137,6 +126,7 @@ rct_window* window_server_list_open()
     if (window != nullptr)
         return window;
 
+    window_server_list_events_init();
     window = window_create_centred(WWIDTH_MIN, WHEIGHT_MIN, &window_server_list_events, WC_SERVER_LIST, WF_10 | WF_RESIZABLE);
 
     window_server_list_widgets[WIDX_PLAYER_NAME_INPUT].string = _playerName;

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -72,36 +72,19 @@ static void window_server_start_textinput(rct_window *w, rct_widgetindex widgetI
 static void window_server_start_invalidate(rct_window *w);
 static void window_server_start_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_server_start_events = {
-    window_server_start_close,
-    window_server_start_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_server_start_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_server_start_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_server_start_invalidate,
-    window_server_start_paint,
-    nullptr
-};
+static rct_window_event_list window_server_start_events = {};
+
+static void window_server_start_events_init()
+{
+    auto& events = window_server_start_events;
+
+    events.close = window_server_start_close;
+    events.mouse_up = window_server_start_mouseup;
+    events.update = window_server_start_update;
+    events.text_input = window_server_start_textinput;
+    events.invalidate = window_server_start_invalidate;
+    events.paint = window_server_start_paint;
+}
 // clang-format on
 
 rct_window* window_server_start_open()
@@ -113,6 +96,7 @@ rct_window* window_server_start_open()
     if (window != nullptr)
         return window;
 
+    window_server_start_events_init();
     window = window_create_centred(WW, WH, &window_server_start_events, WC_SERVER_START, WF_10);
 
     window_server_start_widgets[WIDX_PORT_INPUT].string = _port;

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -72,19 +72,15 @@ static void window_server_start_textinput(rct_window *w, rct_widgetindex widgetI
 static void window_server_start_invalidate(rct_window *w);
 static void window_server_start_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_server_start_events = {};
-
-static void window_server_start_events_init()
+static rct_window_event_list window_server_start_events([](auto& events)
 {
-    auto& events = window_server_start_events;
-
-    events.close = window_server_start_close;
-    events.mouse_up = window_server_start_mouseup;
-    events.update = window_server_start_update;
-    events.text_input = window_server_start_textinput;
-    events.invalidate = window_server_start_invalidate;
-    events.paint = window_server_start_paint;
-}
+    events.close = &window_server_start_close;
+    events.mouse_up = &window_server_start_mouseup;
+    events.update = &window_server_start_update;
+    events.text_input = &window_server_start_textinput;
+    events.invalidate = &window_server_start_invalidate;
+    events.paint = &window_server_start_paint;
+});
 // clang-format on
 
 rct_window* window_server_start_open()
@@ -96,7 +92,6 @@ rct_window* window_server_start_open()
     if (window != nullptr)
         return window;
 
-    window_server_start_events_init();
     window = window_create_centred(WW, WH, &window_server_start_events, WC_SERVER_START, WF_10);
 
     window_server_start_widgets[WIDX_PORT_INPUT].string = _port;

--- a/src/openrct2-ui/windows/ShortcutKeyChange.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeyChange.cpp
@@ -36,36 +36,15 @@ static void window_shortcut_change_mouseup(rct_window *w, rct_widgetindex widget
 static void window_shortcut_change_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x9A3F7C
-static rct_window_event_list window_shortcut_change_events = {
-    nullptr,
-    window_shortcut_change_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_shortcut_change_paint,
-    nullptr
-};
+static rct_window_event_list window_shortcut_change_events = {};
+
+static void window_shortcut_change_events_init()
+{
+    auto& events = window_shortcut_change_events;
+
+    events.mouse_up = window_shortcut_change_mouseup;
+    events.paint = window_shortcut_change_paint;
+}
 // clang-format on
 
 static rct_string_id CurrentShortcutKeyStringId{};
@@ -79,6 +58,7 @@ rct_window* window_shortcut_change_open(OpenRCT2::Input::Shortcut shortcut, rct_
     gKeyboardShortcutChangeId = shortcut;
     CurrentShortcutKeyStringId = key_string_id;
 
+    window_shortcut_change_events_init();
     rct_window* w = window_create_centred(WW, WH, &window_shortcut_change_events, WC_CHANGE_KEYBOARD_SHORTCUT, 0);
 
     w->widgets = window_shortcut_change_widgets;

--- a/src/openrct2-ui/windows/ShortcutKeyChange.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeyChange.cpp
@@ -36,15 +36,11 @@ static void window_shortcut_change_mouseup(rct_window *w, rct_widgetindex widget
 static void window_shortcut_change_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x9A3F7C
-static rct_window_event_list window_shortcut_change_events = {};
-
-static void window_shortcut_change_events_init()
+static rct_window_event_list window_shortcut_change_events([](auto& events)
 {
-    auto& events = window_shortcut_change_events;
-
-    events.mouse_up = window_shortcut_change_mouseup;
-    events.paint = window_shortcut_change_paint;
-}
+    events.mouse_up = &window_shortcut_change_mouseup;
+    events.paint = &window_shortcut_change_paint;
+});
 // clang-format on
 
 static rct_string_id CurrentShortcutKeyStringId{};
@@ -58,7 +54,6 @@ rct_window* window_shortcut_change_open(OpenRCT2::Input::Shortcut shortcut, rct_
     gKeyboardShortcutChangeId = shortcut;
     CurrentShortcutKeyStringId = key_string_id;
 
-    window_shortcut_change_events_init();
     rct_window* w = window_create_centred(WW, WH, &window_shortcut_change_events, WC_CHANGE_KEYBOARD_SHORTCUT, 0);
 
     w->widgets = window_shortcut_change_widgets;

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -50,36 +50,21 @@ static void window_shortcut_scrollmousedown(rct_window *w, int32_t scrollIndex, 
 static void window_shortcut_scrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void window_shortcut_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_shortcut_events = {
-    nullptr,
-    window_shortcut_mouseup,
-    window_shortcut_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_shortcut_scrollgetsize,
-    window_shortcut_scrollmousedown,
-    nullptr,
-    window_shortcut_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_shortcut_invalidate,
-    window_shortcut_paint,
-    window_shortcut_scrollpaint
-};
+static rct_window_event_list window_shortcut_events = {};
+
+static void window_shortcut_events_init()
+{
+    auto& events = window_shortcut_events;
+
+    events.mouse_up = window_shortcut_mouseup;
+    events.resize = window_shortcut_resize;
+    events.get_scroll_size = window_shortcut_scrollgetsize;
+    events.scroll_mousedown = window_shortcut_scrollmousedown;
+    events.scroll_mouseover = window_shortcut_scrollmouseover;
+    events.invalidate = window_shortcut_invalidate;
+    events.paint = window_shortcut_paint;
+    events.scroll_paint = window_shortcut_scrollpaint;
+}
 
 struct ShortcutStringPair
 {
@@ -222,6 +207,7 @@ rct_window* window_shortcut_keys_open()
     rct_window* w = window_bring_to_front_by_class(WC_KEYBOARD_SHORTCUT_LIST);
     if (w == nullptr)
     {
+        window_shortcut_events_init();
         w = window_create_auto_pos(WW, WH, &window_shortcut_events, WC_KEYBOARD_SHORTCUT_LIST, WF_RESIZABLE);
 
         w->widgets = window_shortcut_widgets;

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -50,21 +50,17 @@ static void window_shortcut_scrollmousedown(rct_window *w, int32_t scrollIndex, 
 static void window_shortcut_scrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void window_shortcut_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_shortcut_events = {};
-
-static void window_shortcut_events_init()
+static rct_window_event_list window_shortcut_events([](auto& events)
 {
-    auto& events = window_shortcut_events;
-
-    events.mouse_up = window_shortcut_mouseup;
-    events.resize = window_shortcut_resize;
-    events.get_scroll_size = window_shortcut_scrollgetsize;
-    events.scroll_mousedown = window_shortcut_scrollmousedown;
-    events.scroll_mouseover = window_shortcut_scrollmouseover;
-    events.invalidate = window_shortcut_invalidate;
-    events.paint = window_shortcut_paint;
-    events.scroll_paint = window_shortcut_scrollpaint;
-}
+    events.mouse_up = &window_shortcut_mouseup;
+    events.resize = &window_shortcut_resize;
+    events.get_scroll_size = &window_shortcut_scrollgetsize;
+    events.scroll_mousedown = &window_shortcut_scrollmousedown;
+    events.scroll_mouseover = &window_shortcut_scrollmouseover;
+    events.invalidate = &window_shortcut_invalidate;
+    events.paint = &window_shortcut_paint;
+    events.scroll_paint = &window_shortcut_scrollpaint;
+});
 
 struct ShortcutStringPair
 {
@@ -207,7 +203,6 @@ rct_window* window_shortcut_keys_open()
     rct_window* w = window_bring_to_front_by_class(WC_KEYBOARD_SHORTCUT_LIST);
     if (w == nullptr)
     {
-        window_shortcut_events_init();
         w = window_create_auto_pos(WW, WH, &window_shortcut_events, WC_KEYBOARD_SHORTCUT_LIST, WF_RESIZABLE);
 
         w->widgets = window_shortcut_widgets;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -62,46 +62,32 @@ static void window_sign_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 
 // 0x98E44C
-static rct_window_event_list window_sign_events = {};
-
-static void window_sign_events_init()
+static rct_window_event_list window_sign_events([](auto& events)
 {
-    auto& events = window_sign_events;
-
-    events.mouse_up = window_sign_mouseup;
-    events.mouse_down = window_sign_mousedown;
-    events.dropdown = window_sign_dropdown;
-    events.text_input = window_sign_textinput;
-    events.viewport_rotate = window_sign_viewport_rotate;
-    events.invalidate = window_sign_invalidate;
-    events.paint = window_sign_paint;
-}
+    events.mouse_up = &window_sign_mouseup;
+    events.mouse_down = &window_sign_mousedown;
+    events.dropdown = &window_sign_dropdown;
+    events.text_input = &window_sign_textinput;
+    events.viewport_rotate = &window_sign_viewport_rotate;
+    events.invalidate = &window_sign_invalidate;
+    events.paint = &window_sign_paint;
+});
 
 static void window_sign_small_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_sign_small_dropdown(rct_window *w, rct_widgetindex widgetIndex, int32_t dropdownIndex);
 static void window_sign_small_invalidate(rct_window *w);
 
 // 0x9A410C
-static rct_window_event_list window_sign_small_events = {};
-
-static void window_sign_small_events_init()
+static rct_window_event_list window_sign_small_events([](auto& events)
 {
-    auto& events = window_sign_small_events;
-
-    events.mouse_up = window_sign_small_mouseup;
-    events.mouse_down = window_sign_mousedown;
-    events.dropdown = window_sign_small_dropdown;
-    events.text_input = window_sign_textinput;
-    events.viewport_rotate = window_sign_viewport_rotate;
-    events.invalidate = window_sign_small_invalidate;
-    events.paint = window_sign_paint;
-}
-
-static void window_sign_events_init_all()
-{
-    window_sign_events_init();
-    window_sign_small_events_init();
-}
+    events.mouse_up = &window_sign_small_mouseup;
+    events.mouse_down = &window_sign_mousedown;
+    events.dropdown = &window_sign_small_dropdown;
+    events.text_input = &window_sign_textinput;
+    events.viewport_rotate = &window_sign_viewport_rotate;
+    events.invalidate = &window_sign_small_invalidate;
+    events.paint = &window_sign_paint;
+});
 // clang-format on
 
 static void window_sign_show_text_input(rct_window* w);
@@ -120,7 +106,6 @@ rct_window* window_sign_open(rct_windownumber number)
     if (w != nullptr)
         return w;
 
-    window_sign_events_init_all();
     w = window_create_auto_pos(WW, WH, &window_sign_events, WC_BANNER, WF_NO_SCROLLING);
     w->widgets = window_sign_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_SIGN_TEXT) | (1 << WIDX_SIGN_DEMOLISH) | (1 << WIDX_MAIN_COLOUR)
@@ -370,7 +355,6 @@ rct_window* window_sign_small_open(rct_windownumber number)
     if (w != nullptr)
         return w;
 
-    window_sign_events_init_all();
     w = window_create_auto_pos(WW, WH, &window_sign_small_events, WC_BANNER, 0);
     w->widgets = window_sign_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_SIGN_TEXT) | (1 << WIDX_SIGN_DEMOLISH) | (1 << WIDX_MAIN_COLOUR)

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -62,72 +62,46 @@ static void window_sign_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 
 // 0x98E44C
-static rct_window_event_list window_sign_events = {
-    nullptr,
-    window_sign_mouseup,
-    nullptr,
-    window_sign_mousedown,
-    window_sign_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_sign_textinput,
-    window_sign_viewport_rotate,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_sign_invalidate,
-    window_sign_paint,
-    nullptr
-};
+static rct_window_event_list window_sign_events = {};
+
+static void window_sign_events_init()
+{
+    auto& events = window_sign_events;
+
+    events.mouse_up = window_sign_mouseup;
+    events.mouse_down = window_sign_mousedown;
+    events.dropdown = window_sign_dropdown;
+    events.text_input = window_sign_textinput;
+    events.viewport_rotate = window_sign_viewport_rotate;
+    events.invalidate = window_sign_invalidate;
+    events.paint = window_sign_paint;
+}
 
 static void window_sign_small_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_sign_small_dropdown(rct_window *w, rct_widgetindex widgetIndex, int32_t dropdownIndex);
 static void window_sign_small_invalidate(rct_window *w);
 
 // 0x9A410C
-static rct_window_event_list window_sign_small_events = {
-    nullptr,
-    window_sign_small_mouseup,
-    nullptr,
-    window_sign_mousedown,
-    window_sign_small_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_sign_textinput,
-    window_sign_viewport_rotate,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_sign_small_invalidate,
-    window_sign_paint,
-    nullptr
-};
+static rct_window_event_list window_sign_small_events = {};
+
+static void window_sign_small_events_init()
+{
+    auto& events = window_sign_small_events;
+
+    events.mouse_up = window_sign_small_mouseup;
+    events.mouse_down = window_sign_mousedown;
+    events.dropdown = window_sign_small_dropdown;
+    events.text_input = window_sign_textinput;
+    events.viewport_rotate = window_sign_viewport_rotate;
+    events.invalidate = window_sign_small_invalidate;
+    events.paint = window_sign_paint;
+}
+
+static void window_sign_events_init_all()
+{
+    window_sign_events_init();
+    window_sign_small_events_init();
+}
 // clang-format on
 
 static void window_sign_show_text_input(rct_window* w);
@@ -146,6 +120,7 @@ rct_window* window_sign_open(rct_windownumber number)
     if (w != nullptr)
         return w;
 
+    window_sign_events_init_all();
     w = window_create_auto_pos(WW, WH, &window_sign_events, WC_BANNER, WF_NO_SCROLLING);
     w->widgets = window_sign_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_SIGN_TEXT) | (1 << WIDX_SIGN_DEMOLISH) | (1 << WIDX_MAIN_COLOUR)
@@ -395,6 +370,7 @@ rct_window* window_sign_small_open(rct_windownumber number)
     if (w != nullptr)
         return w;
 
+    window_sign_events_init_all();
     w = window_create_auto_pos(WW, WH, &window_sign_small_events, WC_BANNER, 0);
     w->widgets = window_sign_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_SIGN_TEXT) | (1 << WIDX_SIGN_DEMOLISH) | (1 << WIDX_MAIN_COLOUR)

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -153,100 +153,67 @@ static void window_staff_stats_tab_paint(rct_window* w, rct_drawpixelinfo* dpi);
 void window_staff_set_colours();
 
 // 0x992AEC
-static rct_window_event_list window_staff_overview_events = {
-    window_staff_overview_close,
-    window_staff_overview_mouseup,
-    window_staff_overview_resize,
-    window_staff_overview_mousedown,
-    window_staff_overview_dropdown,
-    nullptr,
-    window_staff_overview_update,
-    nullptr,
-    nullptr,
-    window_staff_overview_tool_update,
-    window_staff_overview_tool_down,
-    window_staff_overview_tool_drag,
-    window_staff_overview_tool_up,
-    window_staff_overview_tool_abort,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_overview_text_input,
-    window_staff_overview_viewport_rotate,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_overview_invalidate,
-    window_staff_overview_paint,
-    nullptr
-};
+static rct_window_event_list window_staff_overview_events = {};
+
+static void window_staff_overview_events_init()
+{
+    auto& events = window_staff_overview_events;
+
+    events.close = window_staff_overview_close;
+    events.mouse_up = window_staff_overview_mouseup;
+    events.resize = window_staff_overview_resize;
+    events.mouse_down = window_staff_overview_mousedown;
+    events.dropdown = window_staff_overview_dropdown;
+    events.update = window_staff_overview_update;
+    events.tool_update = window_staff_overview_tool_update;
+    events.tool_down = window_staff_overview_tool_down;
+    events.tool_drag = window_staff_overview_tool_drag;
+    events.tool_up = window_staff_overview_tool_up;
+    events.tool_abort = window_staff_overview_tool_abort;
+    events.text_input = window_staff_overview_text_input;
+    events.viewport_rotate = window_staff_overview_viewport_rotate;
+    events.invalidate = window_staff_overview_invalidate;
+    events.paint = window_staff_overview_paint;
+}
 
 // 0x992B5C
-static rct_window_event_list window_staff_options_events = {
-    nullptr,
-    window_staff_options_mouseup,
-    window_staff_stats_resize,
-    window_staff_options_mousedown,
-    window_staff_options_dropdown,
-    window_staff_unknown_05,
-    window_staff_options_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_options_invalidate,
-    window_staff_options_paint,
-    nullptr
-};
+static rct_window_event_list window_staff_options_events = {};
+
+static void window_staff_options_events_init()
+{
+    auto& events = window_staff_options_events;
+
+    events.mouse_up = window_staff_options_mouseup;
+    events.resize = window_staff_stats_resize;
+    events.mouse_down = window_staff_options_mousedown;
+    events.dropdown = window_staff_options_dropdown;
+    events.unknown_05 = window_staff_unknown_05;
+    events.update = window_staff_options_update;
+    events.invalidate = window_staff_options_invalidate;
+    events.paint = window_staff_options_paint;
+}
 
 // 0x992BCC
-static rct_window_event_list window_staff_stats_events = {
-    nullptr,
-    window_staff_stats_mouseup,
-    window_staff_stats_resize,
-    nullptr,
-    nullptr,
-    window_staff_unknown_05,
-    window_staff_stats_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_stats_invalidate,
-    window_staff_stats_paint,
-    nullptr
-};
+static rct_window_event_list window_staff_stats_events = {};
+
+static void window_staff_stats_events_init()
+{
+    auto& events = window_staff_stats_events;
+
+    events.mouse_up = window_staff_stats_mouseup;
+    events.resize = window_staff_stats_resize;
+    events.unknown_05 = window_staff_unknown_05;
+    events.update = window_staff_stats_update;
+    events.invalidate = window_staff_stats_invalidate;
+    events.paint = window_staff_stats_paint;
+}
+
+static void window_staff_events_init_all()
+{
+    window_staff_overview_events_init();
+    window_staff_options_events_init();
+    window_staff_stats_events_init();
+}
 
 static rct_window_event_list *window_staff_page_events[] = {
     &window_staff_overview_events,
@@ -313,6 +280,7 @@ rct_window* window_staff_open(Peep* peep)
     rct_window* w = window_bring_to_front_by_number(WC_PEEP, peep->sprite_index);
     if (w == nullptr)
     {
+        window_staff_events_init_all();
         w = window_create_auto_pos(WW, WH, &window_staff_overview_events, WC_PEEP, WF_10 | WF_RESIZABLE);
 
         w->number = peep->sprite_index;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -179,8 +179,8 @@ static rct_window_event_list window_staff_overview_events = {
     nullptr,
     nullptr,
     nullptr,
-    window_staff_overview_invalidate, //Invalidate
-    window_staff_overview_paint, //Paint
+    window_staff_overview_invalidate,
+    window_staff_overview_paint,
     nullptr
 };
 
@@ -211,8 +211,8 @@ static rct_window_event_list window_staff_options_events = {
     nullptr,
     nullptr,
     nullptr,
-    window_staff_options_invalidate, //Invalidate
-    window_staff_options_paint, //Paint
+    window_staff_options_invalidate,
+    window_staff_options_paint,
     nullptr
 };
 
@@ -243,8 +243,8 @@ static rct_window_event_list window_staff_stats_events = {
     nullptr,
     nullptr,
     nullptr,
-    window_staff_stats_invalidate, //Invalidate
-    window_staff_stats_paint, //Paint
+    window_staff_stats_invalidate,
+    window_staff_stats_paint,
     nullptr
 };
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -153,67 +153,48 @@ static void window_staff_stats_tab_paint(rct_window* w, rct_drawpixelinfo* dpi);
 void window_staff_set_colours();
 
 // 0x992AEC
-static rct_window_event_list window_staff_overview_events = {};
-
-static void window_staff_overview_events_init()
+static rct_window_event_list window_staff_overview_events([](auto& events)
 {
-    auto& events = window_staff_overview_events;
-
-    events.close = window_staff_overview_close;
-    events.mouse_up = window_staff_overview_mouseup;
-    events.resize = window_staff_overview_resize;
-    events.mouse_down = window_staff_overview_mousedown;
-    events.dropdown = window_staff_overview_dropdown;
-    events.update = window_staff_overview_update;
-    events.tool_update = window_staff_overview_tool_update;
-    events.tool_down = window_staff_overview_tool_down;
-    events.tool_drag = window_staff_overview_tool_drag;
-    events.tool_up = window_staff_overview_tool_up;
-    events.tool_abort = window_staff_overview_tool_abort;
-    events.text_input = window_staff_overview_text_input;
-    events.viewport_rotate = window_staff_overview_viewport_rotate;
-    events.invalidate = window_staff_overview_invalidate;
-    events.paint = window_staff_overview_paint;
-}
+    events.close = &window_staff_overview_close;
+    events.mouse_up = &window_staff_overview_mouseup;
+    events.resize = &window_staff_overview_resize;
+    events.mouse_down = &window_staff_overview_mousedown;
+    events.dropdown = &window_staff_overview_dropdown;
+    events.update = &window_staff_overview_update;
+    events.tool_update = &window_staff_overview_tool_update;
+    events.tool_down = &window_staff_overview_tool_down;
+    events.tool_drag = &window_staff_overview_tool_drag;
+    events.tool_up = &window_staff_overview_tool_up;
+    events.tool_abort = &window_staff_overview_tool_abort;
+    events.text_input = &window_staff_overview_text_input;
+    events.viewport_rotate = &window_staff_overview_viewport_rotate;
+    events.invalidate = &window_staff_overview_invalidate;
+    events.paint = &window_staff_overview_paint;
+});
 
 // 0x992B5C
-static rct_window_event_list window_staff_options_events = {};
-
-static void window_staff_options_events_init()
+static rct_window_event_list window_staff_options_events([](auto& events)
 {
-    auto& events = window_staff_options_events;
-
-    events.mouse_up = window_staff_options_mouseup;
-    events.resize = window_staff_stats_resize;
-    events.mouse_down = window_staff_options_mousedown;
-    events.dropdown = window_staff_options_dropdown;
-    events.unknown_05 = window_staff_unknown_05;
-    events.update = window_staff_options_update;
-    events.invalidate = window_staff_options_invalidate;
-    events.paint = window_staff_options_paint;
-}
+    events.mouse_up = &window_staff_options_mouseup;
+    events.resize = &window_staff_stats_resize;
+    events.mouse_down = &window_staff_options_mousedown;
+    events.dropdown = &window_staff_options_dropdown;
+    events.unknown_05 = &window_staff_unknown_05;
+    events.update = &window_staff_options_update;
+    events.invalidate = &window_staff_options_invalidate;
+    events.paint = &window_staff_options_paint;
+});
 
 // 0x992BCC
-static rct_window_event_list window_staff_stats_events = {};
-
-static void window_staff_stats_events_init()
+static rct_window_event_list window_staff_stats_events([](auto& events)
 {
-    auto& events = window_staff_stats_events;
-
-    events.mouse_up = window_staff_stats_mouseup;
-    events.resize = window_staff_stats_resize;
-    events.unknown_05 = window_staff_unknown_05;
-    events.update = window_staff_stats_update;
-    events.invalidate = window_staff_stats_invalidate;
-    events.paint = window_staff_stats_paint;
-}
-
-static void window_staff_events_init_all()
-{
-    window_staff_overview_events_init();
-    window_staff_options_events_init();
-    window_staff_stats_events_init();
-}
+    events.mouse_up = &window_staff_stats_mouseup;
+    events.resize = &window_staff_stats_resize;
+    events.unknown_05 = &window_staff_unknown_05;
+    events.update = &window_staff_stats_update;
+    events.invalidate = &window_staff_stats_invalidate;
+    events.paint = &window_staff_stats_paint;
+});
 
 static rct_window_event_list *window_staff_page_events[] = {
     &window_staff_overview_events,
@@ -280,7 +261,6 @@ rct_window* window_staff_open(Peep* peep)
     rct_window* w = window_bring_to_front_by_number(WC_PEEP, peep->sprite_index);
     if (w == nullptr)
     {
-        window_staff_events_init_all();
         w = window_create_auto_pos(WW, WH, &window_staff_overview_events, WC_PEEP, WF_10 | WF_RESIZABLE);
 
         w->number = peep->sprite_index;

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -41,15 +41,11 @@ static void window_staff_fire_mouseup(rct_window *w, rct_widgetindex widgetIndex
 static void window_staff_fire_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 //0x9A3F7C
-static rct_window_event_list window_staff_fire_events = {};
-
-static void window_staff_fire_events_init()
+static rct_window_event_list window_staff_fire_events([](auto& events)
 {
-    auto& events = window_staff_fire_events;
-
-    events.mouse_up = window_staff_fire_mouseup;
-    events.paint = window_staff_fire_paint;
-}
+    events.mouse_up = &window_staff_fire_mouseup;
+    events.paint = &window_staff_fire_paint;
+});
 // clang-format on
 
 /** Based off of rct2: 0x6C0A77 */
@@ -64,7 +60,6 @@ rct_window* window_staff_fire_prompt_open(Peep* peep)
         return w;
     }
 
-    window_staff_fire_events_init();
     w = window_create_centred(WW, WH, &window_staff_fire_events, WC_FIRE_PROMPT, WF_TRANSPARENT);
     w->widgets = window_staff_fire_widgets;
     w->enabled_widgets |= (1 << WIDX_CLOSE) | (1 << WIDX_YES) | (1 << WIDX_CANCEL);

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -41,36 +41,15 @@ static void window_staff_fire_mouseup(rct_window *w, rct_widgetindex widgetIndex
 static void window_staff_fire_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 //0x9A3F7C
-static rct_window_event_list window_staff_fire_events = {
-    nullptr,
-    window_staff_fire_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_fire_paint,
-    nullptr
-};
+static rct_window_event_list window_staff_fire_events = {};
+
+static void window_staff_fire_events_init()
+{
+    auto& events = window_staff_fire_events;
+
+    events.mouse_up = window_staff_fire_mouseup;
+    events.paint = window_staff_fire_paint;
+}
 // clang-format on
 
 /** Based off of rct2: 0x6C0A77 */
@@ -85,6 +64,7 @@ rct_window* window_staff_fire_prompt_open(Peep* peep)
         return w;
     }
 
+    window_staff_fire_events_init();
     w = window_create_centred(WW, WH, &window_staff_fire_events, WC_FIRE_PROMPT, WF_TRANSPARENT);
     w->widgets = window_staff_fire_widgets;
     w->enabled_widgets |= (1 << WIDX_CLOSE) | (1 << WIDX_YES) | (1 << WIDX_CANCEL);

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -56,36 +56,27 @@ static void window_staff_list_invalidate(rct_window *w);
 static void window_staff_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_staff_list_events = {
-    window_staff_list_close,
-    window_staff_list_mouseup,
-    window_staff_list_resize,
-    window_staff_list_mousedown,
-    window_staff_list_dropdown,
-    nullptr,
-    window_staff_list_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_list_tooldown,
-    nullptr,
-    nullptr,
-    window_staff_list_toolabort,
-    nullptr,
-    window_staff_list_scrollgetsize,
-    window_staff_list_scrollmousedown,
-    nullptr,
-    window_staff_list_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_staff_list_invalidate,
-    window_staff_list_paint,
-    window_staff_list_scrollpaint,
-};
+static rct_window_event_list window_staff_list_events = {};
+
+static void window_staff_list_events_init()
+{
+    auto& events = window_staff_list_events;
+
+    events.close = window_staff_list_close;
+    events.mouse_up = window_staff_list_mouseup;
+    events.resize = window_staff_list_resize;
+    events.mouse_down = window_staff_list_mousedown;
+    events.dropdown = window_staff_list_dropdown;
+    events.update = window_staff_list_update;
+    events.tool_down = window_staff_list_tooldown;
+    events.tool_abort = window_staff_list_toolabort;
+    events.get_scroll_size = window_staff_list_scrollgetsize;
+    events.scroll_mousedown = window_staff_list_scrollmousedown;
+    events.scroll_mouseover = window_staff_list_scrollmouseover;
+    events.invalidate = window_staff_list_invalidate;
+    events.paint = window_staff_list_paint;
+    events.scroll_paint = window_staff_list_scrollpaint;
+}
 
 enum WINDOW_STAFF_LIST_WIDGET_IDX {
     WIDX_STAFF_LIST_BACKGROUND,
@@ -158,6 +149,7 @@ rct_window* window_staff_list_open()
     if (window != nullptr)
         return window;
 
+    window_staff_list_events_init();
     window = window_create_auto_pos(WW, WH, &window_staff_list_events, WC_STAFF_LIST, WF_10 | WF_RESIZABLE);
     window->widgets = window_staff_list_widgets;
     window->enabled_widgets = (1 << WIDX_STAFF_LIST_CLOSE) | (1 << WIDX_STAFF_LIST_HANDYMEN_TAB)

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -56,27 +56,23 @@ static void window_staff_list_invalidate(rct_window *w);
 static void window_staff_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_staff_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_staff_list_events = {};
-
-static void window_staff_list_events_init()
+static rct_window_event_list window_staff_list_events([](auto& events)
 {
-    auto& events = window_staff_list_events;
-
-    events.close = window_staff_list_close;
-    events.mouse_up = window_staff_list_mouseup;
-    events.resize = window_staff_list_resize;
-    events.mouse_down = window_staff_list_mousedown;
-    events.dropdown = window_staff_list_dropdown;
-    events.update = window_staff_list_update;
-    events.tool_down = window_staff_list_tooldown;
-    events.tool_abort = window_staff_list_toolabort;
-    events.get_scroll_size = window_staff_list_scrollgetsize;
-    events.scroll_mousedown = window_staff_list_scrollmousedown;
-    events.scroll_mouseover = window_staff_list_scrollmouseover;
-    events.invalidate = window_staff_list_invalidate;
-    events.paint = window_staff_list_paint;
-    events.scroll_paint = window_staff_list_scrollpaint;
-}
+    events.close = &window_staff_list_close;
+    events.mouse_up = &window_staff_list_mouseup;
+    events.resize = &window_staff_list_resize;
+    events.mouse_down = &window_staff_list_mousedown;
+    events.dropdown = &window_staff_list_dropdown;
+    events.update = &window_staff_list_update;
+    events.tool_down = &window_staff_list_tooldown;
+    events.tool_abort = &window_staff_list_toolabort;
+    events.get_scroll_size = &window_staff_list_scrollgetsize;
+    events.scroll_mousedown = &window_staff_list_scrollmousedown;
+    events.scroll_mouseover = &window_staff_list_scrollmouseover;
+    events.invalidate = &window_staff_list_invalidate;
+    events.paint = &window_staff_list_paint;
+    events.scroll_paint = &window_staff_list_scrollpaint;
+});
 
 enum WINDOW_STAFF_LIST_WIDGET_IDX {
     WIDX_STAFF_LIST_BACKGROUND,
@@ -149,7 +145,6 @@ rct_window* window_staff_list_open()
     if (window != nullptr)
         return window;
 
-    window_staff_list_events_init();
     window = window_create_auto_pos(WW, WH, &window_staff_list_events, WC_STAFF_LIST, WF_10 | WF_RESIZABLE);
     window->widgets = window_staff_list_widgets;
     window->enabled_widgets = (1 << WIDX_STAFF_LIST_CLOSE) | (1 << WIDX_STAFF_LIST_HANDYMEN_TAB)

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -54,36 +54,18 @@ static void window_text_input_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void draw_ime_composition(rct_drawpixelinfo * dpi, int cursorX, int cursorY);
 
 //0x9A3F7C
-static rct_window_event_list window_text_input_events = {
-    window_text_input_close,
-    window_text_input_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_text_input_periodic_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_text_input_invalidate,
-    window_text_input_paint,
-    nullptr
-};
+static rct_window_event_list window_text_input_events = {};
+
+static void window_text_input_events_init()
+{
+    auto& events = window_text_input_events;
+
+    events.close = window_text_input_close;
+    events.mouse_up = window_text_input_mouseup;
+    events.periodic_update = window_text_input_periodic_update;
+    events.invalidate = window_text_input_invalidate;
+    events.paint = window_text_input_paint;
+}
 // clang-format on
 
 static rct_string_id input_text_description;
@@ -140,6 +122,7 @@ void window_text_input_raw_open(
     int32_t height = no_lines * 10 + WH;
 
     // Window will be in the centre of the screen
+    window_text_input_events_init();
     rct_window* w = window_create_centred(WW, height, &window_text_input_events, WC_TEXTINPUT, WF_STICK_TO_FRONT);
 
     w->widgets = window_text_input_widgets;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -54,18 +54,14 @@ static void window_text_input_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void draw_ime_composition(rct_drawpixelinfo * dpi, int cursorX, int cursorY);
 
 //0x9A3F7C
-static rct_window_event_list window_text_input_events = {};
-
-static void window_text_input_events_init()
+static rct_window_event_list window_text_input_events([](auto& events)
 {
-    auto& events = window_text_input_events;
-
-    events.close = window_text_input_close;
-    events.mouse_up = window_text_input_mouseup;
-    events.periodic_update = window_text_input_periodic_update;
-    events.invalidate = window_text_input_invalidate;
-    events.paint = window_text_input_paint;
-}
+    events.close = &window_text_input_close;
+    events.mouse_up = &window_text_input_mouseup;
+    events.periodic_update = &window_text_input_periodic_update;
+    events.invalidate = &window_text_input_invalidate;
+    events.paint = &window_text_input_paint;
+});
 // clang-format on
 
 static rct_string_id input_text_description;
@@ -122,7 +118,6 @@ void window_text_input_raw_open(
     int32_t height = no_lines * 10 + WH;
 
     // Window will be in the centre of the screen
-    window_text_input_events_init();
     rct_window* w = window_create_centred(WW, height, &window_text_input_events, WC_TEXTINPUT, WF_STICK_TO_FRONT);
 
     w->widgets = window_text_input_widgets;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -49,36 +49,25 @@ static void window_themes_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_themes_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 static void window_themes_draw_tab_images(rct_drawpixelinfo *dpi, rct_window *w);
 
-static rct_window_event_list window_themes_events = {
-    nullptr,
-    window_themes_mouseup,
-    window_themes_resize,
-    window_themes_mousedown,
-    window_themes_dropdown,
-    nullptr,
-    window_themes_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_themes_scrollgetsize,
-    window_themes_scrollmousedown,
-    nullptr,
-    window_themes_scrollmouseover,
-    window_themes_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_themes_invalidate,
-    window_themes_paint,
-    window_themes_scrollpaint,
-};
+static rct_window_event_list window_themes_events = {};
+
+static void window_themes_events_init()
+{
+    auto& events = window_themes_events;
+
+    events.mouse_up = window_themes_mouseup;
+    events.resize = window_themes_resize;
+    events.mouse_down = window_themes_mousedown;
+    events.dropdown = window_themes_dropdown;
+    events.update = window_themes_update;
+    events.get_scroll_size = window_themes_scrollgetsize;
+    events.scroll_mousedown = window_themes_scrollmousedown;
+    events.scroll_mouseover = window_themes_scrollmouseover;
+    events.text_input = window_themes_textinput;
+    events.invalidate = window_themes_invalidate;
+    events.paint = window_themes_paint;
+    events.scroll_paint = window_themes_scrollpaint;
+}
 
 enum WINDOW_STAFF_LIST_WIDGET_IDX {
     WIDX_THEMES_BACKGROUND,
@@ -334,6 +323,7 @@ rct_window* window_themes_open()
     if (window != nullptr)
         return window;
 
+    window_themes_events_init();
     window = window_create_auto_pos(320, 107, &window_themes_events, WC_THEMES, WF_10 | WF_RESIZABLE);
     window->widgets = window_themes_widgets;
     window->enabled_widgets = (1 << WIDX_THEMES_CLOSE) | (1 << WIDX_THEMES_SETTINGS_TAB) | (1 << WIDX_THEMES_MAIN_UI_TAB)

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -49,25 +49,21 @@ static void window_themes_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_themes_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 static void window_themes_draw_tab_images(rct_drawpixelinfo *dpi, rct_window *w);
 
-static rct_window_event_list window_themes_events = {};
-
-static void window_themes_events_init()
+static rct_window_event_list window_themes_events([](auto& events)
 {
-    auto& events = window_themes_events;
-
-    events.mouse_up = window_themes_mouseup;
-    events.resize = window_themes_resize;
-    events.mouse_down = window_themes_mousedown;
-    events.dropdown = window_themes_dropdown;
-    events.update = window_themes_update;
-    events.get_scroll_size = window_themes_scrollgetsize;
-    events.scroll_mousedown = window_themes_scrollmousedown;
-    events.scroll_mouseover = window_themes_scrollmouseover;
-    events.text_input = window_themes_textinput;
-    events.invalidate = window_themes_invalidate;
-    events.paint = window_themes_paint;
-    events.scroll_paint = window_themes_scrollpaint;
-}
+    events.mouse_up = &window_themes_mouseup;
+    events.resize = &window_themes_resize;
+    events.mouse_down = &window_themes_mousedown;
+    events.dropdown = &window_themes_dropdown;
+    events.update = &window_themes_update;
+    events.get_scroll_size = &window_themes_scrollgetsize;
+    events.scroll_mousedown = &window_themes_scrollmousedown;
+    events.scroll_mouseover = &window_themes_scrollmouseover;
+    events.text_input = &window_themes_textinput;
+    events.invalidate = &window_themes_invalidate;
+    events.paint = &window_themes_paint;
+    events.scroll_paint = &window_themes_scrollpaint;
+});
 
 enum WINDOW_STAFF_LIST_WIDGET_IDX {
     WIDX_THEMES_BACKGROUND,
@@ -323,7 +319,6 @@ rct_window* window_themes_open()
     if (window != nullptr)
         return window;
 
-    window_themes_events_init();
     window = window_create_auto_pos(320, 107, &window_themes_events, WC_THEMES, WF_10 | WF_RESIZABLE);
     window->widgets = window_themes_widgets;
     window->enabled_widgets = (1 << WIDX_THEMES_CLOSE) | (1 << WIDX_THEMES_SETTINGS_TAB) | (1 << WIDX_THEMES_MAIN_UI_TAB)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -439,27 +439,23 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
 static void window_tile_inspector_set_page(rct_window* w, const TILE_INSPECTOR_PAGE page);
 
 // clang-format off
-static rct_window_event_list TileInspectorWindowEvents = {};
-
-static void TileInspectorWindowEvents_init()
+static rct_window_event_list TileInspectorWindowEvents([](auto& events)
 {
-    auto& events = TileInspectorWindowEvents;
-
-    events.mouse_up = window_tile_inspector_mouseup;
-    events.resize = window_tile_inspector_resize;
-    events.mouse_down = window_tile_inspector_mousedown;
-    events.dropdown = window_tile_inspector_dropdown;
-    events.update = window_tile_inspector_update;
-    events.tool_update = window_tile_inspector_tool_update;
-    events.tool_down = window_tile_inspector_tool_down;
-    events.tool_drag = window_tile_inspector_tool_drag;
-    events.get_scroll_size = window_tile_inspector_scrollgetsize;
-    events.scroll_mousedown = window_tile_inspector_scrollmousedown;
-    events.scroll_mouseover = window_tile_inspector_scrollmouseover;
-    events.invalidate = window_tile_inspector_invalidate;
-    events.paint = window_tile_inspector_paint;
-    events.scroll_paint = window_tile_inspector_scrollpaint;
-}
+    events.mouse_up = &window_tile_inspector_mouseup;
+    events.resize = &window_tile_inspector_resize;
+    events.mouse_down = &window_tile_inspector_mousedown;
+    events.dropdown = &window_tile_inspector_dropdown;
+    events.update = &window_tile_inspector_update;
+    events.tool_update = &window_tile_inspector_tool_update;
+    events.tool_down = &window_tile_inspector_tool_down;
+    events.tool_drag = &window_tile_inspector_tool_drag;
+    events.get_scroll_size = &window_tile_inspector_scrollgetsize;
+    events.scroll_mousedown = &window_tile_inspector_scrollmousedown;
+    events.scroll_mouseover = &window_tile_inspector_scrollmouseover;
+    events.invalidate = &window_tile_inspector_invalidate;
+    events.paint = &window_tile_inspector_paint;
+    events.scroll_paint = &window_tile_inspector_scrollpaint;
+});
 
 static uint64_t PageEnabledWidgets[] = {
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT),
@@ -510,7 +506,6 @@ rct_window* window_tile_inspector_open()
     if (window != nullptr)
         return window;
 
-    TileInspectorWindowEvents_init();
     window = window_create(ScreenCoordsXY(0, 29), WW, WH, &TileInspectorWindowEvents, WC_TILE_INSPECTOR, WF_RESIZABLE);
 
     window_tile_inspector_set_page(window, TILE_INSPECTOR_PAGE_DEFAULT);

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -439,36 +439,27 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
 static void window_tile_inspector_set_page(rct_window* w, const TILE_INSPECTOR_PAGE page);
 
 // clang-format off
-static rct_window_event_list TileInspectorWindowEvents = {
-    nullptr,
-    window_tile_inspector_mouseup,
-    window_tile_inspector_resize,
-    window_tile_inspector_mousedown,
-    window_tile_inspector_dropdown,
-    nullptr,
-    window_tile_inspector_update,
-    nullptr,
-    nullptr,
-    window_tile_inspector_tool_update,
-    window_tile_inspector_tool_down,
-    window_tile_inspector_tool_drag,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_tile_inspector_scrollgetsize,
-    window_tile_inspector_scrollmousedown,
-    nullptr,
-    window_tile_inspector_scrollmouseover,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_tile_inspector_invalidate,
-    window_tile_inspector_paint,
-    window_tile_inspector_scrollpaint
-};
+static rct_window_event_list TileInspectorWindowEvents = {};
+
+static void TileInspectorWindowEvents_init()
+{
+    auto& events = TileInspectorWindowEvents;
+
+    events.mouse_up = window_tile_inspector_mouseup;
+    events.resize = window_tile_inspector_resize;
+    events.mouse_down = window_tile_inspector_mousedown;
+    events.dropdown = window_tile_inspector_dropdown;
+    events.update = window_tile_inspector_update;
+    events.tool_update = window_tile_inspector_tool_update;
+    events.tool_down = window_tile_inspector_tool_down;
+    events.tool_drag = window_tile_inspector_tool_drag;
+    events.get_scroll_size = window_tile_inspector_scrollgetsize;
+    events.scroll_mousedown = window_tile_inspector_scrollmousedown;
+    events.scroll_mouseover = window_tile_inspector_scrollmouseover;
+    events.invalidate = window_tile_inspector_invalidate;
+    events.paint = window_tile_inspector_paint;
+    events.scroll_paint = window_tile_inspector_scrollpaint;
+}
 
 static uint64_t PageEnabledWidgets[] = {
     (1ULL << WIDX_CLOSE) | (1ULL << WIDX_BUTTON_CORRUPT),
@@ -519,6 +510,7 @@ rct_window* window_tile_inspector_open()
     if (window != nullptr)
         return window;
 
+    TileInspectorWindowEvents_init();
     window = window_create(ScreenCoordsXY(0, 29), WW, WH, &TileInspectorWindowEvents, WC_TILE_INSPECTOR, WF_RESIZABLE);
 
     window_tile_inspector_set_page(window, TILE_INSPECTOR_PAGE_DEFAULT);

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -122,22 +122,18 @@ static TITLE_COMMAND_ORDER get_command_info(int32_t index);
 static TileCoordsXY get_location();
 static uint8_t get_zoom();
 
-static rct_window_event_list window_title_command_editor_events = {};
-
-static void window_title_command_editor_events_init()
+static rct_window_event_list window_title_command_editor_events([](auto& events)
 {
-    auto& events = window_title_command_editor_events;
-
-    events.close = window_title_command_editor_close;
-    events.mouse_up = window_title_command_editor_mouseup;
-    events.mouse_down = window_title_command_editor_mousedown;
-    events.dropdown = window_title_command_editor_dropdown;
-    events.update = window_title_command_editor_update;
-    events.tool_down = window_title_command_editor_tool_down;
-    events.text_input = window_title_command_editor_textinput;
-    events.invalidate = window_title_command_editor_invalidate;
-    events.paint = window_title_command_editor_paint;
-}
+    events.close = &window_title_command_editor_close;
+    events.mouse_up = &window_title_command_editor_mouseup;
+    events.mouse_down = &window_title_command_editor_mousedown;
+    events.dropdown = &window_title_command_editor_dropdown;
+    events.update = &window_title_command_editor_update;
+    events.tool_down = &window_title_command_editor_tool_down;
+    events.text_input = &window_title_command_editor_textinput;
+    events.invalidate = &window_title_command_editor_invalidate;
+    events.paint = &window_title_command_editor_paint;
+});
 // clang-format on
 
 static void scenario_select_callback(const utf8* path)
@@ -216,7 +212,6 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
     if (window_find_by_class(WC_TITLE_COMMAND_EDITOR) != nullptr)
         return;
 
-    window_title_command_editor_events_init();
     rct_window* window = window_create_centred(
         WW, WH, &window_title_command_editor_events, WC_TITLE_COMMAND_EDITOR, WF_STICK_TO_FRONT);
     window_title_command_editor_widgets[WIDX_TEXTBOX_FULL].string = textbox1Buffer;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -122,36 +122,22 @@ static TITLE_COMMAND_ORDER get_command_info(int32_t index);
 static TileCoordsXY get_location();
 static uint8_t get_zoom();
 
-static rct_window_event_list window_title_command_editor_events = {
-    window_title_command_editor_close,
-    window_title_command_editor_mouseup,
-    nullptr,
-    window_title_command_editor_mousedown,
-    window_title_command_editor_dropdown,
-    nullptr,
-    window_title_command_editor_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_command_editor_tool_down,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_command_editor_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_command_editor_invalidate,
-    window_title_command_editor_paint,
-    nullptr
-};
+static rct_window_event_list window_title_command_editor_events = {};
+
+static void window_title_command_editor_events_init()
+{
+    auto& events = window_title_command_editor_events;
+
+    events.close = window_title_command_editor_close;
+    events.mouse_up = window_title_command_editor_mouseup;
+    events.mouse_down = window_title_command_editor_mousedown;
+    events.dropdown = window_title_command_editor_dropdown;
+    events.update = window_title_command_editor_update;
+    events.tool_down = window_title_command_editor_tool_down;
+    events.text_input = window_title_command_editor_textinput;
+    events.invalidate = window_title_command_editor_invalidate;
+    events.paint = window_title_command_editor_paint;
+}
 // clang-format on
 
 static void scenario_select_callback(const utf8* path)
@@ -230,6 +216,7 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
     if (window_find_by_class(WC_TITLE_COMMAND_EDITOR) != nullptr)
         return;
 
+    window_title_command_editor_events_init();
     rct_window* window = window_create_centred(
         WW, WH, &window_title_command_editor_events, WC_TITLE_COMMAND_EDITOR, WF_STICK_TO_FRONT);
     window_title_command_editor_widgets[WIDX_TEXTBOX_FULL].string = textbox1Buffer;

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -62,26 +62,22 @@ static bool window_title_editor_check_can_edit();
 static void window_title_editor_add_park_callback(int32_t result, const utf8 * path);
 static void window_title_editor_rename_park(size_t index, const utf8 * name);
 
-static rct_window_event_list window_title_editor_events = {};
-
-static void window_title_editor_events_init()
+static rct_window_event_list window_title_editor_events([](auto& events)
 {
-    auto& events = window_title_editor_events;
-
-    events.close = window_title_editor_close;
-    events.mouse_up = window_title_editor_mouseup;
-    events.resize = window_title_editor_resize;
-    events.mouse_down = window_title_editor_mousedown;
-    events.dropdown = window_title_editor_dropdown;
-    events.update = window_title_editor_update;
-    events.get_scroll_size = window_title_editor_scrollgetsize;
-    events.scroll_mousedown = window_title_editor_scrollmousedown;
-    events.scroll_mouseover = window_title_editor_scrollmouseover;
-    events.text_input = window_title_editor_textinput;
-    events.invalidate = window_title_editor_invalidate;
-    events.paint = window_title_editor_paint;
-    events.scroll_paint = window_title_editor_scrollpaint;
-}
+    events.close = &window_title_editor_close;
+    events.mouse_up = &window_title_editor_mouseup;
+    events.resize = &window_title_editor_resize;
+    events.mouse_down = &window_title_editor_mousedown;
+    events.dropdown = &window_title_editor_dropdown;
+    events.update = &window_title_editor_update;
+    events.get_scroll_size = &window_title_editor_scrollgetsize;
+    events.scroll_mousedown = &window_title_editor_scrollmousedown;
+    events.scroll_mouseover = &window_title_editor_scrollmouseover;
+    events.text_input = &window_title_editor_textinput;
+    events.invalidate = &window_title_editor_invalidate;
+    events.paint = &window_title_editor_paint;
+    events.scroll_paint = &window_title_editor_scrollpaint;
+});
 
 enum WINDOW_TITLE_EDITOR_WIDGET_IDX {
     WIDX_TITLE_EDITOR_BACKGROUND,
@@ -213,7 +209,6 @@ void window_title_editor_open(int32_t tab)
     if (_selectedTitleSequence == SIZE_MAX)
         _selectedTitleSequence = title_get_config_sequence();
 
-    window_title_editor_events_init();
     window = window_create_auto_pos(WW, WH2, &window_title_editor_events, WC_TITLE_EDITOR, WF_10 | WF_RESIZABLE);
     window->widgets = window_title_editor_widgets;
     window->enabled_widgets = (1 << WIDX_TITLE_EDITOR_CLOSE) | (1 << WIDX_TITLE_EDITOR_PRESETS_TAB)

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -62,36 +62,26 @@ static bool window_title_editor_check_can_edit();
 static void window_title_editor_add_park_callback(int32_t result, const utf8 * path);
 static void window_title_editor_rename_park(size_t index, const utf8 * name);
 
-static rct_window_event_list window_title_editor_events = {
-    window_title_editor_close,
-    window_title_editor_mouseup,
-    window_title_editor_resize,
-    window_title_editor_mousedown,
-    window_title_editor_dropdown,
-    nullptr,
-    window_title_editor_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_editor_scrollgetsize,
-    window_title_editor_scrollmousedown,
-    nullptr,
-    window_title_editor_scrollmouseover,
-    window_title_editor_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_editor_invalidate,
-    window_title_editor_paint,
-    window_title_editor_scrollpaint,
-};
+static rct_window_event_list window_title_editor_events = {};
+
+static void window_title_editor_events_init()
+{
+    auto& events = window_title_editor_events;
+
+    events.close = window_title_editor_close;
+    events.mouse_up = window_title_editor_mouseup;
+    events.resize = window_title_editor_resize;
+    events.mouse_down = window_title_editor_mousedown;
+    events.dropdown = window_title_editor_dropdown;
+    events.update = window_title_editor_update;
+    events.get_scroll_size = window_title_editor_scrollgetsize;
+    events.scroll_mousedown = window_title_editor_scrollmousedown;
+    events.scroll_mouseover = window_title_editor_scrollmouseover;
+    events.text_input = window_title_editor_textinput;
+    events.invalidate = window_title_editor_invalidate;
+    events.paint = window_title_editor_paint;
+    events.scroll_paint = window_title_editor_scrollpaint;
+}
 
 enum WINDOW_TITLE_EDITOR_WIDGET_IDX {
     WIDX_TITLE_EDITOR_BACKGROUND,
@@ -223,6 +213,7 @@ void window_title_editor_open(int32_t tab)
     if (_selectedTitleSequence == SIZE_MAX)
         _selectedTitleSequence = title_get_config_sequence();
 
+    window_title_editor_events_init();
     window = window_create_auto_pos(WW, WH2, &window_title_editor_events, WC_TITLE_EDITOR, WF_10 | WF_RESIZABLE);
     window->widgets = window_title_editor_widgets;
     window->enabled_widgets = (1 << WIDX_TITLE_EDITOR_CLOSE) | (1 << WIDX_TITLE_EDITOR_PRESETS_TAB)

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -28,36 +28,15 @@ static rct_widget window_title_exit_widgets[] = {
 static void window_title_exit_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_title_exit_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 
-static rct_window_event_list window_title_exit_events = {
-    nullptr,
-    window_title_exit_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_exit_paint,
-    nullptr
-};
+static rct_window_event_list window_title_exit_events = {};
+
+static void window_title_exit_events_init()
+{
+    auto& events = window_title_exit_events;
+
+    events.mouse_up = window_title_exit_mouseup;
+    events.paint = window_title_exit_paint;
+}
 // clang-format on
 
 /**
@@ -68,6 +47,7 @@ rct_window* window_title_exit_open()
 {
     rct_window* window;
 
+    window_title_exit_events_init();
     window = window_create(
         ScreenCoordsXY(context_get_width() - 40, context_get_height() - 64), 40, 64, &window_title_exit_events, WC_TITLE_EXIT,
         WF_STICK_TO_BACK | WF_TRANSPARENT);

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -28,15 +28,11 @@ static rct_widget window_title_exit_widgets[] = {
 static void window_title_exit_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_title_exit_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 
-static rct_window_event_list window_title_exit_events = {};
-
-static void window_title_exit_events_init()
+static rct_window_event_list window_title_exit_events([](auto& events)
 {
-    auto& events = window_title_exit_events;
-
-    events.mouse_up = window_title_exit_mouseup;
-    events.paint = window_title_exit_paint;
-}
+    events.mouse_up = &window_title_exit_mouseup;
+    events.paint = &window_title_exit_paint;
+});
 // clang-format on
 
 /**
@@ -47,7 +43,6 @@ rct_window* window_title_exit_open()
 {
     rct_window* window;
 
-    window_title_exit_events_init();
     window = window_create(
         ScreenCoordsXY(context_get_width() - 40, context_get_height() - 64), 40, 64, &window_title_exit_events, WC_TITLE_EXIT,
         WF_STICK_TO_BACK | WF_TRANSPARENT);

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -31,36 +31,15 @@ static void window_title_menu_mouseup(rct_window* w, rct_widgetindex widgetIndex
 static void window_title_logo_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
 // clang-format off
-static rct_window_event_list window_title_logo_events = {
-    nullptr,
-    window_title_menu_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_logo_paint,
-    nullptr
-};
+static rct_window_event_list window_title_logo_events = {};
+
+static void window_title_logo_events_init()
+{
+    auto& events = window_title_logo_events;
+
+    events.mouse_up = window_title_menu_mouseup;
+    events.paint = window_title_logo_paint;
+}
 // clang-format on
 
 /**
@@ -69,6 +48,7 @@ static rct_window_event_list window_title_logo_events = {
  */
 rct_window* window_title_logo_open()
 {
+    window_title_logo_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), WW, WH, &window_title_logo_events, WC_TITLE_LOGO, WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_logo_widgets;

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -31,15 +31,11 @@ static void window_title_menu_mouseup(rct_window* w, rct_widgetindex widgetIndex
 static void window_title_logo_paint(rct_window* w, rct_drawpixelinfo* dpi);
 
 // clang-format off
-static rct_window_event_list window_title_logo_events = {};
-
-static void window_title_logo_events_init()
+static rct_window_event_list window_title_logo_events([](auto& events)
 {
-    auto& events = window_title_logo_events;
-
-    events.mouse_up = window_title_menu_mouseup;
-    events.paint = window_title_logo_paint;
-}
+    events.mouse_up = &window_title_menu_mouseup;
+    events.paint = &window_title_logo_paint;
+});
 // clang-format on
 
 /**
@@ -48,7 +44,6 @@ static void window_title_logo_events_init()
  */
 rct_window* window_title_logo_open()
 {
-    window_title_logo_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), WW, WH, &window_title_logo_events, WC_TITLE_LOGO, WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_logo_widgets;

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -51,19 +51,15 @@ static void window_title_menu_cursor(rct_window *w, rct_widgetindex widgetIndex,
 static void window_title_menu_invalidate(rct_window *w);
 static void window_title_menu_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_title_menu_events = {};
-
-static void window_title_menu_events_init()
+static rct_window_event_list window_title_menu_events([](auto& events)
 {
-    auto& events = window_title_menu_events;
-
-    events.mouse_up = window_title_menu_mouseup;
-    events.mouse_down = window_title_menu_mousedown;
-    events.dropdown = window_title_menu_dropdown;
-    events.cursor = window_title_menu_cursor;
-    events.invalidate = window_title_menu_invalidate;
-    events.paint = window_title_menu_paint;
-}
+    events.mouse_up = &window_title_menu_mouseup;
+    events.mouse_down = &window_title_menu_mousedown;
+    events.dropdown = &window_title_menu_dropdown;
+    events.cursor = &window_title_menu_cursor;
+    events.invalidate = &window_title_menu_invalidate;
+    events.paint = &window_title_menu_paint;
+});
 // clang-format on
 
 /**
@@ -75,7 +71,6 @@ rct_window* window_title_menu_open()
     rct_window* window;
 
     const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
-    window_title_menu_events_init();
     window = window_create(
         ScreenCoordsXY(0, context_get_height() - 182), 0, windowHeight, &window_title_menu_events, WC_TITLE_MENU,
         WF_STICK_TO_BACK | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -51,36 +51,19 @@ static void window_title_menu_cursor(rct_window *w, rct_widgetindex widgetIndex,
 static void window_title_menu_invalidate(rct_window *w);
 static void window_title_menu_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_title_menu_events = {
-    nullptr,
-    window_title_menu_mouseup,
-    nullptr,
-    window_title_menu_mousedown,
-    window_title_menu_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_menu_cursor,
-    nullptr,
-    window_title_menu_invalidate,
-    window_title_menu_paint,
-    nullptr
-};
+static rct_window_event_list window_title_menu_events = {};
+
+static void window_title_menu_events_init()
+{
+    auto& events = window_title_menu_events;
+
+    events.mouse_up = window_title_menu_mouseup;
+    events.mouse_down = window_title_menu_mousedown;
+    events.dropdown = window_title_menu_dropdown;
+    events.cursor = window_title_menu_cursor;
+    events.invalidate = window_title_menu_invalidate;
+    events.paint = window_title_menu_paint;
+}
 // clang-format on
 
 /**
@@ -92,6 +75,7 @@ rct_window* window_title_menu_open()
     rct_window* window;
 
     const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
+    window_title_menu_events_init();
     window = window_create(
         ScreenCoordsXY(0, context_get_height() - 182), 0, windowHeight, &window_title_menu_events, WC_TITLE_MENU,
         WF_STICK_TO_BACK | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -27,36 +27,15 @@ static rct_widget window_title_options_widgets[] = {
 static void window_title_options_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_title_options_events = {
-    nullptr,
-    window_title_options_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_title_options_paint,
-    nullptr
-};
+static rct_window_event_list window_title_options_events = {};
+
+static void window_title_options_events_init()
+{
+    auto& events = window_title_options_events;
+
+    events.mouse_up = window_title_options_mouseup;
+    events.paint = window_title_options_paint;
+}
 // clang-format on
 
 /**
@@ -64,6 +43,7 @@ static rct_window_event_list window_title_options_events = {
  */
 rct_window* window_title_options_open()
 {
+    window_title_options_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(context_get_width() - 80, 0), 80, 15, &window_title_options_events, WC_TITLE_OPTIONS,
         WF_STICK_TO_BACK | WF_TRANSPARENT);

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -27,15 +27,11 @@ static rct_widget window_title_options_widgets[] = {
 static void window_title_options_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_options_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_title_options_events = {};
-
-static void window_title_options_events_init()
+static rct_window_event_list window_title_options_events([](auto& events)
 {
-    auto& events = window_title_options_events;
-
-    events.mouse_up = window_title_options_mouseup;
-    events.paint = window_title_options_paint;
-}
+    events.mouse_up = &window_title_options_mouseup;
+    events.paint = &window_title_options_paint;
+});
 // clang-format on
 
 /**
@@ -43,7 +39,6 @@ static void window_title_options_events_init()
  */
 rct_window* window_title_options_open()
 {
-    window_title_options_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(context_get_width() - 80, 0), 80, 15, &window_title_options_events, WC_TITLE_OPTIONS,
         WF_STICK_TO_BACK | WF_TRANSPARENT);

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -28,15 +28,11 @@ static rct_widget window_tooltip_widgets[] = {
 static void window_tooltip_update(rct_window *w);
 static void window_tooltip_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_tooltip_events = {};
-
-static void window_tooltip_events_init()
+static rct_window_event_list window_tooltip_events([](auto& events)
 {
-    auto& events = window_tooltip_events;
-
-    events.update = window_tooltip_update;
-    events.paint = window_tooltip_paint;
-}
+    events.update = &window_tooltip_update;
+    events.paint = &window_tooltip_paint;
+});
 // clang-format on
 
 static utf8 _tooltipText[sizeof(gCommonStringFormatBuffer)];
@@ -99,7 +95,6 @@ void window_tooltip_show(rct_string_id id, ScreenCoordsXY screenCoords)
         screenCoords.y -= height + 40;
     screenCoords.y = std::clamp(screenCoords.y, 22, max_y);
 
-    window_tooltip_events_init();
     w = window_create(screenCoords, width, height, &window_tooltip_events, WC_TOOLTIP, WF_TRANSPARENT | WF_STICK_TO_FRONT);
     w->widgets = window_tooltip_widgets;
 

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -28,36 +28,15 @@ static rct_widget window_tooltip_widgets[] = {
 static void window_tooltip_update(rct_window *w);
 static void window_tooltip_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_tooltip_events = {
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_tooltip_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_tooltip_paint,
-    nullptr
-};
+static rct_window_event_list window_tooltip_events = {};
+
+static void window_tooltip_events_init()
+{
+    auto& events = window_tooltip_events;
+
+    events.update = window_tooltip_update;
+    events.paint = window_tooltip_paint;
+}
 // clang-format on
 
 static utf8 _tooltipText[sizeof(gCommonStringFormatBuffer)];
@@ -120,6 +99,7 @@ void window_tooltip_show(rct_string_id id, ScreenCoordsXY screenCoords)
         screenCoords.y -= height + 40;
     screenCoords.y = std::clamp(screenCoords.y, 22, max_y);
 
+    window_tooltip_events_init();
     w = window_create(screenCoords, width, height, &window_tooltip_events, WC_TOOLTIP, WF_TRANSPARENT | WF_STICK_TO_FRONT);
     w->widgets = window_tooltip_widgets;
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -270,23 +270,19 @@ static void window_top_toolbar_tool_abort(rct_window *w, rct_widgetindex widgetI
 static void window_top_toolbar_invalidate(rct_window *w);
 static void window_top_toolbar_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_top_toolbar_events = {};
-
-static void window_top_toolbar_events_init()
+static rct_window_event_list window_top_toolbar_events([](auto& events)
 {
-    auto& events = window_top_toolbar_events;
-
-    events.mouse_up = window_top_toolbar_mouseup;
-    events.mouse_down = window_top_toolbar_mousedown;
-    events.dropdown = window_top_toolbar_dropdown;
-    events.tool_update = window_top_toolbar_tool_update;
-    events.tool_down = window_top_toolbar_tool_down;
-    events.tool_drag = window_top_toolbar_tool_drag;
-    events.tool_up = window_top_toolbar_tool_up;
-    events.tool_abort = window_top_toolbar_tool_abort;
-    events.invalidate = window_top_toolbar_invalidate;
-    events.paint = window_top_toolbar_paint;
-}
+    events.mouse_up = &window_top_toolbar_mouseup;
+    events.mouse_down = &window_top_toolbar_mousedown;
+    events.dropdown = &window_top_toolbar_dropdown;
+    events.tool_update = &window_top_toolbar_tool_update;
+    events.tool_down = &window_top_toolbar_tool_down;
+    events.tool_drag = &window_top_toolbar_tool_drag;
+    events.tool_up = &window_top_toolbar_tool_up;
+    events.tool_abort = &window_top_toolbar_tool_abort;
+    events.invalidate = &window_top_toolbar_invalidate;
+    events.paint = &window_top_toolbar_paint;
+});
 // clang-format on
 
 static void top_toolbar_init_view_menu(rct_window* window, rct_widget* widget);
@@ -328,7 +324,6 @@ static colour_t _tertiaryColour;
  */
 rct_window* window_top_toolbar_open()
 {
-    window_top_toolbar_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), context_get_width(), TOP_TOOLBAR_HEIGHT + 1, &window_top_toolbar_events, WC_TOP_TOOLBAR,
         WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -270,36 +270,23 @@ static void window_top_toolbar_tool_abort(rct_window *w, rct_widgetindex widgetI
 static void window_top_toolbar_invalidate(rct_window *w);
 static void window_top_toolbar_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_top_toolbar_events = {
-    nullptr,
-    window_top_toolbar_mouseup,
-    nullptr,
-    window_top_toolbar_mousedown,
-    window_top_toolbar_dropdown,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_top_toolbar_tool_update,
-    window_top_toolbar_tool_down,
-    window_top_toolbar_tool_drag,
-    window_top_toolbar_tool_up,
-    window_top_toolbar_tool_abort,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_top_toolbar_invalidate,
-    window_top_toolbar_paint,
-    nullptr
-};
+static rct_window_event_list window_top_toolbar_events = {};
+
+static void window_top_toolbar_events_init()
+{
+    auto& events = window_top_toolbar_events;
+
+    events.mouse_up = window_top_toolbar_mouseup;
+    events.mouse_down = window_top_toolbar_mousedown;
+    events.dropdown = window_top_toolbar_dropdown;
+    events.tool_update = window_top_toolbar_tool_update;
+    events.tool_down = window_top_toolbar_tool_down;
+    events.tool_drag = window_top_toolbar_tool_drag;
+    events.tool_up = window_top_toolbar_tool_up;
+    events.tool_abort = window_top_toolbar_tool_abort;
+    events.invalidate = window_top_toolbar_invalidate;
+    events.paint = window_top_toolbar_paint;
+}
 // clang-format on
 
 static void top_toolbar_init_view_menu(rct_window* window, rct_widget* widget);
@@ -341,6 +328,7 @@ static colour_t _tertiaryColour;
  */
 rct_window* window_top_toolbar_open()
 {
+    window_top_toolbar_events_init();
     rct_window* window = window_create(
         ScreenCoordsXY(0, 0), context_get_width(), TOP_TOOLBAR_HEIGHT + 1, &window_top_toolbar_events, WC_TOP_TOOLBAR,
         WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -279,12 +279,12 @@ static rct_window_event_list window_top_toolbar_events = {
     nullptr,
     nullptr,
     nullptr,
-    nullptr,                                           // check if editor versions are significantly different...
-    window_top_toolbar_tool_update,                 // editor: 0x0066fB0E
-    window_top_toolbar_tool_down,                   // editor: 0x0066fB5C
-    window_top_toolbar_tool_drag,                   // editor: 0x0066fB37
-    window_top_toolbar_tool_up,                     // editor: 0x0066fC44 (Exactly the same)
-    window_top_toolbar_tool_abort,                  // editor: 0x0066fA74 (Exactly the same)
+    nullptr,
+    window_top_toolbar_tool_update,
+    window_top_toolbar_tool_down,
+    window_top_toolbar_tool_drag,
+    window_top_toolbar_tool_up,
+    window_top_toolbar_tool_abort,
     nullptr,
     nullptr,
     nullptr,

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -61,68 +61,34 @@ static void window_track_delete_prompt_mouseup(rct_window *w, rct_widgetindex wi
 static void window_track_delete_prompt_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x009940EC
-static rct_window_event_list window_track_manage_events = {
-    window_track_manage_close,
-    window_track_manage_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_manage_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_manage_paint,
-    nullptr
-};
+static rct_window_event_list window_track_manage_events = {};
+
+static void window_track_manage_events_init()
+{
+    auto& events = window_track_manage_events;
+
+    events.close = window_track_manage_close;
+    events.mouse_up = window_track_manage_mouseup;
+    events.text_input = window_track_manage_textinput;
+    events.paint = window_track_manage_paint;
+}
 
 // 0x0099415C
-static rct_window_event_list window_track_delete_prompt_events = {
-    nullptr,
-    window_track_delete_prompt_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_delete_prompt_paint,
-    nullptr
-};
+static rct_window_event_list window_track_delete_prompt_events = {};
+
+static void window_track_delete_prompt_events_init()
+{
+    auto& events = window_track_delete_prompt_events;
+
+    events.mouse_up = window_track_delete_prompt_mouseup;
+    events.paint = window_track_delete_prompt_paint;
+}
+
+static void window_track_events_init_all()
+{
+    window_track_manage_events_init();
+    window_track_delete_prompt_events_init();
+}
 // clang-format on
 
 #pragma endregion
@@ -140,6 +106,7 @@ rct_window* window_track_manage_open(track_design_file_ref* tdFileRef)
 {
     window_close_by_class(WC_MANAGE_TRACK_DESIGN);
 
+    window_track_events_init_all();
     rct_window* w = window_create_centred(
         250, 44, &window_track_manage_events, WC_MANAGE_TRACK_DESIGN, WF_STICK_TO_FRONT | WF_TRANSPARENT);
     w->widgets = window_track_manage_widgets;
@@ -247,6 +214,7 @@ static void window_track_delete_prompt_open()
 
     int32_t screenWidth = context_get_width();
     int32_t screenHeight = context_get_height();
+    window_track_events_init_all();
     rct_window* w = window_create(
         ScreenCoordsXY(std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - 250) / 2), (screenHeight - 44) / 2), 250, 74,
         &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -61,34 +61,20 @@ static void window_track_delete_prompt_mouseup(rct_window *w, rct_widgetindex wi
 static void window_track_delete_prompt_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 // 0x009940EC
-static rct_window_event_list window_track_manage_events = {};
-
-static void window_track_manage_events_init()
+static rct_window_event_list window_track_manage_events([](auto& events)
 {
-    auto& events = window_track_manage_events;
-
-    events.close = window_track_manage_close;
-    events.mouse_up = window_track_manage_mouseup;
-    events.text_input = window_track_manage_textinput;
-    events.paint = window_track_manage_paint;
-}
+    events.close = &window_track_manage_close;
+    events.mouse_up = &window_track_manage_mouseup;
+    events.text_input = &window_track_manage_textinput;
+    events.paint = &window_track_manage_paint;
+});
 
 // 0x0099415C
-static rct_window_event_list window_track_delete_prompt_events = {};
-
-static void window_track_delete_prompt_events_init()
+static rct_window_event_list window_track_delete_prompt_events([](auto& events)
 {
-    auto& events = window_track_delete_prompt_events;
-
-    events.mouse_up = window_track_delete_prompt_mouseup;
-    events.paint = window_track_delete_prompt_paint;
-}
-
-static void window_track_events_init_all()
-{
-    window_track_manage_events_init();
-    window_track_delete_prompt_events_init();
-}
+    events.mouse_up = &window_track_delete_prompt_mouseup;
+    events.paint = &window_track_delete_prompt_paint;
+});
 // clang-format on
 
 #pragma endregion
@@ -106,7 +92,6 @@ rct_window* window_track_manage_open(track_design_file_ref* tdFileRef)
 {
     window_close_by_class(WC_MANAGE_TRACK_DESIGN);
 
-    window_track_events_init_all();
     rct_window* w = window_create_centred(
         250, 44, &window_track_manage_events, WC_MANAGE_TRACK_DESIGN, WF_STICK_TO_FRONT | WF_TRANSPARENT);
     w->widgets = window_track_manage_widgets;
@@ -214,7 +199,6 @@ static void window_track_delete_prompt_open()
 
     int32_t screenWidth = context_get_width();
     int32_t screenHeight = context_get_height();
-    window_track_events_init_all();
     rct_window* w = window_create(
         ScreenCoordsXY(std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - 250) / 2), (screenHeight - 44) / 2), 250, 74,
         &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -79,22 +79,18 @@ static void window_track_place_unknown14(rct_window *w);
 static void window_track_place_invalidate(rct_window *w);
 static void window_track_place_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_track_place_events = {};
-
-static void window_track_place_events_init()
+static rct_window_event_list window_track_place_events([](auto& events)
 {
-    auto& events = window_track_place_events;
-
-    events.close = window_track_place_close;
-    events.mouse_up = window_track_place_mouseup;
-    events.update = window_track_place_update;
-    events.tool_update = window_track_place_toolupdate;
-    events.tool_down = window_track_place_tooldown;
-    events.tool_abort = window_track_place_toolabort;
-    events.viewport_rotate = window_track_place_unknown14;
-    events.invalidate = window_track_place_invalidate;
-    events.paint = window_track_place_paint;
-}
+    events.close = &window_track_place_close;
+    events.mouse_up = &window_track_place_mouseup;
+    events.update = &window_track_place_update;
+    events.tool_update = &window_track_place_toolupdate;
+    events.tool_down = &window_track_place_tooldown;
+    events.tool_abort = &window_track_place_toolabort;
+    events.viewport_rotate = &window_track_place_unknown14;
+    events.invalidate = &window_track_place_invalidate;
+    events.paint = &window_track_place_paint;
+});
 // clang-format on
 
 static std::vector<uint8_t> _window_track_place_mini_preview;
@@ -146,7 +142,6 @@ rct_window* window_track_place_open(const track_design_file_ref* tdFileRef)
 
     _window_track_place_mini_preview.resize(TRACK_MINI_PREVIEW_SIZE);
 
-    window_track_place_events_init();
     rct_window* w = window_create(ScreenCoordsXY(0, 29), 200, 124, &window_track_place_events, WC_TRACK_DESIGN_PLACE, 0);
     w->widgets = window_track_place_widgets;
     w->enabled_widgets = 1 << WIDX_CLOSE | 1 << WIDX_ROTATE | 1 << WIDX_MIRROR | 1 << WIDX_SELECT_DIFFERENT_DESIGN;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -79,36 +79,22 @@ static void window_track_place_unknown14(rct_window *w);
 static void window_track_place_invalidate(rct_window *w);
 static void window_track_place_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_track_place_events = {
-    window_track_place_close,
-    window_track_place_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_place_update,
-    nullptr,
-    nullptr,
-    window_track_place_toolupdate,
-    window_track_place_tooldown,
-    nullptr,
-    nullptr,
-    window_track_place_toolabort,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_place_unknown14,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_place_invalidate,
-    window_track_place_paint,
-    nullptr
-};
+static rct_window_event_list window_track_place_events = {};
+
+static void window_track_place_events_init()
+{
+    auto& events = window_track_place_events;
+
+    events.close = window_track_place_close;
+    events.mouse_up = window_track_place_mouseup;
+    events.update = window_track_place_update;
+    events.tool_update = window_track_place_toolupdate;
+    events.tool_down = window_track_place_tooldown;
+    events.tool_abort = window_track_place_toolabort;
+    events.viewport_rotate = window_track_place_unknown14;
+    events.invalidate = window_track_place_invalidate;
+    events.paint = window_track_place_paint;
+}
 // clang-format on
 
 static std::vector<uint8_t> _window_track_place_mini_preview;
@@ -160,6 +146,7 @@ rct_window* window_track_place_open(const track_design_file_ref* tdFileRef)
 
     _window_track_place_mini_preview.resize(TRACK_MINI_PREVIEW_SIZE);
 
+    window_track_place_events_init();
     rct_window* w = window_create(ScreenCoordsXY(0, 29), 200, 124, &window_track_place_events, WC_TRACK_DESIGN_PLACE, 0);
     w->widgets = window_track_place_widgets;
     w->enabled_widgets = 1 << WIDX_CLOSE | 1 << WIDX_ROTATE | 1 << WIDX_MIRROR | 1 << WIDX_SELECT_DIFFERENT_DESIGN;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -67,23 +67,19 @@ static void window_track_list_invalidate(rct_window *w);
 static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_track_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_track_list_events = {};
-
-static void window_track_list_events_init()
+static rct_window_event_list window_track_list_events([](auto& events)
 {
-    auto& events = window_track_list_events;
-
-    events.close = window_track_list_close;
-    events.mouse_up = window_track_list_mouseup;
-    events.update = window_track_list_update;
-    events.get_scroll_size = window_track_list_scrollgetsize;
-    events.scroll_mousedown = window_track_list_scrollmousedown;
-    events.scroll_mouseover = window_track_list_scrollmouseover;
-    events.text_input = window_track_list_textinput;
-    events.invalidate = window_track_list_invalidate;
-    events.paint = window_track_list_paint;
-    events.scroll_paint = window_track_list_scrollpaint;
-}
+    events.close = &window_track_list_close;
+    events.mouse_up = &window_track_list_mouseup;
+    events.update = &window_track_list_update;
+    events.get_scroll_size = &window_track_list_scrollgetsize;
+    events.scroll_mousedown = &window_track_list_scrollmousedown;
+    events.scroll_mouseover = &window_track_list_scrollmouseover;
+    events.text_input = &window_track_list_textinput;
+    events.invalidate = &window_track_list_invalidate;
+    events.paint = &window_track_list_paint;
+    events.scroll_paint = &window_track_list_scrollpaint;
+});
 // clang-format on
 
 constexpr uint16_t TRACK_DESIGN_INDEX_UNLOADED = UINT16_MAX;
@@ -124,7 +120,6 @@ rct_window* window_track_list_open(RideSelection item)
         screenPos = { 0, TOP_TOOLBAR_HEIGHT + 2 };
     }
 
-    window_track_list_events_init();
     rct_window* w = window_create(screenPos, 600, 432, &window_track_list_events, WC_TRACK_DESIGN_LIST, 0);
 
     window_track_list_widgets[WIDX_FILTER_STRING].string = _filterString;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -67,36 +67,23 @@ static void window_track_list_invalidate(rct_window *w);
 static void window_track_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_track_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static rct_window_event_list window_track_list_events = {
-    window_track_list_close,
-    window_track_list_mouseup,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_list_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_list_scrollgetsize,
-    window_track_list_scrollmousedown,
-    nullptr,
-    window_track_list_scrollmouseover,
-    window_track_list_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_track_list_invalidate,
-    window_track_list_paint,
-    window_track_list_scrollpaint
-};
+static rct_window_event_list window_track_list_events = {};
+
+static void window_track_list_events_init()
+{
+    auto& events = window_track_list_events;
+
+    events.close = window_track_list_close;
+    events.mouse_up = window_track_list_mouseup;
+    events.update = window_track_list_update;
+    events.get_scroll_size = window_track_list_scrollgetsize;
+    events.scroll_mousedown = window_track_list_scrollmousedown;
+    events.scroll_mouseover = window_track_list_scrollmouseover;
+    events.text_input = window_track_list_textinput;
+    events.invalidate = window_track_list_invalidate;
+    events.paint = window_track_list_paint;
+    events.scroll_paint = window_track_list_scrollpaint;
+}
 // clang-format on
 
 constexpr uint16_t TRACK_DESIGN_INDEX_UNLOADED = UINT16_MAX;
@@ -137,6 +124,7 @@ rct_window* window_track_list_open(RideSelection item)
         screenPos = { 0, TOP_TOOLBAR_HEIGHT + 2 };
     }
 
+    window_track_list_events_init();
     rct_window* w = window_create(screenPos, 600, 432, &window_track_list_events, WC_TRACK_DESIGN_LIST, 0);
 
     window_track_list_widgets[WIDX_FILTER_STRING].string = _filterString;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -89,24 +89,20 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi);
 static void window_view_clipping_scrollgetsize(rct_window* w, int scrollIndex, int* width, int* height);
 static void window_view_clipping_close();
 
-static rct_window_event_list window_view_clipping_events = {};
-
-static void window_view_clipping_events_init()
+static rct_window_event_list window_view_clipping_events([](auto& events)
 {
-    auto& events = window_view_clipping_events;
-
-    events.close = window_view_clipping_close_button;
-    events.mouse_up = window_view_clipping_mouseup;
-    events.mouse_down = window_view_clipping_mousedown;
-    events.update = window_view_clipping_update;
-    events.tool_update = window_view_clipping_tool_update;
-    events.tool_down = window_view_clipping_tool_down;
-    events.tool_drag = window_view_clipping_tool_drag;
-    events.tool_up = window_view_clipping_tool_up;
-    events.get_scroll_size = window_view_clipping_scrollgetsize;
-    events.invalidate = window_view_clipping_invalidate;
-    events.paint = window_view_clipping_paint;
-}
+    events.close = &window_view_clipping_close_button;
+    events.mouse_up = &window_view_clipping_mouseup;
+    events.mouse_down = &window_view_clipping_mousedown;
+    events.update = &window_view_clipping_update;
+    events.tool_update = &window_view_clipping_tool_update;
+    events.tool_down = &window_view_clipping_tool_down;
+    events.tool_drag = &window_view_clipping_tool_drag;
+    events.tool_up = &window_view_clipping_tool_up;
+    events.get_scroll_size = &window_view_clipping_scrollgetsize;
+    events.invalidate = &window_view_clipping_invalidate;
+    events.paint = &window_view_clipping_paint;
+});
 // clang-format on
 
 #pragma endregion
@@ -134,7 +130,6 @@ rct_window* window_view_clipping_open()
     }
 
     // Window is not open - create it.
-    window_view_clipping_events_init();
     window = window_create(ScreenCoordsXY(32, 32), WW, WH, &window_view_clipping_events, WC_VIEW_CLIPPING, 0);
     window->widgets = window_view_clipping_widgets;
     window->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_CLIP_CHECKBOX_ENABLE) | (1ULL << WIDX_CLIP_HEIGHT_VALUE)

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -89,36 +89,24 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi);
 static void window_view_clipping_scrollgetsize(rct_window* w, int scrollIndex, int* width, int* height);
 static void window_view_clipping_close();
 
-static rct_window_event_list window_view_clipping_events = {
-    window_view_clipping_close_button,
-    window_view_clipping_mouseup,
-    nullptr,
-    window_view_clipping_mousedown,
-    nullptr,
-    nullptr,
-    window_view_clipping_update,
-    nullptr,
-    nullptr,
-    window_view_clipping_tool_update,
-    window_view_clipping_tool_down,
-    window_view_clipping_tool_drag,
-    window_view_clipping_tool_up,
-    nullptr,
-    nullptr,
-    window_view_clipping_scrollgetsize,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_view_clipping_invalidate,
-    window_view_clipping_paint,
-    nullptr
-};
+static rct_window_event_list window_view_clipping_events = {};
+
+static void window_view_clipping_events_init()
+{
+    auto& events = window_view_clipping_events;
+
+    events.close = window_view_clipping_close_button;
+    events.mouse_up = window_view_clipping_mouseup;
+    events.mouse_down = window_view_clipping_mousedown;
+    events.update = window_view_clipping_update;
+    events.tool_update = window_view_clipping_tool_update;
+    events.tool_down = window_view_clipping_tool_down;
+    events.tool_drag = window_view_clipping_tool_drag;
+    events.tool_up = window_view_clipping_tool_up;
+    events.get_scroll_size = window_view_clipping_scrollgetsize;
+    events.invalidate = window_view_clipping_invalidate;
+    events.paint = window_view_clipping_paint;
+}
 // clang-format on
 
 #pragma endregion
@@ -146,6 +134,7 @@ rct_window* window_view_clipping_open()
     }
 
     // Window is not open - create it.
+    window_view_clipping_events_init();
     window = window_create(ScreenCoordsXY(32, 32), WW, WH, &window_view_clipping_events, WC_VIEW_CLIPPING, 0);
     window->widgets = window_view_clipping_widgets;
     window->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_CLIP_CHECKBOX_ENABLE) | (1ULL << WIDX_CLIP_HEIGHT_VALUE)

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -47,18 +47,14 @@ static void window_viewport_update(rct_window *w);
 static void window_viewport_invalidate(rct_window *w);
 static void window_viewport_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_viewport_events = {};
-
-static void window_viewport_events_init()
+static rct_window_event_list window_viewport_events([](auto& events)
 {
-    auto& events = window_viewport_events;
-
-    events.mouse_up = window_viewport_mouseup;
-    events.resize = window_viewport_resize;
-    events.update = window_viewport_update;
-    events.invalidate = window_viewport_invalidate;
-    events.paint = window_viewport_paint;
-}
+    events.mouse_up = &window_viewport_mouseup;
+    events.resize = &window_viewport_resize;
+    events.update = &window_viewport_update;
+    events.invalidate = &window_viewport_invalidate;
+    events.paint = &window_viewport_paint;
+});
 // clang-format on
 
 static int32_t _viewportNumber = 1;
@@ -68,7 +64,6 @@ static int32_t _viewportNumber = 1;
  */
 rct_window* window_viewport_open()
 {
-    window_viewport_events_init();
     rct_window* w = window_create_auto_pos(WW, WH, &window_viewport_events, WC_VIEWPORT, WF_RESIZABLE);
     w->widgets = window_viewport_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_ZOOM_IN) | (1 << WIDX_ZOOM_OUT) | (1 << WIDX_LOCATE);

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -47,36 +47,18 @@ static void window_viewport_update(rct_window *w);
 static void window_viewport_invalidate(rct_window *w);
 static void window_viewport_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
-static rct_window_event_list window_viewport_events = {
-    nullptr,
-    window_viewport_mouseup,
-    window_viewport_resize,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_viewport_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_viewport_invalidate,
-    window_viewport_paint,
-    nullptr
-};
+static rct_window_event_list window_viewport_events = {};
+
+static void window_viewport_events_init()
+{
+    auto& events = window_viewport_events;
+
+    events.mouse_up = window_viewport_mouseup;
+    events.resize = window_viewport_resize;
+    events.update = window_viewport_update;
+    events.invalidate = window_viewport_invalidate;
+    events.paint = window_viewport_paint;
+}
 // clang-format on
 
 static int32_t _viewportNumber = 1;
@@ -86,6 +68,7 @@ static int32_t _viewportNumber = 1;
  */
 rct_window* window_viewport_open()
 {
+    window_viewport_events_init();
     rct_window* w = window_create_auto_pos(WW, WH, &window_viewport_events, WC_VIEWPORT, WF_RESIZABLE);
     w->widgets = window_viewport_widgets;
     w->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_ZOOM_IN) | (1 << WIDX_ZOOM_OUT) | (1 << WIDX_LOCATE);

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -47,36 +47,20 @@ static void window_water_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_water_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_water_inputsize(rct_window *w);
 
-static rct_window_event_list window_water_events = {
-    window_water_close,
-    window_water_mouseup,
-    nullptr,
-    window_water_mousedown,
-    nullptr,
-    nullptr,
-    window_water_update,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_water_textinput,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    window_water_invalidate,
-    window_water_paint,
-    nullptr
-};
+static rct_window_event_list window_water_events = {};
+
+static void window_water_events_init()
+{
+    auto& events = window_water_events;
+
+    events.close = window_water_close;
+    events.mouse_up = window_water_mouseup;
+    events.mouse_down = window_water_mousedown;
+    events.update = window_water_update;
+    events.text_input = window_water_textinput;
+    events.invalidate = window_water_invalidate;
+    events.paint = window_water_paint;
+}
 // clang-format on
 
 /**
@@ -92,6 +76,7 @@ rct_window* window_water_open()
     if (window != nullptr)
         return window;
 
+    window_water_events_init();
     window = window_create(ScreenCoordsXY(context_get_width() - 76, 29), 76, 77, &window_water_events, WC_WATER, 0);
     window->widgets = window_water_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_PREVIEW);

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -47,20 +47,16 @@ static void window_water_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_water_textinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
 static void window_water_inputsize(rct_window *w);
 
-static rct_window_event_list window_water_events = {};
-
-static void window_water_events_init()
+static rct_window_event_list window_water_events([](auto& events)
 {
-    auto& events = window_water_events;
-
-    events.close = window_water_close;
-    events.mouse_up = window_water_mouseup;
-    events.mouse_down = window_water_mousedown;
-    events.update = window_water_update;
-    events.text_input = window_water_textinput;
-    events.invalidate = window_water_invalidate;
-    events.paint = window_water_paint;
-}
+    events.close = &window_water_close;
+    events.mouse_up = &window_water_mouseup;
+    events.mouse_down = &window_water_mousedown;
+    events.update = &window_water_update;
+    events.text_input = &window_water_textinput;
+    events.invalidate = &window_water_invalidate;
+    events.paint = &window_water_paint;
+});
 // clang-format on
 
 /**
@@ -76,7 +72,6 @@ rct_window* window_water_open()
     if (window != nullptr)
         return window;
 
-    window_water_events_init();
     window = window_create(ScreenCoordsXY(context_get_width() - 76, 29), 76, 77, &window_water_events, WC_WATER, 0);
     window->widgets = window_water_widgets;
     window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_PREVIEW);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -241,6 +241,12 @@ struct rct_window_event_list
     void (*invalidate)(struct rct_window*);
     void (*paint)(struct rct_window*, rct_drawpixelinfo*);
     void (*scroll_paint)(struct rct_window*, rct_drawpixelinfo*, int32_t);
+
+    typedef void (*fnEventInitializer)(rct_window_event_list&);
+    rct_window_event_list(fnEventInitializer fn)
+    {
+        fn(*this);
+    }
 };
 
 struct campaign_variables


### PR DESCRIPTION
Currently, the window event list struct only has one (default) constructor, which leads to a bunch of null-pointers having to be set for most windows. It's not obvious which events they represent, which leaves these lists hard to maintain. Unfortunately, we cannot use named initialisers. Therefore, I propose a replacement set of definitions for the event lists using functions, giving them a syntax [similar to OpenLoco](https://github.com/OpenLoco/OpenLoco/blob/9b419912746c1b4930b1165e6dd4c149aeb48704/src/OpenLoco/Windows/Options.cpp#L633-L643).

I generated all of this using [a Python script](https://gist.github.com/AaronVanGeffen/110509418eca7bd22f6fbfb93c1406d3), which hopefully reduces the chance of errors. From brief testing on my end, all appears to work correctly. However, we should test this properly before merging.