### PR TITLE
Fix #13019: Prevent ghost trains from opening the construction window when crashing

### DIFF
--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -18,6 +18,7 @@
 #include "../world/MapAnimation.h"
 #include "../world/Surface.h"
 #include "GameAction.h"
+#include "RideSetSetting.hpp"
 
 class TrackPlaceActionResult final : public GameActions::Result
 {
@@ -561,14 +562,19 @@ public:
                         ride->CableLiftLoc = mapLoc;
                         break;
                     case TrackElemType::BlockBrakes:
+                    {
                         ride->num_block_brakes++;
                         ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_OPERATING;
 
-                        ride->mode = RideMode::ContinuousCircuitBlockSectioned;
+                        RideMode newMode = RideMode::ContinuousCircuitBlockSectioned;
                         if (ride->type == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER)
-                            ride->mode = RideMode::PoweredLaunchBlockSectioned;
+                            newMode = RideMode::PoweredLaunchBlockSectioned;
 
+                        auto rideSetSetting = RideSetSettingAction(
+                            ride->id, RideSetSetting::Mode, static_cast<uint8_t>(newMode));
+                        GameActions::ExecuteNested(&rideSetSetting);
                         break;
+                    }
                 }
 
                 if (trackBlock->index == 0)

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -18,6 +18,7 @@
 #include "../world/MapAnimation.h"
 #include "../world/Surface.h"
 #include "GameAction.h"
+#include "RideSetSetting.hpp"
 
 DEFINE_GAME_ACTION(TrackRemoveAction, GAME_COMMAND_REMOVE_TRACK, GameActions::Result)
 {
@@ -472,12 +473,17 @@ public:
                     if (ride->num_block_brakes == 0)
                     {
                         ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_OPERATING;
-                        ride->mode = RideMode::ContinuousCircuit;
+                        RideMode newMode = RideMode::ContinuousCircuit;
                         if (ride->type == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER)
                         {
-                            ride->mode = RideMode::PoweredLaunch;
+                            newMode = RideMode::PoweredLaunch;
                         }
+
+                        auto rideSetSetting = RideSetSettingAction(
+                            ride->id, RideSetSetting::Mode, static_cast<uint8_t>(newMode));
+                        GameActions::ExecuteNested(&rideSetSetting);
                     }
+
                     break;
             }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2077,9 +2077,18 @@ void Ride::Update()
     // If ride is simulating but crashed, reset the vehicles
     if (status == RIDE_STATUS_SIMULATING && (lifecycle_flags & RIDE_LIFECYCLE_CRASHED))
     {
-        // We require this to execute right away during the simulation, always ignore network and queue.
-        auto gameAction = RideSetStatusAction(id, RIDE_STATUS_SIMULATING);
-        GameActions::ExecuteNested(&gameAction);
+        if (mode == RideMode::ContinuousCircuitBlockSectioned || mode == RideMode::PoweredLaunchBlockSectioned)
+        {
+            // We require this to execute right away during the simulation, always ignore network and queue.
+            RideSetStatusAction gameAction = RideSetStatusAction(id, RIDE_STATUS_CLOSED);
+            GameActions::ExecuteNested(&gameAction);
+        }
+        else
+        {
+            // We require this to execute right away during the simulation, always ignore network and queue.
+            RideSetStatusAction gameAction = RideSetStatusAction(id, RIDE_STATUS_SIMULATING);
+            GameActions::ExecuteNested(&gameAction);
+        }
     }
 }
 


### PR DESCRIPTION
The forced open of the construction window reported in #13019 happens whenever a ride is in block mode and a ghost train reaches the end of the track (crashes). Usually this shouldn't happen, because starting a simulation in block mode isn't allowed. However such a situation may still occur when the track is being modified while the simulation is already running for two reasons:
1. If a track piece is removed during simulation in block mode (this tries to reset the simulation, which isn't possible due to the block mode. The construction window is probably opened while attempting to display the error)
2. If a block brake is added to a ride that was previously in circuit mode the ride will be switched to block mode without resetting the trains.

I addressed 1 by closing down the ride instead of resetting the simulation if the ride is in block mode. I preferred doing this over closing the ride already when removing a track piece as this allows players to still swap out small pieces during simulation (for example adding a photo section or banked curve).

While 1 would already be enough to fix the reported issue, I also added a second change: Currently when adding a block brake the operation mode is switched without the side effects that a mode switch would have when the mode was switched by the player (like clearing the trains). This means that there might be multiple trains within a single block (which should never happen for block operation mode). As such the simulation wouldn't provide any beneficial insight for the player and I think it's better to just clear out the track entirely. To accomplish this I switch the mode using the game command instead of directly modifying the mode variable.