### PR TITLE
Add Execute and FindApp to Platform class

### DIFF
--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -37,6 +37,8 @@ namespace Platform
     bool FileExists(const std::string path);
     rct2_time GetTimeLocal();
     rct2_date GetDateLocal();
+    bool FindApp(const std::string& app, std::string* output);
+    int32_t Execute(const std::string& command, std::string* output = nullptr);
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
     std::string GetEnvironmentPath(const char* name);


### PR DESCRIPTION
Split off from this PR https://github.com/OpenRCT2/OpenRCT2/pull/13172

This adds `::Execute` and `::FindApp` to the Platform class, as it seems like that should be brought up, and because pre-existing logic was found in `UiContext.Linux` when it was needed outside the `UiContext`. There is equivalent logic in the Windows-specific code too.

HOLD for merge until I get confirmation the code still builds and runs on platforms other than Linux