### PR TITLE
Fix #12368: Don't modify station properties when placing or removing ghost tiles

### DIFF
--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -686,7 +686,7 @@ public:
                 }
             }
 
-            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN)
+            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
             {
                 if (trackBlock->index == 0)
                 {

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -428,7 +428,8 @@ public:
 
             cost += (_support_height / 2) * RideTypeDescriptors[ride->type].BuildCosts.SupportPrice;
 
-            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
+            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && !(tileElement->Flags & TILE_ELEMENT_FLAG_GHOST)
+                && (tileElement->AsTrack()->GetSequenceIndex() == 0))
             {
                 if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, GAME_COMMAND_FLAG_APPLY))
                 {


### PR DESCRIPTION
This fixes the desync described in #12368. When building a station, the ghost station tile placed in front of the already existing station will change the station properties. One of the modified properties is the Depart-Variable. This modification prevents ghost trains from departing properly (because the value is continually reset to 1), leading to different behavior of the train as if the ghost tile wasn't present. Since the ghost tile isn't present on other clients this causes a desync. Additionally, it causes a bug affecting even single player games where the train gets stuck on the ghost piece, jiggling back and forth.

This PR addresses this issue by ensuring that ghost station tiles don't modify the station properties. Now they are only modified once the tile is actually placed (and thus synchronized to other clients).