### PR TITLE
Fix #12918: Cannot place "Blue Hurricane" (hypercoaster)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,7 +24,7 @@
 - Fix: [#12881] Guests' favourite rides are not listed in the guest window.
 - Fix: [#12910] Plugin API: getRide sometimes returns null for valid ride IDs.
 - Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
-- Fix: [#12918] Cannot place "Blue Hurricane" (hypercoaster).
+- Fix: [#12918] Cannot place vanilla TD6 tracks of the Hypercoasters, Monster Trucks, Classic Mini Roller Coasters, Spinning Wild Mouses and Hyper-Twisters types.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Improved: [#12806] Add Esperanto diacritics to the sprite font.
 - Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,7 +24,7 @@
 - Fix: [#12881] Guests' favourite rides are not listed in the guest window.
 - Fix: [#12910] Plugin API: getRide sometimes returns null for valid ride IDs.
 - Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
-- Fix: [#12918] Cannot place vanilla TD6 tracks of the Hypercoasters, Monster Trucks, Classic Mini Roller Coasters, Spinning Wild Mouses and Hyper-Twisters types.
+- Fix: [#12918] Cannot place vanilla TD6 tracks of the Hypercoaster, Monster Trucks, Classic Mini Roller Coaster, Spinning Wild Mouse and Hyper-Twister types.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Improved: [#12806] Add Esperanto diacritics to the sprite font.
 - Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#12881] Guests' favourite rides are not listed in the guest window.
 - Fix: [#12910] Plugin API: getRide sometimes returns null for valid ride IDs.
 - Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
+- Fix: [#12918] Cannot place "Blue Hurricane" (hypercoaster).
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Improved: [#12806] Add Esperanto diacritics to the sprite font.
 - Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -13,12 +13,18 @@
 #include "../core/MemoryStream.h"
 #include "../core/Path.hpp"
 #include "../core/String.hpp"
+#include "../object/ObjectRepository.h"
+#include "../object/RideObject.h"
 #include "../rct12/SawyerChunkReader.h"
 #include "../rct12/SawyerEncoding.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../ride/TrackDesign.h"
 #include "../ride/TrackDesignRepository.h"
+
+#include <mutex>
+
+static std::mutex _objectLookupMutex;
 
 /**
  * Class to import RollerCoaster Tycoon 2 track designs (*.TD6).
@@ -200,7 +206,29 @@ public:
         }
 
         td->name = _name;
+
+        UpdateRideType(td);
+
         return td;
+    }
+
+    void UpdateRideType(std::unique_ptr<TrackDesign>& td)
+    {
+        if (RCT2RideTypeNeedsConversion(td->type))
+        {
+            std::scoped_lock<std::mutex> lock(_objectLookupMutex);
+            auto* rawObject = object_repository_load_object(&td->vehicle_object);
+            if (rawObject != nullptr)
+            {
+                const auto* rideEntry = static_cast<const rct_ride_entry*>(
+                    static_cast<RideObject*>(rawObject)->GetLegacyData());
+                if (rideEntry != nullptr)
+                {
+                    td->type = RCT2RideTypeToOpenRCT2RideType(td->type, rideEntry);
+                }
+                object_delete(rawObject);
+            }
+        }
     }
 };
 


### PR DESCRIPTION
The track design was recognised as a Corkscrew RC, not as a Hypercoaster. Moved the conversion code from the track design repository to the TD6Importer (where it should have been, really).

This also fixes the issue that Hypercoasters, Monster Trucks, Classic Mini Roller Coasters, Spinning Wild Mouses and Hyper-Twisters placed from a track design have the wrong ride type.