### PR TITLE
Fix hybrid coaster

### DIFF
--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -1017,6 +1017,7 @@ uint8_t RideObject::ParseRideType(const std::string& s)
         { "mini_rc", RIDE_TYPE_MINI_ROLLER_COASTER },
         { "mine_ride", RIDE_TYPE_MINE_RIDE },
         { "lim_launched_rc", RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER },
+        { "hybrid_rc", RIDE_TYPE_HYBRID_COASTER },
     };
     auto result = LookupTable.find(s);
     return (result != LookupTable.end()) ? result->second : static_cast<uint8_t>(RIDE_TYPE_NULL);

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -25,14 +25,6 @@
 #include "../TrackData.h"
 #include "../TrackPaint.h"
 
-// Dynamic glitches
-// Steep to gentle/gentle to steep - sprite splitting issue requiring manual fix
-
-// Glitches present on original (fixing optional)
-// Sloped turns
-// Steep to vertical
-// Helixes (check height of bounding box but probably a sprite mask issue)
-
 namespace HybridRC
 {
     static uint32_t GetTrackColour(paint_session* session)
@@ -10010,7 +10002,6 @@ namespace HybridRC
         paint_util_set_general_support_height(session, height + 32, 0x20);
     }
 
-    /** rct2: 0x008ADA44 */
     static void TrackOnRidePhoto(
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
@@ -10026,7 +10017,6 @@ namespace HybridRC
         paint_util_set_general_support_height(session, height + 48, 0x20);
     }
 
-    /** rct2: 0x008ADED4 */
     static void TrackFlatTo60DegUpLongBase(
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
@@ -10165,7 +10155,6 @@ namespace HybridRC
         }
     }
 
-    /** rct2: 0x008ADEE4 */
     static void Track60DegUpToFlatLongBase(
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
@@ -10304,7 +10293,6 @@ namespace HybridRC
         }
     }
 
-    /** rct2: 0x008ADEF4 */
     static void TrackFlatTo60DegDownLongBase(
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
@@ -10312,7 +10300,6 @@ namespace HybridRC
         Track60DegUpToFlatLongBase(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
-    /** rct2: 0x008ADF04 */
     static void Track60DegDownToFlatLongBase(
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -127,58 +127,43 @@ namespace HybridRC
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        if (tileElement->AsTrack()->HasChain())
-        {
-            switch (direction)
+        const CoordsXYZ boundBoxOffsets[4] = {
+            { 0, 6, height },
+            { 28, 4, height - 16 },
+            { 28, 4, height - 16 },
+            { 0, 6, height },
+        };
+        static const CoordsXYZ boundBoxLengths[4] = {
+            { 32, 20, 3 },
+            { 2, 24, 93 },
+            { 2, 24, 93 },
+            { 32, 20, 3 },
+        };
+        static const uint32_t imageIds[2][4] = {
             {
-                case 0:
-                    sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 12), 0, 0, 32, 20, 3,
-                        height, 0, 6, height);
-                    break;
-                case 1:
-                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 13), 0, 0, 2, 24, 93,
-                        height, 28, 4, height - 16);
-                    break;
-                case 2:
-                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 14), 0, 0, 2, 24, 93,
-                        height, 28, 4, height - 16);
-                    break;
-                case 3:
-                    sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 15), 0, 0, 32, 20, 3,
-                        height, 0, 6, height);
-                    break;
-            }
-        }
-        else
-        {
-            switch (direction)
+                SPR_G2_HYBRID_LIFT_TRACK_STEEP + 12,
+                SPR_G2_HYBRID_LIFT_TRACK_STEEP + 13,
+                SPR_G2_HYBRID_LIFT_TRACK_STEEP + 14,
+                SPR_G2_HYBRID_LIFT_TRACK_STEEP + 15,
+            },
             {
-                case 0:
-                    sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 12), 0, 0, 32, 20, 3, height,
-                        0, 6, height);
-                    break;
-                case 1:
-                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 13), 0, 0, 2, 24, 93, height,
-                        28, 4, height - 16);
-                    break;
-                case 2:
-                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 14), 0, 0, 2, 24, 93, height,
-                        28, 4, height - 16);
-                    break;
-                case 3:
-                    sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 15), 0, 0, 32, 20, 3, height,
-                        0, 6, height);
-                    break;
-            }
+                SPR_G2_HYBRID_TRACK_STEEP + 12,
+                SPR_G2_HYBRID_TRACK_STEEP + 13,
+                SPR_G2_HYBRID_TRACK_STEEP + 14,
+                SPR_G2_HYBRID_TRACK_STEEP + 15,
+            },
+        };
+
+        auto* ps = sub_98197C_rotated(
+            session, direction, GetTrackColour(session) | imageIds[tileElement->AsTrack()->HasChain() ? 0 : 1][direction], 0, 0,
+            boundBoxLengths[direction].x, boundBoxLengths[direction].y, boundBoxLengths[direction].z, height,
+            boundBoxOffsets[direction].x, boundBoxOffsets[direction].y, boundBoxOffsets[direction].z);
+
+        if (direction == 1 || direction == 2)
+        {
+            session->WoodenSupportsPrependTo = ps;
         }
