### PR TITLE
Remove common format formatter where possible

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -787,7 +787,7 @@ static std::pair<rct_string_id, Formatter> window_editor_inventions_list_prepare
 {
     rct_string_id drawString;
     rct_string_id stringId = researchItem->GetName();
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
 
     if (researchItem->type == Research::EntryType::Ride
         && !RideTypeDescriptors[researchItem->baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -238,37 +238,49 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
-    RideNaming rideName;
-    rct_string_id friendlyTrackName;
-
-    void* objectEntry = object_manager_load_object(&td6->vehicle_object);
-    if (objectEntry != nullptr)
+    // Friendly Track name
     {
-        auto groupIndex = object_manager_get_loaded_object_entry_index(objectEntry);
-        rideName = get_ride_naming(td6->type, get_ride_entry(groupIndex));
-        friendlyTrackName = rideName.Name;
-    }
-    else
-    {
-        // Fall back on the technical track name if the vehicle object cannot be loaded
-        friendlyTrackName = RideTypeDescriptors[td6->type].Naming.Name;
-    }
+        auto ft = Formatter();
 
-    gfx_draw_string_left(dpi, STR_TRACK_DESIGN_TYPE, &friendlyTrackName, COLOUR_BLACK, screenPos);
-    screenPos.y += LIST_ROW_HEIGHT + 4;
+        void* objectEntry = object_manager_load_object(&td6->vehicle_object);
+        if (objectEntry != nullptr)
+        {
+            auto groupIndex = object_manager_get_loaded_object_entry_index(objectEntry);
+            auto rideName = get_ride_naming(td6->type, get_ride_entry(groupIndex));
+            ft.Add<rct_string_id>(rideName.Name);
+        }
+        else
+        {
+            // Fall back on the technical track name if the vehicle object cannot be loaded
+            ft.Add<rct_string_id>(RideTypeDescriptors[td6->type].Naming.Name);
+        }
+
+        gfx_draw_string_left(dpi, STR_TRACK_DESIGN_TYPE, ft.Data(), COLOUR_BLACK, screenPos);
+        screenPos.y += LIST_ROW_HEIGHT + 4;
+    }
 
     // Stats
-    fixed32_2dp rating = td6->excitement * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, &rating, COLOUR_BLACK, screenPos);
-    screenPos.y += LIST_ROW_HEIGHT;
-
-    rating = td6->intensity * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, &rating, COLOUR_BLACK, screenPos);
-    screenPos.y += LIST_ROW_HEIGHT;
-
-    rating = td6->nausea * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, &rating, COLOUR_BLACK, screenPos);
-    screenPos.y += LIST_ROW_HEIGHT + 4;
+    {
+        fixed32_2dp rating = td6->excitement * 10;
+        auto ft = Formatter();
+        ft.Add<int32_t>(rating);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, ft.Data(), COLOUR_BLACK, screenPos);
+        screenPos.y += LIST_ROW_HEIGHT;
+    }
+    {
+        fixed32_2dp rating = td6->intensity * 10;
+        auto ft = Formatter();
+        ft.Add<int32_t>(rating);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, ft.Data(), COLOUR_BLACK, screenPos);
+        screenPos.y += LIST_ROW_HEIGHT;
+    }
+    {
+        fixed32_2dp rating = td6->nausea * 10;
+        auto ft = Formatter();
+        ft.Add<int32_t>(rating);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, ft.Data(), COLOUR_BLACK, screenPos);
+        screenPos.y += LIST_ROW_HEIGHT + 4;
+    }
 
     if (td6->type != RIDE_TYPE_MAZE)
     {
@@ -276,24 +288,33 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Holes
             uint16_t holes = td6->holes & 0x1F;
-            gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, screenPos);
+            auto ft = Formatter();
+            ft.Add<uint16_t>(holes);
+            gfx_draw_string_left(dpi, STR_HOLES, ft.Data(), COLOUR_BLACK, screenPos);
             screenPos.y += LIST_ROW_HEIGHT;
         }
         else
         {
             // Maximum speed
-            uint16_t speed = ((td6->max_speed << 16) * 9) >> 18;
-            gfx_draw_string_left(dpi, STR_MAX_SPEED, &speed, COLOUR_BLACK, screenPos);
-            screenPos.y += LIST_ROW_HEIGHT;
-
+            {
+                uint16_t speed = ((td6->max_speed << 16) * 9) >> 18;
+                auto ft = Formatter();
+                ft.Add<uint16_t>(speed);
+                gfx_draw_string_left(dpi, STR_MAX_SPEED, ft.Data(), COLOUR_BLACK, screenPos);
+                screenPos.y += LIST_ROW_HEIGHT;
+            }
             // Average speed
-            speed = ((td6->average_speed << 16) * 9) >> 18;
-            gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &speed, COLOUR_BLACK, screenPos);
-            screenPos.y += LIST_ROW_HEIGHT;
+            {
+                uint16_t speed = ((td6->average_speed << 16) * 9) >> 18;
+                auto ft = Formatter();
+                ft.Add<uint16_t>(speed);
+                gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, ft.Data(), COLOUR_BLACK, screenPos);
+                screenPos.y += LIST_ROW_HEIGHT;
+            }
         }
 
         // Ride length
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
         ft.Add<uint16_t>(td6->ride_length);
         DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft, COLOUR_BLACK);
@@ -303,25 +324,36 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride_type_has_flag(td6->type, RIDE_TYPE_FLAG_HAS_G_FORCES))
     {
         // Maximum positive vertical Gs
-        int32_t gForces = td6->max_positive_vertical_g * 32;
-        gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos);
-        screenPos.y += LIST_ROW_HEIGHT;
-
+        {
+            int32_t gForces = td6->max_positive_vertical_g * 32;
+            auto ft = Formatter();
+            ft.Add<int32_t>(gForces);
+            gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, ft.Data(), COLOUR_BLACK, screenPos);
+            screenPos.y += LIST_ROW_HEIGHT;
+        }
         // Maximum negative vertical Gs
-        gForces = td6->max_negative_vertical_g * 32;
-        gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos);
-        screenPos.y += LIST_ROW_HEIGHT;
-
+        {
+            int32_t gForces = td6->max_negative_vertical_g * 32;
+            auto ft = Formatter();
+            ft.Add<int32_t>(gForces);
+            gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, ft.Data(), COLOUR_BLACK, screenPos);
+            screenPos.y += LIST_ROW_HEIGHT;
+        }
         // Maximum lateral Gs
-        gForces = td6->max_lateral_g * 32;
-        gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, &gForces, COLOUR_BLACK, screenPos);
-        screenPos.y += LIST_ROW_HEIGHT;
-
+        {
+            int32_t gForces = td6->max_lateral_g * 32;
+            auto ft = Formatter();
+            ft.Add<int32_t>(gForces);
+            gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, ft.Data(), COLOUR_BLACK, screenPos);
+            screenPos.y += LIST_ROW_HEIGHT;
+        }
         if (td6->total_air_time != 0)
         {
             // Total air time
             int32_t airTime = td6->total_air_time * 25;
-            gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &airTime, COLOUR_BLACK, screenPos);
+            auto ft = Formatter();
+            ft.Add<int32_t>(airTime);
+            gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, ft.Data(), COLOUR_BLACK, screenPos);
             screenPos.y += LIST_ROW_HEIGHT;
         }
     }
