### PR TITLE
Make add_news_item assoc optional

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -158,6 +158,7 @@ The following people are not part of the development team, but have been contrib
 * Tom Parsons (tombomp)
 * Stephan Spengler (Sadret)
 * Roger Seekell (rpstester)
+* Ben Johnston (gsckoco)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#13000] objective_options command for console
 - Fix: [#3200] Close Construction window upon selecting vehicle page
-- Improved: [#13013] Made add_news_item console command last argument, assoc, optional.
+- Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#13000] objective_options command for console
 - Fix: [#3200] Close Construction window upon selecting vehicle page
+- Improved: [#13013] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1661,11 +1661,11 @@ static int32_t cc_assert([[maybe_unused]] InteractiveConsole& console, [[maybe_u
 static int32_t cc_add_news_item([[maybe_unused]] InteractiveConsole& console, [[maybe_unused]] const arguments_t& argv)
 {
     printf("argv.size() = %zu\n", argv.size());
-    if (argv.size() < 3)
+    if (argv.size() < 2)
     {
         console.WriteLineWarning("Too few arguments");
         static_assert(News::ItemTypeCount == 10, "News::ItemType::Count changed, update console command!");
-        console.WriteLine("add_news_item <type> <message> <assoc>");
+        console.WriteLine("add_news_item <type> <message> [assoc]");
         console.WriteLine("type is one of:");
         console.WriteLine("    0 (News::ItemType::Null)");
         console.WriteLine("    1 (News::ItemType::Ride)");
@@ -1678,13 +1678,32 @@ static int32_t cc_add_news_item([[maybe_unused]] InteractiveConsole& console, [[
         console.WriteLine("    8 (News::ItemType::Award)");
         console.WriteLine("    9 (News::ItemType::Graph)");
         console.WriteLine("message is the message to display, wrapped in quotes for multiple words");
-        console.WriteLine("assoc is the associated id of ride/peep/tile/etc.");
+        console.WriteLine("assoc is the associated id of ride/peep/tile/etc. If the selected ItemType doesn't need an assoc "
+                          "(Null, Money, Award, Graph), you can leave this field blank");
         return 1;
     }
+
     auto type = atoi(argv[0].c_str());
     auto msg = argv[1].c_str();
-    auto assoc = atoi(argv[2].c_str());
-    News::AddItemToQueue(static_cast<News::ItemType>(type), msg, assoc);
+    auto assoc = 0;
+
+    News::ItemType itemType = static_cast<News::ItemType>(type);
+
+    if (argv.size() == 3) // 3 arguments passed, set assoc
+    {
+        assoc = atoi(argv[2].c_str());
+    }
+    else
+    {
+        if (News::CheckIfItemRequiresAssoc(itemType))
+        {
+            console.WriteLine("Selected ItemType requires an assoc");
+            return 0;
+        }
+    }
+
+    News::AddItemToQueue(itemType, msg, assoc);
+    console.WriteLine("Successfully added News Item");
     return 0;
 }
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -315,13 +315,32 @@ News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t
     News::Item* newsItem = gNewsItems.FirstOpenOrNewSlot();
     newsItem->Type = type;
     newsItem->Flags = 0;
-    newsItem->Assoc = assoc;
+    newsItem->Assoc = assoc; // Make optional for Award, Money, Graph and Null
     newsItem->Ticks = 0;
     newsItem->MonthYear = static_cast<uint16_t>(gDateMonthsElapsed);
     newsItem->Day = ((days_in_month[date_get_month(newsItem->MonthYear)] * gDateMonthTicks) >> 16) + 1;
     safe_strcpy(newsItem->Text, text, sizeof(newsItem->Text));
 
     return newsItem;
+}
+
+/**
+ * Checks if News::ItemType requires an assoc
+ * @return A boolean if assoc is required.
+ */
+
+bool News::CheckIfItemRequiresAssoc(News::ItemType type)
+{
+    switch (type)
+    {
+        case News::ItemType::Null:
+        case News::ItemType::Award:
+        case News::ItemType::Money:
+        case News::ItemType::Graph:
+            return false;
+        default:
+            return true; // Everything else requires assoc
+    }
 }
 
 /**

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -292,6 +292,8 @@ namespace News
     News::Item* AddItemToQueue(News::ItemType type, rct_string_id string_id, uint32_t assoc, const Formatter& formatter);
     News::Item* AddItemToQueue(News::ItemType type, const utf8* text, uint32_t assoc);
 
+    bool CheckIfItemRequiresAssoc(News::ItemType type);
+
     void OpenSubject(News::ItemType type, int32_t subject);
 
     void DisableNewsItems(News::ItemType type, uint32_t assoc);


### PR DESCRIPTION
Based on issue #12979
Added new method bool `News::CheckIfItemRequiresAssoc(News::ItemType type)`
Also changed the usage output for `add_news_item` to reflect changes.
![image](https://user-images.githubusercontent.com/46426171/94427337-cf4b5c00-0186-11eb-9f79-b62fb2c57036.png)

Remade the pull request because I messed up trying to rebase, newbie mistake.