### PR TITLE
Implement track info command

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -63,6 +63,9 @@
 		4CF67197206B7E720034ADDD /* object in Resources */ = {isa = PBXBuildFile; fileRef = 4CF67196206B7E720034ADDD /* object */; };
 		6341F4E12400AA0F0052902B /* Drawing.Sprite.RLE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6341F4DF2400AA0E0052902B /* Drawing.Sprite.RLE.cpp */; };
 		6341F4E22400AA0F0052902B /* Drawing.Sprite.BMP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6341F4E02400AA0F0052902B /* Drawing.Sprite.BMP.cpp */; };
+		72C38FCB2533CC0100D4E3A1 /* TrackCommands.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72C38FCA2533CC0100D4E3A1 /* TrackCommands.cpp */; };
+		72C38FCE2533CE7600D4E3A1 /* CmdlineTrack.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C38FCC2533CE7500D4E3A1 /* CmdlineTrack.h */; };
+		72C38FCF2533CE7600D4E3A1 /* CmdlineTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72C38FCD2533CE7500D4E3A1 /* CmdlineTrack.cpp */; };
 		9308D9FE209908090079EE96 /* TileElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9308D9FA209908080079EE96 /* TileElement.cpp */; };
 		9308D9FF209908090079EE96 /* TileElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9308D9FA209908080079EE96 /* TileElement.cpp */; };
 		9308DA00209908090079EE96 /* TileElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9308D9FA209908080079EE96 /* TileElement.cpp */; };
@@ -984,6 +987,9 @@
 		6341F4DF2400AA0E0052902B /* Drawing.Sprite.RLE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Drawing.Sprite.RLE.cpp; sourceTree = "<group>"; };
 		6341F4E02400AA0F0052902B /* Drawing.Sprite.BMP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Drawing.Sprite.BMP.cpp; sourceTree = "<group>"; };
 		6341F4E32400AA1C0052902B /* ZoomLevel.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ZoomLevel.hpp; sourceTree = "<group>"; };
+		72C38FCA2533CC0100D4E3A1 /* TrackCommands.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TrackCommands.cpp; sourceTree = "<group>"; };
+		72C38FCC2533CE7500D4E3A1 /* CmdlineTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CmdlineTrack.h; sourceTree = "<group>"; };
+		72C38FCD2533CE7500D4E3A1 /* CmdlineTrack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CmdlineTrack.cpp; sourceTree = "<group>"; };
 		9308D9FA209908080079EE96 /* TileElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TileElement.cpp; sourceTree = "<group>"; };
 		9308D9FB209908080079EE96 /* Surface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Surface.cpp; sourceTree = "<group>"; };
 		9308D9FC209908080079EE96 /* TileElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TileElement.h; sourceTree = "<group>"; };
@@ -2719,6 +2725,8 @@
 				4C6A66911FE14C9500694CB6 /* Cheats.h */,
 				4CC4B8E21FE00C4100660D62 /* CmdlineSprite.cpp */,
 				4CC4B8E31FE00C4200660D62 /* CmdlineSprite.h */,
+				72C38FCD2533CE7500D4E3A1 /* CmdlineTrack.cpp */,
+				72C38FCC2533CE7500D4E3A1 /* CmdlineTrack.h */,
 				F76C836C1EC4E7CC00FA49E2 /* common.h */,
 				F76C83761EC4E7CC00FA49E2 /* Context.cpp */,
 				F76C83771EC4E7CC00FA49E2 /* Context.h */,
