### PR TITLE
Fix #4617: Crash when rotating with invalid viewport open

### DIFF
--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -322,10 +322,7 @@ static void window_sign_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void window_sign_viewport_rotate(rct_window* w)
 {
-    rct_viewport* view = w->viewport;
-    w->viewport = nullptr;
-
-    view->width = 0;
+    w->RemoveViewport();
 
     auto banner = GetBanner(w->number);
 

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -42,3 +42,12 @@ void rct_window::Invalidate()
 {
     gfx_set_dirty_blocks({ windowPos, windowPos + ScreenCoordsXY{ width, height } });
 }
+
+void rct_window::RemoveViewport()
+{
+    if (viewport == nullptr)
+        return;
+
+    viewport->width = 0;
+    viewport = nullptr;
+}

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -94,6 +94,7 @@ struct rct_window
     void SetLocation(const CoordsXYZ& coords);
     void ScrollToViewport();
     void Invalidate();
+    void RemoveViewport();
 };
 
 // rct2: 0x01420078


### PR DESCRIPTION
This fixes the issue described here: https://github.com/OpenRCT2/OpenRCT2/pull/11094#issuecomment-606820960 when clicking on those banners:
![openrct2_2020-09-28_23-39-56](https://user-images.githubusercontent.com/5415177/94483753-03a13580-01e4-11eb-8dba-5f836771d8a7.png)
and then rotating.

The main issue is that the viewport is actually not working correctly with those, this just prevents the crash but the viewport issue remains.