@@ -330,11 +362,13 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         // Drops
         uint16_t drops = td6->drops & 0x3F;
-        gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, screenPos);
+        auto ft = Formatter();
+        ft.Add<uint16_t>(drops);
+        gfx_draw_string_left(dpi, STR_DROPS, ft.Data(), COLOUR_BLACK, screenPos);
         screenPos.y += LIST_ROW_HEIGHT;
 
         // Drop height is multiplied by 0.75
-        gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &drops, COLOUR_BLACK, screenPos);
+        gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, ft.Data(), COLOUR_BLACK, screenPos);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
@@ -344,7 +378,9 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (inversions != 0)
         {
             // Inversions
-            gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, screenPos);
+            auto ft = Formatter();
+            ft.Add<uint16_t>(inversions);
+            gfx_draw_string_left(dpi, STR_INVERSIONS, ft.Data(), COLOUR_BLACK, screenPos);
             screenPos.y += LIST_ROW_HEIGHT;
         }
     }
@@ -353,18 +389,18 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (td6->space_required_x != 0xFF)
     {
         // Space required
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<uint16_t>(td6->space_required_x);
         ft.Add<uint16_t>(td6->space_required_y);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, screenPos);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, ft.Data(), COLOUR_BLACK, screenPos);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
     if (td6->cost != 0)
     {
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<uint32_t>(td6->cost);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, screenPos);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, ft.Data(), COLOUR_BLACK, screenPos);
     }
 }
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -373,9 +373,9 @@ static void window_land_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         if (price != 0)
         {
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<money32>(price);
-            gfx_draw_string_centred(dpi, STR_COST_AMOUNT, screenCoords, COLOUR_BLACK, gCommonFormatArgs);
+            gfx_draw_string_centred(dpi, STR_COST_AMOUNT, screenCoords, COLOUR_BLACK, ft.Data());
         }
     }
 }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -698,7 +698,7 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
     safe_strcpy(ch, _shortenedDirectory, sizeof(buffer) - (ch - buffer));
 
     // Draw path text
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<utf8*>(Platform::StrDecompToPrecomp(buffer));
     DrawTextEllipsised(dpi, { w->windowPos.x + 4, w->windowPos.y + 20 }, w->width - 8, STR_STRING, ft, COLOUR_BLACK);
 
@@ -755,13 +755,13 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         // display a marker next to the currently loaded game file
         if (_listItems[i].loaded)
         {
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<rct_string_id>(STR_RIGHTGUILLEMET);
-            gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, { 0, y });
+            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, { 0, y });
         }
 
         // Print filename
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<char*>(_listItems[i].name.c_str());
         int32_t max_file_width = w->widgets[WIDX_SORT_NAME].width() - 10;
@@ -770,13 +770,13 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         // Print formatted modified date, if this is a file
         if (_listItems[i].type == TYPE_FILE)
         {
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<char*>(_listItems[i].date_formatted.c_str());
             DrawTextEllipsised(
                 dpi, { dateAnchor - DATE_TIME_GAP, y }, maxDateWidth, stringId, ft, COLOUR_BLACK, TextAlignment::RIGHT);
 
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<char*>(_listItems[i].time_formatted.c_str());
             DrawTextEllipsised(dpi, { dateAnchor + DATE_TIME_GAP, y }, maxTimeWidth, stringId, ft, COLOUR_BLACK);
@@ -1197,13 +1197,13 @@ static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_draw_widgets(w, dpi);
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<char*>(_window_overwrite_prompt_name);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + w->width / 2, w->windowPos.y + (w->height / 2) - 3);
     gfx_draw_string_centred_wrapped(
-        dpi, gCommonFormatArgs, stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
+        dpi, ft.Data(), stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -1202,8 +1202,7 @@ static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ft.Add<char*>(_window_overwrite_prompt_name);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + w->width / 2, w->windowPos.y + (w->height / 2) - 3);
-    gfx_draw_string_centred_wrapped(
-        dpi, ft.Data(), stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
+    gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -617,7 +617,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
 
             // Draw last action
             int32_t action = network_get_player_last_action(i, 2000);
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             if (action != -999)
             {
                 ft.Add<rct_string_id>(network_get_action_name_string_id(action));
@@ -835,7 +835,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         lineCh = buffer;
         lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
         safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<const char*>(buffer);
         DrawTextEllipsised(
             dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
@@ -862,7 +862,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         lineCh = buffer;
         lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
         safe_strcpy(lineCh, network_get_group_name(group), sizeof(buffer) - (lineCh - buffer));
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<const char*>(buffer);
         DrawTextEllipsised(
             dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
@@ -906,9 +906,9 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
             }
 
             // Draw action name
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<uint16_t>(network_get_action_name_string_id(i));
-            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, COLOUR_BLACK, { 10, screenCoords.y });
+            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, ft.Data(), COLOUR_BLACK, { 10, screenCoords.y });
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -896,10 +896,10 @@ static void window_new_ride_paint_ride_information(
 
     // Ride name and description
     rideNaming = get_ride_naming(item.Type, rideEntry);
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(rideNaming.Name);
     ft.Add<rct_string_id>(rideNaming.Description);
-    gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, screenPos, width, STR_NEW_RIDE_NAME_AND_DESCRIPTION, COLOUR_BLACK);
+    gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, width, STR_NEW_RIDE_NAME_AND_DESCRIPTION, COLOUR_BLACK);
 
     char availabilityString[AVAILABILITY_STRING_SIZE];
     window_new_ride_list_vehicles_for(item.Type, rideEntry, availabilityString, sizeof(availabilityString));
@@ -907,15 +907,17 @@ static void window_new_ride_paint_ride_information(
     if (availabilityString[0] != 0)
     {
         const char* drawString = availabilityString;
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<const char*>(drawString);
         DrawTextEllipsised(dpi, screenPos + ScreenCoordsXY{ 0, 39 }, WW - 2, STR_AVAILABLE_VEHICLES, ft, COLOUR_BLACK);
     }
 
+    ft = Formatter();
     if (item.Type != _lastTrackDesignCountRideType.Type || item.EntryIndex != _lastTrackDesignCountRideType.EntryIndex)
     {
         _lastTrackDesignCountRideType = item;
         _lastTrackDesignCount = get_num_track_designs(item);
+        ft.Add<int32_t>(_lastTrackDesignCount);
     }
 
     rct_string_id designCountStringId;
@@ -932,7 +934,7 @@ static void window_new_ride_paint_ride_information(
             break;
     }
 
-    gfx_draw_string_left(dpi, designCountStringId, &_lastTrackDesignCount, COLOUR_BLACK, screenPos + ScreenCoordsXY{ 0, 51 });
+    gfx_draw_string_left(dpi, designCountStringId, ft.Data(), COLOUR_BLACK, screenPos + ScreenCoordsXY{ 0, 51 });
 
     // Price
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -238,15 +238,19 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
             dpi, { -1, y, 383, y + itemHeight - 1 }, w->colours[1], (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_GREY));
 
         // Date text
