### PR TITLE
Small research releated refactor

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -576,7 +576,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
 
     // Item category
     screenPos.x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
-    stringId = EditorInventionsResearchCategories[researchItem->category];
+    stringId = EditorInventionsResearchCategories[EnumValue(researchItem->category)];
     gfx_draw_string_left(dpi, STR_INVENTION_RESEARCH_GROUP, &stringId, COLOUR_BLACK, screenPos);
 }
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -113,15 +113,6 @@ static rct_window_event_list window_editor_inventions_list_drag_events([](auto& 
 
 static ResearchItem _editorInventionsListDraggedItem;
 
-static constexpr const rct_string_id EditorInventionsResearchCategories[] = {
-    STR_RESEARCH_NEW_TRANSPORT_RIDES,
-    STR_RESEARCH_NEW_GENTLE_RIDES,
-    STR_RESEARCH_NEW_ROLLER_COASTERS,
-    STR_RESEARCH_NEW_THRILL_RIDES,
-    STR_RESEARCH_NEW_WATER_RIDES,
-    STR_RESEARCH_NEW_SHOPS_AND_STALLS,
-    STR_RESEARCH_NEW_SCENERY_AND_THEMING,
-};
 // clang-format on
 
 static void window_editor_inventions_list_drag_open(ResearchItem* researchItem);
@@ -576,7 +567,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
 
     // Item category
     screenPos.x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
-    stringId = EditorInventionsResearchCategories[EnumValue(researchItem->category)];
+    stringId = researchItem->GetCategoryInventionString();
     gfx_draw_string_left(dpi, STR_INVENTION_RESEARCH_GROUP, &stringId, COLOUR_BLACK, screenPos);
 }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1319,7 +1319,7 @@ static void editor_load_selected_objects()
                     {
                         rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
                         uint8_t rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
-                        uint8_t category = RideTypeDescriptors[rideType].Category;
+                        ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
                         research_insert_ride_entry(rideType, entryIndex, category, true);
                     }
                     else if (objectType == OBJECT_TYPE_SCENERY_GROUP)

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -164,16 +164,6 @@ static uint32_t window_research_page_enabled_widgets[] = {
 
 const int32_t window_research_tab_animation_loops[] = { 16, 16 };
 
-static constexpr const rct_string_id ResearchCategoryNames[] = {
-    STR_RESEARCH_CATEGORY_TRANSPORT,
-    STR_RESEARCH_CATEGORY_GENTLE,
-    STR_RESEARCH_CATEGORY_ROLLERCOASTER,
-    STR_RESEARCH_CATEGORY_THRILL,
-    STR_RESEARCH_CATEGORY_WATER,
-    STR_RESEARCH_CATEGORY_SHOP,
-    STR_RESEARCH_CATEGORY_SCENERY_GROUP,
-};
-
 static constexpr const rct_string_id ResearchStageNames[] = {
     STR_RESEARCH_STAGE_INITIAL_RESEARCH,
     STR_RESEARCH_STAGE_DESIGNING,
@@ -329,7 +319,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         rct_string_id label = STR_RESEARCH_TYPE_LABEL;
         if (gResearchProgressStage != RESEARCH_STAGE_INITIAL_RESEARCH)
         {
-            strings[0] = ResearchCategoryNames[EnumValue(gResearchNextItem->category)];
+            strings[0] = gResearchNextItem->GetCategoryName();
             if (gResearchProgressStage != RESEARCH_STAGE_DESIGNING)
             {
                 strings[0] = gResearchNextItem->GetName();

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -329,7 +329,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         rct_string_id label = STR_RESEARCH_TYPE_LABEL;
         if (gResearchProgressStage != RESEARCH_STAGE_INITIAL_RESEARCH)
         {
-            strings[0] = ResearchCategoryNames[gResearchNextItem->category];
+            strings[0] = ResearchCategoryNames[EnumValue(gResearchNextItem->category)];
             if (gResearchProgressStage != RESEARCH_STAGE_DESIGNING)
             {
                 strings[0] = gResearchNextItem->GetName();

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1087,7 +1087,7 @@ static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& ar
                 rideType = rideEntry->ride_type[j];
                 if (rideType != RIDE_TYPE_NULL)
                 {
-                    uint8_t category = RideTypeDescriptors[rideType].Category;
+                    ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
                     research_insert_ride_entry(rideType, groupIndex, category, true);
                 }
             }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1087,7 +1087,7 @@ static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& ar
                 rideType = rideEntry->ride_type[j];
                 if (rideType != RIDE_TYPE_NULL)
                 {
-                    ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
+                    ResearchCategory category = RideTypeDescriptors[rideType].GetResearchCategory();
                     research_insert_ride_entry(rideType, groupIndex, category, true);
                 }
             }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -377,7 +377,7 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             break;
         case News::ItemType::Research:
         {
-            auto item = ResearchItem(subject, 0, 0);
+            auto item = ResearchItem(subject, ResearchCategory::Transport, 0);
             if (item.type == Research::EntryType::Ride)
             {
                 auto intent = Intent(INTENT_ACTION_NEW_RIDE_OF_TYPE);

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -469,7 +469,7 @@ void research_populate_list_random()
         {
             if (rideType != RIDE_TYPE_NULL)
             {
-                ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
+                ResearchCategory category = RideTypeDescriptors[rideType].GetResearchCategory();
                 research_insert_ride_entry(rideType, i, category, researched);
             }
         }
@@ -508,7 +508,7 @@ void research_insert_ride_entry(ObjectEntryIndex entryIndex, bool researched)
     {
         if (rideType != RIDE_TYPE_NULL)
         {
-            ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
+            ResearchCategory category = RideTypeDescriptors[rideType].GetResearchCategory();
             research_insert_ride_entry(rideType, entryIndex, category, researched);
         }
     }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -890,50 +890,42 @@ bool ResearchItem::Exists() const
     return false;
 }
 
+// clang-format off
+static constexpr const rct_string_id _editorInventionsResearchCategories[] = {
+    STR_RESEARCH_NEW_TRANSPORT_RIDES,
+    STR_RESEARCH_NEW_GENTLE_RIDES,
+    STR_RESEARCH_NEW_ROLLER_COASTERS,
+    STR_RESEARCH_NEW_THRILL_RIDES,
+    STR_RESEARCH_NEW_WATER_RIDES,
+    STR_RESEARCH_NEW_SHOPS_AND_STALLS,
+    STR_RESEARCH_NEW_SCENERY_AND_THEMING,
+};
+// clang-format on
+
 rct_string_id ResearchItem::GetCategoryInventionString() const
 {
-    switch (category)
-    {
-        case ResearchCategory::Transport:
-            return STR_RESEARCH_NEW_TRANSPORT_RIDES;
-        case ResearchCategory::Gentle:
-            return STR_RESEARCH_NEW_GENTLE_RIDES;
-        case ResearchCategory::Rollercoaster:
-            return STR_RESEARCH_NEW_ROLLER_COASTERS;
-        case ResearchCategory::Thrill:
-            return STR_RESEARCH_NEW_THRILL_RIDES;
-        case ResearchCategory::Water:
-            return STR_RESEARCH_NEW_WATER_RIDES;
-        case ResearchCategory::Shop:
-            return STR_RESEARCH_NEW_SHOPS_AND_STALLS;
-        case ResearchCategory::SceneryGroup:
-            return STR_RESEARCH_NEW_SCENERY_AND_THEMING;
-    }
-    log_error("Unsupported category invention string");
-    return STR_NONE;
+    const auto categoryValue = EnumValue(category);
+    Guard::Assert(categoryValue <= 6, "Unsupported category invention string");
+    return _editorInventionsResearchCategories[categoryValue];
 }
+
+// clang-format off
+static constexpr const rct_string_id _researchCategoryNames[] = {
+    STR_RESEARCH_CATEGORY_TRANSPORT,
+    STR_RESEARCH_CATEGORY_GENTLE,
+    STR_RESEARCH_CATEGORY_ROLLERCOASTER,
+    STR_RESEARCH_CATEGORY_THRILL,
+    STR_RESEARCH_CATEGORY_WATER,
+    STR_RESEARCH_CATEGORY_SHOP,
+    STR_RESEARCH_CATEGORY_SCENERY_GROUP,
+};
+// clang-format on
 
 rct_string_id ResearchItem::GetCategoryName() const
 {
-    switch (category)
-    {
-        case ResearchCategory::Transport:
-            return STR_RESEARCH_CATEGORY_TRANSPORT;
-        case ResearchCategory::Gentle:
-            return STR_RESEARCH_CATEGORY_GENTLE;
-        case ResearchCategory::Rollercoaster:
-            return STR_RESEARCH_CATEGORY_ROLLERCOASTER;
-        case ResearchCategory::Thrill:
-            return STR_RESEARCH_CATEGORY_THRILL;
-        case ResearchCategory::Water:
-            return STR_RESEARCH_CATEGORY_WATER;
-        case ResearchCategory::Shop:
-            return STR_RESEARCH_CATEGORY_SHOP;
-        case ResearchCategory::SceneryGroup:
-            return STR_RESEARCH_CATEGORY_SCENERY_GROUP;
-    }
-    log_error("Unsupported category name");
-    return STR_NONE;
+    const auto categoryValue = EnumValue(category);
+    Guard::Assert(categoryValue <= 6, "Unsupported category name");
+    return _researchCategoryNames[categoryValue];
 }
 
 static std::bitset<RIDE_TYPE_COUNT> _seenRideType = {};

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -890,6 +890,52 @@ bool ResearchItem::Exists() const
     return false;
 }
 
+rct_string_id ResearchItem::GetCategoryInventionString() const
+{
+    switch (category)
+    {
+        case ResearchCategory::Transport:
+            return STR_RESEARCH_NEW_TRANSPORT_RIDES;
+        case ResearchCategory::Gentle:
+            return STR_RESEARCH_NEW_GENTLE_RIDES;
+        case ResearchCategory::Rollercoaster:
+            return STR_RESEARCH_NEW_ROLLER_COASTERS;
+        case ResearchCategory::Thrill:
+            return STR_RESEARCH_NEW_THRILL_RIDES;
+        case ResearchCategory::Water:
+            return STR_RESEARCH_NEW_WATER_RIDES;
+        case ResearchCategory::Shop:
+            return STR_RESEARCH_NEW_SHOPS_AND_STALLS;
+        case ResearchCategory::SceneryGroup:
+            return STR_RESEARCH_NEW_SCENERY_AND_THEMING;
+    }
+    log_error("Unsupported category invention string");
+    return STR_NONE;
+}
+
+rct_string_id ResearchItem::GetCategoryName() const
+{
+    switch (category)
+    {
+        case ResearchCategory::Transport:
+            return STR_RESEARCH_CATEGORY_TRANSPORT;
+        case ResearchCategory::Gentle:
+            return STR_RESEARCH_CATEGORY_GENTLE;
+        case ResearchCategory::Rollercoaster:
+            return STR_RESEARCH_CATEGORY_ROLLERCOASTER;
+        case ResearchCategory::Thrill:
+            return STR_RESEARCH_CATEGORY_THRILL;
+        case ResearchCategory::Water:
+            return STR_RESEARCH_CATEGORY_WATER;
+        case ResearchCategory::Shop:
+            return STR_RESEARCH_CATEGORY_SHOP;
+        case ResearchCategory::SceneryGroup:
+            return STR_RESEARCH_CATEGORY_SCENERY_GROUP;
+    }
+    log_error("Unsupported category name");
+    return STR_NONE;
+}
+
 static std::bitset<RIDE_TYPE_COUNT> _seenRideType = {};
 
 static void research_update_first_of_type(ResearchItem* researchItem)

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -82,7 +82,7 @@ void research_update_uncompleted_types()
 
     for (auto const& researchItem : gResearchItemsUninvented)
     {
-        uncompletedResearchTypes |= (1 << researchItem.category);
+        uncompletedResearchTypes |= EnumToFlag(researchItem.category);
     }
 
     gResearchUncompletedCategories = uncompletedResearchTypes;
@@ -165,7 +165,7 @@ static void research_next_design()
                 return;
             }
         }
-        else if (ignoreActiveResearchTypes || (gResearchPriorities & (1 << researchItem.category)))
+        else if (ignoreActiveResearchTypes || (gResearchPriorities & EnumToFlag(researchItem.category)))
         {
             break;
         }
@@ -469,7 +469,7 @@ void research_populate_list_random()
         {
             if (rideType != RIDE_TYPE_NULL)
             {
-                uint8_t category = RideTypeDescriptors[rideType].Category;
+                ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
                 research_insert_ride_entry(rideType, i, category, researched);
             }
         }
@@ -489,7 +489,7 @@ void research_populate_list_random()
     }
 }
 
-bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, uint8_t category, bool researched)
+bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched)
 {
     if (rideType != RIDE_TYPE_NULL && entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
@@ -508,7 +508,7 @@ void research_insert_ride_entry(ObjectEntryIndex entryIndex, bool researched)
     {
         if (rideType != RIDE_TYPE_NULL)
         {
-            uint8_t category = RideTypeDescriptors[rideType].Category;
+            ResearchCategory category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
             research_insert_ride_entry(rideType, entryIndex, category, researched);
         }
     }
@@ -519,7 +519,7 @@ bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool resea
     if (entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {
         auto tmpItem = ResearchItem(
-            Research::EntryType::Scenery, entryIndex, RIDE_TYPE_NULL, EnumValue(ResearchCategory::SceneryGroup), 0);
+            Research::EntryType::Scenery, entryIndex, RIDE_TYPE_NULL, ResearchCategory::SceneryGroup, 0);
         research_insert(tmpItem, researched);
         return true;
     }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -66,6 +66,8 @@ struct ResearchItem
     bool Exists() const;
     bool IsAlwaysResearched() const;
     rct_string_id GetName() const;
+    rct_string_id GetCategoryInventionString() const;
+    rct_string_id GetCategoryName() const;
 
     ResearchItem() = default;
     constexpr ResearchItem(uint32_t _rawValue, ResearchCategory _category, uint8_t _flags)

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -36,13 +36,13 @@ enum
 
 enum class ResearchCategory : uint8_t
 {
-    Transport,
-    Gentle,
-    Rollercoaster,
-    Thrill,
-    Water,
-    Shop,
-    SceneryGroup
+    Transport = 0,
+    Gentle = 1,
+    Rollercoaster = 2,
+    Thrill = 3,
+    Water = 4,
+    Shop = 5,
+    SceneryGroup = 6,
 };
 
 struct ResearchItem

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -12,6 +12,7 @@
 #include "../common.h"
 #include "../object/ObjectLimits.h"
 #include "../ride/Ride.h"
+#include "../util/Util.h"
 
 #include <optional>
 
@@ -33,6 +34,17 @@ enum
     RESEARCH_ENTRY_FLAG_RIDE_ALWAYS_RESEARCHED = (1 << 6),
 };
 
+enum class ResearchCategory : uint8_t
+{
+    Transport,
+    Gentle,
+    Rollercoaster,
+    Thrill,
+    Water,
+    Shop,
+    SceneryGroup
+};
+
 struct ResearchItem
 {
     union
@@ -46,7 +58,7 @@ struct ResearchItem
         };
     };
     uint8_t flags;
