### PR TITLE
Remove incorrect variable from interval names

### DIFF
--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -92,7 +92,6 @@ const rct_string_id RideInspectionIntervalNames[] = {
     STR_EVERY_HOUR,
     STR_EVERY_2_HOURS,
     STR_NEVER,
-    RIDE_SETTING_INSPECTION_INTERVAL
 };
 
 const rct_string_id PeepThoughts[] = {


### PR DESCRIPTION
Not sure why this has ended up in the interval names as it is not a rct_string_id. Luckily nothing at present was accessing this.