### PR TITLE
Fix #13118: Closing construction window resets ride viewport

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
+- Fix: [#13118] Closing construction window resets ride viewport.
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1291,6 +1291,11 @@ rct_window* window_ride_main_open(Ride* ride)
     {
         w = window_ride_open(ride);
         w->ride.var_482 = -1;
+        w->ride.view = 0;
+    }
+    else if (w->ride.view >= (1 + ride->num_vehicles + ride->num_stations))
+    {
+        w->ride.view = 0;
     }
 
     if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE))
@@ -1306,7 +1311,6 @@ rct_window* window_ride_main_open(Ride* ride)
         window_ride_set_page(w, WINDOW_RIDE_PAGE_MAIN);
     }
 
-    w->ride.view = 0;
     window_ride_init_viewport(w);
     return w;
 }


### PR DESCRIPTION
Now it only resets if the window hadn't been open or if the view is larger than what it currently supports