-    uint8_t category;
+    ResearchCategory category;
 
     bool IsNull() const;
     void SetNull();
@@ -56,14 +68,15 @@ struct ResearchItem
     rct_string_id GetName() const;
 
     ResearchItem() = default;
-    constexpr ResearchItem(uint32_t _rawValue, uint8_t _category, uint8_t _flags)
+    constexpr ResearchItem(uint32_t _rawValue, ResearchCategory _category, uint8_t _flags)
         : rawValue(_rawValue)
         , flags(_flags)
         , category(_category)
     {
     }
     ResearchItem(
-        Research::EntryType _type, ObjectEntryIndex _entryIndex, uint8_t _baseRideType, uint8_t _category, uint8_t _flags)
+        Research::EntryType _type, ObjectEntryIndex _entryIndex, uint8_t _baseRideType, ResearchCategory _category,
+        uint8_t _flags)
         : entryIndex(_entryIndex)
         , baseRideType(_baseRideType)
         , type(_type)
@@ -85,7 +98,7 @@ struct ResearchItem
             retItem.baseRideType = OpenRCT2RideTypeToRCT2RideType(baseRideType);
             retItem.type = static_cast<uint8_t>(type);
             retItem.flags = (flags & ~RESEARCH_ENTRY_FLAG_FIRST_OF_TYPE);