+
         wooden_a_supports_paint_setup(
             session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
         if (direction == 0 || direction == 3)
@@ -464,32 +449,31 @@ namespace HybridRC
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
+        const CoordsXYZ boundBoxOffsets[4] = {
+            { 4, 6, height + 8 },
+            { 24, 6, height + 8 },
+            { 24, 6, height + 8 },
+            { 4, 6, height + 8 },
+        };
+        static const CoordsXYZ boundBoxLengths[4] = {
+            { 2, 20, 31 },
+            { 2, 20, 31 },
+            { 2, 20, 31 },
+            { 2, 20, 31 },
+        };
+        static const uint32_t imageIds[4] = {
+            SPR_G2_HYBRID_TRACK_VERTICAL + 8,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 9,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 10,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 11,
+        };
         switch (trackSequence)
         {
             case 0:
-                switch (direction)
-                {
-                    case 0:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 8), 0, 0, 2, 20, 31,
-                            height, 4, 6, height + 8);
-                        break;
-                    case 1:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 9), 0, 0, 2, 20, 31,
-                            height, 24, 6, height + 8);
-                        break;
-                    case 2:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 10), 0, 0, 2, 20, 31,
-                            height, 24, 6, height + 8);
-                        break;
-                    case 3:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 11), 0, 0, 2, 20, 31,
-                            height, 4, 6, height + 8);
-                        break;
-                }
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | imageIds[direction], 0, 0, boundBoxLengths[direction].x,
+                    boundBoxLengths[direction].y, boundBoxLengths[direction].z, height, boundBoxOffsets[direction].x,
+                    boundBoxOffsets[direction].y, boundBoxOffsets[direction].z);
                 paint_util_set_vertical_tunnel(session, height + 32);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -510,32 +494,32 @@ namespace HybridRC
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
+        const CoordsXYZ boundBoxOffsets[4] = {
+            { 0, 6, height },
+            { 24, 6, height },
+            { 24, 6, height },
+            { 0, 6, height },
+        };
+        static const CoordsXYZ boundBoxLengths[4] = {
+            { 32, 20, 3 },
+            { 2, 20, 55 },
+            { 2, 20, 55 },
+            { 32, 20, 3 },
+        };
+        static const uint32_t imageIds[4] = {
+            SPR_G2_HYBRID_TRACK_VERTICAL + 0,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 1,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 2,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 3,
+        };
+
         switch (trackSequence)
         {
             case 0:
-                switch (direction)
-                {
-                    case 0:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 0), 0, 0, 32, 20, 3,
-                            height, 0, 6, height);
-                        break;
-                    case 1:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 1), 0, 0, 2, 20, 55,
-                            height, 24, 6, height);
-                        break;
-                    case 2:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 2), 0, 0, 2, 20, 55,
-                            height, 24, 6, height);
-                        break;
-                    case 3:
-                        sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 3), 0, 0, 32, 20, 3,
-                            height, 0, 6, height);
-                        break;
-                }
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | imageIds[direction], 0, 0, boundBoxLengths[direction].x,
+                    boundBoxLengths[direction].y, boundBoxLengths[direction].z, height, boundBoxOffsets[direction].x,
+                    boundBoxOffsets[direction].y, boundBoxOffsets[direction].z);
                 wooden_a_supports_paint_setup(
                     session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
                 if (direction == 0 || direction == 3)
@@ -562,29 +546,29 @@ namespace HybridRC
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        switch (direction)
-        {
-            case 0:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 4), 0, 0, 32, 20, 3, height,
-                    0, 6, height + 8);
-                break;
-            case 1:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 5), 0, 0, 2, 20, 31, height,
-                    24, 6, height + 8);
-                break;
-            case 2:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 6), 0, 0, 2, 20, 31, height,
-                    24, 6, height + 8);
-                break;
-            case 3:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 7), 0, 0, 32, 20, 3, height,
-                    0, 6, height + 8);
-                break;
-        }
+        const CoordsXYZ boundBoxOffsets[4] = {
+            { 0, 6, height + 8 },
+            { 24, 6, height + 8 },
+            { 24, 6, height + 8 },
+            { 0, 6, height + 8 },
+        };
+        static const CoordsXYZ boundBoxLengths[4] = {
+            { 32, 20, 3 },
+            { 2, 20, 31 },
+            { 2, 20, 31 },
+            { 32, 20, 3 },
+        };
+        static const uint32_t imageIds[4] = {
+            SPR_G2_HYBRID_TRACK_VERTICAL + 4,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 5,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 6,
+            SPR_G2_HYBRID_TRACK_VERTICAL + 7,
+        };
+
+        sub_98197C_rotated(
+            session, direction, GetTrackColour(session) | imageIds[direction], 0, 0, boundBoxLengths[direction].x,
+            boundBoxLengths[direction].y, boundBoxLengths[direction].z, height, boundBoxOffsets[direction].x,
+            boundBoxOffsets[direction].y, boundBoxOffsets[direction].z);
         switch (direction)
         {
             case 1:

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -69,7 +69,7 @@ namespace HybridRC
             { (SPR_G2_HYBRID_TRACK_BRAKE + 1), (SPR_G2_HYBRID_TRACK_BLOCK_BRAKE + 1), SPR_STATION_BASE_A_NW_SE },
         };
 
