### PR TITLE
Fix #13044: Rides in RCT1 saves all have "0 customers per hour"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
+- Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -125,22 +125,14 @@ struct rct1_ride
     uint8_t unk_CC[2];              // 0x0CC
     uint8_t num_sheltered_sections; // 0x0CE
     // see cur_test_track_location
-    uint8_t cur_test_track_z;                 // 0x0CF
-    int16_t unk_D0;                           // 0x0D0
-    int16_t unk_D2;                           // 0x0D2
-    int16_t customers_per_hour;               // 0x0D4
-    int16_t unk_D6;                           // 0x0D6
-    int16_t unk_D8;                           // 0x0D8
-    int16_t unk_DA;                           // 0x0DA
-    int16_t unk_DC;                           // 0x0DC
-    int16_t unk_DE;                           // 0x0DE
-    uint16_t age;                             // 0x0E0
-    int16_t running_cost;                     // 0x0E2
-    int16_t unk_E4;                           // 0x0E4
-    int16_t unk_E6;                           // 0x0E6
-    money16 price;                            // 0x0E8
-    RCT12xy8 chairlift_bullwheel_location[2]; // 0x0EA
-    uint8_t chairlift_bullwheel_z[2];         // 0x0EE
+    uint8_t cur_test_track_z; // 0x0CF
+    int16_t unk_D0;           // 0x0D0
+    int16_t unk_D2;           // 0x0D2
+    // Customer count in the last 10 * 960 game ticks (sliding window)
+    uint16_t num_customers[CUSTOMER_HISTORY_SIZE]; // 0xD4
+    money16 price;                                 // 0x0E8
+    RCT12xy8 chairlift_bullwheel_location[2];      // 0x0EA
+    uint8_t chairlift_bullwheel_z[2];              // 0x0EE
     union
     {
         RatingTuple ratings;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -950,6 +950,10 @@ private:
         dst->profit = src->profit;
         dst->total_profit = src->total_profit;
         dst->value = src->value;
+        for (size_t i = 0; i < std::size(src->num_customers); i++)
+        {
+            dst->num_customers[i] = src->num_customers[i];
+        }
 
         dst->satisfaction = src->satisfaction;
         dst->satisfaction_time_out = src->satisfaction_time_out;


### PR DESCRIPTION
This issue was caused by misidentified fields. It didn't help that the TID was also incomplete (it only mentioned the first field). Luckily, RCT2 has the same data at the same place.

(Values cross-checked in RCT1)