### PR TITLE
Refactor loc_6B51C0

### DIFF
--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -377,6 +377,7 @@ private:
     void UpdateSpiralSlide();
     void UpdateQueueLength(StationIndex stationIndex);
     money32 CalculateIncomePerHour() const;
+    void ConstructMissingEntranceOrExit() const;
 
 public:
     bool CanBreakDown() const;


### PR DESCRIPTION
loc_6B51C0 goes through all stations of the ride and checks for entrances/exits. On the first entrance/exit found to be missing it opens the construction window for the ride, prompting the user to place the respective building. This function is invoked when testing/opening the ride after determining that entraces/exits aren't set up correctly.

I renamed the function accordingly and did a small refactor to increase readability. Since the function is only concerned with a specific ride I moved the function into the `Ride` struct (and made it private since it was static before, keeping access rights the same). The move into `Ride` feels a bit odd to me, since the function in the end opens a window (which doesn't seem to belong in `Ride` at all to me), however I didn't see any better alternative either.