-        if (tileElement->AsTrack()->GetType() == TrackElemType::EndStation)
+        if (tileElement->AsTrack()->GetTrackType() == TrackElemType::EndStation)
         {
             sub_98197C_rotated(
                 session, direction, imageIds[direction][1] | GetTrackColour(session), 0, 0, 32, 20, 1, height, 0, 6,

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -131,26 +131,26 @@ namespace HybridRC
         {
             switch (direction)
             {
-            case 0:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 12), 0, 0, 32,
-                    20, 3, height, 0, 6, height);
-                break;
-            case 1:
-                session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 13), 0, 0, 2,
-                    24, 93, height, 28, 4, height - 16);
-                break;
-            case 2:
-                session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 14), 0, 0, 2,
-                    24, 93, height, 28, 4, height - 16);
-                break;
-            case 3:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 15), 0, 0, 32,
-                    20, 3, height, 0, 6, height);
-                break;
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 12), 0, 0, 32, 20, 3,
+                        height, 0, 6, height);
+                    break;
+                case 1:
+                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 13), 0, 0, 2, 24, 93,
+                        height, 28, 4, height - 16);
+                    break;
+                case 2:
+                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 14), 0, 0, 2, 24, 93,
+                        height, 28, 4, height - 16);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 15), 0, 0, 32, 20, 3,
+                        height, 0, 6, height);
+                    break;
             }
         }
         else
@@ -159,23 +159,23 @@ namespace HybridRC
             {
                 case 0:
                     sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 12), 0, 0, 32, 20, 3,
-                        height, 0, 6, height);
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 12), 0, 0, 32, 20, 3, height,
+                        0, 6, height);
                     break;
                 case 1:
                     session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 13), 0, 0, 2, 24, 93,
-                        height, 28, 4, height - 16);
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 13), 0, 0, 2, 24, 93, height,
+                        28, 4, height - 16);
                     break;
                 case 2:
                     session->WoodenSupportsPrependTo = sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 14), 0, 0, 2, 24, 93,
-                        height, 28, 4, height - 16);
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 14), 0, 0, 2, 24, 93, height,
+                        28, 4, height - 16);
                     break;
                 case 3:
                     sub_98197C_rotated(
-                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 15), 0, 0, 32, 20, 3,
-                        height, 0, 6, height);
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 15), 0, 0, 32, 20, 3, height,
+                        0, 6, height);
                     break;
             }
         }