-        auto ft = Formatter::Common();
-        ft.Add<rct_string_id>(DateDayNames[newsItem.Day - 1]);
-        ft.Add<rct_string_id>(DateGameMonthNames[date_get_month(newsItem.MonthYear)]);
-        gfx_draw_string_left(dpi, STR_NEWS_DATE_FORMAT, gCommonFormatArgs, COLOUR_WHITE, { 2, y });
-
+        {
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(DateDayNames[newsItem.Day - 1]);
+            ft.Add<rct_string_id>(DateGameMonthNames[date_get_month(newsItem.MonthYear)]);
+            gfx_draw_string_left(dpi, STR_NEWS_DATE_FORMAT, ft.Data(), COLOUR_WHITE, { 2, y });
+        }
         // Item text
-        auto text = newsItem.Text;
-        gfx_draw_string_left_wrapped(dpi, &text, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, COLOUR_BRIGHT_GREEN);
-
+        {
+            auto ft = Formatter();
+            ft.Add<utf8*>(newsItem.Text);
+            gfx_draw_string_left_wrapped(
+                dpi, ft.Data(), { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, COLOUR_BRIGHT_GREEN);
+        }
         // Subject button
         if ((newsItem.TypeHasSubject()) && !(newsItem.HasButton()))
         {

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -537,13 +537,13 @@ static void window_object_load_error_paint(rct_window* w, rct_drawpixelinfo* dpi
     window_draw_widgets(w, dpi);
 
     // Draw explanatory message
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(STR_OBJECT_ERROR_WINDOW_EXPLANATION);
     gfx_draw_string_left_wrapped(
-        dpi, gCommonFormatArgs, w->windowPos + ScreenCoordsXY{ 5, 18 }, WW - 10, STR_BLACK_STRING, COLOUR_BLACK);
+        dpi, ft.Data(), w->windowPos + ScreenCoordsXY{ 5, 18 }, WW - 10, STR_BLACK_STRING, COLOUR_BLACK);
 
     // Draw file name
-    ft = Formatter::Common();
+    ft = Formatter();
     ft.Add<rct_string_id>(STR_OBJECT_ERROR_WINDOW_FILE);
     ft.Add<utf8*>(file_path.c_str());
     DrawTextEllipsised(dpi, { w->windowPos.x + 5, w->windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft, COLOUR_BLACK);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2059,7 +2059,7 @@ static void window_options_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 });
 
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<utf8*>(Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));
 
             rct_widget pathWidget = window_options_advanced_widgets[WIDX_PATH_TO_RCT1_BUTTON];

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -723,7 +723,7 @@ static void window_park_entrance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     // Draw park closed / open label
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(park_is_open() ? STR_PARK_OPEN : STR_PARK_CLOSED);
 
     labelWidget = &window_park_entrance_widgets[WIDX_STATUS];
@@ -1289,33 +1289,37 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         stringIndex = STR_PARK_SIZE_IMPERIAL_LABEL;
         parkSize = squaredmetres_to_squaredfeet(parkSize);
     }
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<uint32_t>(parkSize);
-    gfx_draw_string_left(dpi, stringIndex, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+    gfx_draw_string_left(dpi, stringIndex, ft.Data(), COLOUR_BLACK, screenCoords);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Draw number of rides / attractions
     if (w->list_information_type != 0xFFFF)
     {
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<uint32_t>(w->list_information_type);
-        gfx_draw_string_left(dpi, STR_NUMBER_OF_RIDES_LABEL, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        gfx_draw_string_left(dpi, STR_NUMBER_OF_RIDES_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Draw number of staff
     if (w->numberOfStaff != -1)
     {
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<uint32_t>(w->numberOfStaff);
-        gfx_draw_string_left(dpi, STR_STAFF_LABEL, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        gfx_draw_string_left(dpi, STR_STAFF_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Draw number of guests in park
-    gfx_draw_string_left(dpi, STR_GUESTS_IN_PARK_LABEL, &gNumGuestsInPark, COLOUR_BLACK, screenCoords);
+    ft = Formatter();
+    ft.Add<uint32_t>(gNumGuestsInPark);
+    gfx_draw_string_left(dpi, STR_GUESTS_IN_PARK_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_TOTAL_ADMISSIONS, &gTotalAdmissions, COLOUR_BLACK, screenCoords);
+    ft = Formatter();
+    ft.Add<uint32_t>(gTotalAdmissions);
+    gfx_draw_string_left(dpi, STR_TOTAL_ADMISSIONS, ft.Data(), COLOUR_BLACK, screenCoords);
 }
 
 #pragma endregion
@@ -1458,10 +1462,10 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto screenCoords = w->windowPos
         + ScreenCoordsXY{ window_park_objective_widgets[WIDX_PAGE_BACKGROUND].left + 4,
                           window_park_objective_widgets[WIDX_PAGE_BACKGROUND].top + 7 };
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(gScenarioDetails.c_str());
-    screenCoords.y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, screenCoords, 222, STR_BLACK_STRING, COLOUR_BLACK);
+    screenCoords.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 222, STR_BLACK_STRING, COLOUR_BLACK);
     screenCoords.y += 5;
 
     // Your objective:
@@ -1469,7 +1473,7 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Objective
-    ft = Formatter::Common();
+    ft = Formatter();
     if (gScenarioObjective.Type == OBJECTIVE_BUILD_THE_BEST)
     {
         rct_string_id rideTypeString = STR_NONE;
@@ -1488,7 +1492,7 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     screenCoords.y += gfx_draw_string_left_wrapped(
-        dpi, gCommonFormatArgs, screenCoords, 221, ObjectiveNames[gScenarioObjective.Type], COLOUR_BLACK);
+        dpi, ft.Data(), screenCoords, 221, ObjectiveNames[gScenarioObjective.Type], COLOUR_BLACK);
     screenCoords.y += 5;
 
     // Objective outcome
@@ -1502,9 +1506,9 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
         else
         {
             // Objective completed
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<money32>(gScenarioCompletedCompanyValue);
-            gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, screenCoords, 222, STR_OBJECTIVE_ACHIEVED, COLOUR_BLACK);
+            gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 222, STR_OBJECTIVE_ACHIEVED, COLOUR_BLACK);
         }
     }
 }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -334,7 +334,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         lineCh = buffer;
         lineCh = utf8_write_codepoint(lineCh, FORMAT_WINDOW_COLOUR_2);
         safe_strcpy(lineCh, network_get_group_name(groupindex), sizeof(buffer) - (lineCh - buffer));
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<const char*>(buffer);
 
         DrawTextEllipsised(
@@ -345,9 +345,9 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw ping
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 90, 24 };
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(STR_PING);
-    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, gCommonFormatArgs, 0, screenCoords);
+    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, ft.Data(), 0, screenCoords);
     char ping[64];
     snprintf(ping, 64, "%d ms", network_get_player_ping(player));
     gfx_draw_string(dpi, ping, w->colours[2], screenCoords + ScreenCoordsXY(30, 0));
@@ -356,7 +356,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenCoords = w->windowPos + ScreenCoordsXY{ w->width / 2, w->height - 13 };
     int32_t width = w->width - 8;
     int32_t lastaction = network_get_player_last_action(player, 0);
