### PR TITLE
Close#5178: Lighting effects are disabled in software mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#1324] Last track piece map selection still visible when placing ride entrance or exit (original bug).
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
 - Fix: [#4041] Garbled park option on scenario editor with custom theme.
+- Fix: [#5178] Lighting effects are disabled in software mode
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
 - Fix: [#7748] Tooltips would not timeout for normal UI elements.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,7 +9,7 @@
 - Fix: [#1324] Last track piece map selection still visible when placing ride entrance or exit (original bug).
 - Fix: [#3200] Close Construction window upon selecting vehicle page.
 - Fix: [#4041] Garbled park option on scenario editor with custom theme.
-- Fix: [#5178] Lighting effects are disabled in software mode
+- Fix: [#5178] Lighting effects cannot be disabled in software mode
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
 - Fix: [#7748] Tooltips would not timeout for normal UI elements.

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1041,6 +1041,7 @@ static void window_options_rendering_invalidate(rct_window* w)
     else
     {
         w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
+        gConfigGeneral.enable_light_fx = false;
     }
 
     widget_set_checkbox_value(w, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
@@ -1052,6 +1053,7 @@ static void window_options_rendering_invalidate(rct_window* w)
     else
     {
         w->disabled_widgets |= (1 << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
+        gConfigGeneral.enable_light_fx_for_vehicles = false;
     }
 
     widget_set_checkbox_value(

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -187,16 +187,9 @@ namespace Config
 
             // Default config setting is false until the games canvas can be separated from the effect
             model->day_night_cycle = reader->GetBoolean("day_night_cycle", false);
-            if (model->drawing_engine != DrawingEngine::Software)
-            {
-                model->enable_light_fx = reader->GetBoolean("enable_light_fx", false);
-                model->enable_light_fx_for_vehicles = reader->GetBoolean("enable_light_fx_for_vehicles", false);
-            }
-            else
-            {
-                model->enable_light_fx = false;
-                model->enable_light_fx_for_vehicles = false;
-            }
+            const bool isHardware = model->drawing_engine != DrawingEngine::Software;
+            model->enable_light_fx = isHardware && reader->GetBoolean("enable_light_fx", false);
+            model->enable_light_fx_for_vehicles = isHardware && reader->GetBoolean("enable_light_fx_for_vehicles", false);
             model->upper_case_banners = reader->GetBoolean("upper_case_banners", false);
             model->disable_lightning_effect = reader->GetBoolean("disable_lightning_effect", false);
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -187,9 +187,16 @@ namespace Config
 
             // Default config setting is false until the games canvas can be separated from the effect
             model->day_night_cycle = reader->GetBoolean("day_night_cycle", false);
-
-            model->enable_light_fx = reader->GetBoolean("enable_light_fx", false);
-            model->enable_light_fx_for_vehicles = reader->GetBoolean("enable_light_fx_for_vehicles", false);
+            if (model->drawing_engine != DrawingEngine::Software)
+            {
+                model->enable_light_fx = reader->GetBoolean("enable_light_fx", false);
+                model->enable_light_fx_for_vehicles = reader->GetBoolean("enable_light_fx_for_vehicles", false);
+            }
+            else
+            {
+                model->enable_light_fx = false;
+                model->enable_light_fx_for_vehicles = false;
+            }
             model->upper_case_banners = reader->GetBoolean("upper_case_banners", false);
             model->disable_lightning_effect = reader->GetBoolean("disable_lightning_effect", false);
             model->allow_loading_with_incorrect_checksum = reader->GetBoolean("allow_loading_with_incorrect_checksum", true);


### PR DESCRIPTION
Lightning effect are now automatically turned off when software renderer is selected.

The change is made once in file `openrct2-ui/windows/Options.cpp`, but does not affect config.ini file.
Here it is only cosmetic change, which is visible right after renderer change.
Second check of selected renderer is done when loading settings from file. This changes the state of disabled checkboxes after game restart.