### PR TITLE
Fix #13083: Dialog for renaming conflicting track design cropped

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
+- Fix: [#13083] Dialog for renaming conflicting track design crops text out.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -236,8 +236,8 @@ static void window_text_input_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t no_lines = 0;
     int32_t font_height = 0;
 
-    gfx_draw_string_centred(
-        dpi, input_text_description, { w->windowPos.x + WW / 2, screenCoords.y }, w->colours[1], &TextInputDescriptionArgs);
+    gfx_draw_string_centred_wrapped(
+        dpi, &TextInputDescriptionArgs, { w->windowPos.x + WW / 2, screenCoords.y }, WW, input_text_description, w->colours[1]);
 
     screenCoords.y += 25;
 


### PR DESCRIPTION
Change description drawing from gfx_draw_string_centred to gfx_draw_string_centred_wrapped.

EDIT: adding before and after screenshots as requested.

Before:
![ConflictingTrackDialog_old](https://user-images.githubusercontent.com/29646196/95405440-c3c60680-08e5-11eb-8a50-d0760a9913ff.png)

After:
![ConflictingTrackDialog](https://user-images.githubusercontent.com/29646196/95404690-af810a00-08e3-11eb-8b4a-fe1aa4e9a0c1.png)