### PR TITLE
Construction arrow pulse improvements

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#5178] Lighting effects cannot be disabled in software mode
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
+- Fix: [#7443] Construction arrows pulse at irregular intervals.
 - Fix: [#7748] Tooltips would not timeout for normal UI elements.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#8957] Error title missing when building with insufficient funds

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
+- Fix: [#13097] Missing direction arrow for stations
 - Fix: [#13098] UI buttons for entrance and exit don't toggle according to them being built.
 - Fix: [#13098] Maze can still be constructed while placing entrance and exit (original bug).
 - Fix: [#13118] Closing construction window resets ride viewport.

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -19,6 +19,7 @@
 #include <openrct2/audio/audio.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/object/ObjectLimits.h>
+#include <openrct2/platform/platform.h>
 #include <openrct2/sprites.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
@@ -27,6 +28,7 @@
 static constexpr const rct_string_id WINDOW_TITLE = STR_FOOTPATHS;
 static constexpr const int32_t WH = 381;
 static constexpr const int32_t WW = 106;
+static constexpr const uint16_t ARROW_PULSE_DURATION = 200;
 
 // clang-format off
 enum
@@ -129,7 +131,7 @@ static rct_window_event_list window_footpath_events([](auto& events)
 // clang-format on
 
 static money32 _window_footpath_cost;
-static int8_t _window_footpath_provisional_path_arrow_timer;
+static uint32_t _footpathConstructionNextArrowPulse = 0;
 static uint8_t _lastUpdatedCameraRotation = UINT8_MAX;
 static bool _footpathErrorOccured;
 
@@ -473,10 +475,13 @@ static void window_footpath_update_provisional_path_for_bridge_mode(rct_window* 
         widget_invalidate(w, WIDX_CONSTRUCT);
     }
 
+    auto curTime = platform_get_ticks();
+
     // Update little directional arrow on provisional bridge mode path
-    if (--_window_footpath_provisional_path_arrow_timer < 0)
+    if (_footpathConstructionNextArrowPulse < curTime)
     {
-        _window_footpath_provisional_path_arrow_timer = 5;
+        _footpathConstructionNextArrowPulse = curTime + ARROW_PULSE_DURATION;
+
         gFootpathProvisionalFlags ^= PROVISIONAL_PATH_FLAG_SHOW_ARROW;
         CoordsXYZ footpathLoc;
         footpath_get_next_path_info(&type, footpathLoc, &slope);
@@ -932,7 +937,6 @@ static void window_footpath_start_bridge_at_point(const ScreenCoordsXY& screenCo
     gFootpathConstructFromPosition = { mapCoords, z };
     gFootpathConstructDirection = direction;
     gFootpathProvisionalFlags = 0;
-    _window_footpath_provisional_path_arrow_timer = 0;
     gFootpathConstructSlope = 0;
     gFootpathConstructionMode = PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL;
     gFootpathConstructValidDirections = INVALID_DIRECTION;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1372,13 +1372,16 @@ void ride_construction_invalidate_current_track()
         case RIDE_CONSTRUCTION_STATE_MAZE_BUILD:
         case RIDE_CONSTRUCTION_STATE_MAZE_MOVE:
         case RIDE_CONSTRUCTION_STATE_MAZE_FILL:
+        case RIDE_CONSTRUCTION_STATE_FRONT:
+        case RIDE_CONSTRUCTION_STATE_BACK:
             if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ARROW)
             {
                 map_invalidate_tile_full(_currentTrackBegin.ToTileStart());
-                gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
             }
             ride_construction_remove_ghosts();
             break;
+        case RIDE_CONSTRUCTION_STATE_PLACE:
+        case RIDE_CONSTRUCTION_STATE_ENTRANCE_EXIT:
         default:
             if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ARROW)
             {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -101,7 +101,6 @@ CoordsXYZ _currentTrackBegin;
 uint8_t _currentTrackPieceDirection;
 track_type_t _currentTrackPieceType;
 uint8_t _currentTrackSelectionFlags;
-int8_t _rideConstructionArrowPulseTime;
 uint8_t _currentTrackSlopeEnd;
 uint8_t _currentTrackBankEnd;
 uint8_t _currentTrackLiftHill;
@@ -1611,6 +1610,12 @@ void ride_select_next_section()
                 // Set next element's height.
                 virtual_floor_set_height(tileElement->GetBaseZ());
             }
+
+            _currentTrackBegin = *newCoords;
+            _currentTrackPieceDirection = tileElement->GetDirection();
+            _currentTrackPieceType = tileElement->AsTrack()->GetTrackType();
+            _currentTrackSelectionFlags = 0;
+            window_ride_construction_update_active_elements();
         }
         else
         {
@@ -1619,18 +1624,9 @@ void ride_select_next_section()
             _currentTrackPieceDirection = direction;
             _currentTrackPieceType = tileElement->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
-            _rideConstructionArrowPulseTime = 0;
             ride_construction_set_default_next_piece();
             window_ride_construction_update_active_elements();
-            return;
         }
-
-        _currentTrackBegin = *newCoords;
-        _currentTrackPieceDirection = tileElement->GetDirection();
-        _currentTrackPieceType = tileElement->AsTrack()->GetTrackType();
-        _currentTrackSelectionFlags = 0;
-        _rideConstructionArrowPulseTime = 0;
-        window_ride_construction_update_active_elements();
     }
     else if (_rideConstructionState == RIDE_CONSTRUCTION_STATE_BACK)
     {
@@ -1673,7 +1669,6 @@ void ride_select_previous_section()
             _currentTrackPieceDirection = trackBeginEnd.begin_direction;
             _currentTrackPieceType = trackBeginEnd.begin_element->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
-            _rideConstructionArrowPulseTime = 0;
             if (!scenery_tool_is_active())
             {
                 // Set previous element's height.
@@ -1690,7 +1685,6 @@ void ride_select_previous_section()
             _currentTrackPieceDirection = trackBeginEnd.end_direction;
             _currentTrackPieceType = tileElement->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
-            _rideConstructionArrowPulseTime = 0;
             ride_construction_set_default_next_piece();
             window_ride_construction_update_active_elements();
         }
@@ -1799,7 +1793,6 @@ static bool ride_modify_maze(const CoordsXYE& tileElement)
             _currentTrackBegin.y = tileElement.y;
             _currentTrackBegin.z = trackElement->GetBaseZ();
             _currentTrackSelectionFlags = 0;
-            _rideConstructionArrowPulseTime = 0;
 
             auto intent = Intent(INTENT_ACTION_UPDATE_MAZE_CONSTRUCTION);
             context_broadcast_intent(&intent);
@@ -1880,7 +1873,6 @@ bool ride_modify(CoordsXYE* input)
     _currentTrackPieceDirection = direction;
     _currentTrackPieceType = type;
     _currentTrackSelectionFlags = 0;
-    _rideConstructionArrowPulseTime = 0;
 
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_NO_TRACK))
     {
@@ -1900,7 +1892,6 @@ bool ride_modify(CoordsXYE* input)
     _currentTrackPieceDirection = direction;
     _currentTrackPieceType = type;
     _currentTrackSelectionFlags = 0;
-    _rideConstructionArrowPulseTime = 0;
 
     ride_select_previous_section();
 
@@ -1911,7 +1902,6 @@ bool ride_modify(CoordsXYE* input)
         _currentTrackPieceDirection = direction;
         _currentTrackPieceType = type;
         _currentTrackSelectionFlags = 0;
-        _rideConstructionArrowPulseTime = 0;
     }
 
     window_ride_construction_update_active_elements();
@@ -1958,7 +1948,6 @@ int32_t ride_initialise_construction_window(Ride* ride)
     _currentTrackPieceDirection = 0;
     _rideConstructionState = RIDE_CONSTRUCTION_STATE_PLACE;
     _currentTrackSelectionFlags = 0;
-    _rideConstructionArrowPulseTime = 0;
 
     window_ride_construction_update_active_elements();
     return 1;
@@ -6260,7 +6249,6 @@ bool ride_select_backwards_from_front()
             _currentTrackPieceDirection = trackBeginEnd.begin_direction;
             _currentTrackPieceType = trackBeginEnd.begin_element->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
-            _rideConstructionArrowPulseTime = 0;
             return true;
         }
     }
@@ -6286,7 +6274,6 @@ bool ride_select_forwards_from_back()
             _currentTrackPieceDirection = next_track.element->GetDirection();
             _currentTrackPieceType = next_track.element->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
-            _rideConstructionArrowPulseTime = 0;
             return true;
         }
     }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1061,7 +1061,6 @@ extern CoordsXYZ _currentTrackBegin;
 extern uint8_t _currentTrackPieceDirection;
 extern track_type_t _currentTrackPieceType;
 extern uint8_t _currentTrackSelectionFlags;
