### PR TITLE
Fix #12940 : Windows cause issues with snow drawing

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#8957] Error title missing when building with insufficient funds
 - Fix: [#10186] Placing multiple saved rides ignores design name (original bug).
+- Fix: [#12940] Windows cause issues with snow drawing.
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13024] Console cursor does not correctly render at current cursor position.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -130,16 +130,17 @@ static void DrawHeavyRain(IWeatherDrawer* weatherDrawer, int32_t left, int32_t t
 static void DrawLightSnow(IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const uint32_t t = gScenarioTicks / 2;
-    const double t2 = static_cast<double>(gScenarioTicks) / 2.0f;
+    const int32_t negT = -static_cast<int32_t>(t);
+    const double cosTick = static_cast<double>(gScenarioTicks) * 0.05;
 
-    int32_t x_start = -static_cast<int32_t>(t) + 1 + (cos(1.0 + left + t2 / 10.0) * 3);
+    int32_t x_start = negT + 1 + (cos(1.0 + cosTick) * 6);
     int32_t y_start = t + 1;
     y_start = -y_start;
     x_start += left;
     y_start += top;
     weatherDrawer->Draw(left, top, width, height, x_start, y_start, SnowPattern);
 
-    x_start = -static_cast<int32_t>(t) + 16 + (cos(left + t2 / 10.0) * 3);
+    x_start = negT + 16 + (cos(cosTick) * 6);
     y_start = t + 16;
     y_start = -y_start;
     x_start += left;


### PR DESCRIPTION
Windows' left value inside of cosine function is causing glitch-feel movement for snows but in fact, x_start can simply modified by another magic numbers.

* One thing I wonder, do we add all the "Fix" to changelog with no exception? I'm just curious because I didn't add it