### PR TITLE
Fix #13289: Litter and vomit sometimes not loading with RCT1 saves

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -42,6 +42,7 @@
 - Fix: [#13226, #7280] No error is shown when attempting to load a corrupted save.
 - Fix: [#13266] Plugin API: Deleting key of sharedStorage not working.
 - Fix: [#13278] Desync caused by ghost tiles changing the ride mode.
+- Fix: [#13289] Litter and vomit sometimes not loading with RCT1 saved game or scenario
 - Fix: [#13292] Impossible excitement rating requirements with finish building 5 coasters goal
 - Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
 - Improved: [#13098] Improvements to the maze construction window user interface

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -571,6 +571,7 @@ void game_load_init()
         GameActions::ClearQueue();
     }
     reset_sprite_spatial_index();
+    reset_all_sprite_quadrant_placements();
     scenery_set_default_placement_configuration();
 
     auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);


### PR DESCRIPTION
Issue was actually caused by loading RCT1 saves from certain rotations, and fixed by reseting sprite quadrants when loading. Wasn't an issue with RCT2 saves as litter screen coordinates are set directly from the save, rather than calculated based on rotation and sprite width/height.