### PR TITLE
Fix logical sort

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
+- Fix: [#13138] Fix logical sorting of list windows.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 
 0.3.1 (2020-09-27)

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -333,8 +333,8 @@ int32_t strlogicalcmp(const char* s1, const char* s2)
             return -1;
         else if (!(isdigit(*s1) && isdigit(*s2)))
         {
-            if (tolower(*s1) != tolower(*s2))
-                return tolower(*s1) - tolower(*s2);
+            if (toupper(*s1) != toupper(*s2))
+                return toupper(*s1) - toupper(*s2);
             else
             {
                 ++s1;


### PR DESCRIPTION
Fix logical sort for items like "^Abcde" to be at the end.