-extern int8_t _rideConstructionArrowPulseTime;
 extern uint8_t _currentTrackSlopeEnd;
 extern uint8_t _currentTrackBankEnd;
 extern uint8_t _currentTrackLiftHill;

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -434,7 +434,6 @@ void window_ride_construction_mouseup_demolish_next_piece(const CoordsXYZD& piec
         _currentTrackBegin.z = floor2(piecePos.z, COORDS_Z_STEP);
         _rideConstructionState = RIDE_CONSTRUCTION_STATE_FRONT;
         _currentTrackSelectionFlags = 0;
-        _rideConstructionArrowPulseTime = 0;
         _currentTrackPieceDirection = piecePos.direction & 3;
         int32_t savedCurrentTrackCurve = _currentTrackCurve;
         int32_t savedPreviousTrackSlopeEnd = _previousTrackSlopeEnd;
@@ -489,7 +488,6 @@ void window_ride_construction_mouseup_demolish_next_piece(const CoordsXYZD& piec
         _currentTrackPieceDirection = piecePos.direction;
         _currentTrackPieceType = type;
         _currentTrackSelectionFlags = 0;
-        _rideConstructionArrowPulseTime = 0;
         if (_rideConstructionState2 == RIDE_CONSTRUCTION_STATE_FRONT)
         {
             ride_select_next_section();


### PR DESCRIPTION
While working on #13074, I noticed that the arrow/maze section pulsing was inconsistent and would occasionally flash on and off in bursts. This PR changes the pulsing for ride and footpath construction to be time based. Additionally, the arrow pulse for station pieces has been restored.

The pulse speed of the arrow can be controlled with the `ARROW_PULSE_DURATION` static variable in `RideConstruction.cpp` and `Footpath.cpp`.