@@ -471,23 +471,23 @@ namespace HybridRC
                 {
                     case 0:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 8), 0, 0, 2,
-                            20, 31, height, 4, 6, height + 8);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 8), 0, 0, 2, 20, 31,
+                            height, 4, 6, height + 8);
                         break;
                     case 1:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 9), 0, 0, 2,
-                            20, 31, height, 24, 6, height + 8);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 9), 0, 0, 2, 20, 31,
+                            height, 24, 6, height + 8);
                         break;
                     case 2:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 10), 0, 0, 2,
-                            20, 31, height, 24, 6, height + 8);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 10), 0, 0, 2, 20, 31,
+                            height, 24, 6, height + 8);
                         break;
                     case 3:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 11), 0, 0, 2,
-                            20, 31, height, 4, 6, height + 8);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 11), 0, 0, 2, 20, 31,
+                            height, 4, 6, height + 8);
                         break;
                 }
                 paint_util_set_vertical_tunnel(session, height + 32);
@@ -517,23 +517,23 @@ namespace HybridRC
                 {
                     case 0:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 0), 0, 0, 32,
-                            20, 3, height, 0, 6, height);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 0), 0, 0, 32, 20, 3,
+                            height, 0, 6, height);
                         break;
                     case 1:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 1), 0, 0, 2,
-                            20, 55, height, 24, 6, height);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 1), 0, 0, 2, 20, 55,
+                            height, 24, 6, height);
                         break;
                     case 2:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 2), 0, 0, 2,
-                            20, 55, height, 24, 6, height);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 2), 0, 0, 2, 20, 55,
+                            height, 24, 6, height);
                         break;
                     case 3:
                         sub_98197C_rotated(
-                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 3), 0, 0, 32,
-                            20, 3, height, 0, 6, height);
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 3), 0, 0, 32, 20, 3,
+                            height, 0, 6, height);
                         break;
                 }
                 wooden_a_supports_paint_setup(
@@ -566,23 +566,23 @@ namespace HybridRC
         {
             case 0:
                 sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 4), 0, 0, 32, 20, 3,
-                    height, 0, 6, height + 8);
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 4), 0, 0, 32, 20, 3, height,
+                    0, 6, height + 8);
                 break;
             case 1:
                 sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 5), 0, 0, 2, 20, 31,
-                    height, 24, 6, height + 8);
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 5), 0, 0, 2, 20, 31, height,
+                    24, 6, height + 8);
                 break;
             case 2:
                 sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 6), 0, 0, 2, 20, 31,
-                    height, 24, 6, height + 8);
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 6), 0, 0, 2, 20, 31, height,
+                    24, 6, height + 8);
                 break;
             case 3:
                 sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 7), 0, 0, 32, 20, 3,
-                    height, 0, 6, height + 8);
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 7), 0, 0, 32, 20, 3, height,
+                    0, 6, height + 8);
                 break;
         }
         switch (direction)
@@ -10108,8 +10108,8 @@ namespace HybridRC
     {
         sub_98196C_rotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
         sub_98197C_rotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), 0, 0, 32, 20, 0, height, 0, 6,
