### PR TITLE
Fix #7518 : Water isn't cut down by view clipping tool

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
 - Fix: [#7443] Construction arrows pulse at irregular intervals.
+- Fix: [#7518] Water isn't cut down by view clipping tool.
 - Fix: [#7748] Tooltips would not timeout for normal UI elements.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#8957] Error title missing when building with insufficient funds


### PR DESCRIPTION
By checking GetWaterHeight for surface tile, it can be clipped properly since surface tile's base_height is not being modified and being used to show base surface level.

Just one concern, I was trying to make a virtual function call to make a clean api but it feels like too much work for this small bug fix. 

So even though [this line](https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/paint/tile_element/Paint.TileElement.cpp#L248) is the proper sanity check for clip height and also I can even just do a cast beside that line, I'm just checking it inside of surface_paint. 

Any better idea to check the value?