### PR TITLE
Fix: #13292: Impossible excitement rating requirements...

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -161,6 +161,7 @@ The following people are not part of the development team, but have been contrib
 * Stephan Spengler (Sadret)
 * Roger Seekell (rpstester)
 * Ben Johnston (gsckoco)
+* (evilclownattack)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -42,6 +42,7 @@
 - Fix: [#13226, #7280] No error is shown when attempting to load a corrupted save.
 - Fix: [#13266] Plugin API: Deleting key of sharedStorage not working.
 - Fix: [#13278] Desync caused by to ghost tiles changing the ride mode.
+- Fix: [#13292] Impossible excitement rating requirements with finish building 5 coasters goal
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface
 - Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -854,9 +854,13 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
                 stringId = STR_WINDOW_OBJECTIVE_VALUE_LENGTH;
                 arg = gScenarioObjective.MinimumLength;
                 break;
-            default:
+            case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
                 stringId = STR_WINDOW_OBJECTIVE_VALUE_RATING;
                 arg = gScenarioObjective.MinimumExcitement;
+                break;
+            default:
+                stringId = STR_WINDOW_OBJECTIVE_VALUE_RATING;
+                arg = gScenarioObjective.Currency;
                 break;
         }
         gfx_draw_string_left(dpi, stringId, &arg, COLOUR_BLACK, screenCoords);

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -856,7 +856,7 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
                 break;
             default:
                 stringId = STR_WINDOW_OBJECTIVE_VALUE_RATING;
-                arg = gScenarioObjective.Currency;
+                arg = gScenarioObjective.MinimumExcitement;
                 break;
         }
         gfx_draw_string_left(dpi, stringId, &arg, COLOUR_BLACK, screenCoords);


### PR DESCRIPTION
Incorrect argument was used when drawing the minimum excitement rating in the Objective Selection window. Appears to have been a typo.