### PR TITLE
Close #8848 Refactor TimeInPark

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1423,10 +1423,11 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Time in park
     screenCoords.y += LIST_ROW_HEIGHT + 1;
-    if (peep->TimeInPark != -1)
+    int32_t guestEntryTime = peep->GetParkEntryTime();
+    if (guestEntryTime != -1)
     {
         int32_t eax = gScenarioTicks;
-        eax -= peep->TimeInPark;
+        eax -= guestEntryTime;
         eax >>= 11;
         auto ft = Formatter();
         ft.Add<uint16_t>(eax & 0xFFFF);
@@ -1497,7 +1498,7 @@ void window_guest_rides_update(rct_window* w)
     }
 
     // Every 2048 ticks do a full window_invalidate
-    int32_t number_of_ticks = gScenarioTicks - guest->TimeInPark;
+    int32_t number_of_ticks = gScenarioTicks - guest->GetParkEntryTime();
     if (!(number_of_ticks & 0x7FF))
         w->Invalidate();
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1102,7 +1102,7 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     auto ft = Formatter();
-    ft.Add<int32_t>(peep->TimeInPark);
+    ft.Add<int32_t>(peep->GetHireDate());
     gfx_draw_string_left(dpi, STR_STAFF_STAT_EMPLOYED_FOR, ft.Data(), COLOUR_BLACK, screenCoords);
     screenCoords.y += LIST_ROW_HEIGHT;
 

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -281,7 +281,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, Id);
         COMPARE_FIELD(Peep, CashInPocket);
         COMPARE_FIELD(Peep, CashSpent);
-        COMPARE_FIELD(Peep, TimeInPark);
+        COMPARE_FIELD(Peep, ParkEntryTime);
         COMPARE_FIELD(Peep, RejoinQueueTimeout);
         COMPARE_FIELD(Peep, PreviousRide);
         COMPARE_FIELD(Peep, PreviousRideTimeOut);

--- a/src/openrct2/actions/StaffHireNewAction.hpp
+++ b/src/openrct2/actions/StaffHireNewAction.hpp
@@ -227,7 +227,7 @@ private:
             }
 
             // Staff uses this
-            newPeep->TimeInPark = gDateMonthsElapsed;
+            newPeep->AsStaff()->SetHireDate(gDateMonthsElapsed);
             newPeep->PathfindGoal.x = 0xFF;
             newPeep->PathfindGoal.y = 0xFF;
             newPeep->PathfindGoal.z = 0xFF;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -983,7 +983,7 @@ void Guest::Tick128UpdateGuest(int32_t index)
         if (State == PeepState::Walking && !OutsideOfPark && !(PeepFlags & PEEP_FLAGS_LEAVING_PARK) && GuestNumRides == 0
             && GuestHeadingToRideId == RIDE_ID_NULL)
         {
-            uint32_t time_duration = gScenarioTicks - TimeInPark;
+            uint32_t time_duration = gScenarioTicks - ParkEntryTime;
             time_duration /= 2048;
 
             if (time_duration >= 5)
@@ -2397,6 +2397,16 @@ bool Guest::HasRiddenRideType(int32_t rideType) const
     // This is needed to avoid desyncs. TODO: remove once the new save format is introduced.
     rideType = OpenRCT2RideTypeToRCT2RideType(rideType);
     return RideTypesBeenOn[rideType / 8] & (1 << (rideType % 8));
+}
+
+void Guest::SetParkEntryTime(int32_t entryTime)
+{
+    ParkEntryTime = entryTime;
+}
+
+int32_t Guest::GetParkEntryTime() const
+{
+    return ParkEntryTime;
 }
 
 void Guest::ChoseNotToGoOnRide(Ride* ride, bool peepAtRide, bool updateLastRide)
@@ -5694,7 +5704,7 @@ void Guest::UpdateEnteringPark()
     SetState(PeepState::Falling);
 
     OutsideOfPark = false;
-    TimeInPark = gScenarioTicks;
+    ParkEntryTime = gScenarioTicks;
     increment_guests_in_park();
     decrement_guests_heading_for_park();
     auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1709,7 +1709,7 @@ Peep* Peep::Generate(const CoordsXYZ& coords)
 
     peep->CashInPocket = cash;
     peep->CashSpent = 0;
-    peep->TimeInPark = -1;
+    peep->ParkEntryTime = -1;
     peep->ResetPathfindGoal();
     peep->ItemStandardFlags = 0;
     peep->ItemExtraFlags = 0;

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -703,7 +703,11 @@ struct Peep : SpriteBase
     uint32_t Id;
     money32 CashInPocket;
     money32 CashSpent;
-    int32_t TimeInPark;
+    union
+    {
+        int32_t ParkEntryTime;
+        int32_t HireDate;
+    };
     int8_t RejoinQueueTimeout; // whilst waiting for a free vehicle (or pair) in the entrance
     uint8_t PreviousRide;
     uint16_t PreviousRideTimeOut;
@@ -854,6 +858,8 @@ public:
     bool HasRidden(const Ride* ride) const;
     void SetHasRiddenRideType(int32_t rideType);
     bool HasRiddenRideType(int32_t rideType) const;
