### PR TITLE
Fix #13158: Cursors are drawn incorrectly in text input fields

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Fix: [#13118] Closing construction window resets ride viewport.
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Fix: [#13138] Fix logical sorting of list windows.
+- Fix: [#13158] Cursors are drawn incorrectly in text input fields.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -1088,7 +1088,7 @@ static void widget_text_box_draw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     if (gTextBoxFrameNo <= 15)
     {
         colour = ColourMapA[w->colours[1]].mid_light;
-        auto y = topLeft.x + (widget->height() - 1);
+        auto y = topLeft.y + (widget->height() - 1);
         gfx_fill_rect(dpi, { { cur_x, y }, { cur_x + width, y } }, colour + 5);
     }
 }


### PR DESCRIPTION
Caused by 2857f9d276, which means this made it into the v0.3.1 release.