### PR TITLE
Add compile-time check for nlohmann json version

### DIFF
--- a/src/openrct2/core/Json.hpp
+++ b/src/openrct2/core/Json.hpp
@@ -15,6 +15,10 @@
 #include <string>
 #include <string_view>
 
+#if NLOHMANN_JSON_VERSION_MAJOR < 3 || (NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR < 6)
+#    error "Unsupported version of nlohmann json library, must be >= 3.6"
+#endif // NLOHMANN_JSON_VERSION_MAJOR < 3 || (NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR < 6)
+
 using json_t = nlohmann::json;
 
 namespace Json


### PR DESCRIPTION
Currently, the version of nlohmann json distributed with [certain Linux distros](https://repology.org/project/nlohmann-json/versions) is <3.6, notably this includes Raspbian.
A user following this guide for example: https://forums.openrct2.org/topic/5145-building-openrct2-on-rpi4-with-raspberry-pi-os/ will hit compile errors, due to the version being distributed is too old (3.5).

Just a bit ago was helping a user on Discord who following aforementioned guide wa shaving build errors caused by too old a version being distributed with Raspberry Pi OS.

