### PR TITLE
Fix #13236: Researching new ride type appears like new vehicle type

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -40,6 +40,7 @@
 - Fix: [#13158] Cursors are drawn incorrectly in text input fields.
 - Fix: [#13222] Vehicle collision causes negative number of passengers (original bug).
 - Fix: [#13226, #7280] No error is shown when attempting to load a corrupted save.
+- Fix: [#13236] Researching new ride type appears like new vehicle type instead.
 - Fix: [#13266] Plugin API: Deleting key of sharedStorage not working.
 - Fix: [#13278] Desync caused by to ghost tiles changing the ride mode.
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -916,8 +916,6 @@ static void research_update_first_of_type(ResearchItem* researchItem)
 
     if (!_seenRideType[rideType])
         researchItem->flags |= RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE;
-
-    _seenRideType[rideType] = true;
 }
 
 static void research_mark_ride_type_as_seen(const ResearchItem& researchItem)
@@ -966,7 +964,6 @@ void research_determine_first_of_type()
     if (gResearchNextItem.has_value())
     {
         research_update_first_of_type(&gResearchNextItem.value());
-        research_mark_ride_type_as_seen(gResearchNextItem.value());
     }
 
     for (auto& researchItem : gResearchItemsUninvented)


### PR DESCRIPTION
There are a couple of bugs here:
- `research_update_first_of_type` only checks if a ride has been seen or not and updates the flag accordingly, but it was erroneously also marking this ride as seen, so every uninvented item would be marked as such and there was never a new ride type, just new vehicles.
- Regardless of the above, `research_mark_ride_type_as_seen` was being called for the item still to be invented
- Regarding the code for the last item, it seems like it should be marked as seen first, then the first of type would be updated, but I didn't want to touch that for now, given the comments on the for loop above it (which seem weird for `gResearchLastItem`)
```
    if (gResearchLastItem.has_value())
    {
        research_update_first_of_type(&gResearchLastItem.value());
        research_mark_ride_type_as_seen(gResearchLastItem.value());
    }
```

I did some basic testing with the provided save and it fixed the issue.