-    ft = Formatter::Common();
+    ft = Formatter();
     if (lastaction != -999)
     {
         ft.Add<rct_string_id>(network_get_action_name_string_id(lastaction));
@@ -512,15 +512,15 @@ void window_player_statistics_paint(rct_window* w, rct_drawpixelinfo* dpi)
         + ScreenCoordsXY{ window_player_overview_widgets[WIDX_PAGE_BACKGROUND].left + 4,
                           window_player_overview_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<uint32_t>(network_get_player_commands_ran(player));
-    gfx_draw_string_left(dpi, STR_COMMANDS_RAN, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+    gfx_draw_string_left(dpi, STR_COMMANDS_RAN, ft.Data(), COLOUR_BLACK, screenCoords);
 
     screenCoords.y += LIST_ROW_HEIGHT;
 
-    ft = Formatter::Common();
+    ft = Formatter();
     ft.Add<uint32_t>(network_get_player_money_spent(player));
-    gfx_draw_string_left(dpi, STR_MONEY_SPENT, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+    gfx_draw_string_left(dpi, STR_MONEY_SPENT, ft.Data(), COLOUR_BLACK, screenCoords);
 }
 
 static void window_player_set_page(rct_window* w, int32_t page)

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -302,18 +302,25 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
 
     if (gResearchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
     {
-        stringId = STR_RESEARCH_UNKNOWN;
-        gfx_draw_string_left_wrapped(dpi, &stringId, screenCoords, 296, STR_RESEARCH_TYPE_LABEL, COLOUR_BLACK);
-        screenCoords.y += 25;
-
+        {
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(STR_RESEARCH_UNKNOWN);
+            gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 296, STR_RESEARCH_TYPE_LABEL, COLOUR_BLACK);
+            screenCoords.y += 25;
+        }
         // Progress
-        stringId = STR_RESEARCH_COMPLETED_AL;
-        gfx_draw_string_left_wrapped(dpi, &stringId, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, COLOUR_BLACK);
-        screenCoords.y += 15;
+        {
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(STR_RESEARCH_COMPLETED_AL);
+            gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, COLOUR_BLACK);
+            screenCoords.y += 15;
+        }
 
-        auto ft = Formatter::Common();
-        ft.Add<rct_string_id>(STR_RESEARCH_STAGE_UNKNOWN);
-        gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        {
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(STR_RESEARCH_STAGE_UNKNOWN);
+            gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
+        }
     }
     else
     {
@@ -353,7 +360,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         screenCoords.y += 15;
 
         // Expected
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         if (gResearchProgressStage != RESEARCH_STAGE_INITIAL_RESEARCH && gResearchExpectedDay != 255)
         {
             // TODO: Should probably use game date format setting
@@ -365,7 +372,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         {
             ft.Add<rct_string_id>(STR_RESEARCH_STAGE_UNKNOWN);
         }
-        gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
     }
 
     // Last development

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3585,11 +3585,9 @@ static void window_ride_operating_invalidate(rct_window* w)
     {
         if (ride->type == RIDE_TYPE_TWIST)
         {
-            uint16_t arg;
-            std::memcpy(&arg, gCommonFormatArgs + 18, sizeof(uint16_t));
             ft = Formatter::Common();
             ft.Increment(18);
-            ft.Add<uint16_t>(arg * 3);
+            ft.Add<uint16_t>(ride->operation_option * 3);
         }
 
         window_ride_operating_widgets[WIDX_MODE_TWEAK_LABEL].type = WWT_LABEL;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2635,7 +2635,7 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride == nullptr)
         return;
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     if (w->ride.view != 0)
     {
         if (w->ride.view > ride->num_vehicles)
@@ -2657,11 +2657,10 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     widget = &window_ride_main_widgets[WIDX_VIEW];
     gfx_draw_string_centred(
         dpi, STR_WINDOW_COLOUR_2_STRINGID,
-        { w->windowPos.x + (widget->left + widget->right - 11) / 2, w->windowPos.y + widget->top }, COLOUR_BLACK,
-        gCommonFormatArgs);
+        { w->windowPos.x + (widget->left + widget->right - 11) / 2, w->windowPos.y + widget->top }, COLOUR_BLACK, ft.Data());
 
     // Status
-    ft = Formatter::Common();
+    ft = Formatter();
     widget = &window_ride_main_widgets[WIDX_STATUS];
     rct_string_id rideStatus = window_ride_get_status(w, ft);
     DrawTextEllipsised(
@@ -4122,10 +4121,10 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 auto staff = GetEntity<Staff>(ride->mechanic);
                 if (staff != nullptr && staff->IsMechanic())
                 {
-                    auto ft = Formatter::Common();
+                    auto ft = Formatter();
                     staff->FormatNameTo(ft);
                     gfx_draw_string_left_wrapped(
-                        dpi, gCommonFormatArgs, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
+                        dpi, ft.Data(), screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
                 }
             }
         }
@@ -4853,8 +4852,7 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
             }
         }
 
-        DrawTextEllipsised(
-            dpi, { w->windowPos.x + 3, w->windowPos.y + 103 }, 97, STR_STATION_STYLE, Formatter::Common(), COLOUR_BLACK);
+        DrawTextEllipsised(dpi, { w->windowPos.x + 3, w->windowPos.y + 103 }, 97, STR_STATION_STYLE, {}, COLOUR_BLACK);
     }
 }
 
