### PR TITLE
Fix #13125, make initial RCT2 directory picking not be hardcoded

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -89,6 +89,7 @@ The following people are not part of the development team, but have been contrib
 * Hudson Oliveira (hdpoliveira) - Misc.
 * Jim Verheijde (Jimver) - Make handymen less likely to get stuck in queue lines, misc.
 * Helio Batimarqui (batimarqui) - Misc.
+* Keith Stellyes - Misc.
 
 ## Bug fixes
 * (halfbro)

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3646,6 +3646,11 @@ STR_6387    :Can't lower element here…
 STR_6388    :Can't raise element here…
 STR_6389    :Invalid clearance
 
+# Picking RCT2 directory 
+STR_6390    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 in order to work. Please select the directory where you installed RollerCoaster Tycoon 2.
+STR_6391    :Please select your RCT2 directory
+STR_6392    :Could not find {STRING} at this path.
+
 #############
 # Scenarios #
 ################

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3645,8 +3645,6 @@ STR_6386    :Blizzard
 STR_6387    :Can't lower element here…
 STR_6388    :Can't raise element here…
 STR_6389    :Invalid clearance
-
-# Picking RCT2 directory 
 STR_6390    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 in order to work. Please select the directory where you installed RollerCoaster Tycoon 2.
 STR_6391    :Please select your RCT2 directory
 STR_6392    :Could not find {STRING} at this path.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
+- Fix: [#13125] Support localisation for RollerCoaster Tycoon 2 data picker dialogs
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,9 +17,9 @@
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
-- Fix: [#13125] Support localisation for RollerCoaster Tycoon 2 data picker dialogs
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
+- Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -361,9 +361,9 @@ namespace OpenRCT2
                 {
                     _localisationService->OpenLanguage(LANGUAGE_ENGLISH_UK);
                 }
-                catch (const std::exception&)
+                catch (const std::exception& eFallback)
                 {
-                    log_fatal("Failed to open fallback language: %s", e.what());
+                    log_fatal("Failed to open fallback language: %s", eFallback.what());
                     return false;
                 }
             }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -350,6 +350,24 @@ namespace OpenRCT2
                 config_save_default();
             }
 
+            try
+            {
+                _localisationService->OpenLanguage(gConfigGeneral.language);
+            }
+            catch (const std::exception& e)
+            {
+                log_error("Failed to open configured language: %s", e.what());
+                try
+                {
+                    _localisationService->OpenLanguage(LANGUAGE_ENGLISH_UK);
+                }
+                catch (const std::exception&)
+                {
+                    log_fatal("Failed to open fallback language: %s", e.what());
+                    return false;
+                }
+            }
+
             // TODO add configuration option to allow multiple instances
             // if (!gOpenRCT2Headless && !platform_lock_single_instance()) {
             //  log_fatal("OpenRCT2 is already running.");
@@ -378,24 +396,6 @@ namespace OpenRCT2
                 _discordService = std::make_unique<DiscordService>();
             }
 #endif
-
-            try
-            {
-                _localisationService->OpenLanguage(gConfigGeneral.language, *_objectManager);
-            }
-            catch (const std::exception& e)
-            {
-                log_error("Failed to open configured language: %s", e.what());
-                try
-                {
-                    _localisationService->OpenLanguage(LANGUAGE_ENGLISH_UK, *_objectManager);
-                }
-                catch (const std::exception&)
-                {
-                    log_fatal("Failed to open fallback language: %s", e.what());
-                    return false;
-                }
-            }
 
             if (platform_process_is_elevated())
             {

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -794,8 +794,6 @@ bool config_find_or_browse_install_directory()
         try
         {
             const char* g1DatPath = PATH_SEPARATOR "Data" PATH_SEPARATOR "g1.dat";
-            char cantFindG1Dat[1024];
-
             while (true)
             {
                 auto uiContext = GetContext()->GetUiContext();
@@ -815,8 +813,7 @@ bool config_find_or_browse_install_directory()
                     return true;
                 }
 
-                format_string(cantFindG1Dat, 1024, STR_COULD_NOT_FIND_AT_PATH, &g1DatPath);
-                uiContext->ShowMessageBox(cantFindG1Dat);
+                uiContext->ShowMessageBox(format_string(STR_COULD_NOT_FIND_AT_PATH, &g1DatPath));
             }
         }
         catch (const std::exception& ex)

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -22,6 +22,8 @@
 #include "../localisation/Currency.h"
 #include "../localisation/Date.h"
 #include "../localisation/Language.h"
+#include "../localisation/Localisation.h"
+#include "../localisation/StringIds.h"
 #include "../network/network.h"
 #include "../paint/VirtualFloor.h"
 #include "../platform/Platform2.h"
