### PR TITLE
Close #12408: Refactor CURSOR_ID to use strong enum

### DIFF
--- a/src/openrct2-ui/CursorData.cpp
+++ b/src/openrct2-ui/CursorData.cpp
@@ -11,9 +11,9 @@
 
 #include <openrct2/interface/Cursors.h>
 
-// clang-format off
 namespace OpenRCT2::Ui
 {
+    // clang-format off
     static constexpr const CursorData BlankCursorData =
     {
         { 0, 0 }, { 0 }, { 0 }
@@ -650,14 +650,14 @@ namespace OpenRCT2::Ui
         &HandClosedDownCursorData,  // CURSOR_HAND_CLOSED
     };
 
-    const CursorData * CursorRepository::GetCursorData(CURSOR_ID cursorId)
+    // clang-format on
+    const CursorData* CursorRepository::GetCursorData(CursorID cursorId)
     {
-        const CursorData * result = nullptr;
-        if (cursorId >= 0 && cursorId < CURSOR_COUNT)
+        const CursorData* result = nullptr;
+        if (cursorId != CursorID::Undefined && cursorId != CursorID::Count)
         {
-            result = RawCursorData[cursorId];
+            result = RawCursorData[EnumValue(cursorId)];
         }
         return result;
     }
-}
-// clang-format on
+} // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/CursorRepository.cpp
+++ b/src/openrct2-ui/CursorRepository.cpp
@@ -20,22 +20,22 @@ using namespace OpenRCT2::Ui;
 CursorRepository::~CursorRepository()
 {
     _scaledCursors.clear();
-    _currentCursor = CURSOR_UNDEFINED;
+    _currentCursor = CursorID::Undefined;
     _currentCursorScale = 1;
 }
 
 void CursorRepository::LoadCursors()
 {
     SetCursorScale(static_cast<uint8_t>(round(gConfigGeneral.window_scale)));
-    SetCurrentCursor(CURSOR_ARROW);
+    SetCurrentCursor(CursorID::Arrow);
 }
 
-CURSOR_ID CursorRepository::GetCurrentCursor()
+CursorID CursorRepository::GetCurrentCursor()
 {
     return _currentCursor;
 }
 
