### PR TITLE
Ride window: position graph buttons properly for CJK

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5742,7 +5742,7 @@ static void window_ride_graphs_mouseup(rct_window* w, rct_widgetindex widgetInde
  */
 static void window_ride_graphs_resize(rct_window* w)
 {
-    window_set_resize(w, 316, 180, 500, 450);
+    window_set_resize(w, 316, 182, 500, 450);
 }
 
 /**
@@ -5909,7 +5909,7 @@ static void window_ride_graphs_invalidate(rct_window* w)
 
     // Anchor graph widget
     auto x = w->width - 4;
-    auto y = w->height - 18;
+    auto y = w->height - BUTTON_FACE_HEIGHT - 8;
 
     window_ride_graphs_widgets[WIDX_GRAPH].right = x;
     window_ride_graphs_widgets[WIDX_GRAPH].bottom = y;
@@ -5918,7 +5918,7 @@ static void window_ride_graphs_invalidate(rct_window* w)
     window_ride_graphs_widgets[WIDX_GRAPH_ALTITUDE].top = y;
     window_ride_graphs_widgets[WIDX_GRAPH_VERTICAL].top = y;
     window_ride_graphs_widgets[WIDX_GRAPH_LATERAL].top = y;
-    y += 11;
+    y += BUTTON_FACE_HEIGHT + 1;
     window_ride_graphs_widgets[WIDX_GRAPH_VELOCITY].bottom = y;
     window_ride_graphs_widgets[WIDX_GRAPH_ALTITUDE].bottom = y;
     window_ride_graphs_widgets[WIDX_GRAPH_VERTICAL].bottom = y;


### PR DESCRIPTION
This is a subtle change concerning the ride window, specifically the four buttons at the bottom of the graph tab. Their widget definitions were already set to the correct height; it's just the invalidate event that needed changing.

### Before/after (French)

![Diamond Heights 2020-10-14 16-57-07](https://user-images.githubusercontent.com/604665/96007531-d63cc480-0e3e-11eb-9bf5-46ea69cf1b37.png) ![Diamond Heights 2020-10-14 16-59-10](https://user-images.githubusercontent.com/604665/96007515-d4730100-0e3e-11eb-9593-2f298affa3c2.png)

### Before/after (Japanese)

![Diamond Heights 2020-10-14 16-57-14](https://user-images.githubusercontent.com/604665/96007527-d5a42e00-0e3e-11eb-8193-8073e1799723.png) ![Diamond Heights 2020-10-14 16-59-03](https://user-images.githubusercontent.com/604665/96007522-d50b9780-0e3e-11eb-9a02-b3f6b80ce401.png)