### PR TITLE
Fix #13250. Crash when opening parks with new ride types

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3651,6 +3651,7 @@ STR_6394    :Objective
 STR_6395    :Maintenance
 STR_6396    :Disable screensaver and monitor power saving
 STR_6397    :{SMALLFONT}{BLACK}If checked, screensaver and other monitor power saving features will be inhibited while OpenRCT2 is running.
+STR_6398    :File contains unsupported ride types. Please Update.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3651,7 +3651,7 @@ STR_6394    :Objective
 STR_6395    :Maintenance
 STR_6396    :Disable screensaver and monitor power saving
 STR_6397    :{SMALLFONT}{BLACK}If checked, screensaver and other monitor power saving features will be inhibited while OpenRCT2 is running.
-STR_6398    :File contains unsupported ride types. Please Update.
+STR_6398    :File contains unsupported ride types. Please update to a newer version of OpenRCT2.
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1286,9 +1286,12 @@ static rct_window* window_ride_open(Ride* ride)
  */
 rct_window* window_ride_main_open(Ride* ride)
 {
-    rct_window* w;
+    if (ride->type >= RIDE_TYPE_COUNT)
+    {
+        return nullptr;
+    }
 
-    w = window_bring_to_front_by_number(WC_RIDE, ride->id);
+    rct_window* w = window_bring_to_front_by_number(WC_RIDE, ride->id);
     if (w == nullptr)
     {
         w = window_ride_open(ride);
@@ -1323,6 +1326,9 @@ rct_window* window_ride_main_open(Ride* ride)
  */
 static rct_window* window_ride_open_station(Ride* ride, StationIndex stationIndex)
 {
+    if (ride->type >= RIDE_TYPE_COUNT)
+        return nullptr;
+
     if (ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_NO_VEHICLES))
         return window_ride_main_open(ride);
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -680,6 +680,11 @@ namespace OpenRCT2
                 ft.Add<uint16_t>(e.Flag);
                 windowManager->ShowError(STR_FAILED_TO_LOAD_IMCOMPATIBLE_RCTC_FLAG, STR_NONE, ft);
             }
+            catch (const UnsupportedRideTypeException&)
+            {
+                auto windowManager = _uiContext->GetWindowManager();
+                windowManager->ShowError(STR_FILE_CONTAINS_UNSUPPORTED_RIDE_TYPES, STR_NONE, {});
+            }
             catch (const std::exception& e)
             {
                 Console::Error::WriteLine(e.what());

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -564,7 +564,7 @@ namespace OpenRCT2
                     auto fs = FileStream(path, FILE_MODE_OPEN);
                     if (!LoadParkFromStream(&fs, path, loadTitleScreenOnFail))
                     {
-                        throw std::runtime_error("Failed to load park");
+                        return false;
                     }
                     return true;
                 }
@@ -610,6 +610,11 @@ namespace OpenRCT2
                 }
 
                 auto result = parkImporter->LoadFromStream(stream, info.Type == FILE_TYPE::SCENARIO, false, path.c_str());
+
+                // From this point onwards the currently loaded park will be corrupted if loading fails
+                // so reload the title screen if that happens.
+                loadTitleScreenFirstOnFail = true;
+
                 _objectManager->LoadObjects(result.RequiredObjects.data(), result.RequiredObjects.size());
                 parkImporter->Import();
                 gScenarioSavePath = path;
@@ -663,6 +668,11 @@ namespace OpenRCT2
             }
             catch (const ObjectLoadException& e)
             {
+                // If loading the SV6 or SV4 failed return to the title screen if requested.
+                if (loadTitleScreenFirstOnFail)
+                {
+                    title_load();
+                }
                 // The path needs to be duplicated as it's a const here
                 // which the window function doesn't like
                 auto intent = Intent(WC_OBJECT_LOAD_ERROR);
@@ -675,6 +685,11 @@ namespace OpenRCT2
             }
             catch (const UnsupportedRCTCFlagException& e)
             {
+                // If loading the SV6 or SV4 failed return to the title screen if requested.
+                if (loadTitleScreenFirstOnFail)
+                {
+                    title_load();
+                }
                 auto windowManager = _uiContext->GetWindowManager();
                 auto ft = Formatter();
                 ft.Add<uint16_t>(e.Flag);
@@ -682,18 +697,22 @@ namespace OpenRCT2
             }
             catch (const UnsupportedRideTypeException&)
             {
+                // If loading the SV6 or SV4 failed return to the title screen if requested.
+                if (loadTitleScreenFirstOnFail)
+                {
+                    title_load();
+                }
                 auto windowManager = _uiContext->GetWindowManager();
                 windowManager->ShowError(STR_FILE_CONTAINS_UNSUPPORTED_RIDE_TYPES, STR_NONE, {});
             }
             catch (const std::exception& e)
             {
+                // If loading the SV6 or SV4 failed return to the title screen if requested.
+                if (loadTitleScreenFirstOnFail)
+                {
+                    title_load();
+                }
                 Console::Error::WriteLine(e.what());
-            }
-
-            // If loading the SV6 or SV4 failed return to the title screen if requested.
-            if (loadTitleScreenFirstOnFail)
-            {
-                title_load();
             }
 
             return false;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -427,6 +427,20 @@ void game_convert_strings_to_rct2(rct_s6_data* s6)
     }
 }
 