@@ -5499,17 +5497,17 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
         {
             // Excitement
             rct_string_id ratingName = get_rating_name(ride->excitement);
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<uint32_t>(ride->excitement);
             ft.Add<rct_string_id>(ratingName);
             rct_string_id stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE
                                                                                : STR_EXCITEMENT_RATING;
-            gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             // Intensity
             ratingName = get_rating_name(ride->intensity);
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<uint32_t>(ride->intensity);
             ft.Add<rct_string_id>(ratingName);
 
@@ -5519,16 +5517,16 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
             else if (ride->intensity >= RIDE_RATING(10, 00))
                 stringId = STR_INTENSITY_RATING_RED;
 
-            gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             // Nausea
             ratingName = get_rating_name(ride->nausea);
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<uint32_t>(ride->nausea);
             ft.Add<rct_string_id>(ratingName);
             stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
-            gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += 2 * LIST_ROW_HEIGHT;
 
             // Horizontal rule
@@ -5558,7 +5556,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Ride time
-                    ft = Formatter::Common();
+                    ft = Formatter();
                     int32_t numTimes = 0;
                     for (int32_t i = 0; i < ride->num_stations; i++)
                     {
@@ -5595,7 +5593,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                 }
 
                 // Ride length
-                ft = Formatter::Common();
+                ft = Formatter();
                 int32_t numLengths = 0;
                 for (int32_t i = 0; i < ride->num_stations; i++)
                 {
@@ -6828,10 +6826,10 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     shopItem = ride->GetRideEntry()->shop_item[0];
     if (shopItem != SHOP_ITEM_NONE)
     {
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<rct_string_id>(ShopItems[shopItem].Naming.Plural);
         ft.Add<uint32_t>(ride->no_primary_items_sold);
-        gfx_draw_string_left(dpi, STR_ITEMS_SOLD, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        gfx_draw_string_left(dpi, STR_ITEMS_SOLD, ft.Data(), COLOUR_BLACK, screenCoords);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
@@ -6840,10 +6838,10 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                                                       : ride->GetRideEntry()->shop_item[1];
     if (shopItem != SHOP_ITEM_NONE)
     {
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<rct_string_id>(ShopItems[shopItem].Naming.Plural);
         ft.Add<uint32_t>(ride->no_secondary_items_sold);
-        gfx_draw_string_left(dpi, STR_ITEMS_SOLD, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        gfx_draw_string_left(dpi, STR_ITEMS_SOLD, ft.Data(), COLOUR_BLACK, screenCoords);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -688,29 +688,39 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                 }
                 break;
             case INFORMATION_TYPE_QUEUE_LENGTH:
-                ft.Add<uint16_t>(ride->GetTotalQueueLength());
-                formatSecondary = STR_QUEUE_EMPTY;
-                {
-                    uint16_t arg;
-                    std::memcpy(&arg, gCommonFormatArgs + 2, sizeof(uint16_t));
+            {
+                auto queueLength = ride->GetTotalQueueLength();
+                ft.Add<uint16_t>(queueLength);
 
-                    if (arg == 1)
-                        formatSecondary = STR_QUEUE_ONE_PERSON;
-                    else if (arg > 1)
-                        formatSecondary = STR_QUEUE_PEOPLE;
+                if (queueLength == 1)
+                {
+                    formatSecondary = STR_QUEUE_ONE_PERSON;
+                }
+                else if (queueLength > 1)
+                {
+                    formatSecondary = STR_QUEUE_PEOPLE;
+                }
+                else
+                {
+                    formatSecondary = STR_QUEUE_EMPTY;
                 }
                 break;
+            }
             case INFORMATION_TYPE_QUEUE_TIME:
-                ft.Add<uint16_t>(ride->GetMaxQueueTime());
-                formatSecondary = STR_QUEUE_TIME_LABEL;
-                {
-                    uint16_t arg;
-                    std::memcpy(&arg, gCommonFormatArgs + 2, sizeof(uint16_t));
+            {
+                auto maxQueueTime = ride->GetMaxQueueTime();
+                ft.Add<uint16_t>(maxQueueTime);
 
-                    if (arg > 1)
-                        formatSecondary = STR_QUEUE_TIME_PLURAL_LABEL;
+                if (maxQueueTime > 1)
+                {
+                    formatSecondary = STR_QUEUE_TIME_PLURAL_LABEL;
+                }
+                else
+                {
+                    formatSecondary = STR_QUEUE_TIME_LABEL;
                 }
                 break;
+            }
             case INFORMATION_TYPE_RELIABILITY:
                 ft.Add<uint16_t>(ride->reliability_percentage);
                 formatSecondary = STR_RELIABILITY_LABEL;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -591,12 +591,12 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
             continue;
 
         // Ride name
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ride->FormatNameTo(ft);
         DrawTextEllipsised(dpi, { 0, y - 1 }, 159, format, ft, COLOUR_BLACK);
 
         // Ride information
-        ft.Rewind();
+        ft = Formatter();
         ft.Increment(2);
         auto formatSecondaryEnabled = true;
         rct_string_id formatSecondary = 0;

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -434,7 +434,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (widget->type == WWT_EMPTY)
             continue;
 
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN || _titleEditor)
         {
             ft.Add<rct_string_id>(ScenarioOriginStringIds[i]);
@@ -445,7 +445,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         }
 
         ScreenCoordsXY stringCoords(widget->midX() + w->windowPos.x, widget->midY() + w->windowPos.y - 3);
-        gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, stringCoords, 87, format, COLOUR_AQUAMARINE);
+        gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, 87, format, COLOUR_AQUAMARINE);
     }
 
     // Return if no scenario highlighted
@@ -459,8 +459,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 + ScreenCoordsXY{ window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4,
                                   window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5 };
             DrawTextEllipsised(
-                dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, Formatter::Common(), COLOUR_BLACK,
-                TextAlignment::CENTRE);
+                dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, {}, COLOUR_BLACK, TextAlignment::CENTRE);
             gfx_draw_string_left_wrapped(
                 dpi, nullptr, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_LOCKED_DESC, COLOUR_BLACK);
         }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -484,7 +484,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto screenPos = w->windowPos
         + ScreenCoordsXY{ window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4,
                           window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5 };
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->name);
     DrawTextEllipsised(
@@ -492,13 +492,13 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenPos.y += 15;
 
     // Scenario details
-    ft = Formatter::Common();
+    ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->details);
-    screenPos.y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, screenPos, 170, STR_BLACK_STRING, COLOUR_BLACK) + 5;
+    screenPos.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, 170, STR_BLACK_STRING, COLOUR_BLACK) + 5;
 
     // Scenario objective
-    ft = Formatter::Common();
+    ft = Formatter();
     ft.Add<rct_string_id>(ObjectiveNames[scenario->objective_type]);
     if (scenario->objective_type == OBJECTIVE_BUILD_THE_BEST)
     {
@@ -516,7 +516,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<int16_t>(date_get_total_months(MONTH_OCTOBER, scenario->objective_arg_1));
         ft.Add<int32_t>(scenario->objective_arg_2);
     }
-    screenPos.y += gfx_draw_string_left_wrapped(dpi, gCommonFormatArgs, screenPos, 170, STR_OBJECTIVE, COLOUR_BLACK) + 5;
+    screenPos.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, 170, STR_OBJECTIVE, COLOUR_BLACK) + 5;
 
     // Scenario score
     if (scenario->highscore != nullptr)
@@ -527,12 +527,12 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             completedByName = scenario->highscore->name;
         }
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(completedByName);
         ft.Add<money32>(scenario->highscore->company_value);
         screenPos.y += gfx_draw_string_left_wrapped(
-            dpi, gCommonFormatArgs, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, COLOUR_BLACK);
+            dpi, ft.Data(), screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, COLOUR_BLACK);
     }
 }
 
@@ -596,7 +596,7 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                 safe_strcpy(buffer, scenario->name, sizeof(buffer));
                 rct_string_id format = isDisabled ? static_cast<rct_string_id>(STR_STRINGID)
                                                   : (isHighlighted ? highlighted_format : unhighlighted_format);
-                auto ft = Formatter::Common();
+                auto ft = Formatter();
                 ft.Add<rct_string_id>(STR_STRING);
                 ft.Add<char*>(buffer);
                 colour = isDisabled ? w->colours[1] | COLOUR_FLAG_INSET : COLOUR_BLACK;
@@ -604,7 +604,7 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                 {
                     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
                 }
-                gfx_draw_string_centred(dpi, format, { wide ? 270 : 210, y + 1 }, colour, gCommonFormatArgs);
+                gfx_draw_string_centred(dpi, format, { wide ? 270 : 210, y + 1 }, colour, ft.Data());
 
                 // Check if scenario is completed
                 if (isCompleted)
@@ -619,12 +619,12 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                         completedByName = scenario->highscore->name;
                     }
                     safe_strcpy(buffer, completedByName, 64);
-                    ft = Formatter::Common();
+                    ft = Formatter();
                     ft.Add<rct_string_id>(STR_COMPLETED_BY);
                     ft.Add<rct_string_id>(STR_STRING);
                     ft.Add<char*>(buffer);
                     gfx_draw_string_centred(
-                        dpi, format, { wide ? 270 : 210, y + scenarioTitleHeight + 1 }, COLOUR_BLACK, gCommonFormatArgs);
+                        dpi, format, { wide ? 270 : 210, y + scenarioTitleHeight + 1 }, COLOUR_BLACK, ft.Data());
                 }
 
                 y += scenarioItemHeight;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1176,7 +1176,7 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
             TextAlignment::RIGHT);
     }
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(sceneryEntry != nullptr ? sceneryEntry->name : static_cast<rct_string_id>(STR_UNKNOWN_OBJECT_TYPE));
     DrawTextEllipsised(
         dpi, { w->windowPos.x + 3, w->windowPos.y + w->height - 13 }, w->width - 19, STR_BLACK_STRING, ft, COLOUR_BLACK);

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -466,7 +466,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         }
 
         // Finally, draw the server information.
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<const char*>(serverInfoToShow);
         DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, colour);
 

