### PR TITLE
Change GL_TEXTURE_RECTANGLE to NPOT GL_TEXTURE_2D 

### DIFF
--- a/data/shaders/applytransparency.frag
+++ b/data/shaders/applytransparency.frag
@@ -4,7 +4,7 @@ uniform usampler2D      uOpaqueTex;
 uniform sampler2D       uOpaqueDepth;
 uniform usampler2D      uTransparentTex;
 uniform sampler2D       uTransparentDepth;
-uniform usampler2DRect  uPaletteTex;
+uniform usampler2D      uPaletteTex;
 
 in vec2 fTextureCoordinate;
 
@@ -22,5 +22,5 @@ void main()
         transparent = 0u;
     }
 
-    oColour = texture(uPaletteTex, vec2(opaque, transparent)).r;
+    oColour = texture(uPaletteTex, vec2(opaque, transparent) / 256.f).r;
 }

--- a/data/shaders/drawrect.frag
+++ b/data/shaders/drawrect.frag
@@ -6,7 +6,7 @@ const int FLAG_MASK                 = (1 << 3);
 const int FLAG_CROSS_HATCH          = (1 << 4);
 
 uniform usampler2DArray uTexture;
-uniform usampler2DRect  uPaletteTex;
+uniform usampler2D      uPaletteTex;
 
 uniform sampler2D       uPeelingTex;
 uniform bool            uPeeling;
@@ -51,15 +51,15 @@ void main()
     int paletteCount = fFlags & MASK_REMAP_COUNT;
     if (paletteCount >= 3 && texel >= 0x2Eu && texel < 0x3Au)
     {
-        texel = texture(uPaletteTex, vec2(texel + 0xC5u, fPalettes.z)).r;
+        texel = texture(uPaletteTex, vec2(texel + 0xC5u, fPalettes.z) / 256.0f).r;
     }
     else if (paletteCount >= 2 && texel >= 0xCAu && texel < 0xD6u)
     {
-        texel = texture(uPaletteTex, vec2(texel + 0x29u, fPalettes.y)).r;
+        texel = texture(uPaletteTex, vec2(texel + 0x29u, fPalettes.y) / 256.f).r;
     }
     else if (paletteCount >= 1)
     {
-        texel = texture(uPaletteTex, vec2(texel, fPalettes.x)).r;
+        texel = texture(uPaletteTex, vec2(texel, fPalettes.x) / 256.f).r;
     }
 
     if (texel == 0u)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#5178] Lighting effects cannot be disabled in software mode
 - Fix: [#5904] Empty errors on tile inspector base height change.
 - Fix: [#6086] Cannot install existing track design with another name.
+- Fix: [#6614, #8623] Colours are distorted when using OpenGL with Intel integrated graphics drivers.
 - Fix: [#7443] Construction arrows pulse at irregular intervals.
 - Fix: [#7518] Water isn't cut down by view clipping tool.
 - Fix: [#7748] Tooltips would not timeout for normal UI elements.

--- a/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/ApplyTransparencyShader.cpp
@@ -81,7 +81,7 @@ void ApplyTransparencyShader::SetTextures(
     OpenGLAPI::SetTexture(1, GL_TEXTURE_2D, opaqueDepth);
     OpenGLAPI::SetTexture(2, GL_TEXTURE_2D, transparentTex);
     OpenGLAPI::SetTexture(3, GL_TEXTURE_2D, transparentDepth);
-    OpenGLAPI::SetTexture(4, GL_TEXTURE_RECTANGLE, paletteTex);
+    OpenGLAPI::SetTexture(4, GL_TEXTURE_2D, paletteTex);
 }
 
 void ApplyTransparencyShader::Draw()

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -963,7 +963,7 @@ void OpenGLDrawingContext::FlushRectangles()
         return;
 
     OpenGLAPI::SetTexture(0, GL_TEXTURE_2D_ARRAY, _textureCache->GetAtlasesTexture());
-    OpenGLAPI::SetTexture(1, GL_TEXTURE_RECTANGLE, _textureCache->GetPaletteTexture());
+    OpenGLAPI::SetTexture(1, GL_TEXTURE_2D, _textureCache->GetPaletteTexture());
 
     _drawRectShader->Use();
     _drawRectShader->SetInstances(_commandBuffers.rects);
@@ -997,7 +997,7 @@ void OpenGLDrawingContext::HandleTransparency()
         }
 
         OpenGLAPI::SetTexture(0, GL_TEXTURE_2D_ARRAY, _textureCache->GetAtlasesTexture());
-        OpenGLAPI::SetTexture(1, GL_TEXTURE_RECTANGLE, _textureCache->GetPaletteTexture());
+        OpenGLAPI::SetTexture(1, GL_TEXTURE_2D, _textureCache->GetPaletteTexture());
 
         _drawRectShader->Use();
         _drawRectShader->DrawInstances();

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -170,10 +170,13 @@ void TextureCache::CreateTextures()
 
 void TextureCache::GeneratePaletteTexture()
 {
-    rct_drawpixelinfo dpi = CreateDPI(256, PALETTE_TO_G1_OFFSET_COUNT + 5);
+    static_assert(PALETTE_TO_G1_OFFSET_COUNT + 5 < 256, "Height of palette too large!");
+    constexpr int32_t height = 256;
+    constexpr int32_t width = height;
+    rct_drawpixelinfo dpi = CreateDPI(width, height);
 
     // Init no-op palette
-    for (int i = 0; i < 256; ++i)
+    for (int i = 0; i < width; ++i)
     {
         dpi.bits[i] = i;
     }
@@ -191,8 +194,7 @@ void TextureCache::GeneratePaletteTexture()
     }
 
     glBindTexture(GL_TEXTURE_RECTANGLE, _paletteTexture);
-    glTexImage2D(
-        GL_TEXTURE_RECTANGLE, 0, GL_R8UI, 256, PALETTE_TO_G1_OFFSET_COUNT + 5, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, dpi.bits);
+    glTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_R8UI, width, height, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, dpi.bits);
     DeleteDPI(dpi);
 }
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -156,9 +156,9 @@ void TextureCache::CreateTextures()
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
         glGenTextures(1, &_paletteTexture);
-        glBindTexture(GL_TEXTURE_RECTANGLE, _paletteTexture);
-        glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glBindTexture(GL_TEXTURE_2D, _paletteTexture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
         GeneratePaletteTexture();
 
@@ -193,8 +193,8 @@ void TextureCache::GeneratePaletteTexture()
         }
     }
 
-    glBindTexture(GL_TEXTURE_RECTANGLE, _paletteTexture);
-    glTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_R8UI, width, height, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, dpi.bits);
+    glBindTexture(GL_TEXTURE_2D, _paletteTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R8UI, width, height, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, dpi.bits);
     DeleteDPI(dpi);
 }
 


### PR DESCRIPTION
This improves GLES compatiblity due to missing rectangle textures, but
NPOT 2D ones being universally available.