### PR TITLE
Closes #12407: Refactor CHAT_INPUT to use strong enum

### DIFF
--- a/src/openrct2-ui/input/Input.cpp
+++ b/src/openrct2-ui/input/Input.cpp
@@ -61,18 +61,18 @@ static void input_handle_console(int32_t key)
 
 static void input_handle_chat(int32_t key)
 {
-    CHAT_INPUT input = CHAT_INPUT_NONE;
+    ChatInput input = ChatInput::None;
     switch (key)
     {
         case SDL_SCANCODE_ESCAPE:
-            input = CHAT_INPUT_CLOSE;
+            input = ChatInput::Close;
             break;
         case SDL_SCANCODE_RETURN:
         case SDL_SCANCODE_KP_ENTER:
-            input = CHAT_INPUT_SEND;
+            input = ChatInput::Send;
             break;
     }
-    if (input != CHAT_INPUT_NONE)
+    if (input != ChatInput::None)
     {
         chat_input(input);
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -248,11 +248,11 @@ void chat_history_add(const char* src)
     Mixer_Play_Effect(SoundId::NewsItem, 0, MIXER_VOLUME_MAX, 0.5f, 1.5f, true);
 }
 
-void chat_input(CHAT_INPUT input)
+void chat_input(ChatInput input)
 {
     switch (input)
     {
-        case CHAT_INPUT_SEND:
+        case ChatInput::Send:
             if (strlen(_chatCurrentLine) > 0)
             {
                 network_send_chat(_chatCurrentLine);
@@ -260,7 +260,7 @@ void chat_input(CHAT_INPUT input)
             chat_clear_input();
             chat_close();
             break;
-        case CHAT_INPUT_CLOSE:
+        case ChatInput::Close:
             chat_close();
             break;
         default:

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -20,11 +20,11 @@
 struct rct_drawpixelinfo;
 struct ScreenCoordsXY;
 
-enum CHAT_INPUT
+enum class ChatInput : uint8_t
 {
-    CHAT_INPUT_NONE,
-    CHAT_INPUT_SEND,
-    CHAT_INPUT_CLOSE,
+    None,
+    Send,
+    Close,
 };
 
 extern bool gChatOpen;
@@ -39,7 +39,7 @@ void chat_update();
 void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColour);
 
 void chat_history_add(const char* src);
-void chat_input(CHAT_INPUT input);
+void chat_input(ChatInput input);
 
 int32_t chat_string_wrapped_get_height(void* args, int32_t width);
 int32_t chat_history_draw_string(rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& screenCoords, int32_t width);


### PR DESCRIPTION
Following on from #13115 (technical difficulties....), this PR refactors CHAT_INPUT to use a strong enum (#12407), and contains no merge commit. I'll use rebase in future. Chat tested working as normal.