### PR TITLE
Fix #12981: Heartline Twister Coaster (reverse car) does not appear

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#10186] Placing multiple saved rides ignores design name (original bug).
 - Fix: [#12368] Desync due to ghost station pieces affecting changing ride settings.
 - Fix: [#12940] Windows cause issues with snow drawing.
+- Fix: [#12981] Heartline Twister Coaster (reverse car) does not appears during game.
 - Fix: [#13019] Simulated trains sometimes open construction window when they crash.
 - Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
 - Fix: [#13024] Console cursor does not correctly render at current cursor position.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2088,7 +2088,7 @@ static void populate_vehicle_type_dropdown(Ride* ride)
         rideTypeIterator = ride->type;
         rideTypeIteratorMax = ride->type;
     }
-   
+    
     // Check if the list of researched items has changed
     bool sameResearch = VehicleDropdownInventions.size() == gResearchItemsInvented.size()
         && std::equal(VehicleDropdownInventions.begin(), VehicleDropdownInventions.end(), gResearchItemsInvented.begin(),

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2102,7 +2102,7 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     // Don't repopulate the list if we just did.
     auto& ls = OpenRCT2::GetContext()->GetLocalisationService();
     if (VehicleDropdownExpanded == selectionShouldBeExpanded && VehicleDropdownRideType == rideEntry
-        && VehicleDropdownDataLanguage == ls.GetCurrentLanguage() && !sameResearch
+        && VehicleDropdownDataLanguage == ls.GetCurrentLanguage() && sameResearch
         && VehicleDropdownIgnoreResearch == gCheatsIgnoreResearchStatus)
         return;
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2090,14 +2090,9 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     }
    
     // Check if the list of researched items has changed
-    bool sameResearch = VehicleDropdownInventions.size() == gResearchItemsInvented.size() && std::equal(
-        VehicleDropdownInventions.begin(),
-        VehicleDropdownInventions.end(),
-        gResearchItemsInvented.begin(),
-        [](const ResearchItem& r1, const ResearchItem& r2) -> bool
-        {
-            return r1.Equals(&r2);
-        });
+    bool sameResearch = VehicleDropdownInventions.size() == gResearchItemsInvented.size()
+        && std::equal(VehicleDropdownInventions.begin(), VehicleDropdownInventions.end(), gResearchItemsInvented.begin(),
+            [](const ResearchItem& r1, const ResearchItem& r2) -> bool { return r1.Equals(&r2); });
 
     // Don't repopulate the list if we just did.
     auto& ls = OpenRCT2::GetContext()->GetLocalisationService();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2088,7 +2088,7 @@ static void populate_vehicle_type_dropdown(Ride* ride)
         rideTypeIterator = ride->type;
         rideTypeIteratorMax = ride->type;
     }
-    
+
     // Check if the list of researched items has changed
     bool sameResearch = VehicleDropdownInventions.size() == gResearchItemsInvented.size()
         && std::equal(VehicleDropdownInventions.begin(), VehicleDropdownInventions.end(), gResearchItemsInvented.begin(),

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2092,7 +2092,7 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     // Check if the list of researched items has changed
     bool sameResearch = VehicleDropdownInventions.size() == gResearchItemsInvented.size()
         && std::equal(VehicleDropdownInventions.begin(), VehicleDropdownInventions.end(), gResearchItemsInvented.begin(),
-            [](const ResearchItem& r1, const ResearchItem& r2) -> bool { return r1.Equals(&r2); });
+                      [](const ResearchItem& r1, const ResearchItem& r2) -> bool { return r1.Equals(&r2); });
 
     // Don't repopulate the list if we just did.
     auto& ls = OpenRCT2::GetContext()->GetLocalisationService();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -956,6 +956,8 @@ struct VehicleTypeLabel
 static int32_t VehicleDropdownDataLanguage = LANGUAGE_UNDEFINED;
 static rct_ride_entry* VehicleDropdownRideType = nullptr;
 static bool VehicleDropdownExpanded = false;
+static bool VehicleDropdownIgnoreResearch = false;
+static std::vector<ResearchItem> VehicleDropdownInventions;
 static std::vector<VehicleTypeLabel> VehicleDropdownData;
 
 static void window_ride_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
@@ -2086,11 +2088,22 @@ static void populate_vehicle_type_dropdown(Ride* ride)
         rideTypeIterator = ride->type;
         rideTypeIteratorMax = ride->type;
     }
+   
+    // Check if the list of researched items has changed
+    bool sameResearch = VehicleDropdownInventions.size() == gResearchItemsInvented.size() && std::equal(
+        VehicleDropdownInventions.begin(),
+        VehicleDropdownInventions.end(),
+        gResearchItemsInvented.begin(),
+        [](const ResearchItem& r1, const ResearchItem& r2) -> bool
+        {
+            return r1.Equals(&r2);
+        });
 
     // Don't repopulate the list if we just did.
     auto& ls = OpenRCT2::GetContext()->GetLocalisationService();
     if (VehicleDropdownExpanded == selectionShouldBeExpanded && VehicleDropdownRideType == rideEntry
-        && VehicleDropdownDataLanguage == ls.GetCurrentLanguage())
+        && VehicleDropdownDataLanguage == ls.GetCurrentLanguage() && !sameResearch
+        && VehicleDropdownIgnoreResearch == gCheatsIgnoreResearchStatus)
         return;
 
     VehicleDropdownData.clear();
@@ -2124,6 +2137,8 @@ static void populate_vehicle_type_dropdown(Ride* ride)
     VehicleDropdownExpanded = selectionShouldBeExpanded;
     VehicleDropdownRideType = rideEntry;
     VehicleDropdownDataLanguage = ls.GetCurrentLanguage();
+    VehicleDropdownIgnoreResearch = gCheatsIgnoreResearchStatus;
+    VehicleDropdownInventions = gResearchItemsInvented;
 }
 
 static void window_ride_show_vehicle_type_dropdown(rct_window* w, rct_widget* widget)


### PR DESCRIPTION
Newly researched vehicle types were not appearing in the dropdown menu. Fixed by checking if research list has changed, or if "ignore research status" cheat was activated.

Marking this as a draft because I'm unsure about the implementation, admittedly this fix is less than elegant. An alternative solution would be to skip checking if the list has changed altogether, and just repopulate it every time.