### PR TITLE
Workaround, Close#2287: Sound is disabled at game start when starting without focus

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -368,11 +368,12 @@ public:
 
                     if (gConfigSound.audio_focus)
                     {
-                        if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+                        if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED || e.window.event == SDL_WINDOWEVENT_ENTER)
                         {
                             Mixer_SetVolume(1);
                         }
-                        if (e.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+                        if (e.window.event == SDL_WINDOWEVENT_FOCUS_LOST || e.window.event == SDL_WINDOWEVENT_LEAVE
+                            || e.window.event == SDL_WINDOWEVENT_TAKE_FOCUS)
                         {
                             Mixer_SetVolume(0);
                         }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -26,6 +26,7 @@
 #include "Version.h"
 #include "actions/GameAction.h"
 #include "audio/AudioContext.h"
+#include "audio/AudioMixer.h"
 #include "audio/audio.h"
 #include "config/Config.h"
 #include "core/Console.hpp"
@@ -770,6 +771,8 @@ namespace OpenRCT2
                     title_load();
                     break;
                 case StartupAction::Title:
+                    if (gConfigSound.audio_focus)
+                        Mixer_SetVolume(0);
                     title_load();
                     break;
                 case StartupAction::Open:

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -15,7 +15,6 @@
 #include "../Input.h"
 #include "../OpenRCT2.h"
 #include "../Version.h"
-#include "../audio/AudioMixer.h"
 #include "../audio/audio.h"
 #include "../config/Config.h"
 #include "../core/Console.hpp"
@@ -133,10 +132,6 @@ void TitleScreen::Load()
     CreateWindows();
     TitleInitialise();
     OpenRCT2::Audio::PlayTitleMusic();
-    if (gConfigSound.audio_focus)
-    {
-        Mixer_SetVolume(0);
-    }
 
     if (gOpenRCT2ShowChangelog)
     {

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -15,6 +15,7 @@
 #include "../Input.h"
 #include "../OpenRCT2.h"
 #include "../Version.h"
+#include "../audio/AudioMixer.h"
 #include "../audio/audio.h"
 #include "../config/Config.h"
 #include "../core/Console.hpp"
@@ -132,6 +133,10 @@ void TitleScreen::Load()
     CreateWindows();
     TitleInitialise();
     OpenRCT2::Audio::PlayTitleMusic();
+    if (gConfigSound.audio_focus)
+    {
+        Mixer_SetVolume(0);
+    }
 
     if (gOpenRCT2ShowChangelog)
     {


### PR DESCRIPTION
Added also mouse focus monitoring to mute game (if said option is active) whenever mouse or keyboard leaves window.