### PR TITLE
Fix #13021: Mowed grass and weeds don't show up

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#12999] .sea (RCT Classic) scenarios are now listed in the “New Scenario” dialog.
 - Feature: [#13000] objective_options command for console.
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
+- Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1044,7 +1044,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         const bool showGridlines = (session->ViewFlags & VIEWPORT_FLAG_GRIDLINES);
 
         auto grassLength = -1;
-        if (zoomLevel == 0)
+        if (zoomLevel <= 0)
         {
             if ((session->ViewFlags & (VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_UNDERGROUND_INSIDE)) == 0)
             {


### PR DESCRIPTION
In OpenGL, mowed grass and weeds would not show up when using the extra zoom-in functionality.