-void CursorRepository::SetCurrentCursor(CURSOR_ID cursorId)
+void CursorRepository::SetCurrentCursor(CursorID cursorId)
 {
     if (_currentCursor != cursorId)
     {
@@ -120,13 +120,13 @@ void CursorRepository::GenerateScaledCursorSetHolder(uint8_t scale)
 {
     if (_scaledCursors.find(scale) == _scaledCursors.end())
     {
-        std::function<SDL_Cursor*(CURSOR_ID)> cursorGenerator = [this, scale](CURSOR_ID cursorId) {
+        std::function<SDL_Cursor*(CursorID)> cursorGenerator = [this, scale](CursorID cursorId) {
             switch (cursorId)
             {
                 // We can't scale the system cursors, but they should be appropriately scaled anyway
-                case CURSOR_ARROW:
+                case CursorID::Arrow:
                     return SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
-                case CURSOR_HAND_POINT:
+                case CursorID::HandPoint:
                     return SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
                 default:
                     return this->Create(GetCursorData(cursorId), scale);

--- a/src/openrct2-ui/CursorRepository.h
+++ b/src/openrct2-ui/CursorRepository.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <map>
 #include <openrct2/interface/Cursors.h>
+#include <openrct2/util/Util.h>
 
 struct SDL_Cursor;
 
@@ -24,35 +25,35 @@ namespace OpenRCT2::Ui
         class CursorSetHolder
         {
         private:
-            SDL_Cursor* _cursors[CURSOR_COUNT] = { nullptr };
+            SDL_Cursor* _cursors[EnumValue(CursorID::Count)] = { nullptr };
 
         public:
-            CursorSetHolder(const std::function<SDL_Cursor*(CURSOR_ID)>& getCursor)
+            CursorSetHolder(const std::function<SDL_Cursor*(CursorID)>& getCursor)
             {
-                for (size_t i = 0; i < CURSOR_COUNT; i++)
+                for (size_t i = 0; i < EnumValue(CursorID::Count); i++)
                 {
-                    _cursors[i] = getCursor(static_cast<CURSOR_ID>(i));
+                    _cursors[i] = getCursor(static_cast<CursorID>(i));
                 }
             }
 
             ~CursorSetHolder()
             {
-                for (size_t i = 0; i < CURSOR_COUNT; i++)
+                for (size_t i = 0; i < EnumValue(CursorID::Count); i++)
                 {
                     SDL_FreeCursor(_cursors[i]);
                 }
             }
 
-            SDL_Cursor* getScaledCursor(CURSOR_ID cursorId)
+            SDL_Cursor* getScaledCursor(CursorID cursorId)
             {
-                return _cursors[cursorId];
+                return _cursors[EnumValue(cursorId)];
             }
         };
 
         constexpr static int32_t BASE_CURSOR_WIDTH = 32;
         constexpr static int32_t BASE_CURSOR_HEIGHT = 32;
 
-        CURSOR_ID _currentCursor = CURSOR_UNDEFINED;
+        CursorID _currentCursor = CursorID::Undefined;
         uint8_t _currentCursorScale = 1;
 
         std::map<uint8_t, CursorSetHolder> _scaledCursors;
@@ -60,13 +61,13 @@ namespace OpenRCT2::Ui
     public:
         ~CursorRepository();
         void LoadCursors();
-        CURSOR_ID GetCurrentCursor();
-        void SetCurrentCursor(CURSOR_ID cursorId);
+        CursorID GetCurrentCursor();
+        void SetCurrentCursor(CursorID cursorId);
         void SetCursorScale(uint8_t cursorScale);
 
     private:
         SDL_Cursor* Create(const CursorData* cursorInfo, uint8_t scale);
         void GenerateScaledCursorSetHolder(uint8_t scale);
-        static const CursorData* GetCursorData(CURSOR_ID cursorId);
+        static const CursorData* GetCursorData(CursorID cursorId);
     };
 } // namespace OpenRCT2::Ui

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -231,12 +231,12 @@ public:
         return _keysPressed;
     }
 
-    CURSOR_ID GetCursor() override
+    CursorID GetCursor() override
     {
         return _cursorRepository.GetCurrentCursor();
     }
 
-    void SetCursor(CURSOR_ID cursor) override
+    void SetCursor(CursorID cursor) override
     {
         _cursorRepository.SetCurrentCursor(cursor);
     }

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -76,7 +76,7 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
 static void input_widget_left(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex);
 void input_state_widget_pressed(
     const ScreenCoordsXY& screenCoords, int32_t state, rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
-void set_cursor(uint8_t cursor_id);
+void set_cursor(CursorID cursor_id);
 static void input_window_position_continue(
     rct_window* w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords);
 static void input_window_position_end(rct_window* w, const ScreenCoordsXY& screenCoords);
@@ -1075,9 +1075,7 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
 {
     rct_window* window;
 
-    int32_t cursorId;
-
-    cursorId = CURSOR_ARROW;
+    CursorID cursorId = CursorID::Arrow;
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_NONE);
     SetMapTooltip(ft);
@@ -1095,12 +1093,12 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
                     {
                         if (viewport_interaction_left_over(screenCoords))
                         {
-                            set_cursor(CURSOR_HAND_POINT);
+                            set_cursor(CursorID::HandPoint);
                             return;
                         }
                         break;
                     }
-                    cursorId = gCurrentToolId;
+                    cursorId = static_cast<CursorID>(gCurrentToolId);
                     break;
 
                 case WWT_FRAME:
@@ -1117,7 +1115,7 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
                     if (screenCoords.y < window->windowPos.y + window->height - 0x13)
                         break;
 
-                    cursorId = CURSOR_DIAGONAL_ARROWS;
+                    cursorId = CursorID::DiagonalArrows;
                     break;
 
                 case WWT_SCROLL:
@@ -1126,22 +1124,21 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
                     ScreenCoordsXY scrollCoords;
                     widget_scroll_get_part(
                         window, &window->widgets[widgetId], screenCoords, scrollCoords, &output_scroll_area, &scroll_id);
-                    cursorId = scroll_id;
                     if (output_scroll_area != SCROLL_PART_VIEW)
                     {
-                        cursorId = CURSOR_ARROW;
+                        cursorId = CursorID::Arrow;
                         break;
                     }
                     // Same as default but with scroll_x/y
                     cursorId = window_event_cursor_call(window, widgetId, scrollCoords);
-                    if (cursorId == -1)
-                        cursorId = CURSOR_ARROW;
+                    if (cursorId == CursorID::Undefined)
+                        cursorId = CursorID::Arrow;
                     break;
                 }
                 default:
                     cursorId = window_event_cursor_call(window, widgetId, screenCoords);
-                    if (cursorId == -1)
-                        cursorId = CURSOR_ARROW;
+                    if (cursorId == CursorID::Undefined)
+                        cursorId = CursorID::Arrow;
                     break;
             }
         }
@@ -1486,11 +1483,12 @@ int32_t get_next_key()
  *
  *  rct2: 0x006ED990
  */
-void set_cursor(uint8_t cursor_id)
+void set_cursor(CursorID cursor_id)
 {
+    assert(cursor_id != CursorID::Undefined);
     if (_inputState == InputState::Resizing)
     {
-        cursor_id = CURSOR_DIAGONAL_ARROWS;
+        cursor_id = CursorID::DiagonalArrows;
     }
     context_setcurrentcursor(cursor_id);
 }

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -20,16 +20,17 @@ namespace OpenRCT2::Scripting
     std::optional<CustomTool> ActiveCustomTool;
     std::vector<CustomToolbarMenuItem> CustomMenuItems;
 
-    static constexpr std::array<std::string_view, CURSOR_COUNT> CursorNames = {
+    static constexpr std::array<std::string_view, EnumValue(CursorID::Count)> CursorNames = {
         "arrow",         "blank",      "up_arrow",      "up_down_arrow", "hand_point", "zzz",         "diagonal_arrows",
         "picker",        "tree_down",  "fountain_down", "statue_down",   "bench_down", "cross_hair",  "bin_down",
         "lamppost_down", "fence_down", "flower_down",   "path_down",     "dig_down",   "water_down",  "house_down",
         "volcano_down",  "walk_down",  "paint_down",    "entrance_down", "hand_open",  "hand_closed",
     };
 
-    template<> DukValue ToDuk(duk_context* ctx, const CURSOR_ID& value)
+    template<> DukValue ToDuk(duk_context* ctx, const CursorID& cursorId)
     {
-        if (value >= 0 && static_cast<size_t>(value) < std::size(CursorNames))
+        auto value = EnumValue(cursorId);
+        if (value < std::size(CursorNames))
         {
             auto str = CursorNames[value];
             duk_push_lstring(ctx, str.data(), str.size());
@@ -38,17 +39,17 @@ namespace OpenRCT2::Scripting
         return {};
     }
 
-    template<> CURSOR_ID FromDuk(const DukValue& s)
+    template<> CursorID FromDuk(const DukValue& s)
     {
         if (s.type() == DukValue::Type::STRING)
         {
             auto it = std::find(std::begin(CursorNames), std::end(CursorNames), s.as_c_string());
             if (it != std::end(CursorNames))
             {
-                return static_cast<CURSOR_ID>(std::distance(std::begin(CursorNames), it));
+                return static_cast<CursorID>(std::distance(std::begin(CursorNames), it));
             }
         }
-        return CURSOR_UNDEFINED;
+        return CursorID::Undefined;
     }
 
     static void RemoveMenuItemsAndTool(std::shared_ptr<Plugin> owner)
@@ -167,10 +168,10 @@ namespace OpenRCT2::Scripting
                 CustomTool customTool;
                 customTool.Owner = scriptEngine.GetExecInfo().GetCurrentPlugin();
                 customTool.Id = dukValue["id"].as_string();
-                customTool.Cursor = FromDuk<CURSOR_ID>(dukValue["cursor"]);
-                if (customTool.Cursor == CURSOR_UNDEFINED)
+                customTool.Cursor = FromDuk<CursorID>(dukValue["cursor"]);
+                if (customTool.Cursor == CursorID::Undefined)
                 {
-                    customTool.Cursor = CURSOR_ARROW;
+                    customTool.Cursor = CursorID::Arrow;
                 }
                 customTool.onStart = dukValue["onStart"];
                 customTool.onDown = dukValue["onDown"];

--- a/src/openrct2-ui/scripting/CustomMenu.h
+++ b/src/openrct2-ui/scripting/CustomMenu.h
@@ -19,6 +19,8 @@
 #    include <string>
 #    include <vector>
 
+enum class CursorID : uint8_t;
+
 namespace OpenRCT2::Scripting
 {
     class CustomToolbarMenuItem
@@ -46,7 +48,7 @@ namespace OpenRCT2::Scripting
     {
         std::shared_ptr<Plugin> Owner;
         std::string Id;
-        CURSOR_ID Cursor{};
+        CursorID Cursor = CursorID::Undefined;
         bool MouseDown{};
 
         // Event handlers
@@ -73,8 +75,8 @@ namespace OpenRCT2::Scripting
     void InitialiseCustomMenuItems(ScriptEngine& scriptEngine);
     void InitialiseCustomTool(ScriptEngine& scriptEngine, const DukValue& dukValue);
 
-    template<> DukValue ToDuk(duk_context* ctx, const CURSOR_ID& value);
-    template<> CURSOR_ID FromDuk(const DukValue& s);
+    template<> DukValue ToDuk(duk_context* ctx, const CursorID& value);
+    template<> CursorID FromDuk(const DukValue& s);
 
 } // namespace OpenRCT2::Scripting
 

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -64,7 +64,7 @@ namespace OpenRCT2::Scripting
 
         DukValue cursor_get() const
         {
-            return ToDuk(_ctx, static_cast<CURSOR_ID>(gCurrentToolId));
+            return ToDuk(_ctx, static_cast<CursorID>(gCurrentToolId));
         }
 
         void cancel()

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -74,12 +74,12 @@ static void window_editor_inventions_list_update(rct_window *w);
 static void window_editor_inventions_list_scrollgetheight(rct_window *w, int32_t scrollIndex, int32_t *width, int32_t *height);
 static void window_editor_inventions_list_scrollmousedown(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void window_editor_inventions_list_scrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
-static void window_editor_inventions_list_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t *cursorId);
+static void window_editor_inventions_list_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
 static void window_editor_inventions_list_invalidate(rct_window *w);
 static void window_editor_inventions_list_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_editor_inventions_list_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
-static void window_editor_inventions_list_drag_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t *cursorId);
+static void window_editor_inventions_list_drag_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
 static void window_editor_inventions_list_drag_moved(rct_window* w, const ScreenCoordsXY& screenCoords);
 static void window_editor_inventions_list_drag_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
@@ -425,7 +425,7 @@ static void window_editor_inventions_list_scrollmouseover(
  *  rct2: 0x00685291
  */
 static void window_editor_inventions_list_cursor(
-    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t* cursorId)
+    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID* cursorId)
 {
     ResearchItem* researchItem;
     int32_t scrollIndex;
@@ -446,7 +446,7 @@ static void window_editor_inventions_list_cursor(
     researchItem = window_editor_inventions_list_get_item_from_scroll_y(scrollIndex, screenCoords.y);
     if (researchItem != nullptr && !researchItem->IsAlwaysResearched())
     {
-        *cursorId = CURSOR_HAND_OPEN;
+        *cursorId = CursorID::HandOpen;
     }
 }
 
@@ -727,7 +727,7 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
  *  rct2: 0x0068549C
  */
 static void window_editor_inventions_list_drag_cursor(
-    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t* cursorId)
+    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID* cursorId)
 {
     rct_window* inventionListWindow = window_find_by_class(WC_EDITOR_INVENTION_LIST);
     if (inventionListWindow != nullptr)
@@ -740,7 +740,7 @@ static void window_editor_inventions_list_drag_cursor(
         }
     }
 
-    *cursorId = CURSOR_HAND_CLOSED;
+    *cursorId = CursorID::HandClosed;
 }
 
 /**

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -72,7 +72,7 @@ static OpenRCT2String window_game_bottom_toolbar_tooltip(rct_window* w, const rc
 static void window_game_bottom_toolbar_invalidate(rct_window *w);
 static void window_game_bottom_toolbar_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_game_bottom_toolbar_update(rct_window* w);
-static void window_game_bottom_toolbar_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t *cursorId);
+static void window_game_bottom_toolbar_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
 static void window_game_bottom_toolbar_unknown05(rct_window *w);
 
 static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo *dpi, rct_window *w);
@@ -702,7 +702,7 @@ static void window_game_bottom_toolbar_update(rct_window* w)
  *  rct2: 0x0066C644
  */
 static void window_game_bottom_toolbar_cursor(
-    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t* cursorId)
+    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID* cursorId)
 {
     switch (widgetIndex)
     {

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -47,7 +47,7 @@ static rct_widget window_title_menu_widgets[] = {
 static void window_title_menu_mouseup(rct_window *w, rct_widgetindex widgetIndex);
 static void window_title_menu_mousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget* widget);
 static void window_title_menu_dropdown(rct_window *w, rct_widgetindex widgetIndex, int32_t dropdownIndex);
-static void window_title_menu_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t *cursorId);
+static void window_title_menu_cursor(rct_window *w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
 static void window_title_menu_invalidate(rct_window *w);
 static void window_title_menu_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
@@ -214,7 +214,7 @@ static void window_title_menu_dropdown(rct_window* w, rct_widgetindex widgetInde
 }
 
 static void window_title_menu_cursor(
-    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, int32_t* cursorId)
+    rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID* cursorId)
 {
     gTooltipTimeout = 2000;
 }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1231,9 +1231,9 @@ void openrct2_finish()
     GetContext()->Finish();
 }
 
-void context_setcurrentcursor(int32_t cursor)
+void context_setcurrentcursor(CursorID cursor)
 {
-    GetContext()->GetUiContext()->SetCursor(static_cast<CURSOR_ID>(cursor));
+    GetContext()->GetUiContext()->SetCursor(cursor);
 }
 
 void context_update_cursor_scale()

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -19,6 +19,7 @@ struct IObjectManager;
 struct IObjectRepository;
 struct IScenarioRepository;
 enum class DrawingEngine : int32_t;
+enum class CursorID : uint8_t;
 
 namespace OpenRCT2
 {
@@ -231,7 +232,7 @@ enum
 };
 
 void context_init();
-void context_setcurrentcursor(int32_t cursor);
+void context_setcurrentcursor(CursorID cursor);
 void context_update_cursor_scale();
 void context_hide_cursor();
 void context_show_cursor();

--- a/src/openrct2/interface/Cursors.cpp
+++ b/src/openrct2/interface/Cursors.cpp
@@ -14,36 +14,37 @@
 
 namespace Cursor
 {
-    uint8_t FromString(const std::string& s, uint8_t defaultValue)
+    CursorID FromString(const std::string& s, CursorID defaultValue)
     {
-        static const std::unordered_map<std::string, uint8_t> LookupTable{
-            { "CURSOR_BLANK", CURSOR_BLANK },
-            { "CURSOR_UP_ARROW", CURSOR_UP_ARROW },
-            { "CURSOR_UP_DOWN_ARROW", CURSOR_UP_DOWN_ARROW },
-            { "CURSOR_HAND_POINT", CURSOR_HAND_POINT },
-            { "CURSOR_ZZZ", CURSOR_ZZZ },
-            { "CURSOR_DIAGONAL_ARROWS", CURSOR_DIAGONAL_ARROWS },
-            { "CURSOR_PICKER", CURSOR_PICKER },
-            { "CURSOR_TREE_DOWN", CURSOR_TREE_DOWN },
-            { "CURSOR_FOUNTAIN_DOWN", CURSOR_FOUNTAIN_DOWN },
-            { "CURSOR_STATUE_DOWN", CURSOR_STATUE_DOWN },
-            { "CURSOR_BENCH_DOWN", CURSOR_BENCH_DOWN },
-            { "CURSOR_CROSS_HAIR", CURSOR_CROSS_HAIR },
-            { "CURSOR_BIN_DOWN", CURSOR_BIN_DOWN },
-            { "CURSOR_LAMPPOST_DOWN", CURSOR_LAMPPOST_DOWN },
-            { "CURSOR_FENCE_DOWN", CURSOR_FENCE_DOWN },
-            { "CURSOR_FLOWER_DOWN", CURSOR_FLOWER_DOWN },
-            { "CURSOR_PATH_DOWN", CURSOR_PATH_DOWN },
-            { "CURSOR_DIG_DOWN", CURSOR_DIG_DOWN },
-            { "CURSOR_WATER_DOWN", CURSOR_WATER_DOWN },
-            { "CURSOR_HOUSE_DOWN", CURSOR_HOUSE_DOWN },
-            { "CURSOR_VOLCANO_DOWN", CURSOR_VOLCANO_DOWN },
-            { "CURSOR_WALK_DOWN", CURSOR_WALK_DOWN },
-            { "CURSOR_PAINT_DOWN", CURSOR_PAINT_DOWN },
-            { "CURSOR_ENTRANCE_DOWN", CURSOR_ENTRANCE_DOWN },
-            { "CURSOR_HAND_OPEN", CURSOR_HAND_OPEN },
-            { "CURSOR_HAND_CLOSED", CURSOR_HAND_CLOSED },
-            { "CURSOR_ARROW", CURSOR_ARROW },
+        assert(defaultValue != CursorID::Undefined);
+        static const std::unordered_map<std::string, CursorID> LookupTable{
+            { "CURSOR_BLANK", CursorID::Blank },
+            { "CURSOR_UP_ARROW", CursorID::UpArrow },
+            { "CURSOR_UP_DOWN_ARROW", CursorID::UpDownArrow },
+            { "CURSOR_HAND_POINT", CursorID::HandPoint },
+            { "CURSOR_ZZZ", CursorID::ZZZ },
+            { "CURSOR_DIAGONAL_ARROWS", CursorID::DiagonalArrows },
+            { "CURSOR_PICKER", CursorID::Picker },
+            { "CURSOR_TREE_DOWN", CursorID::TreeDown },
+            { "CURSOR_FOUNTAIN_DOWN", CursorID::FountainDown },
+            { "CURSOR_STATUE_DOWN", CursorID::StatueDown },
+            { "CURSOR_BENCH_DOWN", CursorID::BenchDown },
+            { "CURSOR_CROSS_HAIR", CursorID::CrossHair },
+            { "CURSOR_BIN_DOWN", CursorID::BinDown },
+            { "CURSOR_LAMPPOST_DOWN", CursorID::LamppostDown },
+            { "CURSOR_FENCE_DOWN", CursorID::FenceDown },
+            { "CURSOR_FLOWER_DOWN", CursorID::FlowerDown },
+            { "CURSOR_PATH_DOWN", CursorID::PathDown },
+            { "CURSOR_DIG_DOWN", CursorID::DigDown },
+            { "CURSOR_WATER_DOWN", CursorID::WaterDown },
+            { "CURSOR_HOUSE_DOWN", CursorID::HouseDown },
+            { "CURSOR_VOLCANO_DOWN", CursorID::VolcanoDown },
+            { "CURSOR_WALK_DOWN", CursorID::WalkDown },
+            { "CURSOR_PAINT_DOWN", CursorID::PaintDown },
+            { "CURSOR_ENTRANCE_DOWN", CursorID::EntranceDown },
+            { "CURSOR_HAND_OPEN", CursorID::HandOpen },
+            { "CURSOR_HAND_CLOSED", CursorID::HandClosed },
+            { "CURSOR_ARROW", CursorID::Arrow },
         };
 
         auto result = LookupTable.find(s);

--- a/src/openrct2/interface/Cursors.h
+++ b/src/openrct2/interface/Cursors.h
@@ -11,42 +11,43 @@
 
 #include "../common.h"
 
-enum CURSOR_ID
+enum class CursorID : uint8_t
 {
-    CURSOR_UNDEFINED = -1,
-    CURSOR_ARROW,
-    CURSOR_BLANK,
-    CURSOR_UP_ARROW,
-    CURSOR_UP_DOWN_ARROW,
-    CURSOR_HAND_POINT,
-    CURSOR_ZZZ,
-    CURSOR_DIAGONAL_ARROWS,
-    CURSOR_PICKER,
-    CURSOR_TREE_DOWN,
-    CURSOR_FOUNTAIN_DOWN,
-    CURSOR_STATUE_DOWN,
-    CURSOR_BENCH_DOWN,
-    CURSOR_CROSS_HAIR,
-    CURSOR_BIN_DOWN,
-    CURSOR_LAMPPOST_DOWN,
-    CURSOR_FENCE_DOWN,
-    CURSOR_FLOWER_DOWN,
-    CURSOR_PATH_DOWN,
-    CURSOR_DIG_DOWN,
-    CURSOR_WATER_DOWN,
-    CURSOR_HOUSE_DOWN,
-    CURSOR_VOLCANO_DOWN,
-    CURSOR_WALK_DOWN,
-    CURSOR_PAINT_DOWN,
-    CURSOR_ENTRANCE_DOWN,
-    CURSOR_HAND_OPEN,
-    CURSOR_HAND_CLOSED,
-    CURSOR_COUNT,
+    Arrow,
+    Blank,
+    UpArrow,
+    UpDownArrow,
+    HandPoint,
+    ZZZ,
+    DiagonalArrows,
+    Picker,
+    TreeDown,
+    FountainDown,
+    StatueDown,
+    BenchDown,
+    CrossHair,
+    BinDown,
+    LamppostDown,
+    FenceDown,
+    FlowerDown,
+    PathDown,
+    DigDown,
+    WaterDown,
+    HouseDown,
+    VolcanoDown,
+    WalkDown,
+    PaintDown,
+    EntranceDown,
+    HandOpen,
+    HandClosed,
+    Count,
+
+    Undefined = 0xFF
 };
 
 namespace Cursor
 {
-    uint8_t FromString(const std::string& s, uint8_t defaultValue);
+    CursorID FromString(const std::string& s, CursorID defaultValue);
 }
 
 namespace OpenRCT2::Ui

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1532,9 +1532,9 @@ OpenRCT2String window_event_tooltip_call(rct_window* w, const rct_widgetindex wi
     }
 }
 
-int32_t window_event_cursor_call(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+CursorID window_event_cursor_call(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
-    int32_t cursorId = CURSOR_ARROW;
+    CursorID cursorId = CursorID::Arrow;
     if (w->event_handlers->cursor != nullptr)
         w->event_handlers->cursor(w, widgetIndex, screenCoords, &cursorId);
     return cursorId;

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -31,6 +31,7 @@ struct TextInputSession;
 struct scenario_index_entry;
 
 enum class VisibilityCache : uint8_t;
+enum class CursorID : uint8_t;
 
 #define SCROLLABLE_ROW_HEIGHT 12
 #define LIST_ROW_HEIGHT 12
@@ -239,7 +240,7 @@ struct rct_window_event_list
     void (*viewport_rotate)(struct rct_window*);
     void (*unknown_15)(struct rct_window*, int32_t, int32_t);
     OpenRCT2String (*tooltip)(struct rct_window*, const rct_widgetindex, const rct_string_id);
-    void (*cursor)(struct rct_window*, rct_widgetindex, const ScreenCoordsXY&, int32_t*);
+    void (*cursor)(struct rct_window*, rct_widgetindex, const ScreenCoordsXY&, CursorID*);
     void (*moved)(struct rct_window*, const ScreenCoordsXY&);
     void (*invalidate)(struct rct_window*);
     void (*paint)(struct rct_window*, rct_drawpixelinfo*);
@@ -798,7 +799,7 @@ void window_event_textinput_call(rct_window* w, rct_widgetindex widgetIndex, cha
 void window_event_viewport_rotate_call(rct_window* w);
 void window_event_unknown_15_call(rct_window* w, int32_t scrollIndex, int32_t scrollAreaType);
 OpenRCT2String window_event_tooltip_call(rct_window* w, const rct_widgetindex widgetIndex, const rct_string_id fallback);
-int32_t window_event_cursor_call(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+CursorID window_event_cursor_call(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
 void window_event_moved_call(rct_window* w, const ScreenCoordsXY& screenCoords);
 void window_event_invalidate_call(rct_window* w);
 void window_event_paint_call(rct_window* w, rct_drawpixelinfo* dpi);

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -25,7 +25,7 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.path_bit.flags = stream->ReadValue<uint16_t>();
     _legacyType.path_bit.draw_type = stream->ReadValue<uint8_t>();
-    _legacyType.path_bit.tool_id = stream->ReadValue<uint8_t>();
+    _legacyType.path_bit.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
     _legacyType.path_bit.price = stream->ReadValue<int16_t>();
     _legacyType.path_bit.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
     stream->Seek(2, OpenRCT2::STREAM_SEEK_CURRENT);
@@ -107,7 +107,7 @@ void FootpathItemObject::ReadJson(IReadObjectContext* context, json_t& root)
     if (properties.is_object())
     {
         _legacyType.path_bit.draw_type = ParseDrawType(Json::GetString(properties["renderAs"]));
-        _legacyType.path_bit.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CURSOR_LAMPPOST_DOWN);
+        _legacyType.path_bit.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::LamppostDown);
         _legacyType.path_bit.price = Json::GetNumber<int16_t>(properties["price"]);
 
         SetPrimarySceneryGroup(Json::GetString(properties["sceneryGroup"]));

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -26,7 +26,7 @@
 void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
     stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
-    _legacyType.large_scenery.tool_id = stream->ReadValue<uint8_t>();
+    _legacyType.large_scenery.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
     _legacyType.large_scenery.flags = stream->ReadValue<uint8_t>();
     _legacyType.large_scenery.price = stream->ReadValue<int16_t>();
     _legacyType.large_scenery.removal_price = stream->ReadValue<int16_t>();
@@ -129,7 +129,7 @@ void LargeSceneryObject::ReadJson(IReadObjectContext* context, json_t& root)
 
     if (properties.is_object())
     {
-        _legacyType.large_scenery.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CURSOR_STATUE_DOWN);
+        _legacyType.large_scenery.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::StatueDown);
 
         _legacyType.large_scenery.price = Json::GetNumber<int16_t>(properties["price"]);
         _legacyType.large_scenery.removal_price = Json::GetNumber<int16_t>(properties["removalPrice"]);

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -28,7 +28,7 @@ void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
     _legacyType.small_scenery.flags = stream->ReadValue<uint32_t>();
     _legacyType.small_scenery.height = stream->ReadValue<uint8_t>();
-    _legacyType.small_scenery.tool_id = stream->ReadValue<uint8_t>();
+    _legacyType.small_scenery.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
     _legacyType.small_scenery.price = stream->ReadValue<int16_t>();
     _legacyType.small_scenery.removal_price = stream->ReadValue<int16_t>();
     stream->Seek(4, OpenRCT2::STREAM_SEEK_CURRENT);
@@ -243,7 +243,7 @@ void SmallSceneryObject::ReadJson(IReadObjectContext* context, json_t& root)
     if (properties.is_object())
     {
         _legacyType.small_scenery.height = Json::GetNumber<uint8_t>(properties["height"]);
-        _legacyType.small_scenery.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CURSOR_STATUE_DOWN);
+        _legacyType.small_scenery.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::StatueDown);
         _legacyType.small_scenery.price = Json::GetNumber<uint16_t>(properties["price"]);
         _legacyType.small_scenery.removal_price = Json::GetNumber<uint16_t>(properties["removalPrice"]);
         _legacyType.small_scenery.animation_delay = Json::GetNumber<uint16_t>(properties["animationDelay"]);

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -20,7 +20,7 @@
 void WallObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
     stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
-    _legacyType.wall.tool_id = stream->ReadValue<uint8_t>();
+    _legacyType.wall.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
     _legacyType.wall.flags = stream->ReadValue<uint8_t>();
     _legacyType.wall.height = stream->ReadValue<uint8_t>();
     _legacyType.wall.flags2 = stream->ReadValue<uint8_t>();
@@ -102,7 +102,7 @@ void WallObject::ReadJson(IReadObjectContext* context, json_t& root)
 
     if (properties.is_object())
     {
-        _legacyType.wall.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CURSOR_FENCE_DOWN);
+        _legacyType.wall.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::FenceDown);
         _legacyType.wall.height = Json::GetNumber<uint8_t>(properties["height"]);
         _legacyType.wall.price = Json::GetNumber<int16_t>(properties["price"]);
 

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -110,11 +110,11 @@ namespace OpenRCT2::Ui
         {
             return nullptr;
         }
-        CURSOR_ID GetCursor() override
+        CursorID GetCursor() override
         {
-            return CURSOR_ARROW;
+            return CursorID::Arrow;
         }
-        void SetCursor(CURSOR_ID /*cursor*/) override
+        void SetCursor(CursorID /*cursor*/) override
         {
         }
         void SetCursorScale(uint8_t /*scale*/) override

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -120,8 +120,8 @@ namespace OpenRCT2
 
             // Input
             virtual const CursorState* GetCursorState() abstract;
-            virtual CURSOR_ID GetCursor() abstract;
-            virtual void SetCursor(CURSOR_ID cursor) abstract;
+            virtual CursorID GetCursor() abstract;
+            virtual void SetCursor(CursorID cursor) abstract;
             virtual void SetCursorScale(uint8_t scale) abstract;
             virtual void SetCursorVisible(bool value) abstract;
             virtual ScreenCoordsXY GetCursorPosition() abstract;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1075,7 +1075,7 @@ void map_invalidate_selection_rect()
  */
 void map_reorganise_elements()
 {
-    context_setcurrentcursor(CURSOR_ZZZ);
+    context_setcurrentcursor(CursorID::ZZZ);
 
     auto newTileElements = std::make_unique<TileElement[]>(MAX_TILE_ELEMENTS_WITH_SPARE_ROOM);
     TileElement* newElementsPtr = newTileElements.get();

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -25,7 +25,7 @@ struct rct_small_scenery_entry
 {
     uint32_t flags;                  // 0x06
     uint8_t height;                  // 0x0A
-    uint8_t tool_id;                 // 0x0B
+    CursorID tool_id;                // 0x0B
     int16_t price;                   // 0x0C
     int16_t removal_price;           // 0x0E
     uint8_t* frame_offsets;          // 0x10
@@ -80,7 +80,7 @@ enum LARGE_SCENERY_TEXT_FLAGS
 
 struct rct_large_scenery_entry
 {
-    uint8_t tool_id;
+    CursorID tool_id;
     uint8_t flags;
     int16_t price;
     int16_t removal_price;
@@ -102,7 +102,7 @@ enum LARGE_SCENERY_FLAGS
 
 struct rct_wall_scenery_entry
 {
-    uint8_t tool_id;
+    CursorID tool_id;
     uint8_t flags;
     uint8_t height;
     uint8_t flags2;
@@ -136,7 +136,7 @@ struct rct_path_bit_scenery_entry
 {
     uint16_t flags;                  // 0x06
     uint8_t draw_type;               // 0x08
-    uint8_t tool_id;                 // 0x09
+    CursorID tool_id;                // 0x09
     int16_t price;                   // 0x0A
     ObjectEntryIndex scenery_tab_id; // 0x0C
 };


### PR DESCRIPTION
Hi,

I have a question if that's ok :)

Some places were using the CURSOR_ID as int32_t, and others as uint8_t.
Since it had the UNDEFINED that equals to -1, I chose int8_t to represent it.
And then, to guarantee the uint8_t behavior in the places that expect it, I used some assertions.

Also, some data such as _legacyType.large_scenery.tool_id has the type uint8_t, and I was considering changing it to int8_t to avoid the need for one more static_cast. What do you think?

Thanks!