-            height + 3);
+            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), 0, 0, 32, 20, 0, height,
+            0, 6, height + 3);
         track_paint_util_onride_photo_paint(session, direction, height + 3, tileElement);
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -129,15 +129,55 @@ namespace HybridRC
     {
         if (tileElement->AsTrack()->HasChain())
         {
-            sub_98197C_rotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + direction + 12), 0, 0, 32, 20,
-                3, height, 0, 6, height);
+            switch (direction)
+            {
+            case 0:
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 12), 0, 0, 32,
+                    20, 3, height, 0, 6, height);
+                break;
+            case 1:
+                session->WoodenSupportsPrependTo = sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 13), 0, 0, 2,
+                    24, 93, height, 28, 4, height - 16);
+                break;
+            case 2:
+                session->WoodenSupportsPrependTo = sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 14), 0, 0, 2,
+                    24, 93, height, 28, 4, height - 16);
+                break;
+            case 3:
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_STEEP + 15), 0, 0, 32,
+                    20, 3, height, 0, 6, height);
+                break;
+            }
         }
         else
         {
-            sub_98197C_rotated(
-                session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + direction + 12), 0, 0, 32, 20, 3,
-                height, 0, 6, height);
+            switch (direction)
+            {
+                case 0:
+                    sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 12), 0, 0, 32, 20, 3,
+                        height, 0, 6, height);
+                    break;
+                case 1:
+                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 13), 0, 0, 2, 24, 93,
+                        height, 28, 4, height - 16);
+                    break;
+                case 2:
+                    session->WoodenSupportsPrependTo = sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 14), 0, 0, 2, 24, 93,
+                        height, 28, 4, height - 16);
+                    break;
+                case 3:
+                    sub_98197C_rotated(
+                        session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP + 15), 0, 0, 32, 20, 3,
+                        height, 0, 6, height);
+                    break;
+            }
         }
         wooden_a_supports_paint_setup(
             session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
@@ -427,9 +467,29 @@ namespace HybridRC
         switch (trackSequence)
         {
             case 0:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + direction + 8), 0, 0, 2, 20,
-                    31, height, 4, 6, height + 8);
+                switch (direction)
+                {
+                    case 0:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 8), 0, 0, 2,
+                            20, 31, height, 4, 6, height + 8);
+                        break;
+                    case 1:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 9), 0, 0, 2,
+                            20, 31, height, 24, 6, height + 8);
+                        break;
+                    case 2:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 10), 0, 0, 2,
+                            20, 31, height, 24, 6, height + 8);
+                        break;
+                    case 3:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 11), 0, 0, 2,
+                            20, 31, height, 4, 6, height + 8);
+                        break;
+                }
                 paint_util_set_vertical_tunnel(session, height + 32);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -453,9 +513,29 @@ namespace HybridRC
         switch (trackSequence)
         {
             case 0:
-                sub_98197C_rotated(
-                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + direction), 0, 0, 32, 20, 3,
-                    height, 0, 6, height);
+                switch (direction)
+                {
+                    case 0:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 0), 0, 0, 32,
+                            20, 3, height, 0, 6, height);
+                        break;
+                    case 1:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 1), 0, 0, 2,
+                            20, 55, height, 24, 6, height);
+                        break;
+                    case 2:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 2), 0, 0, 2,
+                            20, 55, height, 24, 6, height);
+                        break;
+                    case 3:
+                        sub_98197C_rotated(
+                            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 3), 0, 0, 32,
+                            20, 3, height, 0, 6, height);
+                        break;
+                }
                 wooden_a_supports_paint_setup(
                     session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
                 if (direction == 0 || direction == 3)
@@ -482,9 +562,29 @@ namespace HybridRC
         paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        sub_98197C_rotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + direction + 4), 0, 0, 32, 20, 3,
-            height, 0, 6, height + 8);
+        switch (direction)
+        {
+            case 0:
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 4), 0, 0, 32, 20, 3,
+                    height, 0, 6, height + 8);
+                break;
+            case 1:
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 5), 0, 0, 2, 20, 31,
+                    height, 24, 6, height + 8);
+                break;
+            case 2:
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 6), 0, 0, 2, 20, 31,
+                    height, 24, 6, height + 8);
+                break;
+            case 3:
+                sub_98197C_rotated(
+                    session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_VERTICAL + 7), 0, 0, 32, 20, 3,
+                    height, 0, 6, height + 8);
+                break;
+        }
         switch (direction)
         {
             case 1:
@@ -10008,7 +10108,7 @@ namespace HybridRC
     {
         sub_98196C_rotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
         sub_98197C_rotated(
-            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + direction), 0, 0, 32, 20, 0, height, 0, 6,
+            session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), 0, 0, 32, 20, 0, height, 0, 6,
             height + 3);
         track_paint_util_onride_photo_paint(session, direction, height + 3, tileElement);
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);


### PR DESCRIPTION
This PR fixes a few issues with the hybrid coaster that I only noticed after it was merged. These are:

* Train glitches on verticals and steep slopes

* On ride photo displays brake sprite when viewed from some angles

* Block brake sprite not shown on final station tile.

* JSON objects cannot use the hybrid ride type

* Several unnecessary comments were left in