### PR TITLE
Fix #13167: Broken dropdown menu in rendering engine options

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -641,6 +641,8 @@ static void window_options_display_mouseup(rct_window* w, rct_widgetindex widget
 
 static void window_options_display_mousedown(rct_window* w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
+    widget = &w->widgets[widgetIndex - 1];
+
     switch (widgetIndex)
     {
         case WIDX_RESOLUTION_DROPDOWN:
@@ -980,6 +982,8 @@ static void window_options_rendering_mouseup(rct_window* w, rct_widgetindex widg
 
 static void window_options_rendering_mousedown(rct_window* w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
+    widget = &w->widgets[widgetIndex - 1];
+
     switch (widgetIndex)
     {
         case WIDX_VIRTUAL_FLOOR_DROPDOWN:


### PR DESCRIPTION
Introduced by a recent refactor. The other tabs appear to be in order.