### PR TITLE
[Issue #9568] Replace RRC lift sounds LiftWood to match SFRC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.17/objects.zip")
 set(OBJECTS_SHA1 "44a702b58b144e138029f4d096d16f5beec3ddb1")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.18/replays.zip")
-set(REPLAYS_SHA1 "5B1C9A6E91B135A1EB629332BEA488A10CA6AD60")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.19/replays.zip")
+set(REPLAYS_SHA1 "8EAAE223FF9FE4D49949C9F343831977E6DB6CDE")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#12999] .sea (RCT Classic) scenarios are now listed in the “New Scenario” dialog.
 - Feature: [#13000] objective_options command for console.
 - Feature: [#13096] Add Esperanto translation.
+- Change: [#9568] Change lift sounds of Reverser Roller Coaster and Compact Inverted Coaster to better fitting ones.
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.17/objects.zip</ObjectsUrl>
     <ObjectsSha1>44a702b58b144e138029f4d096d16f5beec3ddb1</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.18/replays.zip</ReplaysUrl>
-    <ReplaysSha1>5B1C9A6E91B135A1EB629332BEA488A10CA6AD60</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.19/replays.zip</ReplaysUrl>
+    <ReplaysSha1>8EAAE223FF9FE4D49949C9F343831977E6DB6CDE</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -36,7 +36,7 @@ constexpr const RideTypeDescriptor CompactInvertedCoasterRTD =
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(Heights, { 27, 40, 29, 8, }),
     SET_FIELD(MaxMass, 18),
-    SET_FIELD(LiftData, { SoundId::LiftFrictionWheels, 4, 6 }),
+    SET_FIELD(LiftData, { SoundId::LiftClassic, 4, 6 }),
     SET_FIELD(RatingsCalculationFunction, ride_ratings_calculate_compact_inverted_coaster),
     SET_FIELD(RatingsMultipliers, { 50, 30, 10 }),
     SET_FIELD(UpkeepCosts, { 40, 20, 80, 13, 3, 10 }),

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -35,7 +35,7 @@ constexpr const RideTypeDescriptor ReverserRollerCoasterRTD =
     SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
     SET_FIELD(Heights, { 18, 24, 8, 11, }),
     SET_FIELD(MaxMass, 15),
-    SET_FIELD(LiftData, { SoundId::LiftClassic, 3, 4 }),
+    SET_FIELD(LiftData, { SoundId::LiftWood, 3, 4 }),
     SET_FIELD(RatingsCalculationFunction, ride_ratings_calculate_reverser_roller_coaster),
     SET_FIELD(RatingsMultipliers, { 48, 28, 7 }),
     SET_FIELD(UpkeepCosts, { 39, 20, 80, 10, 3, 10 }),


### PR DESCRIPTION
### Description

Proposed solution to https://github.com/OpenRCT2/OpenRCT2/issues/9568. Updates Reverser RC to have same lift sound [as the Side Friction RC](https://github.com/OpenRCT2/OpenRCT2/blob/d33ddaba2cd3626e9279cb0659960c942ccd8c76/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h#L39). Updates Compact Inverted Coaster to have the classic lift sound.


Ride | Current sound | Proposal
-- | -- | --
SLC | Friction wheels | Classic chain sound or Arrow sound
Reverser RC | Classic chain sound | Side-friction RC sound