+static void RemoveBadRideTypes()
+{
+    for (ride_id_t i = 0; i < RIDE_ID_NULL; ++i)
+    {
+        auto* ride = get_ride(i);
+        if (ride == nullptr || ride->type < RIDE_TYPE_COUNT)
+        {
+            continue;
+        }
+        reset_sprite_spatial_index();
+        ride_action_modify(ride, RIDE_MODIFY_DEMOLISH, GAME_COMMAND_FLAG_APPLY);
+    }
+}
+
 // OpenRCT2 workaround to recalculate some values which are saved redundantly in the save to fix corrupted files.
 // For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
 void game_fix_save_vars()
@@ -540,6 +554,8 @@ void game_fix_save_vars()
 
     // Fix gParkEntrance locations for which the tile_element no longer exists
     fix_park_entrance_locations();
+
+    RemoveBadRideTypes();
 }
 
 void game_load_init()

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -427,20 +427,6 @@ void game_convert_strings_to_rct2(rct_s6_data* s6)
     }
 }
 
-static void RemoveBadRideTypes()
-{
-    for (ride_id_t i = 0; i < RIDE_ID_NULL; ++i)
-    {
-        auto* ride = get_ride(i);
-        if (ride == nullptr || ride->type < RIDE_TYPE_COUNT)
-        {
-            continue;
-        }
-        reset_sprite_spatial_index();
-        ride_action_modify(ride, RIDE_MODIFY_DEMOLISH, GAME_COMMAND_FLAG_APPLY);
-    }
-}
-
 // OpenRCT2 workaround to recalculate some values which are saved redundantly in the save to fix corrupted files.
 // For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
 void game_fix_save_vars()
@@ -554,8 +540,6 @@ void game_fix_save_vars()
 
     // Fix gParkEntrance locations for which the tile_element no longer exists
     fix_park_entrance_locations();
-
-    RemoveBadRideTypes();
 }
 
 void game_load_init()

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -86,3 +86,14 @@ public:
     {
     }
 };
+
+class UnsupportedRideTypeException : public std::exception
+{
+public:
+    ObjectEntryIndex const Type;
+
+    explicit UnsupportedRideTypeException(ObjectEntryIndex type)
+        : Type(type)
+    {
+    }
+};

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -142,7 +142,7 @@ public:
         if (ride->type >= RIDE_TYPE_COUNT)
         {
             log_warning("Ride type not found. ride type = %d.", ride->type);
-            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
+            return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
         const rct_preview_track* trackBlock = get_track_def_from_ride(ride, trackType);
         trackBlock += tileElement->AsTrack()->GetSequenceIndex();

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -138,6 +138,12 @@ public:
             log_warning("Ride not found. ride index = %d.", rideIndex);
             return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
+
+        if (ride->type >= RIDE_TYPE_COUNT)
+        {
+            log_warning("Ride type not found. ride type = %d.", ride->type);
+            return MakeResult(GA_ERROR::INVALID_PARAMETERS, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
+        }
         const rct_preview_track* trackBlock = get_track_def_from_ride(ride, trackType);
         trackBlock += tileElement->AsTrack()->GetSequenceIndex();
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3901,6 +3901,8 @@ enum
 
     STR_DISABLE_SCREENSAVER = 6396,
     STR_DISABLE_SCREENSAVER_TIP = 6397,
+
+    STR_FILE_CONTAINS_UNSUPPORTED_RIDE_TYPES = 6398,
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -523,6 +523,12 @@ public:
                 rideType = RCT2RideTypeToOpenRCT2RideType(src->type, rideEntry);
             }
         }
