### PR TITLE
Fix for no error being shown when loading corrupted park save (#13226)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Fix: [#13138] Fix logical sorting of list windows.
 - Fix: [#13158] Cursors are drawn incorrectly in text input fields.
+- Fix: [#13226] No error is shown when attempting to load a corrupted save.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -562,7 +562,11 @@ namespace OpenRCT2
                 else
                 {
                     auto fs = FileStream(path, FILE_MODE_OPEN);
-                    return LoadParkFromStream(&fs, path, loadTitleScreenOnFail);
+                    if (!LoadParkFromStream(&fs, path, loadTitleScreenOnFail))
+                    {
+                        throw std::runtime_error("Failed to load park");
+                    }
+                    return true;
                 }
             }
             catch (const std::exception& e)


### PR DESCRIPTION
Tested by:

From both main menu, and in-scenario, did both:
* Load corrupted save, ensure error dialog pops up
* Load valid save, ensure loads correctly

![Screenshot from 2020-10-17 20-16-57](https://user-images.githubusercontent.com/13317074/96357868-deeb0000-10b5-11eb-88d3-e8ad1a39db66.png)
![Screenshot from 2020-10-17 20-17-19](https://user-images.githubusercontent.com/13317074/96357869-e01c2d00-10b5-11eb-9c17-02aef4056d40.png)
