### PR TITLE
Close #12435: Refactor FILEDIALOG_TYPE to use strong enum 

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -403,7 +403,7 @@ static bool browse(bool isSave, char* path, size_t pathSize)
     }
 
     desc.initial_directory = _directory;
-    desc.type = isSave ? FD_SAVE : FD_OPEN;
+    desc.type = isSave ? FileDialogType::Save : FileDialogType::Open;
     desc.default_filename = isSave ? path : nullptr;
 
     // Add 'all files' filter. If the number of filters is increased, this code will need to be adjusted.

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -64,15 +64,15 @@ struct rct2_time
     uint8_t second;
 };
 
-enum FILEDIALOG_TYPE
+enum class FileDialogType
 {
-    FD_OPEN,
-    FD_SAVE
+    Open,
+    Save,
 };
 
 struct file_dialog_desc
 {
-    uint8_t type;
+    FileDialogType type;
     const utf8* title;
     const utf8* initial_directory;
     const utf8* default_filename;

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -64,7 +64,7 @@ struct rct2_time
     uint8_t second;
 };
 
-enum class FileDialogType
+enum class FileDialogType : uint8_t
 {
     Open,
     Save,

--- a/src/openrct2/platform/platform.h
+++ b/src/openrct2/platform/platform.h
@@ -67,7 +67,7 @@ struct rct2_time
 enum class FileDialogType : uint8_t
 {
     Open,
-    Save,
+    Save
 };
 
 struct file_dialog_desc


### PR DESCRIPTION
Hi,

This pull request refactors FILEDIALOG_TYPE to use a strongly typed enum (#12435). Loading and saving works as expected.

Thanks!