### PR TITLE
Fix #4041: Garbled park option on scenario editor with custom theme

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#13096] Add Esperanto translation.
 - Change: [#9568] Change lift sounds of Reverser Roller Coaster and Compact Inverted Coaster to better fitting ones.
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
+- Fix: [#4041] Garbled park option on scenario editor with custom theme.
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -1360,7 +1360,6 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
         else
             stringId = STR_PAY_PARK_ENTER;
 
-        gfx_draw_string_left(dpi, stringId, nullptr, COLOUR_BLACK, screenCoords);
         gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
     }
 

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -1351,7 +1351,6 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
         // Pay for park or rides label
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].left + 1, w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].top };
-        gfx_draw_string_left(dpi, STR_FREE_PARK_ENTER, nullptr, COLOUR_BLACK, screenCoords);
 
         // Pay for park and/or rides value
         if (gParkFlags & PARK_FLAGS_UNLOCK_ALL_PRICES)
@@ -1361,6 +1360,7 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
         else
             stringId = STR_PAY_PARK_ENTER;
 
+        gfx_draw_string_left(dpi, stringId, nullptr, COLOUR_BLACK, screenCoords);
         gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
     }
 


### PR DESCRIPTION
Regardless of what had been chosen, it was always drawing `STR_FREE_PARK_ENTER` first.
**Before:**
![before](https://user-images.githubusercontent.com/6443427/95409773-ca11ae00-08f8-11eb-809c-ac079be23726.png)
**After:**
![after](https://user-images.githubusercontent.com/6443427/95409774-caaa4480-08f8-11eb-9a54-36335acb9bdd.png)
