### PR TITLE
Fix desync caused due to ghost tiles changing the ride mode

### DIFF
--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -546,43 +546,46 @@ public:
 
             cost += ((supportHeight / (2 * COORDS_Z_STEP)) * RideTypeDescriptors[ride->type].BuildCosts.SupportPrice) * 5;
 
-            invalidate_test_results(ride);
-            switch (_trackType)
+            if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
             {
-                case TrackElemType::OnRidePhoto:
-                    ride->lifecycle_flags |= RIDE_LIFECYCLE_ON_RIDE_PHOTO;
-                    break;
-                case TrackElemType::CableLiftHill:
-                    if (trackBlock->index != 0)
-                        break;
-                    ride->lifecycle_flags |= RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
-                    ride->CableLiftLoc = mapLoc;
-                    break;
-                case TrackElemType::BlockBrakes:
-                    ride->num_block_brakes++;
-                    ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_OPERATING;
-
-                    ride->mode = RideMode::ContinuousCircuitBlockSectioned;
-                    if (ride->type == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER)
-                        ride->mode = RideMode::PoweredLaunchBlockSectioned;
-
-                    break;
-            }
-
-            if (trackBlock->index == 0)
-            {
+                invalidate_test_results(ride);
                 switch (_trackType)
                 {
-                    case TrackElemType::Up25ToFlat:
-                    case TrackElemType::Up60ToFlat:
-                    case TrackElemType::DiagUp25ToFlat:
-                    case TrackElemType::DiagUp60ToFlat:
-                        if (!(_trackPlaceFlags & CONSTRUCTION_LIFT_HILL_SELECTED))
-                            break;
-                        [[fallthrough]];
-                    case TrackElemType::CableLiftHill:
-                        ride->num_block_brakes++;
+                    case TrackElemType::OnRidePhoto:
+                        ride->lifecycle_flags |= RIDE_LIFECYCLE_ON_RIDE_PHOTO;
                         break;
+                    case TrackElemType::CableLiftHill:
+                        if (trackBlock->index != 0)
+                            break;
+                        ride->lifecycle_flags |= RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
+                        ride->CableLiftLoc = mapLoc;
+                        break;
+                    case TrackElemType::BlockBrakes:
+                        ride->num_block_brakes++;
+                        ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_OPERATING;
+
+                        ride->mode = RideMode::ContinuousCircuitBlockSectioned;
+                        if (ride->type == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER)
+                            ride->mode = RideMode::PoweredLaunchBlockSectioned;
+
+                        break;
+                }
+
+                if (trackBlock->index == 0)
+                {
+                    switch (_trackType)
+                    {
+                        case TrackElemType::Up25ToFlat:
+                        case TrackElemType::Up60ToFlat:
+                        case TrackElemType::DiagUp25ToFlat:
+                        case TrackElemType::DiagUp60ToFlat:
+                            if (!(_trackPlaceFlags & CONSTRUCTION_LIFT_HILL_SELECTED))
+                                break;
+                            [[fallthrough]];
+                        case TrackElemType::CableLiftHill:
+                            ride->num_block_brakes++;
+                            break;
+                    }
                 }
             }
 

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -456,40 +456,43 @@ public:
             }
         }
 
-        switch (trackType)
+        if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            case TrackElemType::OnRidePhoto:
-                ride->lifecycle_flags &= ~RIDE_LIFECYCLE_ON_RIDE_PHOTO;
-                break;
-            case TrackElemType::CableLiftHill:
-                ride->lifecycle_flags &= ~RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
-                break;
-            case TrackElemType::BlockBrakes:
-                ride->num_block_brakes--;
-                if (ride->num_block_brakes == 0)
-                {
-                    ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_OPERATING;
-                    ride->mode = RideMode::ContinuousCircuit;
-                    if (ride->type == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER)
-                    {
-                        ride->mode = RideMode::PoweredLaunch;
-                    }
-                }
-                break;
-        }
-
-        switch (trackType)
-        {
-            case TrackElemType::Up25ToFlat:
-            case TrackElemType::Up60ToFlat:
-            case TrackElemType::DiagUp25ToFlat:
-            case TrackElemType::DiagUp60ToFlat:
-                if (!isLiftHill)
+            switch (trackType)
+            {
+                case TrackElemType::OnRidePhoto:
+                    ride->lifecycle_flags &= ~RIDE_LIFECYCLE_ON_RIDE_PHOTO;
                     break;
-                [[fallthrough]];
-            case TrackElemType::CableLiftHill:
-                ride->num_block_brakes--;
-                break;
+                case TrackElemType::CableLiftHill:
+                    ride->lifecycle_flags &= ~RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
+                    break;
+                case TrackElemType::BlockBrakes:
+                    ride->num_block_brakes--;
+                    if (ride->num_block_brakes == 0)
+                    {
+                        ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_OPERATING;
+                        ride->mode = RideMode::ContinuousCircuit;
+                        if (ride->type == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER)
+                        {
+                            ride->mode = RideMode::PoweredLaunch;
+                        }
+                    }
+                    break;
+            }
+
+            switch (trackType)
+            {
+                case TrackElemType::Up25ToFlat:
+                case TrackElemType::Up60ToFlat:
+                case TrackElemType::DiagUp25ToFlat:
+                case TrackElemType::DiagUp60ToFlat:
+                    if (!isLiftHill)
+                        break;
+                    [[fallthrough]];
+                case TrackElemType::CableLiftHill:
+                    ride->num_block_brakes--;
+                    break;
+            }
         }
 
         money32 price = RideTypeDescriptors[ride->type].BuildCosts.TrackPrice;


### PR DESCRIPTION
Steps to reproduce the desync:
1. Build a track starting with a chain lift
2. Somewhere after the chain lift place a block brake (don't actually build it. Just hover it so the ghost tile appears.)
3. Instead of the blockbrake place a regular straight tile
4. Complete the track

What happens is: When hovering the block brake, the operation mode of the ride will be set to block mode. (Only for the client building the ride though since the ghost tile isn't synchronized). When the block brack ghost is replaced by the ghost of a regular tile the mode isn't reset to circuit mode, since there still exist two blocks (due to the chain lift existing). After finishing the track the mode will be set to block mode for the builder and to circuit mode for all other clients. The desync window will appear when testing/opening the ride as soon as differences emerge due to the different mode.

This PR fixes that (and some related desyncs) by preventing the ghost tile from changing the operation mode. I've been a bit liberal with excluding code for ghost tiles and made it affect other code in the vicinity that appeared to be likely to cause unwanted side effects as well. However so far I've been able to find actual desyncs caused by the code within `case TrackElemType::BlockBrakes:`