--- a/src/openrct2-ui/windows/ShortcutKeyChange.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeyChange.cpp
@@ -86,7 +86,7 @@ static void window_shortcut_change_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     ScreenCoordsXY stringCoords(w->windowPos.x + 125, w->windowPos.y + 30);
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<rct_string_id>(CurrentShortcutKeyStringId);
-    gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, stringCoords, 242, STR_SHORTCUT_CHANGE_PROMPT, COLOUR_BLACK);
+    gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, 242, STR_SHORTCUT_CHANGE_PROMPT, COLOUR_BLACK);
 }

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -351,7 +351,7 @@ static void window_shortcut_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         }
 
         const int32_t bindingOffset = scrollWidth - 150;
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<rct_string_id>(STR_SHORTCUT_ENTRY_FORMAT);
         ft.Add<rct_string_id>(ShortcutList[i].StringId);
         DrawTextEllipsised(dpi, { 0, y - 1 }, bindingOffset, format, ft, COLOUR_BLACK);
@@ -362,7 +362,7 @@ static void window_shortcut_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         if (strlen(keybinding) > 0)
         {
             const int32_t maxWidth = 150;
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<char*>(keybinding);
             DrawTextEllipsised(dpi, { bindingOffset, y - 1 }, maxWidth, format, ft, COLOUR_BLACK);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -944,7 +944,7 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         return;
     }
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     peep->FormatActionTo(ft);
     rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];
     auto screenPos = w->windowPos + ScreenCoordsXY{ widget->midX(), widget->top };
@@ -1101,37 +1101,48 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        Formatter::Common().Add<money32>(gStaffWageTable[static_cast<uint8_t>(peep->AssignedStaffType)]);
-        gfx_draw_string_left(dpi, STR_STAFF_STAT_WAGES, gCommonFormatArgs, COLOUR_BLACK, screenCoords);
+        auto ft = Formatter();
+        ft.Add<money32>(gStaffWageTable[static_cast<uint8_t>(peep->AssignedStaffType)]);
+        gfx_draw_string_left(dpi, STR_STAFF_STAT_WAGES, ft.Data(), COLOUR_BLACK, screenCoords);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
-    gfx_draw_string_left(dpi, STR_STAFF_STAT_EMPLOYED_FOR, static_cast<void*>(&peep->TimeInPark), COLOUR_BLACK, screenCoords);
+    auto ft = Formatter();
+    ft.Add<int32_t>(peep->TimeInPark);
+    gfx_draw_string_left(dpi, STR_STAFF_STAT_EMPLOYED_FOR, ft.Data(), COLOUR_BLACK, screenCoords);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     switch (peep->AssignedStaffType)
     {
         case StaffType::Handyman:
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_LAWNS_MOWN, static_cast<void*>(&peep->StaffLawnsMown), COLOUR_BLACK, screenCoords);
+            ft = Formatter();
+            ft.Add<uint16_t>(peep->StaffLawnsMown);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_LAWNS_MOWN, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_GARDENS_WATERED, static_cast<void*>(&peep->StaffGardensWatered), COLOUR_BLACK,
-                screenCoords);
+
+            ft = Formatter();
+            ft.Add<uint16_t>(peep->StaffGardensWatered);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_GARDENS_WATERED, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_LITTER_SWEPT, static_cast<void*>(&peep->StaffLitterSwept), COLOUR_BLACK, screenCoords);
+
+            ft = Formatter();
+            ft.Add<uint16_t>(peep->StaffLitterSwept);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_LITTER_SWEPT, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_BINS_EMPTIED, static_cast<void*>(&peep->StaffBinsEmptied), COLOUR_BLACK, screenCoords);
+
+            ft = Formatter();
+            ft.Add<uint16_t>(peep->StaffBinsEmptied);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_BINS_EMPTIED, ft.Data(), COLOUR_BLACK, screenCoords);
             break;
         case StaffType::Mechanic:
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_RIDES_INSPECTED, static_cast<void*>(&peep->StaffRidesInspected), COLOUR_BLACK,
-                screenCoords);
+            ft = Formatter();
+            ft.Add<uint16_t>(peep->StaffRidesInspected);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_RIDES_INSPECTED, ft.Data(), COLOUR_BLACK, screenCoords);
             screenCoords.y += LIST_ROW_HEIGHT;
-            gfx_draw_string_left(
-                dpi, STR_STAFF_STAT_RIDES_FIXED, static_cast<void*>(&peep->StaffRidesFixed), COLOUR_BLACK, screenCoords);
+
+            ft = Formatter();
+            ft.Add<uint16_t>(peep->StaffRidesFixed);
+            gfx_draw_string_left(dpi, STR_STAFF_STAT_RIDES_FIXED, ft.Data(), COLOUR_BLACK, screenCoords);
             break;
         case StaffType::Security:
         case StaffType::Entertainer:

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -100,9 +100,9 @@ static void window_staff_fire_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_draw_widgets(w, dpi);
 
     Peep* peep = GetEntity<Peep>(w->number);
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     peep->FormatNameTo(ft);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + WW / 2, w->windowPos.y + (WH / 2) - 3);
-    gfx_draw_string_centred_wrapped(dpi, gCommonFormatArgs, stringCoords, WW - 4, STR_FIRE_STAFF_ID, COLOUR_BLACK);
+    gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, WW - 4, STR_FIRE_STAFF_ID, COLOUR_BLACK);
 }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -619,15 +619,16 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        Formatter::Common().Add<money32>(gStaffWageTable[selectedTab]);
+        auto ft = Formatter();
+        ft.Add<money32>(gStaffWageTable[selectedTab]);
         gfx_draw_string_left(
-            dpi, STR_COST_PER_MONTH, gCommonFormatArgs, COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ w->width - 155, 0x20 });
+            dpi, STR_COST_PER_MONTH, ft.Data(), COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ w->width - 155, 0x20 });
     }
 
     if (selectedTab < 3)
     {
         gfx_draw_string_left(
-            dpi, STR_UNIFORM_COLOUR, w, COLOUR_BLACK,
+            dpi, STR_UNIFORM_COLOUR, nullptr, COLOUR_BLACK,
             w->windowPos + ScreenCoordsXY{ 6, window_staff_list_widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + 1 });
     }
 
@@ -638,12 +639,12 @@ void window_staff_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         staffTypeStringId = StaffNamingConvention[selectedTab].singular;
     }
 
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<uint16_t>(StaffList.size());
     ft.Add<rct_string_id>(staffTypeStringId);
 
     gfx_draw_string_left(
-        dpi, STR_STAFF_LIST_COUNTER, gCommonFormatArgs, COLOUR_BLACK,
+        dpi, STR_STAFF_LIST_COUNTER, ft.Data(), COLOUR_BLACK,
         w->windowPos + ScreenCoordsXY{ 4, window_staff_list_widgets[WIDX_STAFF_LIST_LIST].bottom + 2 });
 }
 
