### PR TITLE
Fix #4022: Mac cursor offset on launch

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Change: [#13160] The lay-out of the Park Cheats tab has been improved.
 - Fix: [#1324] Last track piece map selection still visible when placing ride entrance or exit (original bug).
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
+- Fix: [#4022] Fix Mac cursor offset on launch
 - Fix: [#4041] Garbled park option on scenario editor with custom theme.
 - Fix: [#5178] Lighting effects cannot be disabled in software mode
 - Fix: [#5904] Empty errors on tile inspector base height change.

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -679,8 +679,10 @@ private:
 
         UpdateFullscreenResolutions();
 
-        // Fix #4022: Mac cursor offset on launch issue
-#ifndef __MACOSX__
+        // Fix #4022: Force Mac to windowed to avoid cursor offset on launch issue
+#ifdef __MACOSX__
+        gConfigGeneral.fullscreen_mode = static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::WINDOWED);
+#else
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.fullscreen_mode));
 #endif
         TriggerResize();

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -680,6 +680,9 @@ private:
         UpdateFullscreenResolutions();
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.fullscreen_mode));
 
+#ifndef __MACOSX__
+        SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.fullscreen_mode));
+#endif
         TriggerResize();
     }
 

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -678,8 +678,8 @@ private:
         OnResize(width, height);
 
         UpdateFullscreenResolutions();
-        SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.fullscreen_mode));
 
+        // Fix #4022: Mac cursor offset on launch issue
 #ifndef __MACOSX__
         SetFullscreenMode(static_cast<FULLSCREEN_MODE>(gConfigGeneral.fullscreen_mode));
 #endif


### PR DESCRIPTION
I'm not sure this is the best approach for fixing this bug, but I'll explain my thought process and reproduction steps and I look forward to any feedback, input or suggestions.

### Reproducing the Bug

**Steps**

1. Launch the game
2. Fullscreen game
3. Close game
4. Relaunch game

**Expected**

Game should launch fullscreen and cursor should work as expected.

**Actual**

Game launches windowed as large as it can, and the cursor is off vertically as described in the original issue

### Process

After some experimentation and discussion in the Discord channel, it seems like there is an SDL2 bug with Mac OSX. SetFullscreenMode is called during UiContext's startup flow. Not calling it removes the cursor offset. We still need this function to work on Mac normally since it gets called when the user changes from fullscreen to windowed while playing. By changing only the startup flow and only for Mac OSX, the original issue is fixed without affecting any other platforms.

### Next steps

A better fix would involve a deeper understanding of why exactly the bug occurs and what part SDL2 plays.