+    void SetParkEntryTime(int32_t entryTime);
+    int32_t GetParkEntryTime() const;
     int32_t HasFoodStandardFlag() const;
     int32_t HasFoodExtraFlag() const;
     bool HasDrinkStandardFlag() const;
@@ -927,6 +933,8 @@ public:
     bool DoPathFinding();
     uint8_t GetCostume() const;
     void SetCostume(uint8_t value);
+    void SetHireDate(int32_t hireDate);
+    int32_t GetHireDate() const;
 
     bool CanIgnoreWideFlag(const CoordsXYZ& staffPos, TileElement* path) const;
 

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -362,7 +362,7 @@ void Staff::ResetStats()
 {
     for (auto peep : EntityList<Staff>(EntityListId::Peep))
     {
-        peep->TimeInPark = gDateMonthsElapsed;
+        peep->SetHireDate(gDateMonthsElapsed);
         peep->StaffLawnsMown = 0;
         peep->StaffRidesFixed = 0;
         peep->StaffGardensWatered = 0;
@@ -1056,6 +1056,16 @@ void Staff::SetCostume(uint8_t value)
 {
     auto costume = static_cast<EntertainerCostume>(value);
     SpriteType = EntertainerCostumeToSprite(costume);
+}
+
+void Staff::SetHireDate(int32_t hireDate)
+{
+    HireDate = hireDate;
+}
+
+int32_t Staff::GetHireDate() const
+{
+    return HireDate;
 }
 
 PeepSpriteType EntertainerCostumeToSprite(EntertainerCostume entertainerType)

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -414,7 +414,7 @@ struct rct1_peep : RCT12SpriteBase
     uint32_t id;                                        // 0x9C
     money32 cash_in_pocket;                             // 0xA0
     money32 cash_spent;                                 // 0xA4
-    int32_t time_in_park;                               // 0xA8
+    int32_t park_entry_time;                            // 0xA8
     int8_t rejoin_queue_timeout;                        // 0xAC
     uint8_t previous_ride;                              // 0xAD
     uint16_t previous_ride_time_out;                    // 0xAE

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1489,7 +1489,8 @@ private:
         dst->Id = src->id;
         dst->CashInPocket = src->cash_in_pocket;
         dst->CashSpent = src->cash_spent;
-        dst->TimeInPark = src->time_in_park;
+        // This doubles as staff hire date
+        dst->ParkEntryTime = src->park_entry_time;
 
         // This doubles as staff type
         dst->GuestNumRides = src->no_of_rides;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -654,7 +654,7 @@ struct RCT2SpritePeep : RCT12SpriteBase
     uint32_t id;                                        // 0x9C
     money32 cash_in_pocket;                             // 0xA0
     money32 cash_spent;                                 // 0xA4
-    int32_t time_in_park;                               // 0xA8
+    int32_t park_entry_time;                            // 0xA8
     int8_t rejoin_queue_timeout;                        // 0xAC
     uint8_t previous_ride;                              // 0xAD
     uint16_t previous_ride_time_out;                    // 0xAE

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1198,7 +1198,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->id = src->Id;
     dst->cash_in_pocket = src->CashInPocket;
     dst->cash_spent = src->CashSpent;
-    dst->time_in_park = src->TimeInPark;
+    dst->park_entry_time = src->ParkEntryTime;
     dst->rejoin_queue_timeout = src->RejoinQueueTimeout;
     dst->previous_ride = src->PreviousRide;
     dst->previous_ride_time_out = src->PreviousRideTimeOut;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1487,7 +1487,7 @@ public:
         dst->Id = src->id;
         dst->CashInPocket = src->cash_in_pocket;
         dst->CashSpent = src->cash_spent;
-        dst->TimeInPark = src->time_in_park;
+        dst->ParkEntryTime = src->park_entry_time;
         dst->RejoinQueueTimeout = src->rejoin_queue_timeout;
         dst->PreviousRide = src->previous_ride;
         dst->PreviousRideTimeOut = src->previous_ride_time_out;

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -217,7 +217,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(Id);
     COMPARE_FIELD(CashInPocket);
     COMPARE_FIELD(CashSpent);
-    COMPARE_FIELD(TimeInPark);
+    COMPARE_FIELD(ParkEntryTime);
     COMPARE_FIELD(RejoinQueueTimeout);
     COMPARE_FIELD(PreviousRide);
     COMPARE_FIELD(PreviousRideTimeOut);


### PR DESCRIPTION
Split TimeInPark into a union: ParkEntryTime for guests, HireDate for staff.

Note: Duncan mentioned handling the rct2/rct1 structs in the issue. I updated only the import/export code and didn't change the fields of RCT2SpritePeep/rct1_peep, since I saw that previous refactors of Peep fields to unions (https://github.com/OpenRCT2/OpenRCT2/commit/e8d6383f and https://github.com/OpenRCT2/OpenRCT2/commit/0dd5b3bb)  did the same. If it's desired, I'll change all those fields as well.