### PR TITLE
Fix #13215: lingering arrows after ride construction

### DIFF
--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -148,6 +148,7 @@ static void window_maze_construction_close(rct_window* w)
 
     map_invalidate_map_selection_tiles();
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
+    gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
     // In order to cancel the yellow arrow correctly the
     // selection tool should be cancelled.
@@ -502,6 +503,9 @@ static void window_maze_construction_construct(int32_t direction)
 {
     int32_t x, y, z, flags, mode;
 
+    _currentTrackSelectionFlags = 0;
+    _rideConstructionNextArrowPulse = 0;
+    gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
     ride_construction_invalidate_current_track();
 
     x = _currentTrackBegin.x + (CoordsDirectionDelta[direction].x / 2);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -443,7 +443,6 @@ static uint8_t _currentlyShowingBrakeOrBoosterSpeed;
 static bool _boosterTrackSelected;
 
 static uint32_t _currentDisabledSpecialTrackPieces;
-static uint32_t _rideConstructionNextArrowPulse = 0;
 
 static void window_ride_construction_construct(rct_window* w);
 static void window_ride_construction_mouseup_demolish(rct_window* w);
@@ -583,6 +582,7 @@ static void window_ride_construction_close(rct_window* w)
 
     map_invalidate_map_selection_tiles();
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
+    gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
     // In order to cancel the yellow arrow correctly the
     // selection tool should be cancelled. Don't do a tool cancel if
@@ -1711,6 +1711,8 @@ static void RideConstructPlacedForwardGameActionCallback(const GameAction* ga, c
             _currentTrackPieceType = next_track.element->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
             _rideConstructionState = RIDE_CONSTRUCTION_STATE_SELECTED;
+            _rideConstructionNextArrowPulse = 0;
+            gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
             ride_select_next_section();
         }
         else
@@ -1754,6 +1756,8 @@ static void RideConstructPlacedBackwardGameActionCallback(const GameAction* ga, 
             _currentTrackPieceType = trackBeginEnd.begin_element->AsTrack()->GetTrackType();
             _currentTrackSelectionFlags = 0;
             _rideConstructionState = RIDE_CONSTRUCTION_STATE_SELECTED;
+            _rideConstructionNextArrowPulse = 0;
+            gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
             ride_select_previous_section();
         }
         else

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -101,6 +101,7 @@ CoordsXYZ _currentTrackBegin;
 uint8_t _currentTrackPieceDirection;
 track_type_t _currentTrackPieceType;
 uint8_t _currentTrackSelectionFlags;
+uint32_t _rideConstructionNextArrowPulse = 0;
 uint8_t _currentTrackSlopeEnd;
 uint8_t _currentTrackBankEnd;
 uint8_t _currentTrackLiftHill;
@@ -1633,6 +1634,8 @@ void ride_select_next_section()
     }
     else if (_rideConstructionState == RIDE_CONSTRUCTION_STATE_BACK)
     {
+        gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
+
         if (ride_select_forwards_from_back())
         {
             window_ride_construction_update_active_elements();
@@ -1694,6 +1697,8 @@ void ride_select_previous_section()
     }
     else if (_rideConstructionState == RIDE_CONSTRUCTION_STATE_FRONT)
     {
+        gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
+
         if (ride_select_backwards_from_front())
         {
             window_ride_construction_update_active_elements();
@@ -1796,6 +1801,8 @@ static bool ride_modify_maze(const CoordsXYE& tileElement)
             _currentTrackBegin.y = tileElement.y;
             _currentTrackBegin.z = trackElement->GetBaseZ();
             _currentTrackSelectionFlags = 0;
+            _rideConstructionNextArrowPulse = 0;
+            gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
             auto intent = Intent(INTENT_ACTION_UPDATE_MAZE_CONSTRUCTION);
             context_broadcast_intent(&intent);
@@ -1876,6 +1883,8 @@ bool ride_modify(CoordsXYE* input)
     _currentTrackPieceDirection = direction;
     _currentTrackPieceType = type;
     _currentTrackSelectionFlags = 0;
+    _rideConstructionNextArrowPulse = 0;
+    gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_NO_TRACK))
     {

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1061,6 +1061,7 @@ extern CoordsXYZ _currentTrackBegin;
 extern uint8_t _currentTrackPieceDirection;
 extern track_type_t _currentTrackPieceType;
 extern uint8_t _currentTrackSelectionFlags;
+extern uint32_t _rideConstructionNextArrowPulse;
 extern uint8_t _currentTrackSlopeEnd;
 extern uint8_t _currentTrackBankEnd;
 extern uint8_t _currentTrackLiftHill;


### PR DESCRIPTION
A few things here:

- For rides, I explicitly disable the `MAP_SELECT_FLAG_ENABLE_ARROW` flag when closing construction, the selection changes or something is built
  - When something is built, I reset the timer so the arrow appears immediately for the next piece
- I needed `_rideConstructionNextArrowPulse` to be accessible in `MazeConstruction.cpp` so I moved it to ride.h (where the tick counter originally was)
- For mazes, explicitly disable the `MAP_SELECT_FLAG_ENABLE_ARROW` flag when closing construction or constructing a maze piece
  - I've changed the behaviour so that the maze yellow box selection always appears immediately after construction (whereas originally it would wait up to 9 ticks)
- For both, I disabled the `MAP_SELECT_FLAG_ENABLE_ARROW` flag and reset the timer when a piece is selected via a right click