### PR TITLE
Fix #13306: Restore entrance/exit for prebuilt ride design ghosts

### DIFF
--- a/src/openrct2/actions/TrackPlaceAction.hpp
+++ b/src/openrct2/actions/TrackPlaceAction.hpp
@@ -695,7 +695,10 @@ public:
                 }
             }
 
-            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+            // If the placed tile is a station modify station properties.
+            // Don't do this if the ride is simulating and the tile is a ghost to prevent desyncs.
+            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN
+                && !(ride->status == RIDE_STATUS_SIMULATING && GetFlags() & GAME_COMMAND_FLAG_GHOST))
             {
                 if (trackBlock->index == 0)
                 {

--- a/src/openrct2/actions/TrackRemoveAction.hpp
+++ b/src/openrct2/actions/TrackRemoveAction.hpp
@@ -429,7 +429,10 @@ public:
 
             cost += (_support_height / 2) * RideTypeDescriptors[ride->type].BuildCosts.SupportPrice;
 
-            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && !(tileElement->Flags & TILE_ELEMENT_FLAG_GHOST)
+            // If the removed tile is a station modify station properties.
+            // Don't do this if the ride is simulating and the tile is a ghost to prevent desyncs.
+            if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN
+                && !(ride->status == RIDE_STATUS_SIMULATING && tileElement->Flags & TILE_ELEMENT_FLAG_GHOST)
                 && (tileElement->AsTrack()->GetSequenceIndex() == 0))
             {
                 if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, GAME_COMMAND_FLAG_APPLY))


### PR DESCRIPTION
This fixes the regression introduced by c440dac where prebuilt design ghosts did not display their entrances. To fix this bug (while still getting rid of the desync bug) I've limited the changes I made in c440dac to only apply when the ride is in simulation mode. This fixes the desync - as it only occurs when simulating, while not affecting the prebuilt ghost (since you cannot simulate ride designs during placement).