### PR TITLE
Fix #8015: RCT2 files are not found when put into the OpenRCT2 folder

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#12999] .sea (RCT Classic) scenarios are now listed in the “New Scenario” dialog.
 - Feature: [#13000] objective_options command for console.
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
+- Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.

--- a/src/openrct2/OpenRCT2.cpp
+++ b/src/openrct2/OpenRCT2.cpp
@@ -11,7 +11,6 @@
 
 StartupAction gOpenRCT2StartupAction = StartupAction::Title;
 utf8 gOpenRCT2StartupActionPath[512] = { 0 };
-utf8 gExePath[MAX_PATH];
 utf8 gCustomUserDataPath[MAX_PATH] = { 0 };
 utf8 gCustomOpenRCT2DataPath[MAX_PATH] = { 0 };
 utf8 gCustomRCT1DataPath[MAX_PATH] = { 0 };

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -36,7 +36,6 @@ enum
 
 extern StartupAction gOpenRCT2StartupAction;
 extern utf8 gOpenRCT2StartupActionPath[512];
-extern utf8 gExePath[MAX_PATH];
 extern utf8 gCustomUserDataPath[MAX_PATH];
 extern utf8 gCustomOpenRCT2DataPath[MAX_PATH];
 extern utf8 gCustomRCT1DataPath[MAX_PATH];

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -644,9 +644,10 @@ namespace Config
             }
         }
 
-        if (RCT1DataPresentAtLocation(gExePath))
+        auto exePath = Path::GetDirectory(Platform::GetCurrentExecutablePath());
+        if (RCT1DataPresentAtLocation(exePath.c_str()))
         {
-            return gExePath;
+            return exePath;
         }
         return std::string();
     }
@@ -698,9 +699,10 @@ namespace Config
             return discordPath;
         }
 
-        if (platform_original_game_data_exists(gExePath))
+        auto exePath = Path::GetDirectory(Platform::GetCurrentExecutablePath());
+        if (platform_original_game_data_exists(exePath.c_str()))
         {
-            return gExePath;
+            return exePath;
         }
         return std::string();
     }


### PR DESCRIPTION
As mentioned in #8015, gExePath is never set, so I removed that variable altogether.