### PR TITLE
Fix #7748. Move tooltip timeout reset to correct location

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#4041] Garbled park option on scenario editor with custom theme.
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
+- Fix: [#7748] Tooltips would not timeout for normal UI elements.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#8957] Error title missing when building with insufficient funds
 - Fix: [#10186] Placing multiple saved rides ignores design name (original bug).

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -931,10 +931,6 @@ static void input_widget_over(const ScreenCoordsXY& screenCoords, rct_window* w,
     {
         input_update_tooltip(w, widgetIndex, screenCoords);
     }
-
-    gTooltipTimeout = 0;
-    gTooltipCursorX = screenCoords.x;
-    gTooltipCursorY = screenCoords.y;
 }
 
 /**
@@ -1439,6 +1435,10 @@ static void input_update_tooltip(rct_window* w, rct_widgetindex widgetIndex, con
                 window_tooltip_open(w, widgetIndex, screenCoords);
             }
         }
+
+        gTooltipTimeout = 0;
+        gTooltipCursorX = screenCoords.x;
+        gTooltipCursorY = screenCoords.y;
     }
     else
     {


### PR DESCRIPTION
Fix #7748. Move tooltip timeout reset to correct location

Mistake made in implementation

Not tested yet still a work in progress to see if this fixes the issues.