### PR TITLE
Fix #4022 Mac: Launching game, cursor off. Work around, full screen app, then restore to windowed

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -678,7 +678,11 @@ private:
         OnResize(width, height);
 
         UpdateFullscreenResolutions();
+        
+        // Avoid issue #4022 where cursor is often vertically offset on launch on Mac OSX
+#ifndef __MACOSX__
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.fullscreen_mode));
+#endif
 
         TriggerResize();
     }


### PR DESCRIPTION
I'm not sure this is the best approach for fixing this bug, but I'll explain my thought process and reproduction steps and I look forward to any feedback, input or suggestions.

### Reproducing the Bug

**Steps**

1. Launch the game
2. Fullscreen game
3. Close game
4. Relaunch game

**Expected**

Game should launch fullscreen and cursor should work as expected.

**Actual**

Game launches windowed as large as it can, and the cursor is off vertically as described in the original issue

### Process

After some experimentation and discussion in the Discord channel, it seems like there is an SDL2 bug with Mac OSX. SetFullscreenMode is called during UiContext's startup flow. Not calling it removes the cursor offset. We still need this function to work on Mac normally since it gets called when the user changes from fullscreen to windowed while playing. By changing only the startup flow and only for Mac OSX, the original issue is fixed without affecting any other platforms.

### Next steps

A better fix would involve a deeper understanding of why exactly the bug occurs and what part SDL2 plays.