### PR TITLE
Fix #13222 : Vehicle Collision causes negative number of passengers

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -34,6 +34,7 @@
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Fix: [#13138] Fix logical sorting of list windows.
 - Fix: [#13158] Cursors are drawn incorrectly in text input fields.
+- Fix: [#13222] Vehicle Collision causes negative number of passengers.
 - Fix: [#13226, #7280] No error is shown when attempting to load a corrupted save.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -34,7 +34,7 @@
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
 - Fix: [#13138] Fix logical sorting of list windows.
 - Fix: [#13158] Cursors are drawn incorrectly in text input fields.
-- Fix: [#13222] Vehicle Collision causes negative number of passengers.
+- Fix: [#13222] Vehicle collision causes negative number of passengers.
 - Fix: [#13226, #7280] No error is shown when attempting to load a corrupted save.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5275,7 +5275,6 @@ void Vehicle::KillPassengers(Ride* curRide)
             auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);
             context_broadcast_intent(&intent);
         }
-        curRide->num_riders--;
         peep_sprite_remove(curPeep);
     }
 


### PR DESCRIPTION
when peep_sprite_remove is called, RemoveFromRide() will decrease ride's num_riders