@@ -2780,6 +2788,7 @@
 		F76C83621EC4E7CC00FA49E2 /* cmdline */ = {
 			isa = PBXGroup;
 			children = (
+				72C38FCA2533CC0100D4E3A1 /* TrackCommands.cpp */,
 				D48AFDB61EF78DBF0081C644 /* BenchGfxCommmands.cpp */,
 				4C724B2121F0AD790012ADD0 /* BenchSpriteSort.cpp */,
 				F76C83631EC4E7CC00FA49E2 /* CommandLine.cpp */,
@@ -3699,6 +3708,7 @@
 				933F2CBB20935668001B33FD /* LocalisationService.h in Headers */,
 				C6352B861F477022006CCEE3 /* Endianness.h in Headers */,
 				2ADE2F2C224418B2002598AF /* FileIndex.hpp in Headers */,
+				72C38FCE2533CE7600D4E3A1 /* CmdlineTrack.h in Headers */,
 				93DFD04A24521C1A001FCBAF /* ScConfiguration.hpp in Headers */,
 				93CBA4CC20A7504500867D56 /* ImageImporter.h in Headers */,
 				2ADE2F29224418B2002598AF /* Numerics.hpp in Headers */,
@@ -4141,6 +4151,7 @@
 				C666EE6F1F37ACB10061AA04 /* DebugPaint.cpp in Sources */,
 				F7CB863F1EEDA0B50030C877 /* WindowManager.cpp in Sources */,
 				C68878C620289B710084B384 /* OpenGLFramebuffer.cpp in Sources */,
+				72C38FCB2533CC0100D4E3A1 /* TrackCommands.cpp in Sources */,
 				C654DF301F69C0430040F43D /* Finances.cpp in Sources */,
 				9308DA01209908090079EE96 /* Surface.cpp in Sources */,
 				933CBDBF20CB1BCA00134678 /* Window.cpp in Sources */,
@@ -4336,6 +4347,7 @@
 				C688785B20289A0A0084B384 /* Duck.cpp in Sources */,
 				F76C866A1EC4E88300FA49E2 /* LargeSceneryObject.cpp in Sources */,
 				C688788E20289AE70084B384 /* SSE41Drawing.cpp in Sources */,
+				72C38FCF2533CE7600D4E3A1 /* CmdlineTrack.cpp in Sources */,
 				F76C866C1EC4E88400FA49E2 /* Object.cpp in Sources */,
 				F76C866E1EC4E88400FA49E2 /* ObjectFactory.cpp in Sources */,
 				93FB272124ED3601008241C9 /* Cursors.cpp in Sources */,

--- a/src/openrct2/CmdlineTrack.cpp
+++ b/src/openrct2/CmdlineTrack.cpp
@@ -1,0 +1,164 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma warning(disable : 4706) // assignment within conditional expression
+
+#include "CmdlineTrack.h"
+
+#include "Context.h"
+#include "OpenRCT2.h"
+#include "core/Imaging.h"
+#include "core/Json.hpp"
+#include "drawing/Drawing.h"
+#include "drawing/ImageImporter.h"
+#include "object/ObjectLimits.h"
+#include "object/ObjectManager.h"
+#include "object/ObjectRepository.h"
+#include "platform/platform.h"
+#include "ride/RideData.h"
+#include "ride/TrackDesign.h"
+#include "util/Util.h"
+#include "world/Entrance.h"
+#include "world/Scenery.h"
+
+#include <cmath>
+#include <cstring>
+
+#ifdef _WIN32
+#    include "core/String.hpp"
+#endif
+
+enum class TrackSubcommand
+{
+    None,
+    Info,
+
+};
+
+static TrackSubcommand track_subcommand_from_str(const char* s)
+{
+    if (_strcmpi(s, "info") == 0)
+        return TrackSubcommand::Info;
+    return TrackSubcommand::None;
+}
+
+static bool needs_context(TrackSubcommand c)
+{
+    return true;
+}
+
+static json_t track_to_json(std::unique_ptr<TrackDesign> design)
+{
+    // Logic from window_track_list_paint
+    json_t j;
+    j["name"] = design->name;
+    j["type"] = design->type;
+    j["vehicle_type"] = design->vehicle_type;
+    j["excitement"] = design->excitement / 10.0;
+    j["intensity"] = design->intensity / 10.0;
+    j["nausea"] = design->nausea / 10.0;
+
+    if (ride_type_has_flag(design->type, RIDE_TYPE_FLAG_HAS_TRACK))
+    {
+        if (design->type != RIDE_TYPE_MAZE)
+        {
+            if (design->type == RIDE_TYPE_MINI_GOLF)
+            {
+                j["holes"] = design->holes & 0x1F;
+            }
+            else
+            {
+                uint16_t speed = ((design->max_speed << 16) * 9) >> 18;
+                j["max_speed"] = speed;
+                speed = ((design->average_speed << 16) * 9) >> 18;
+                j["average_speed"] = speed;
+            }
+            j["ride_length"] = design->ride_length;
+            if (ride_type_has_flag(design->type, RIDE_TYPE_FLAG_HAS_G_FORCES))
+            {
+                int32_t gForces = design->max_positive_vertical_g * 32;
+                j["max_positive_vertical_g"] = gForces / 100.0;
+                gForces = design->max_negative_vertical_g * 32;
+                j["max_negative_vertical_g"] = gForces / 100.0;
+                gForces = design->max_lateral_g * 32;
+                j["max_lateral_g"] = gForces / 100.0;
+                if (design->total_air_time != 0)
+                {
+                    int32_t airTime = design->total_air_time * 25;
+                    j["total_air_time"] = airTime;
+                }
+            }
+            if (ride_type_has_flag(design->type, RIDE_TYPE_FLAG_HAS_DROPS))
+            {
+                j["drops"] = design->drops & 0x3F;
+                uint16_t highestDropHeight = (design->highest_drop_height * 3) / 4;
+                j["highest_drop_height"] = highestDropHeight;
+            }
+            if (design->type != RIDE_TYPE_MINI_GOLF)
+            {
+                uint16_t inversions = design->inversions & 0x1F;
+                if (inversions != 0)
+                {
+                    j["inversions"] = inversions;
+                }
+            }
+        }
+    }
+    if (design->space_required_x != 0xFF)
+    {
+        j["space_required"] = { design->space_required_x, design->space_required_y };
+    }
+    if (design->cost != 0)
+    {
+        j["cost"] = design->cost;
+    }
+    return j;
+}
+
+int32_t cmdline_for_track(const char** argv, int32_t argc)
+{
+    gOpenRCT2Headless = true;
+    if (argc == 0)
+        return -1;
+
+    TrackSubcommand subcommand = track_subcommand_from_str(argv[0]);
+    if (subcommand == TrackSubcommand::None)
+    {
+        return -1;
+    }
+
+    std::unique_ptr<OpenRCT2::IContext> context;
+    if (needs_context(subcommand))
+    {
+        context = OpenRCT2::CreateContext();
+        context->Initialise();
+    }
+
+    switch (subcommand)
+    {
+        case TrackSubcommand::Info:
+            for (int32_t i = 1; i < argc; ++i)
+            {
+                const char* path = argv[i];
+                std::unique_ptr<TrackDesign> design = track_design_open(path);
+                if (!design)
+                {
+                    fprintf(stderr, "Failed to load track %s\n", path);
+                    continue;
+                }
+                json_t info = track_to_json(std::move(design));
+                info["path"] = path;
+                puts(info.dump().c_str());
+            }
+
+            break;
+    };
+
+    return 0;
+}

--- a/src/openrct2/CmdlineTrack.cpp
+++ b/src/openrct2/CmdlineTrack.cpp
@@ -27,6 +27,7 @@
 #include "world/Entrance.h"
 #include "world/Scenery.h"
 
+#include <cassert>
 #include <cmath>
 #include <cstring>
 
@@ -158,6 +159,9 @@ int32_t cmdline_for_track(const char** argv, int32_t argc)
             }
 
             break;
+        default:
+            // -Wswitch can't tell that we handled TrackSubcommand::None above
+            assert(false);
     };
 
     return 0;