-            retItem.category = category;
+            retItem.category = EnumValue(category);
         }
 
         return retItem;
@@ -98,7 +111,7 @@ struct ResearchItem
         {
             rawValue = 0;
             flags = 0;
-            category = 0;
+            category = ResearchCategory::Transport;
             SetNull();
         }
         else
@@ -109,7 +122,7 @@ struct ResearchItem
                                                 : oldResearchItem.baseRideType;
             type = Research::EntryType{ oldResearchItem.type };
             flags = oldResearchItem.flags;
-            category = oldResearchItem.category;
+            category = static_cast<ResearchCategory>(oldResearchItem.category);
         }
     }
 };
@@ -138,17 +151,6 @@ enum
     RESEARCH_STAGE_FINISHED_ALL
 };
 
-enum class ResearchCategory : uint8_t
-{
-    Transport,
-    Gentle,
-    Rollercoaster,
-    Thrill,
-    Water,
-    Shop,
-    SceneryGroup
-};
-
 extern uint8_t gResearchFundingLevel;
 extern uint8_t gResearchPriorities;
 extern uint16_t gResearchProgress;
@@ -173,7 +175,7 @@ void research_finish_item(ResearchItem* researchItem);
 void research_insert(ResearchItem item, bool researched);
 void research_remove(ResearchItem* researchItem);
 
-bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, uint8_t category, bool researched);
+bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched);
 void research_insert_ride_entry(ObjectEntryIndex entryIndex, bool researched);
 bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool researched);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2632,7 +2632,7 @@ private:
                     dst->baseRideType = rideType;
                     dst->type = Research::EntryType::Ride;
                     dst->flags = 0;
-                    dst->category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
+                    dst->category = RideTypeDescriptors[rideType].GetResearchCategory();
                 }
             }
         }
@@ -2651,7 +2651,7 @@ private:
                     dst->baseRideType = rideType;
                     dst->type = Research::EntryType::Ride;
                     dst->flags = 0;
-                    dst->category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
+                    dst->category = RideTypeDescriptors[rideType].GetResearchCategory();
                 }
             }
         }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2632,7 +2632,7 @@ private:
                     dst->baseRideType = rideType;
                     dst->type = Research::EntryType::Ride;
                     dst->flags = 0;
-                    dst->category = RideTypeDescriptors[rideType].Category;
+                    dst->category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
                 }
             }
         }
@@ -2651,7 +2651,7 @@ private:
                     dst->baseRideType = rideType;
                     dst->type = Research::EntryType::Ride;
                     dst->flags = 0;
-                    dst->category = RideTypeDescriptors[rideType].Category;
+                    dst->category = static_cast<ResearchCategory>(RideTypeDescriptors[rideType].Category);
                 }
             }
         }