@@ -791,13 +793,15 @@ bool config_find_or_browse_install_directory()
 
         try
         {
+            const char* g1DatPath = PATH_SEPARATOR "Data" PATH_SEPARATOR "g1.dat";
+            char cantFindG1Dat[1024];
+
             while (true)
             {
                 auto uiContext = GetContext()->GetUiContext();
-                uiContext->ShowMessageBox("OpenRCT2 needs files from the original RollerCoaster Tycoon 2 in order to work.\n"
-                                          "Please select the directory where you installed RollerCoaster Tycoon 2.");
+                uiContext->ShowMessageBox(format_string(STR_NEEDS_RCT2_FILES, nullptr));
 
-                std::string installPath = uiContext->ShowDirectoryDialog("Please select your RCT2 directory");
+                std::string installPath = uiContext->ShowDirectoryDialog(format_string(STR_PICK_RCT2_DIR, nullptr));
                 if (installPath.empty())
                 {
                     return false;
@@ -811,9 +815,8 @@ bool config_find_or_browse_install_directory()
                     return true;
                 }
 
-                std::string message = String::StdFormat(
-                    "Could not find %s" PATH_SEPARATOR "Data" PATH_SEPARATOR "g1.dat at this path", installPath.c_str());
-                uiContext->ShowMessageBox(message);
+                format_string(cantFindG1Dat, 1024, STR_COULD_NOT_FIND_AT_PATH, &g1DatPath);
+                uiContext->ShowMessageBox(cantFindG1Dat);
             }
         }
         catch (const std::exception& ex)

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -101,7 +101,9 @@ bool language_open(int32_t id)
     auto& objectManager = context->GetObjectManager();
     try
     {
-        localisationService.OpenLanguage(id, objectManager);
+        localisationService.OpenLanguage(id);
+        // Objects and their localised strings need to be refreshed
+        objectManager.ResetObjects();
         return true;
     }
     catch (const std::exception&)

--- a/src/openrct2/localisation/LocalisationService.cpp
+++ b/src/openrct2/localisation/LocalisationService.cpp
@@ -74,7 +74,7 @@ std::string LocalisationService::GetLanguagePath(uint32_t languageId) const
     return languagePath;
 }
 
-void LocalisationService::OpenLanguage(int32_t id, IObjectManager& objectManager)
+void LocalisationService::OpenLanguage(int32_t id)
 {
     CloseLanguages();
     if (id == LANGUAGE_UNDEFINED)
@@ -96,9 +96,6 @@ void LocalisationService::OpenLanguage(int32_t id, IObjectManager& objectManager
     {
         _currentLanguage = id;
         TryLoadFonts(*this);
-
-        // Objects and their localised strings need to be refreshed
-        objectManager.ResetObjects();
     }
     else
     {

--- a/src/openrct2/localisation/LocalisationService.h
+++ b/src/openrct2/localisation/LocalisationService.h
@@ -60,7 +60,7 @@ namespace OpenRCT2::Localisation
         rct_string_id GetObjectOverrideStringId(const std::string_view& legacyIdentifier, uint8_t index) const;
         std::string GetLanguagePath(uint32_t languageId) const;
 
-        void OpenLanguage(int32_t id, IObjectManager& objectManager);
+        void OpenLanguage(int32_t id);
         void CloseLanguages();
         rct_string_id AllocateObjectString(const std::string& target);
         void FreeObjectString(rct_string_id stringId);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3891,6 +3891,10 @@ enum
     STR_CANT_RAISE_ELEMENT_HERE = 6388,
     STR_NO_CLEARANCE = 6389,
 
+    STR_NEEDS_RCT2_FILES = 6390,
+    STR_PICK_RCT2_DIR = 6391,
+    STR_COULD_NOT_FIND_AT_PATH = 6392
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
An issue that was ran into is that at the point in the lifecycle where the directory is queried, language is not set.

In order to open a language in the `LocalisationService`, an `ObjectManager` was required in the API, of course don't have an `ObjectManager` yet at before we've selected the directory. The API was simply it was just calling `resetObjects()`, assumingly as a convenience measure. To me it makes sense for language and localization to be decoupled from the `ObjectManager` as we may need UI at times where we don't have it. (Like, say, picking an RCT2 directory.) Once decoupled, I simply moved language initialization logic to before picking the directory, then, finally pulling the strings dynamically.

**Testing:**
- deleted local `config.ini`
- ran program, ensured dialog was correct text
- picked bad directory, to get the "Can't find g1.dat" dialog
- picked correct directory
- changed language to Spanish at main menu, ensure texts changed
- started new save, then changed language back to English (US), ensuring text changed back