### PR TITLE
Fix #13282: Autosaves are not deleted when limit is reached

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -723,7 +723,7 @@ static void limit_autosave_count(const size_t numberOfFilesToKeep, bool processL
             autosaveFiles[i].resize(MAX_PATH, 0);
             if (scanner->Next())
             {
-                platform_get_user_directory(autosaveFiles[i].data(), folderDirectory.c_str(), sizeof(utf8) * MAX_PATH);
+                safe_strcpy(autosaveFiles[i].data(), folderDirectory.c_str(), sizeof(utf8) * MAX_PATH);
                 safe_strcat_path(autosaveFiles[i].data(), "autosave", sizeof(utf8) * MAX_PATH);
                 safe_strcat_path(autosaveFiles[i].data(), scanner->GetPathRelative(), sizeof(utf8) * MAX_PATH);
             }
@@ -739,7 +739,10 @@ static void limit_autosave_count(const size_t numberOfFilesToKeep, bool processL
 
     for (size_t i = 0; numAutosavesToDelete > 0; i++, numAutosavesToDelete--)
     {
-        platform_file_delete(autosaveFiles[i].data());
+        if (!platform_file_delete(autosaveFiles[i].data()))
+        {
+            log_warning("Failed to delete autosave file: %s", autosaveFiles[i].data());
+        }
     }
 }
 


### PR DESCRIPTION
Not much to say here, issue was autosave deleter when generating the full path name for the file to be deleted generated a bad path, for example:

`/home/keithstellyes/.config/OpenRCT2/home/keithstellyes/.config/OpenRCT2/save/autosave/autosave_2020-10-24_11-53-58.sv6` (Equivalent to `$CONFIG/$CONFIG/save/autosave/...`)