### PR TITLE
Fix #10186: Placing multiple saved rides ignores design name

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#6086] Cannot install existing track design with another name.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#8957] Error title missing when building with insufficient funds
+- Fix: [#10186] Placing multiple saved rides ignores design name (original bug).
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -221,9 +221,13 @@ GameActionResult::Ptr TrackDesignAction::Execute() const
         ride->vehicle_colours[i].Ternary = _td.vehicle_additional_colour[i];
     }
 
-    auto gameAction = RideSetNameAction(ride->id, _td.name);
-    gameAction.SetFlags(GetFlags());
-    GameActions::ExecuteNested(&gameAction);
+    for (int32_t count = 1; count == 1 || r->Error != GA_ERROR::OK; ++count)
+    {
+        auto name = count == 1 ? _td.name : (_td.name + " " + std::to_string(count));
+        auto gameAction = RideSetNameAction(ride->id, name);
+        gameAction.SetFlags(GetFlags());
+        r = GameActions::ExecuteNested(&gameAction);
+    }
     res->Cost = cost;
     res->rideIndex = ride->id;
     return res;


### PR DESCRIPTION
`RideSetNameAction` returns an uncaught error if the name already exists, thus the renaming never happened for custom rides.