--- a/src/openrct2/CmdlineTrack.h
+++ b/src/openrct2/CmdlineTrack.h
@@ -1,0 +1,17 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifndef _CMDLINE_TRACK_H_
+#define _CMDLINE_TRACK_H_
+
+#include "common.h"
+
+int32_t cmdline_for_track(const char** argv, int32_t argc);
+
+#endif

--- a/src/openrct2/cmdline/CommandLine.hpp
+++ b/src/openrct2/cmdline/CommandLine.hpp
@@ -119,6 +119,7 @@ namespace CommandLine
     extern const CommandLineCommand BenchGfxCommands[];
     extern const CommandLineCommand BenchSpriteSortCommands[];
     extern const CommandLineCommand SimulateCommands[];
+    extern const CommandLineCommand TrackCommands[];
 
     extern const CommandLineExample RootExamples[];
 

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -141,6 +141,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     DefineSubCommand("benchgfx",        CommandLine::BenchGfxCommands         ),
     DefineSubCommand("benchspritesort", CommandLine::BenchSpriteSortCommands  ),
     DefineSubCommand("simulate",        CommandLine::SimulateCommands         ),
+    DefineSubCommand("track",           CommandLine::TrackCommands            ),
     CommandTableEnd
 };
 

--- a/src/openrct2/cmdline/TrackCommands.cpp
+++ b/src/openrct2/cmdline/TrackCommands.cpp
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2020 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "../CmdlineTrack.h"
+#include "CommandLine.hpp"
+
+#ifdef _WIN32
+#    include "../core/String.hpp"
+#endif
+
+
+static constexpr const CommandLineOptionDefinition TrackOptions[]{ OptionTableEnd };
+
+static exitcode_t HandleTrack(CommandLineArgEnumerator* argEnumerator);
+
+const CommandLineCommand CommandLine::TrackCommands[]{ DefineCommand("info", "<trackfile>", TrackOptions, HandleTrack),
+    CommandTableEnd
+};
+
+
+static exitcode_t HandleTrack(CommandLineArgEnumerator* argEnumerator)
+{
+    const char** argv = const_cast<const char**>(argEnumerator->GetArguments()) + argEnumerator->GetIndex() - 1;
+    int32_t argc = argEnumerator->GetCount() - argEnumerator->GetIndex() + 1;
+    int32_t result = cmdline_for_track(argv, argc);
+    if (result < 0)
+    {
+        return EXITCODE_FAIL;
+    }
+    return EXITCODE_OK;
+}