+
+        if (rideType >= RIDE_TYPE_COUNT)
+        {
+            log_error("Invalid ride type for a ride in this save.");
+            throw UnsupportedRideTypeException(rideType);
+        }
         dst->type = rideType;
         dst->subtype = subtype;
         // pad_002;
@@ -1726,6 +1732,10 @@ void load_from_sv6(const char* path)
     {
         log_error("Error loading: %s", loadError.what());
         show_error(ERROR_TYPE_FILE_LOAD, STR_GAME_SAVE_FAILED);
+    }
+    catch (const UnsupportedRideTypeException&)
+    {
+        show_error(ERROR_TYPE_FILE_LOAD, STR_FILE_CONTAINS_UNSUPPORTED_RIDE_TYPES);
     }
     catch (const std::exception&)
     {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -464,6 +464,7 @@ public:
         game_convert_strings_to_utf8();
         map_count_remaining_land_rights();
         determine_ride_entrance_and_exit_locations();
+        RemoveBadRideTypes();
 
         auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
         park.Name = GetUserString(_s6.park_name);
@@ -1685,6 +1686,20 @@ public:
         }
 
         return result;
+    }
+
+    void RemoveBadRideTypes()
+    {
+        for (ride_id_t i = 0; i < RIDE_ID_NULL; ++i)
+        {
+            auto* ride = get_ride(i);
+            if (ride->type < RIDE_TYPE_COUNT)
+            {
+                continue;
+            }
+
+            ride_action_modify(ride, RIDE_MODIFY_DEMOLISH, GAME_COMMAND_FLAG_APPLY);
+        }
     }
 };
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -464,7 +464,6 @@ public:
         game_convert_strings_to_utf8();
         map_count_remaining_land_rights();
         determine_ride_entrance_and_exit_locations();
-        RemoveBadRideTypes();
 
         auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
         park.Name = GetUserString(_s6.park_name);
@@ -1686,20 +1685,6 @@ public:
         }
 
         return result;
-    }
-
-    void RemoveBadRideTypes()
-    {
-        for (ride_id_t i = 0; i < RIDE_ID_NULL; ++i)
-        {
-            auto* ride = get_ride(i);
-            if (ride->type < RIDE_TYPE_COUNT)
-            {
-                continue;
-            }
-
-            ride_action_modify(ride, RIDE_MODIFY_DEMOLISH, GAME_COMMAND_FLAG_APPLY);
-        }
     }
 };
 

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -196,7 +196,7 @@ static void ride_ratings_update_state_2()
 {
     const ride_id_t rideIndex = gRideRatingsCalcData.CurrentRide;
     auto ride = get_ride(rideIndex);
-    if (ride == nullptr || ride->status == RIDE_STATUS_CLOSED)
+    if (ride == nullptr || ride->status == RIDE_STATUS_CLOSED || ride->type >= RIDE_TYPE_COUNT)
     {
         gRideRatingsCalcData.State = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
         return;

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2190,6 +2190,10 @@ void track_paint(paint_session* session, Direction direction, int32_t height, co
             session->TrackColours[SCHEME_3] = ghost_id;
         }
 
+        if (ride->type >= RIDE_TYPE_COUNT)
+        {
+            return;
+        }
         TRACK_PAINT_FUNCTION_GETTER paintFunctionGetter = RideTypeDescriptors[ride->type].TrackPaintFunction;
         if (paintFunctionGetter != nullptr)
         {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1966,6 +1966,9 @@ void Vehicle::Update()
     if (curRide == nullptr)
         return;
 
+    if (curRide->type >= RIDE_TYPE_COUNT)
+        return;
+
     if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_TESTING))
         UpdateMeasurements();
 
@@ -6219,7 +6222,7 @@ GForces Vehicle::GetGForces() const
 void Vehicle::SetMapToolbar() const
 {
     auto curRide = GetRide();
-    if (curRide != nullptr)
+    if (curRide != nullptr && curRide->type < RIDE_TYPE_COUNT)
     {
         const Vehicle* vehicle = GetHead();
 


### PR DESCRIPTION
This only happens when a new ride type is added and the park is opened in the older version of the game where the ride type does not exist.

These changes will prevent it from instantly crashing on open. You still might crash if peeps are queuing or mechanics are fixing. I'm also thinking of adding additional protection so that it just deletes the ride on load.