### PR TITLE
Fix crash when using a writable FileStream to a file in non-existing folder

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
@@ -42,8 +42,10 @@
 #endif
 
 #include <SDL_opengl.h>
-// OpenRCT2: SDL_opengl.h includes windows.h, which defines the CreateWindow macro and causes conflicts
+// OpenRCT2: SDL_opengl.h includes windows.h, which defines some macros that can cause conflicts
 #undef CreateWindow
+#undef CreateDirectory
+#undef GetMessage
 
 #ifdef OPENGL_NO_LINK
 

--- a/src/openrct2/core/FileStream.hpp
+++ b/src/openrct2/core/FileStream.hpp
@@ -12,6 +12,7 @@
 #include "../common.h"
 #include "../localisation/Language.h"
 #include "IStream.hpp"
+#include "Path.hpp"
 #include "String.hpp"
 
 #include <algorithm>
@@ -79,6 +80,16 @@ namespace OpenRCT2
                     break;
                 default:
                     throw;
+            }
+
+            // Make sure the directory exists before writing to a file inside it
+            if (_canWrite)
+            {
+                std::string directory = Path::GetDirectory(path);
+                if (!Path::DirectoryExists(directory))
+                {
+                    Path::CreateDirectory(directory);
+                }
             }
 
 #ifdef _WIN32


### PR DESCRIPTION
Something that I ran in to long ago, but got stuck at the time on an annoying issue with Windows's `CreateDirectory` macro. The second commit fixes this.

This change makes sure the directory exists before `_wfopen` is called.