### PR TITLE
Remove goto from DecideAndBuyItem to fix #12337

### DIFF
--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1580,7 +1580,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         if (itemValue < price)
         {
             itemValue -= price;
-           
+
             if (!isRainingAndUmbrella)
             {
                 itemValue = -itemValue;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1622,16 +1622,6 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             HappinessTarget = std::min((HappinessTarget + happinessGrowth), PEEP_MAX_HAPPINESS);
             Happiness = std::min((Happiness + happinessGrowth), PEEP_MAX_HAPPINESS);
         }
-    }
-
-    if (!hasVoucher)
-    {
-        if (gClimateCurrent.Temperature >= 21)
-            itemValue = ShopItems[shopItem].HotValue;
-        else if (gClimateCurrent.Temperature <= 11)
-            itemValue = ShopItems[shopItem].ColdValue;
-        else
-            itemValue = ShopItems[shopItem].BaseValue;
 
         itemValue -= price;
         uint8_t satisfaction = 0;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1546,9 +1546,11 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
     }
 
     if (shopItem == SHOP_ITEM_UMBRELLA && climate_is_raining())
-        goto loc_69B119;
-
-    if ((shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
+    {
+        //goto loc_69B119;  replaced by "else if" below
+        std::cout << "It's raining and I'm considering an umbrella\n";
+    }
+    else if ((shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
     {
         if (((scenario_rand() & 0x7F) + 0x73) > Happiness)
             return false;
@@ -1556,7 +1558,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             return false;
     }
 
-loc_69B119:
+//loc_69B119: replaced by "else" above
     if (!hasVoucher)
     {
         if (price != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1548,9 +1548,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
 
     if (!isRainingAndUmbrella && (shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
     {
-        if (((scenario_rand() & 0x7F) + 0x73) > Happiness)
-            return false;
-        else if (GuestNumRides < 3)
+        if (((scenario_rand() & 0x7F) + 0x73) > Happiness || GuestNumRides < 3)
             return false;
     }
 
@@ -1585,11 +1583,11 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             {
                 itemValue = -itemValue;
                 if (Happiness >= 128)
+                {
                     itemValue /= 2;
-
-                if (Happiness >= 180)
-                    itemValue /= 2;
-
+                    if (Happiness >= 180)
+                        itemValue /= 2;
+                }
                 if (itemValue > (static_cast<money16>(scenario_rand() & 0x07)))
                 {
                     // "I'm not paying that much for x"

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1610,7 +1610,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
                 }
             }
         }
-        else if (!isRainingAndUmbrella)
+        else // if (!isRainingAndUmbrella)
         {
             itemValue -= price;
             itemValue = std::max(8, itemValue);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1491,7 +1491,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
 
     bool hasVoucher = false;
 
-    bool isRainingAndUmbrella = false;
+    bool isRainingAndUmbrella = shopItem == SHOP_ITEM_UMBRELLA && climate_is_raining();
 
     if ((ItemStandardFlags & PEEP_ITEM_VOUCHER) && (VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
         && (VoucherShopItem == shopItem))
@@ -1547,10 +1547,9 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         return false;
     }
 
-    if (shopItem == SHOP_ITEM_UMBRELLA && climate_is_raining())
+    if (isRainingAndUmbrella)
     {
-        // goto loc_69B119;  replaced by "else if" below
-        std::cout << "It's raining and I'm considering an umbrella\n";
+        // do nothing for now
     }
     else if ((shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
     {
@@ -1560,7 +1559,6 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             return false;
     }
 
-    // loc_69B119: replaced by "else" above
     if (!hasVoucher)
     {
         if (price != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -1587,14 +1585,12 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         if (itemValue < price)
         {
             itemValue -= price;
-            if (shopItem == SHOP_ITEM_UMBRELLA && climate_is_raining())
+            if (isRainingAndUmbrella)
             {
-                // goto loc_69B221; now using below variable to skip all the code
-                // until the place where loc_69B221 was
-                isRainingAndUmbrella = true;
+                // do nothing for now
             }
 
-            if (isRainingAndUmbrella == false)
+            if (!isRainingAndUmbrella)
             {
                 itemValue = -itemValue;
                 if (Happiness >= 128)
@@ -1614,7 +1610,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
                 }
             }
         }
-        else if (isRainingAndUmbrella == false)
+        else if (!isRainingAndUmbrella)
         {
             itemValue -= price;
             itemValue = std::max(8, itemValue);
@@ -1637,7 +1633,6 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         }
     }
 
-    // loc_69B221: replaced by "isRainingAndUmbrella" variable
     if (!hasVoucher)
     {
         if (gClimateCurrent.Temperature >= 21)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1522,17 +1522,16 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             return false;
     }
 
-    if ((shopItem == SHOP_ITEM_BALLOON) || (shopItem == SHOP_ITEM_ICE_CREAM) || (shopItem == SHOP_ITEM_CANDYFLOSS)
-        || (shopItem == SHOP_ITEM_SUNGLASSES))
+    if ((shopItem == SHOP_ITEM_BALLOON || shopItem == SHOP_ITEM_ICE_CREAM || shopItem == SHOP_ITEM_CANDYFLOSS
+         || shopItem == SHOP_ITEM_SUNGLASSES)
+        && climate_is_raining())
     {
-        if (climate_is_raining())
-            return false;
+        return false;
     }
 
-    if ((shopItem == SHOP_ITEM_SUNGLASSES) || (shopItem == SHOP_ITEM_ICE_CREAM))
+    if ((shopItem == SHOP_ITEM_SUNGLASSES || shopItem == SHOP_ITEM_ICE_CREAM) && gClimateCurrent.Temperature < 12)
     {
-        if (gClimateCurrent.Temperature < 12)
-            return false;
+        return false;
     }
 
     if (ShopItems[shopItem].IsFood() && (Hunger > 75))
@@ -1547,11 +1546,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         return false;
     }
 
-    if (isRainingAndUmbrella)
-    {
-        // do nothing for now
-    }
-    else if ((shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
+    if (!isRainingAndUmbrella && (shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
     {
         if (((scenario_rand() & 0x7F) + 0x73) > Happiness)
             return false;
@@ -1585,11 +1580,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         if (itemValue < price)
         {
             itemValue -= price;
-            if (isRainingAndUmbrella)
-            {
-                // do nothing for now
-            }
-
+           
             if (!isRainingAndUmbrella)
             {
                 itemValue = -itemValue;
@@ -1610,7 +1601,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
                 }
             }
         }
-        else // if (!isRainingAndUmbrella)
+        else
         {
             itemValue -= price;
             itemValue = std::max(8, itemValue);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1549,7 +1549,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
 
     if (shopItem == SHOP_ITEM_UMBRELLA && climate_is_raining())
     {
-        //goto loc_69B119;  replaced by "else if" below
+        // goto loc_69B119;  replaced by "else if" below
         std::cout << "It's raining and I'm considering an umbrella\n";
     }
     else if ((shopItem != SHOP_ITEM_MAP) && ShopItems[shopItem].IsSouvenir() && !hasVoucher)
@@ -1560,7 +1560,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             return false;
     }
 
-//loc_69B119: replaced by "else" above
+    // loc_69B119: replaced by "else" above
     if (!hasVoucher)
     {
         if (price != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -1589,8 +1589,8 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             itemValue -= price;
             if (shopItem == SHOP_ITEM_UMBRELLA && climate_is_raining())
             {
-                //goto loc_69B221; now using below variable to skip all the code
-                //until the place where loc_69B221 was;
+                // goto loc_69B221; now using below variable to skip all the code
+                // until the place where loc_69B221 was
                 isRainingAndUmbrella = true;
             }
 
@@ -1637,7 +1637,7 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         }
     }
 
-//loc_69B221: replaced by "isRainingAndUmbrella" variable
+    // loc_69B221: replaced by "isRainingAndUmbrella" variable
     if (!hasVoucher)
     {
         if (gClimateCurrent.Temperature >= 21)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1601,13 +1601,6 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         }
         else
         {
-            // reset itemValue for satisfaction calculation
-            if (gClimateCurrent.Temperature >= 21)
-                itemValue = ShopItems[shopItem].HotValue;
-            else if (gClimateCurrent.Temperature <= 11)
-                itemValue = ShopItems[shopItem].ColdValue;
-            else
-                itemValue = ShopItems[shopItem].BaseValue;
             itemValue -= price;
             itemValue = std::max(8, itemValue);
 
@@ -1628,6 +1621,13 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
             Happiness = std::min((Happiness + happinessGrowth), PEEP_MAX_HAPPINESS);
         }
 
+        // reset itemValue for satisfaction calculation
+        if (gClimateCurrent.Temperature >= 21)
+            itemValue = ShopItems[shopItem].HotValue;
+        else if (gClimateCurrent.Temperature <= 11)
+            itemValue = ShopItems[shopItem].ColdValue;
+        else
+            itemValue = ShopItems[shopItem].BaseValue;
         itemValue -= price;
         uint8_t satisfaction = 0;
         if (itemValue > -8)

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1601,6 +1601,13 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
         }
         else
         {
+            // reset itemValue for satisfaction calculation
+            if (gClimateCurrent.Temperature >= 21)
+                itemValue = ShopItems[shopItem].HotValue;
+            else if (gClimateCurrent.Temperature <= 11)
+                itemValue = ShopItems[shopItem].ColdValue;
+            else
+                itemValue = ShopItems[shopItem].BaseValue;
             itemValue -= price;
             itemValue = std::max(8, itemValue);
 
@@ -1633,7 +1640,6 @@ bool Guest::DecideAndBuyItem(Ride* ride, int32_t shopItem, money32 price)
                     satisfaction++;
             }
         }
-
         ride_update_satisfaction(ride, satisfaction);
     }
 


### PR DESCRIPTION
I did it in two parts as you requested:
remove goto loc_69B119 by using an elseif statement
remove goto loc_69B221 by using a bool variable and some if statements to bypass the code

I am interested next in rewriting more of this function so that it flows better, as well as actually splitting it in two (decide and buy), but I don't want to get carried away to solve #12337.  

Please let me know if you have any questions/comments. Thanks!