### PR TITLE
Fix: Not all Junior RC pieces shown with "Show all track pieces" on

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#13000] objective_options command for console.
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
+- Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
@@ -23,7 +23,7 @@ constexpr const RideTypeDescriptor ClassicMiniRollerCoasterRTD =
                                   | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND)
                                   | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES)
                                   | (1ULL << TRACK_BLOCK_BRAKES) | (1ULL << TRACK_BOOSTER)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_ON_RIDE_PHOTO)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TRACK_ELEM_END_STATION),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_junior_rc),

--- a/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
@@ -24,7 +24,7 @@ constexpr const RideTypeDescriptor JuniorRollerCoasterRTD =
                                   | (1ULL << TRACK_SLOPE_LONG) | (1ULL << TRACK_SLOPE_CURVE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL)
                                   | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_BLOCK_BRAKES)
                                   | (1ULL << TRACK_BOOSTER)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_ON_RIDE_PHOTO)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TRACK_ELEM_END_STATION),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_junior_rc),


### PR DESCRIPTION
There is no corresponding issue. It was originally reported here: https://www.reddit.com/r/openrct2/comments/iyuq2j/enable_all_drawable_track_pieces_missing_pieces/