### PR TITLE
Fix entrance and exit ghosts not being removed for mazes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
-- Fix: Entrance and exit ghosts for mazes not being removed.
+- Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
+- Fix: Entrance and exit ghosts for mazes not being removed.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1378,6 +1378,7 @@ void ride_construction_invalidate_current_track()
                 map_invalidate_tile_full(_currentTrackBegin.ToTileStart());
                 gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
             }
+            ride_construction_remove_ghosts();
             break;
         default:
             if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ARROW)


### PR DESCRIPTION
Currently, when placing the entrance or exit of a maze, the ghost of the entrance or exit will not disappear until you actually place it - even if you exit construction. This PR adds a call in the `ride_construction_invalidate_current_track` function to remove the ghost images for mazes when the track is invalidated.

This also solves a separate issue where `RideEntranceExitRemoveAction` would spew a lot of "Track Element not found" warnings in the console.

I couldn't see an existing issue about this. It's not an original bug, but it looks like it's always been in OpenRCT2.