@@ -2663,7 +2663,7 @@ private:
             {
                 dst->entryIndex = entryIndex;
                 dst->type = Research::EntryType::Scenery;
-                dst->category = EnumValue(ResearchCategory::SceneryGroup);
+                dst->category = ResearchCategory::SceneryGroup;
                 dst->flags = 0;
             }
         }

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -23,6 +23,7 @@
 #include "../audio/audio.h"
 #include "../interface/Colour.h"
 #include "../localisation/Localisation.h"
+#include "../management/Research.h"
 #include "../sprites.h"
 #include "Ride.h"
 #include "ShopItem.h"
@@ -328,4 +329,27 @@ uint64_t RideTypeDescriptor::GetAvailableTrackPieces() const
 bool RideTypeDescriptor::SupportsTrackPiece(const uint64_t trackPiece) const
 {
     return GetAvailableTrackPieces() & (1ULL << trackPiece);
+}
+
+ResearchCategory RideTypeDescriptor::GetResearchCategory() const
+{
+    switch (Category)
+    {
+        case RIDE_CATEGORY_TRANSPORT:
+            return ResearchCategory::Transport;
+        case RIDE_CATEGORY_GENTLE:
+            return ResearchCategory::Gentle;
+        case RIDE_CATEGORY_ROLLERCOASTER:
+            return ResearchCategory::Rollercoaster;
+        case RIDE_CATEGORY_THRILL:
+            return ResearchCategory::Thrill;
+        case RIDE_CATEGORY_WATER:
+            return ResearchCategory::Water;
+        case RIDE_CATEGORY_SHOP:
+            return ResearchCategory::Shop;
+        case RIDE_CATEGORY_NONE:
+            break;
+    }
+    log_error("Cannot get Research Category of invalid RideCategory");
+    return ResearchCategory::Transport;
 }

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -29,6 +29,8 @@
 #include "Track.h"
 #include "TrackPaint.h"
 
+enum class ResearchCategory : uint8_t;
+
 using ride_ratings_calculation = void (*)(Ride* ride);
 struct RideComponentName
 {
@@ -176,6 +178,7 @@ struct RideTypeDescriptor
     bool HasFlag(uint64_t flag) const;
     uint64_t GetAvailableTrackPieces() const;
     bool SupportsTrackPiece(const uint64_t trackPiece) const;
+    ResearchCategory GetResearchCategory() const;
 };
 
 #ifdef _WIN32


### PR DESCRIPTION
Might be clearer to look commit by commit
- Uses `ResearchCategory` as enum throughout
- Moves Research related string stuff into `ResearchItem`
- Add converter from `RideCategory` to `ResearchCategory` to reduce the number of casts (and prevent a possible number mismatch, in case those are ever reordered)