### PR TITLE
Update supported Xcode version in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
   - Desktop development with C++
 
 ### macOS:
-- Xcode 8
+- Xcode 10+
 
 The program can also be built as a command line program using CMake. This type of build requires:
 


### PR DESCRIPTION
I was confused while setting up the project because Xcode 8 won't run on Mac OS 10.15. Turns out latest Xcode works fine. Hopefully this will clarify things for the next person that goes through the Mac OS setup.