--- a/src/openrct2/cmdline/TrackCommands.cpp
+++ b/src/openrct2/cmdline/TrackCommands.cpp
@@ -14,15 +14,18 @@
 #    include "../core/String.hpp"
 #endif
 
-
-static constexpr const CommandLineOptionDefinition TrackOptions[]{ OptionTableEnd };
-
 static exitcode_t HandleTrack(CommandLineArgEnumerator* argEnumerator);
 
-const CommandLineCommand CommandLine::TrackCommands[]{ DefineCommand("info", "<trackfile>", TrackOptions, HandleTrack),
-    CommandTableEnd
+// clang-format off
+static constexpr const CommandLineOptionDefinition TrackOptions[]{
+    OptionTableEnd
 };
 
+const CommandLineCommand CommandLine::TrackCommands[]{
+    DefineCommand("info", "<trackfile>", TrackOptions, HandleTrack),
+    CommandTableEnd
+};
+// clang-format on
 
 static exitcode_t HandleTrack(CommandLineArgEnumerator* argEnumerator)
 {

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="audio\AudioSource.h" />
     <ClInclude Include="Cheats.h" />
     <ClInclude Include="CmdlineSprite.h" />
+    <ClInclude Include="CmdlineTrack.h" />
     <ClInclude Include="cmdline\CommandLine.hpp" />
     <ClInclude Include="common.h" />
     <ClInclude Include="config\Config.h" />
@@ -472,12 +473,14 @@
     <ClCompile Include="CmdlineSprite.cpp" />
     <ClCompile Include="cmdline\BenchGfxCommmands.cpp" />
     <ClCompile Include="cmdline\BenchSpriteSort.cpp" />
+    <ClCompile Include="CmdlineTrack.cpp" />
     <ClCompile Include="cmdline\CommandLine.cpp" />
     <ClCompile Include="cmdline\ConvertCommand.cpp" />
     <ClCompile Include="cmdline\RootCommands.cpp" />
     <ClCompile Include="cmdline\ScreenshotCommands.cpp" />
     <ClCompile Include="cmdline\SimulateCommands.cpp" />
     <ClCompile Include="cmdline\SpriteCommands.cpp" />
+    <ClCompile Include="cmdline\TrackCommands.cpp" />
     <ClCompile Include="cmdline\UriHandler.cpp" />
     <ClCompile Include="config\Config.cpp" />
     <ClCompile Include="config\IniReader.cpp" />


### PR DESCRIPTION
This PR implements a new CLI sub-command `track info` that dumps JSON-formatted information, such as the information shown in the track list screen, about one or more track designs.

When more than one design is given, the JSON-formatted info for each is on its own line, similar to the [JSON Lines](https://jsonlines.org/) format.

This is a two-level command because I envision other `track` subcommands, e.g. `track screenshot` or `track convert`.

## Examples:
### One track:
```sh
$ ./bin/openrct2.exe track info /c/Program\ Files\ \(x86\)/Steam/steamapps/common/Rollercoaster\ Tycoon\ 2/Tracks
/Atomizer.TD6
```
returns
```json
{"average_speed":18,"drops":12,"excitement":7.0,"highest_drop_height":27,"intensity":7.8,"inversions":6,"max_lateral_g":2.24,"max_negative_vertical_g":-1.28,"max_positive_vertical_g":3.2,"max_speed":54,"name":"Atomizer","nausea":4.3,"path":"C:/Program Files (x86)/Steam/steamapps/common/Rollercoaster Tycoon 2/Tracks/Atomizer.TD6","ride_length":986,"space_required":[13,27],"total_air_time":450,"type":51,"vehicle_type":55}
```
### Multiple tracks:
```sh
$ ./bin/openrct2.exe track info /c/Program\ Files\ \(x86\)/Steam/steamapps/common/Rollercoaster\ Tycoon\ 2/Tracks/A*.TD6
```
returns
```json
{"average_speed":2,"excitement":2.1,"intensity":0.2,"max_speed":4,"name":"Aerial Cycles","nausea":0.0,"path":"C:/Program Files (x86)/Steam/steamapps/common/Rollercoaster Tycoon 2/Tracks/Aerial Cycles.TD6","ride_length":209,"space_required":[12,11],"type":72,"vehicle_type":0}
{"average_speed":18,"drops":12,"excitement":7.0,"highest_drop_height":27,"intensity":7.8,"inversions":6,"max_lateral_g":2.24,"max_negative_vertical_g":-1.28,"max_positive_vertical_g":3.2,"max_speed":54,"name":"Atomizer","nausea":4.3,"path":"C:/Program Files (x86)/Steam/steamapps/common/Rollercoaster Tycoon 2/Tracks/Atomizer.TD6","ride_length":986,"space_required":[13,27],"total_air_time":450,"type":51,"vehicle_type":55}
{"average_speed":15,"drops":5,"excitement":5.4,"highest_drop_height":13,"intensity":5.7,"max_lateral_g":1.28,"max_negative_vertical_g":-1.28,"max_positive_vertical_g":2.88,"max_speed":40,"name":"Automania","nausea":4.0,"path":"C:/Program Files (x86)/Steam/steamapps/common/Rollercoaster Tycoon 2/Tracks/Automania.TD6","ride_length":495,"space_required":[18,11],"total_air_time":200,"type":87,"vehicle_type":2}
{"average_speed":13,"excitement":2.9,"intensity":2.6,"max_speed":24,"name":"Automobile Antics","nausea":0.5,"path":"C:/Program Files (x86)/Steam/steamapps/common/Rollercoaster Tycoon 2/Tracks/Automobile Antics.TD6","ride_length":244,"space_required":[14,11],"type":22,"vehicle_type":0}
```