@@ -701,11 +702,11 @@ void window_staff_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_
                 format = (_quick_fire_mode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
             }
 
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             peep->FormatNameTo(ft);
             DrawTextEllipsised(dpi, { 0, y }, nameColumnSize, format, ft, COLOUR_BLACK);
 
-            ft = Formatter::Common();
+            ft = Formatter();
             peep->FormatActionTo(ft);
             DrawTextEllipsised(dpi, { actionOffset, y }, actionColumnSize, format, ft, COLOUR_BLACK);
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -824,7 +824,7 @@ void window_themes_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         size_t activeAvailableThemeIndex = theme_manager_get_active_available_theme_index();
         const utf8* activeThemeName = theme_manager_get_available_theme_name(activeAvailableThemeIndex);
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<const utf8*>(activeThemeName);
 
         auto screenPos = w->windowPos

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1711,31 +1711,31 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_ELEMENT_TYPE, Formatter::Common(), w->colours[1]);
+            STR_TILE_INSPECTOR_ELEMENT_TYPE, {}, w->colours[1]);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_BASEHEIGHT])->type != WWT_EMPTY)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT, Formatter::Common(), w->colours[1]);
+            STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT, {}, w->colours[1]);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_CLEARANCEHEIGHT])->type != WWT_EMPTY)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, Formatter::Common(), w->colours[1]);
+            STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, {}, w->colours[1]);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_GHOSTFLAG])->type != WWT_EMPTY)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_FLAG_GHOST_SHORT, Formatter::Common(), w->colours[1]);
+            STR_TILE_INSPECTOR_FLAG_GHOST_SHORT, {}, w->colours[1]);
     }
     if ((widget = &w->widgets[WIDX_COLUMN_LASTFLAG])->type != WWT_EMPTY)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_FLAG_LAST_SHORT, Formatter::Common(), w->colours[1]);
+            STR_TILE_INSPECTOR_FLAG_LAST_SHORT, {}, w->colours[1]);
     }
 
     ScreenCoordsXY screenCoords(w->windowPos.x, w->windowPos.y);
@@ -1892,10 +1892,10 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     dpi, STR_TILE_INSPECTOR_TRACK_RIDE_ID, &rideId, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 11 });
                 if (ride != nullptr)
                 {
-                    auto ft = Formatter::Common();
+                    auto ft = Formatter();
                     ride->FormatNameTo(ft);
                     gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, gCommonFormatArgs, COLOUR_WHITE,
+                        dpi, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, ft.Data(), COLOUR_WHITE,
                         screenCoords + ScreenCoordsXY{ 0, 22 });
                 }
                 // Track
@@ -1909,22 +1909,20 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 if (trackElement->IsStation())
                 {
                     int16_t stationIndex = trackElement->GetStationIndex();
-                    auto ft = Formatter::Common();
+                    auto ft = Formatter();
                     ft.Add<rct_string_id>(STR_COMMA16);
                     ft.Add<int16_t>(stationIndex);
                     gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, gCommonFormatArgs, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 55 });
+                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, ft.Data(), COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 55 });
                 }
                 else
                 {
                     const char* stationNone = "-";
-                    auto ft = Formatter::Common();
+                    auto ft = Formatter();
                     ft.Add<rct_string_id>(STR_STRING);
                     ft.Add<char*>(stationNone);
                     gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, gCommonFormatArgs, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 55 });
+                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, ft.Data(), COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 55 });
                 }
 
                 rct_string_id colourScheme = ColourSchemeNames[trackElement->GetColourScheme()];
@@ -2043,12 +2041,11 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                         screenCoords + ScreenCoordsXY{ 0, 22 });
                     // Station index
                     int16_t stationIndex = tileElement->AsEntrance()->GetStationIndex();
-                    auto ft = Formatter::Common();
+                    auto ft = Formatter();
                     ft.Add<rct_string_id>(STR_COMMA16);
                     ft.Add<int16_t>(stationIndex);
                     gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, gCommonFormatArgs, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 33 });
+                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, ft.Data(), COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 33 });
                 }
 
                 // Properties
@@ -2058,8 +2055,9 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].left + 3;
-                int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                auto ft = Formatter();
+                ft.Add<int32_t>(tileElement->base_height);
+                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, ft.Data(), COLOUR_WHITE, screenCoords);
                 break;
             }
 
@@ -2309,37 +2307,35 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
 
         // Undo relative scroll offset, but keep the 3 pixel padding
         screenCoords.x = -w->widgets[WIDX_LIST].left;
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<char*>(typeName);
         DrawTextEllipsised(
             dpi, screenCoords + ScreenCoordsXY{ COL_X_TYPE + 3, 0 }, COL_X_BH, stringFormat, ft, COLOUR_BLACK); // 3px padding
 
         // Base height
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<rct_string_id>(STR_FORMAT_INTEGER);
         ft.Add<int32_t>(baseHeight);
-        gfx_draw_string_left(dpi, stringFormat, gCommonFormatArgs, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_BH, 0 });
+        gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_BH, 0 });
 
         // Clearance height
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<rct_string_id>(STR_FORMAT_INTEGER);
         ft.Add<int32_t>(clearanceHeight);
-        gfx_draw_string_left(dpi, stringFormat, gCommonFormatArgs, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_CH, 0 });
+        gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_CH, 0 });
 
         // Checkmarks for ghost and last for tile
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<char*>(CheckBoxMarkString);
         if (ghost)
         {
-            gfx_draw_string_left(
-                dpi, stringFormat, gCommonFormatArgs, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_GF, 0 });
+            gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_GF, 0 });
         }
         if (last)
         {
-            gfx_draw_string_left(
-                dpi, stringFormat, gCommonFormatArgs, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_LF, 0 });
+            gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_LF, 0 });
         }
 
         screenCoords.y -= SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -714,8 +714,8 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
     // Command dropdown name
     DrawTextEllipsised(
         dpi, { w->windowPos.x + w->widgets[WIDX_COMMAND].left + 1, w->windowPos.y + w->widgets[WIDX_COMMAND].top },
-        w->widgets[WIDX_COMMAND_DROPDOWN].left - w->widgets[WIDX_COMMAND].left - 4, command_info.nameStringId,
-        Formatter::Common(), w->colours[1]);
+        w->widgets[WIDX_COMMAND_DROPDOWN].left - w->widgets[WIDX_COMMAND].left - 4, command_info.nameStringId, {},
+        w->colours[1]);
 
     // Label (e.g. "Location:")
     gfx_draw_string_left(dpi, command_info.descStringId, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ WS, BY2 - 14 });
