### PR TITLE
Fix #12969: Crash opening ride window with invalid mechanic assigned

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4295,11 +4295,11 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
             }
             else
             {
-                auto peep = GetEntity<Peep>(ride->mechanic)->AsStaff();
-                if (peep != nullptr && peep->IsMechanic())
+                auto staff = GetEntity<Staff>(ride->mechanic);
+                if (staff != nullptr && staff->IsMechanic())
                 {
                     auto ft = Formatter::Common();
-                    peep->FormatNameTo(ft);
+                    staff->FormatNameTo(ft);
                     gfx_draw_string_left_wrapped(
                         dpi, gCommonFormatArgs, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
                 }


### PR DESCRIPTION
Closes #12969