### PR TITLE
Entrance/exit construction state fixes in ride and maze construction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,10 +20,13 @@
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
+- Fix: [#13098] UI buttons for entrance and exit don't toggle according to them being built.
+- Fix: [#13098] Maze can still be constructed while placing entrance and exit (original bug).
 - Fix: [#13118] Closing construction window resets ride viewport.
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Fix: [#13138] Fix logical sorting of list windows.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
+- Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
 
 0.3.1 (2020-09-27)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#13000] objective_options command for console.
 - Feature: [#13096] Add Esperanto translation.
 - Change: [#9568] Change lift sounds of Reverser Roller Coaster and Compact Inverted Coaster to better fitting ones.
+- Fix: [#1324] Last track piece map selection still visible when placing ride entrance or exit (original bug).
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
 - Fix: [#4041] Garbled park option on scenario editor with custom theme.
 - Fix: [#5904] Empty errors on tile inspector base height change.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2659,6 +2659,9 @@ static void window_ride_construction_update_map_selection()
             trackType = _currentTrackPieceType;
             trackPos = _currentTrackBegin;
             break;
+        case RIDE_CONSTRUCTION_STATE_ENTRANCE_EXIT:
+            gMapSelectionTiles.clear();
+            return;
         default:
             if (window_ride_construction_update_state(&trackType, &trackDirection, nullptr, nullptr, &trackPos, nullptr))
             {


### PR DESCRIPTION
A couple of bug fixes for the RIDE_CONSTRUCTION_STATE_ENTRANCE_EXIT construction state in rides and mazes:

#### Ride Construction map selections

Currently, when placing an entrance or exit on a track ride that's incomplete, the map selection of the last ghost piece is visible:

![image](https://user-images.githubusercontent.com/2857218/95019038-1213a500-065b-11eb-89d8-bd70818bceed.png)

The first commit, 8820d90, removes the existing selection when in the entrance exit construction state

#### Maze construction UX

Currently, when placing an entrance or exit on a maze, the arrow buttons are still usable even though the current position indicator is hidden. This PR makes a few changes to improve the UX of the maze construction window:

* The arrow buttons are disabled in the entrance/exit state
* When leaving the entrance/exit state, the previous state is restored
* When in the entrance/exit state, clicking one of the maze build mode buttons will disabled the active entrance/exit buttons
* The entrance/exit buttons now switch along with the widget switch when the first entrance/exit is placed