@@ -724,14 +724,14 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
-            w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, SpeedNames[command.Speed - 1],
-            Formatter::Common(), w->colours[1]);
+            w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, SpeedNames[command.Speed - 1], {},
+            w->colours[1]);
     }
     if (command.Type == TITLE_SCRIPT_FOLLOW)
     {
         uint8_t colour = COLOUR_BLACK;
         rct_string_id spriteString = STR_TITLE_COMMAND_EDITOR_FORMAT_SPRITE_NAME;
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         if (command.SpriteIndex != SPRITE_INDEX_NULL)
         {
             window_draw_viewport(dpi, w);
@@ -757,11 +757,11 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
                 w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4,
-                STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, Formatter::Common(), w->colours[1]);
+                STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, {}, w->colours[1]);
         }
         else
         {
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<utf8*>(_sequence->Saves[command.SaveIndex].c_str());
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
@@ -775,7 +775,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
                 w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4,
-                STR_TITLE_COMMAND_EDITOR_NO_SCENARIO_SELECTED, Formatter::Common(), w->colours[1]);
+                STR_TITLE_COMMAND_EDITOR_NO_SCENARIO_SELECTED, {}, w->colours[1]);
         }
         else
         {
@@ -790,7 +790,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             {
                 nameString = STR_TITLE_COMMAND_EDITOR_MISSING_SCENARIO;
             }
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<const char*>(name);
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -808,7 +808,7 @@ static void window_title_editor_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, STR_TITLE_SEQUENCE, nullptr, w->colours[1],
                 w->windowPos + ScreenCoordsXY{ 10, window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top + 1 });
 
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<const char*>(_sequenceName);
 
             ScreenCoordsXY screenPos = { w->windowPos.x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].left + 1,
@@ -872,20 +872,20 @@ static void window_title_editor_scrollpaint_saves(rct_window* w, rct_drawpixelin
         }
 
         char buffer[256];
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         ft.Add<const char*>(_editingTitleSequence->Saves[i].c_str());
         if (selected || hover)
         {
-            format_string(buffer, 256, STR_STRING, gCommonFormatArgs);
+            format_string(buffer, 256, STR_STRING, ft.Data());
         }
         else
         {
-            format_string(buffer + 1, 255, STR_STRING, gCommonFormatArgs);
+            format_string(buffer + 1, 255, STR_STRING, ft.Data());
             buffer[0] = static_cast<utf8>(static_cast<uint8_t>(FORMAT_BLACK));
         }
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<const char*>(&buffer);
-        gfx_draw_string_left(dpi, STR_STRING, gCommonFormatArgs, w->colours[1], screenCoords + ScreenCoordsXY{ 5, 0 });
+        gfx_draw_string_left(dpi, STR_STRING, ft.Data(), w->colours[1], screenCoords + ScreenCoordsXY{ 5, 0 });
     }
 }
 
@@ -924,7 +924,7 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
             gfx_fill_rect(dpi, fillRect, ColourMapA[w->colours[1]].lighter | 0x1000000);
         }
 
-        auto ft = Formatter::Common();
+        auto ft = Formatter();
         rct_string_id commandName = STR_NONE;
         switch (command.Type)
         {
@@ -1005,16 +1005,16 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
         char buffer[256];
         if ((selected || hover) && !error)
         {
-            format_string(buffer, 256, commandName, gCommonFormatArgs);
+            format_string(buffer, 256, commandName, ft.Data());
         }
         else
         {
-            format_string(buffer + 1, 255, commandName, gCommonFormatArgs);
+            format_string(buffer + 1, 255, commandName, ft.Data());
             buffer[0] = static_cast<utf8>(error ? ((selected || hover) ? FORMAT_LIGHTPINK : FORMAT_RED) : FORMAT_BLACK);
         }
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<const char*>(&buffer);
-        gfx_draw_string_left(dpi, STR_STRING, gCommonFormatArgs, w->colours[1], screenCoords + ScreenCoordsXY{ 5, 0 });
+        gfx_draw_string_left(dpi, STR_STRING, ft.Data(), w->colours[1], screenCoords + ScreenCoordsXY{ 5, 0 });
     }
 }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -541,8 +541,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         // Vehicle design not available
-        DrawTextEllipsised(
-            dpi, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, Formatter::Common(), COLOUR_BLACK, TextAlignment::CENTRE);
+        DrawTextEllipsised(dpi, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, {}, COLOUR_BLACK, TextAlignment::CENTRE);
         screenPos.y -= SCROLLABLE_ROW_HEIGHT;
     }
 
@@ -552,14 +551,13 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             DrawTextEllipsised(
-                dpi, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, Formatter::Common(), COLOUR_BLACK,
-                TextAlignment::CENTRE);
+                dpi, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, COLOUR_BLACK, TextAlignment::CENTRE);
             screenPos.y -= SCROLLABLE_ROW_HEIGHT;
         }
     }
 
     // Track design name
-    auto ft = Formatter::Common();
+    auto ft = Formatter();
     ft.Add<utf8*>(_trackDesigns[trackIndex].name);
     DrawTextEllipsised(dpi, screenPos, 368, STR_TRACK_PREVIEW_NAME_FORMAT, ft, COLOUR_BLACK, TextAlignment::CENTRE);
 
@@ -605,7 +603,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
             }
 
             // Ride length
-            ft = Formatter::Common();
+            ft = Formatter();
             ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
             ft.Add<uint16_t>(_loadedTrackDesign->ride_length);
             DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft, COLOUR_BLACK);
@@ -667,17 +665,18 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (_loadedTrackDesign->space_required_x != 0xFF)
     {
         // Space required
-        ft = Formatter::Common();
+        ft = Formatter();
         ft.Add<uint16_t>(_loadedTrackDesign->space_required_x);
         ft.Add<uint16_t>(_loadedTrackDesign->space_required_y);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, gCommonFormatArgs, COLOUR_BLACK, screenPos);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, ft.Data(), COLOUR_BLACK, screenPos);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
     if (_loadedTrackDesign->cost != 0)
     {
-        Formatter::Common().Add<uint32_t>(_loadedTrackDesign->cost);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, gCommonFormatArgs, COLOUR_BLACK, screenPos);
+        ft = Formatter();
+        ft.Add<uint32_t>(_loadedTrackDesign->cost);
+        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, ft.Data(), COLOUR_BLACK, screenPos);
     }
 }
 
@@ -743,10 +742,10 @@ static void window_track_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
             }
 
             // Draw track name
-            auto ft = Formatter::Common();
+            auto ft = Formatter();
             ft.Add<rct_string_id>(STR_TRACK_LIST_NAME_FORMAT);
             ft.Add<utf8*>(_trackDesigns[i].name);
-            gfx_draw_string_left(dpi, stringId, gCommonFormatArgs, COLOUR_BLACK, screenCoords - ScreenCoordsXY{ 0, 1 });
+            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords - ScreenCoordsXY{ 0, 1 });
         }
 
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -256,9 +256,9 @@ void TitleScreen::TitleInitialise()
 
         int32_t random = 0;
         bool safeSequence = false;
-        std::string RCT1String = format_string(STR_TITLE_SEQUENCE_RCT1, gCommonFormatArgs);
-        std::string RCT1AAString = format_string(STR_TITLE_SEQUENCE_RCT1_AA, gCommonFormatArgs);
-        std::string RCT1LLString = format_string(STR_TITLE_SEQUENCE_RCT1_AA_LL, gCommonFormatArgs);
+        std::string RCT1String = format_string(STR_TITLE_SEQUENCE_RCT1, nullptr);
+        std::string RCT1AAString = format_string(STR_TITLE_SEQUENCE_RCT1_AA, nullptr);
+        std::string RCT1LLString = format_string(STR_TITLE_SEQUENCE_RCT1_AA_LL, nullptr);
 
         // Ensure the random sequence chosen isn't from RCT1 or expansion if the player doesn't have it installed
         while (!safeSequence)


### PR DESCRIPTION
Eventually should have it limited to tooltips, window titles and widget args

This again does not fully cover everything but this is a nice chunk of them. Where I noticed that a formatter was not being used I've added on in as well.