### PR TITLE
Refactor openrct-ui Input Folder to Title case

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -401,7 +401,7 @@ public:
                     switch (e.button.button)
                     {
                         case SDL_BUTTON_LEFT:
-                            store_mouse_input(MOUSE_STATE_LEFT_PRESS, mousePos);
+                            StoreMouseInput(MOUSE_STATE_LEFT_PRESS, mousePos);
                             _cursorState.left = CURSOR_PRESSED;
                             _cursorState.old = 1;
                             break;
@@ -409,7 +409,7 @@ public:
                             _cursorState.middle = CURSOR_PRESSED;
                             break;
                         case SDL_BUTTON_RIGHT:
-                            store_mouse_input(MOUSE_STATE_RIGHT_PRESS, mousePos);
+                            StoreMouseInput(MOUSE_STATE_RIGHT_PRESS, mousePos);
                             _cursorState.right = CURSOR_PRESSED;
                             _cursorState.old = 2;
                             break;
@@ -428,7 +428,7 @@ public:
                     switch (e.button.button)
                     {
                         case SDL_BUTTON_LEFT:
-                            store_mouse_input(MOUSE_STATE_LEFT_RELEASE, mousePos);
+                            StoreMouseInput(MOUSE_STATE_LEFT_RELEASE, mousePos);
                             _cursorState.left = CURSOR_RELEASED;
                             _cursorState.old = 3;
                             break;
@@ -436,7 +436,7 @@ public:
                             _cursorState.middle = CURSOR_RELEASED;
                             break;
                         case SDL_BUTTON_RIGHT:
-                            store_mouse_input(MOUSE_STATE_RIGHT_RELEASE, mousePos);
+                            StoreMouseInput(MOUSE_STATE_RIGHT_RELEASE, mousePos);
                             _cursorState.right = CURSOR_RELEASED;
                             _cursorState.old = 4;
                             break;
@@ -461,13 +461,13 @@ public:
 
                     if (_cursorState.touchIsDouble)
                     {
-                        store_mouse_input(MOUSE_STATE_RIGHT_PRESS, fingerPos);
+                        StoreMouseInput(MOUSE_STATE_RIGHT_PRESS, fingerPos);
                         _cursorState.right = CURSOR_PRESSED;
                         _cursorState.old = 2;
                     }
                     else
                     {
-                        store_mouse_input(MOUSE_STATE_LEFT_PRESS, fingerPos);
+                        StoreMouseInput(MOUSE_STATE_LEFT_PRESS, fingerPos);
                         _cursorState.left = CURSOR_PRESSED;
                         _cursorState.old = 1;
                     }
@@ -482,13 +482,13 @@ public:
 
                     if (_cursorState.touchIsDouble)
                     {
-                        store_mouse_input(MOUSE_STATE_RIGHT_RELEASE, fingerPos);
+                        StoreMouseInput(MOUSE_STATE_RIGHT_RELEASE, fingerPos);
                         _cursorState.right = CURSOR_RELEASED;
                         _cursorState.old = 4;
                     }
                     else
                     {
-                        store_mouse_input(MOUSE_STATE_LEFT_RELEASE, fingerPos);
+                        StoreMouseInput(MOUSE_STATE_LEFT_RELEASE, fingerPos);
                         _cursorState.left = CURSOR_RELEASED;
                         _cursorState.old = 3;
                     }

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -510,7 +510,7 @@ public:
 
     void HandleKeyboard(bool isTitle) override
     {
-        input_handle_keyboard(isTitle);
+        InputHandleKeyboard(isTitle);
     }
 
     std::string GetKeyboardShortcutString(int32_t shortcut) override

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -505,7 +505,7 @@ public:
 
     void HandleInput() override
     {
-        game_handle_input();
+        GameHandleInput();
     }
 
     void HandleKeyboard(bool isTitle) override

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -516,7 +516,7 @@ public:
     std::string GetKeyboardShortcutString(int32_t shortcut) override
     {
         utf8 buffer[256];
-        keyboard_shortcuts_format_string(buffer, sizeof(buffer), shortcut);
+        KeyboardShortcutsFormatString(buffer, sizeof(buffer), shortcut);
         return std::string(buffer);
     }
 

--- a/src/openrct2-ui/input/Input.cpp
+++ b/src/openrct2-ui/input/Input.cpp
@@ -27,7 +27,7 @@
 
 using namespace OpenRCT2::Ui;
 
-static void input_handle_console(int32_t key)
+static void InputHandleConsole(int32_t key)
 {
     ConsoleInput input = ConsoleInput::None;
     switch (key)
@@ -59,7 +59,7 @@ static void input_handle_console(int32_t key)
     }
 }
 
-static void input_handle_chat(int32_t key)
+static void InputHandleChat(int32_t key)
 {
     ChatInput input = ChatInput::None;
     switch (key)
@@ -78,7 +78,7 @@ static void input_handle_chat(int32_t key)
     }
 }
 
-static void game_handle_key_scroll()
+static void GameHandleKeyScroll()
 {
     rct_window* mainWindow;
 
@@ -108,7 +108,7 @@ static void game_handle_key_scroll()
     input_scroll_viewport(scrollCoords);
 }
 
-static int32_t input_scancode_to_rct_keycode(int32_t sdl_key)
+static int32_t InputScancodeToRCTKeycode(int32_t sdl_key)
 {
     char keycode = static_cast<char>(SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(sdl_key)));
 
@@ -121,7 +121,7 @@ static int32_t input_scancode_to_rct_keycode(int32_t sdl_key)
     return keycode;
 }
 
-void input_handle_keyboard(bool isTitle)
+void InputHandleKeyboard(bool isTitle)
 {
     if (gOpenRCT2Headless)
     {
@@ -166,7 +166,7 @@ void input_handle_keyboard(bool isTitle)
 #endif
         if (!isTitle)
         {
-            game_handle_key_scroll();
+            GameHandleKeyScroll();
         }
     }
 
@@ -197,12 +197,12 @@ void input_handle_keyboard(bool isTitle)
         }
         else if (console.IsOpen())
         {
-            input_handle_console(key);
+            InputHandleConsole(key);
             continue;
         }
         else if (!isTitle && gChatOpen)
         {
-            input_handle_chat(key);
+            InputHandleChat(key);
             continue;
         }
 
@@ -211,7 +211,7 @@ void input_handle_keyboard(bool isTitle)
         rct_window* w = window_find_by_class(WC_TEXTINPUT);
         if (w != nullptr)
         {
-            char keychar = input_scancode_to_rct_keycode(key & 0xFF);
+            char keychar = InputScancodeToRCTKeycode(key & 0xFF);
             window_text_input_key(w, keychar);
         }
         else if (!gUsingWidgetTextBox)

--- a/src/openrct2-ui/input/Input.cpp
+++ b/src/openrct2-ui/input/Input.cpp
@@ -105,7 +105,7 @@ static void GameHandleKeyScroll()
     {
         window_unfollow_sprite(mainWindow);
     }
-    input_scroll_viewport(scrollCoords);
+    InputScrollViewport(scrollCoords);
 }
 
 static int32_t InputScancodeToRCTKeycode(int32_t sdl_key)
@@ -138,7 +138,7 @@ void InputHandleKeyboard(bool isTitle)
             {
                 if (!(gInputPlaceObjectModifier & (PLACE_OBJECT_MODIFIER_SHIFT_Z | PLACE_OBJECT_MODIFIER_COPY_Z)))
                 {
-                    game_handle_edge_scroll();
+                    GameHandleEdgeScroll();
                 }
             }
         }
@@ -180,7 +180,7 @@ void InputHandleKeyboard(bool isTitle)
 
     // Handle key input
     int32_t key;
-    while (!gOpenRCT2Headless && (key = get_next_key()) != 0)
+    while (!gOpenRCT2Headless && (key = GetNextKey()) != 0)
     {
         if (key == 255)
             continue;

--- a/src/openrct2-ui/input/Input.cpp
+++ b/src/openrct2-ui/input/Input.cpp
@@ -99,7 +99,7 @@ static void GameHandleKeyScroll()
         return;
 
     const uint8_t* keysState = context_get_keys_state();
-    auto scrollCoords = get_keyboard_map_scroll(keysState);
+    auto scrollCoords = GetKeyboardMapScroll(keysState);
 
     if (scrollCoords.x != 0 || scrollCoords.y != 0)
     {
@@ -219,13 +219,13 @@ void InputHandleKeyboard(bool isTitle)
             w = window_find_by_class(WC_CHANGE_KEYBOARD_SHORTCUT);
             if (w != nullptr)
             {
-                keyboard_shortcuts_set(key);
+                KeyboardShortcutsSet(key);
                 window_close_by_class(WC_CHANGE_KEYBOARD_SHORTCUT);
                 window_invalidate_by_class(WC_KEYBOARD_SHORTCUT_LIST);
             }
             else
             {
-                keyboard_shortcut_handle(key);
+                KeyboardShortcutHandle(key);
             }
         }
     }

--- a/src/openrct2-ui/input/Input.h
+++ b/src/openrct2-ui/input/Input.h
@@ -9,4 +9,4 @@
 
 #pragma once
 
-void input_handle_keyboard(bool isTitle);
+void InputHandleKeyboard(bool isTitle);

--- a/src/openrct2-ui/input/KeyboardShortcut.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcut.cpp
@@ -53,16 +53,16 @@ namespace
  *  rct2: 0x006E3E68
  */
 using namespace OpenRCT2;
-void keyboard_shortcut_handle(int32_t key)
+void KeyboardShortcutHandle(int32_t key)
 {
-    auto shortcut = keyboard_shortcuts_get_from_key(key);
+    auto shortcut = KeyboardShortcutsGetFromKey(key);
     if (shortcut != Input::Shortcut::Undefined)
     {
-        keyboard_shortcut_handle_command(shortcut);
+        KeyboardShortcutHandleCommand(shortcut);
     }
 }
 
-void keyboard_shortcut_handle_command(Input::Shortcut shortcut)
+void KeyboardShortcutHandleCommand(Input::Shortcut shortcut)
 {
     size_t shortcutIndex = static_cast<size_t>(shortcut);
     if (shortcutIndex < std::size(shortcut_table))
@@ -77,7 +77,7 @@ void keyboard_shortcut_handle_command(Input::Shortcut shortcut)
 
 #pragma region Shortcut Commands
 
-static void toggle_view_flag(int32_t viewportFlag)
+static void ToggleViewFlag(int32_t viewportFlag)
 {
     rct_window* window;
 
@@ -89,12 +89,12 @@ static void toggle_view_flag(int32_t viewportFlag)
     }
 }
 
-static void shortcut_close_top_most_window()
+static void ShortcutCloseTopMostWindow()
 {
     window_close_top();
 }
 
-static void shortcut_close_all_floating_windows()
+static void ShortcutCloseAllFloatingWindow()
 {
     if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR))
         window_close_all();
@@ -102,7 +102,7 @@ static void shortcut_close_all_floating_windows()
         window_close_top();
 }
 
-static void shortcut_cancel_construction_mode()
+static void ShortcutCancelConstructionMode()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -114,7 +114,7 @@ static void shortcut_cancel_construction_mode()
         tool_cancel();
 }
 
-static void shortcut_pause_game()
+static void ShortcutPauseGame()
 {
     if (!(gScreenFlags & (SCREEN_FLAGS_TITLE_DEMO | SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_MANAGER)))
     {
@@ -127,17 +127,17 @@ static void shortcut_pause_game()
     }
 }
 
-static void shortcut_zoom_view_out()
+static void ShortcutZoomViewOut()
 {
     main_window_zoom(false, false);
 }
 
-static void shortcut_zoom_view_in()
+static void ShortcutZoomViewIn()
 {
     main_window_zoom(true, false);
 }
 
-static void shortcut_rotate_view_clockwise()
+static void ShortcutRotateViewClockwise()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -146,7 +146,7 @@ static void shortcut_rotate_view_clockwise()
     window_rotate_camera(w, 1);
 }
 
-static void shortcut_rotate_view_anticlockwise()
+static void ShortcutRotateViewAnticlockwise()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -155,7 +155,7 @@ static void shortcut_rotate_view_anticlockwise()
     window_rotate_camera(w, -1);
 }
 
-static void shortcut_rotate_construction_object()
+static void ShortcutRotateConstructionObject()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -218,31 +218,31 @@ static void shortcut_rotate_construction_object()
     }
 }
 
-static void shortcut_underground_view_toggle()
+static void ShortcutUndergroundViewToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_UNDERGROUND_INSIDE);
+    ToggleViewFlag(VIEWPORT_FLAG_UNDERGROUND_INSIDE);
 }
 
-static void shortcut_remove_base_land_toggle()
+static void ShortcutRemoveBaseLandToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_HIDE_BASE);
+    ToggleViewFlag(VIEWPORT_FLAG_HIDE_BASE);
 }
 
-static void shortcut_remove_vertical_land_toggle()
+static void ShortcutRemoveVerticalLandToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_HIDE_VERTICAL);
+    ToggleViewFlag(VIEWPORT_FLAG_HIDE_VERTICAL);
 }
 
-static void shortcut_remove_top_bottom_toolbar_toggle()
+static void ShortcutRemoveTopBottomToolbarToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
     {
@@ -284,79 +284,79 @@ static void shortcut_remove_top_bottom_toolbar_toggle()
     gfx_invalidate_screen();
 }
 
-static void shortcut_see_through_rides_toggle()
+static void ShortcutSeeThroughRidesToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_SEETHROUGH_RIDES);
+    ToggleViewFlag(VIEWPORT_FLAG_SEETHROUGH_RIDES);
 }
 
-static void shortcut_see_through_scenery_toggle()
+static void ShortcutSeeThroughSceneryToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_SEETHROUGH_SCENERY);
+    ToggleViewFlag(VIEWPORT_FLAG_SEETHROUGH_SCENERY);
 }
 
-static void shortcut_see_through_paths_toggle()
+static void ShortcutSeeThroughPathsToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_SEETHROUGH_PATHS);
+    ToggleViewFlag(VIEWPORT_FLAG_SEETHROUGH_PATHS);
 }
 
-static void shortcut_invisible_supports_toggle()
+static void ShortcutInvisibleSupportsToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_INVISIBLE_SUPPORTS);
+    ToggleViewFlag(VIEWPORT_FLAG_INVISIBLE_SUPPORTS);
 }
 
-static void shortcut_invisible_people_toggle()
+static void ShortcutInvisiblePeopleToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_INVISIBLE_PEEPS);
+    ToggleViewFlag(VIEWPORT_FLAG_INVISIBLE_PEEPS);
 }
 
-static void shortcut_gridlines_toggle()
+static void ShortcutGridlinesToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_GRIDLINES);
+    ToggleViewFlag(VIEWPORT_FLAG_GRIDLINES);
 }
 
-static void shortcut_height_marks_on_land_toggle()
+static void ShortcutHeightMarksOnLandToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_LAND_HEIGHTS);
+    ToggleViewFlag(VIEWPORT_FLAG_LAND_HEIGHTS);
 }
 
-static void shortcut_height_marks_on_ride_tracks_toggle()
+static void ShortcutHeightMarksOnRideTracksToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_TRACK_HEIGHTS);
+    ToggleViewFlag(VIEWPORT_FLAG_TRACK_HEIGHTS);
 }
 
-static void shortcut_height_marks_on_paths_toggle()
+static void ShortcutHeightMarksOnPathsToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_PATH_HEIGHTS);
+    ToggleViewFlag(VIEWPORT_FLAG_PATH_HEIGHTS);
 }
 
-static void shortcut_adjust_land()
+static void ShortcutAdjustLand()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -375,7 +375,7 @@ static void shortcut_adjust_land()
     }
 }
 
-static void shortcut_adjust_water()
+static void ShortcutAdjustWater()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -394,7 +394,7 @@ static void shortcut_adjust_water()
     }
 }
 
-static void shortcut_build_scenery()
+static void ShortcutBuildScenery()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -413,7 +413,7 @@ static void shortcut_build_scenery()
     }
 }
 
-static void shortcut_build_paths()
+static void ShortcutBuildPaths()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -432,7 +432,7 @@ static void shortcut_build_paths()
     }
 }
 
-static void shortcut_build_new_ride()
+static void ShortcutBuildNewRide()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -446,7 +446,7 @@ static void shortcut_build_new_ride()
     }
 }
 
-static void shortcut_show_financial_information()
+static void ShortcutShowFinancialInformation()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -456,7 +456,7 @@ static void shortcut_show_financial_information()
             context_open_window(WC_FINANCES);
 }
 
-static void shortcut_show_research_information()
+static void ShortcutShowResearchInformation()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -467,7 +467,7 @@ static void shortcut_show_research_information()
     }
 }
 
-static void shortcut_show_rides_list()
+static void ShortcutShowRidesList()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -478,7 +478,7 @@ static void shortcut_show_rides_list()
     }
 }
 
-static void shortcut_show_park_information()
+static void ShortcutShowParkInformation()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -489,7 +489,7 @@ static void shortcut_show_park_information()
     }
 }
 
-static void shortcut_show_guest_list()
+static void ShortcutShowGuestList()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -500,7 +500,7 @@ static void shortcut_show_guest_list()
     }
 }
 
-static void shortcut_show_staff_list()
+static void ShortcutShowStaffList()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -511,7 +511,7 @@ static void shortcut_show_staff_list()
     }
 }
 
-static void shortcut_show_recent_messages()
+static void ShortcutShowRecentMessages()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -520,7 +520,7 @@ static void shortcut_show_recent_messages()
         context_open_window(WC_RECENT_NEWS);
 }
 
-static void shortcut_show_map()
+static void ShortcutShowMap()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -530,12 +530,12 @@ static void shortcut_show_map()
             context_open_window(WC_MAP);
 }
 
-static void shortcut_screenshot()
+static void ShortcutScreenshot()
 {
     gScreenshotCountdown = 2;
 }
 
-static void shortcut_reduce_game_speed()
+static void ShortcutReduceGameSpeed()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -544,7 +544,7 @@ static void shortcut_reduce_game_speed()
         game_reduce_game_speed();
 }
 
-static void shortcut_increase_game_speed()
+static void ShortcutIncreaseGameSpeed()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -553,7 +553,7 @@ static void shortcut_increase_game_speed()
         game_increase_game_speed();
 }
 
-static void shortcut_open_cheat_window()
+static void ShortcutOpenCheatWindow()
 {
     if (gScreenFlags != SCREEN_FLAGS_PLAYING)
         return;
@@ -568,7 +568,7 @@ static void shortcut_open_cheat_window()
     context_open_window(WC_CHEATS);
 }
 
-static void shortcut_clear_scenery()
+static void ShortcutClearScenery()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -587,7 +587,7 @@ static void shortcut_clear_scenery()
     }
 }
 
-static void shortcut_open_chat_window()
+static void ShortcutOpenChatWindow()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -595,7 +595,7 @@ static void shortcut_open_chat_window()
     chat_toggle();
 }
 
-static void shortcut_quick_save_game()
+static void ShortcutQuickSaveGame()
 {
     // Do a quick save in playing mode and a regular save in Scenario Editor mode. In other cases, don't do anything.
     if (gScreenFlags == SCREEN_FLAGS_PLAYING)
@@ -612,28 +612,28 @@ static void shortcut_quick_save_game()
     }
 }
 
-static void shortcut_show_options()
+static void ShortcutShowOptions()
 {
     context_open_window(WC_OPTIONS);
 }
 
-static void shortcut_mute_sound()
+static void ShortcutMuteSound()
 {
     OpenRCT2::Audio::ToggleAllSounds();
 }
 
-static void shortcut_windowed_mode_toggle()
+static void ShortcutWindowsModeToggle()
 {
     platform_toggle_windowed_mode();
 }
 
-static void shortcut_show_multiplayer()
+static void ShortcutShowMultiplayer()
 {
     if (network_get_mode() != NETWORK_MODE_NONE)
         context_open_window(WC_MULTIPLAYER);
 }
 
-static void shortcut_debug_paint_toggle()
+static void ShortcutDebugPaintToggle()
 {
     rct_window* window = window_find_by_class(WC_DEBUG_PAINT);
     if (window != nullptr)
@@ -646,7 +646,7 @@ static void shortcut_debug_paint_toggle()
     }
 }
 
-static void shortcut_ride_construction_turn_left()
+static void ShortcutRideConstructionTurnLeft()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -654,7 +654,7 @@ static void shortcut_ride_construction_turn_left()
     window_ride_construction_keyboard_shortcut_turn_left();
 }
 
-static void shortcut_ride_construction_turn_right()
+static void ShortcutRideConstructionTurnRight()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -662,7 +662,7 @@ static void shortcut_ride_construction_turn_right()
     window_ride_construction_keyboard_shortcut_turn_right();
 }
 
-static void shortcut_ride_construction_use_track_default()
+static void ShortcutRideConstructionUseTrackDefault()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -670,7 +670,7 @@ static void shortcut_ride_construction_use_track_default()
     window_ride_construction_keyboard_shortcut_use_track_default();
 }
 
-static void shortcut_ride_construction_slope_down()
+static void ShortcutRideConstructionSlopeDown()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -678,7 +678,7 @@ static void shortcut_ride_construction_slope_down()
     window_ride_construction_keyboard_shortcut_slope_down();
 }
 
-static void shortcut_ride_construction_slope_up()
+static void ShortcutRideConstructionSlopeUp()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -686,7 +686,7 @@ static void shortcut_ride_construction_slope_up()
     window_ride_construction_keyboard_shortcut_slope_up();
 }
 
-static void shortcut_ride_construction_chain_lift_toggle()
+static void ShortcutRideConstructionChainLiftToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -694,7 +694,7 @@ static void shortcut_ride_construction_chain_lift_toggle()
     window_ride_construction_keyboard_shortcut_chain_lift_toggle();
 }
 
-static void shortcut_ride_construction_bank_left()
+static void ShortcutRideConstructionBankLeft()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -702,7 +702,7 @@ static void shortcut_ride_construction_bank_left()
     window_ride_construction_keyboard_shortcut_bank_left();
 }
 
-static void shortcut_ride_construction_bank_right()
+static void ShortcutRideConstructionBankRight()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -710,7 +710,7 @@ static void shortcut_ride_construction_bank_right()
     window_ride_construction_keyboard_shortcut_bank_right();
 }
 
-static void shortcut_ride_construction_previous_track()
+static void ShortcutRideConstructionPreviousTrack()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -718,7 +718,7 @@ static void shortcut_ride_construction_previous_track()
     window_ride_construction_keyboard_shortcut_previous_track();
 }
 
-static void shortcut_ride_construction_next_track()
+static void ShortcutRideConstructionNextTrack()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -726,7 +726,7 @@ static void shortcut_ride_construction_next_track()
     window_ride_construction_keyboard_shortcut_next_track();
 }
 
-static void shortcut_ride_construction_build_current()
+static void ShortcutRideConstructionBuildCurrent()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -734,7 +734,7 @@ static void shortcut_ride_construction_build_current()
     window_ride_construction_keyboard_shortcut_build_current();
 }
 
-static void shortcut_ride_construction_demolish_current()
+static void ShortcutRideConstructionDemolishCurrent()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -742,7 +742,7 @@ static void shortcut_ride_construction_demolish_current()
     window_ride_construction_keyboard_shortcut_demolish_current();
 }
 
-static void shortcut_load_game()
+static void ShortcutLoadGame()
 {
     if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
     {
@@ -751,7 +751,7 @@ static void shortcut_load_game()
     }
 }
 
-static void shortcut_view_clipping()
+static void ShortcutViewClipping()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
@@ -759,15 +759,15 @@ static void shortcut_view_clipping()
     context_open_window(WC_VIEW_CLIPPING);
 }
 
-static void shortcut_highlight_path_issues_toggle()
+static void ShortcutHighlightPathIssuesToggle()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    toggle_view_flag(VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES);
+    ToggleViewFlag(VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES);
 }
 
-static void shortcut_open_tile_inspector()
+static void ShortcutOpenTileInspector()
 {
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO || !gConfigInterface.toolbar_show_cheats)
         return;
@@ -775,7 +775,7 @@ static void shortcut_open_tile_inspector()
     context_open_window(WC_TILE_INSPECTOR);
 }
 
-static void shortcut_advance_to_next_tick()
+static void ShortcutAdvanceToNextTick()
 {
     if (gScreenFlags & (SCREEN_FLAGS_TITLE_DEMO | SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_MANAGER))
         return;
@@ -783,7 +783,7 @@ static void shortcut_advance_to_next_tick()
     gDoSingleUpdate = true;
 }
 
-static void shortcut_open_scenery_picker()
+static void ShortcutOpenSceneryPicker()
 {
     if ((gScreenFlags & (SCREEN_FLAGS_TITLE_DEMO | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
         || (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR && gS6Info.editor_step != EDITOR_STEP_LANDSCAPE_EDITOR))
@@ -810,7 +810,7 @@ static void shortcut_open_scenery_picker()
     }
 }
 
-static void shortcut_scale_up()
+static void ShortcutScaleUp()
 {
     gConfigGeneral.window_scale += 0.25f;
     config_save_default();
@@ -819,7 +819,7 @@ static void shortcut_scale_up()
     context_update_cursor_scale();
 }
 
-static void shortcut_scale_down()
+static void ShortcutScaleDown()
 {
     gConfigGeneral.window_scale -= 0.25f;
     gConfigGeneral.window_scale = std::max(0.5f, gConfigGeneral.window_scale);
@@ -830,7 +830,7 @@ static void shortcut_scale_down()
 }
 
 // Tile inspector shortcuts
-static void shortcut_insert_corrupt_element()
+static void ShortcutInsertCorruptElement()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_CORRUPT)
@@ -841,7 +841,7 @@ static void shortcut_insert_corrupt_element()
     }
 }
 
-static void shortcut_copy_element()
+static void ShortcutCopyElement()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_COPY)
@@ -852,7 +852,7 @@ static void shortcut_copy_element()
     }
 }
 
-static void shortcut_paste_element()
+static void ShortcutPasteElement()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_PASTE)
@@ -863,7 +863,7 @@ static void shortcut_paste_element()
     }
 }
 
-static void shortcut_remove_element()
+static void ShortcutRemoveElement()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_REMOVE)
@@ -874,7 +874,7 @@ static void shortcut_remove_element()
     }
 }
 
-static void shortcut_move_element_up()
+static void ShortcutMoveElementUp()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_MOVE_UP)
@@ -885,7 +885,7 @@ static void shortcut_move_element_up()
     }
 }
 
-static void shortcut_move_element_down()
+static void ShortcutMoveElementDown()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_MOVE_DOWN)
@@ -896,7 +896,7 @@ static void shortcut_move_element_down()
     }
 }
 
-static void shortcut_increase_x_coord()
+static void ShortcutIncreaseXCoord()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_SPINNER_X_INCREASE)
@@ -907,7 +907,7 @@ static void shortcut_increase_x_coord()
     }
 }
 
-static void shortcut_decrease_x_coord()
+static void ShortcutDecreaseXCoord()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_SPINNER_X_DECREASE)
@@ -918,7 +918,7 @@ static void shortcut_decrease_x_coord()
     }
 }
 
-static void shortcut_increase_y_coord()
+static void ShortcutIncreaseYCoord()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_SPINNER_Y_INCREASE)
@@ -929,7 +929,7 @@ static void shortcut_increase_y_coord()
     }
 }
 
-static void shortcut_decrease_y_coord()
+static void ShortcutDecreaseYCoord()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr && !widget_is_disabled(w, WC_TILE_INSPECTOR__WIDX_SPINNER_Y_DECREASE)
@@ -940,7 +940,7 @@ static void shortcut_decrease_y_coord()
     }
 }
 
-static void shortcut_increase_element_height()
+static void ShortcutIncreaseElementHeight()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr)
@@ -982,7 +982,7 @@ static void shortcut_increase_element_height()
     }
 }
 
-static void shortcut_decrease_element_height()
+static void ShortcutDecreaseElementHeight()
 {
     rct_window* w = window_find_by_class(WC_TILE_INSPECTOR);
     if (w != nullptr)
@@ -1024,7 +1024,7 @@ static void shortcut_decrease_element_height()
     }
 }
 
-static void shortcut_toggle_clearance_checks()
+static void ShortcutToggleClearanceChecks()
 {
     auto setCheatAction = SetCheatAction(CheatType::DisableClearanceChecks, gCheatsDisableClearanceChecks ? 0 : 1);
     GameActions::Execute(&setCheatAction);
@@ -1034,93 +1034,93 @@ namespace
 {
     using namespace OpenRCT2::Input;
     const shortcut_action shortcut_table[ShortcutsCount] = {
-        shortcut_close_top_most_window,
-        shortcut_close_all_floating_windows,
-        shortcut_cancel_construction_mode,
-        shortcut_pause_game,
-        shortcut_zoom_view_out,
-        shortcut_zoom_view_in,
-        shortcut_rotate_view_clockwise,
-        shortcut_rotate_view_anticlockwise,
-        shortcut_rotate_construction_object,
-        shortcut_underground_view_toggle,
-        shortcut_remove_base_land_toggle,
-        shortcut_remove_vertical_land_toggle,
-        shortcut_see_through_rides_toggle,
-        shortcut_see_through_scenery_toggle,
-        shortcut_invisible_supports_toggle,
-        shortcut_invisible_people_toggle,
-        shortcut_height_marks_on_land_toggle,
-        shortcut_height_marks_on_ride_tracks_toggle,
-        shortcut_height_marks_on_paths_toggle,
-        shortcut_adjust_land,
-        shortcut_adjust_water,
-        shortcut_build_scenery,
-        shortcut_build_paths,
-        shortcut_build_new_ride,
-        shortcut_show_financial_information,
-        shortcut_show_research_information,
-        shortcut_show_rides_list,
-        shortcut_show_park_information,
-        shortcut_show_guest_list,
-        shortcut_show_staff_list,
-        shortcut_show_recent_messages,
-        shortcut_show_map,
-        shortcut_screenshot,
+        ShortcutCloseTopMostWindow,
+        ShortcutCloseAllFloatingWindow,
+        ShortcutCancelConstructionMode,
+        ShortcutPauseGame,
+        ShortcutZoomViewOut,
+        ShortcutZoomViewIn,
+        ShortcutRotateViewClockwise,
+        ShortcutRotateViewAnticlockwise,
+        ShortcutRotateConstructionObject,
+        ShortcutUndergroundViewToggle,
+        ShortcutRemoveBaseLandToggle,
+        ShortcutRemoveVerticalLandToggle,
+        ShortcutSeeThroughRidesToggle,
+        ShortcutSeeThroughSceneryToggle,
+        ShortcutInvisibleSupportsToggle,
+        ShortcutInvisiblePeopleToggle,
+        ShortcutHeightMarksOnLandToggle,
+        ShortcutHeightMarksOnRideTracksToggle,
+        ShortcutHeightMarksOnPathsToggle,
+        ShortcutAdjustLand,
+        ShortcutAdjustWater,
+        ShortcutBuildScenery,
+        ShortcutBuildPaths,
+        ShortcutBuildNewRide,
+        ShortcutShowFinancialInformation,
+        ShortcutShowResearchInformation,
+        ShortcutShowRidesList,
+        ShortcutShowParkInformation,
+        ShortcutShowGuestList,
+        ShortcutShowStaffList,
+        ShortcutShowRecentMessages,
+        ShortcutShowMap,
+        ShortcutScreenshot,
 
         // new
-        shortcut_reduce_game_speed,
-        shortcut_increase_game_speed,
-        shortcut_open_cheat_window,
-        shortcut_remove_top_bottom_toolbar_toggle,
+        ShortcutReduceGameSpeed,
+        ShortcutIncreaseGameSpeed,
+        ShortcutOpenCheatWindow,
+        ShortcutRemoveTopBottomToolbarToggle,
         nullptr,
         nullptr,
         nullptr,
         nullptr,
-        shortcut_open_chat_window,
-        shortcut_quick_save_game,
-        shortcut_show_options,
-        shortcut_mute_sound,
-        shortcut_windowed_mode_toggle,
-        shortcut_show_multiplayer,
+        ShortcutOpenChatWindow,
+        ShortcutQuickSaveGame,
+        ShortcutShowOptions,
+        ShortcutMuteSound,
+        ShortcutWindowsModeToggle,
+        ShortcutShowMultiplayer,
         nullptr,
-        shortcut_debug_paint_toggle,
-        shortcut_see_through_paths_toggle,
-        shortcut_ride_construction_turn_left,
-        shortcut_ride_construction_turn_right,
-        shortcut_ride_construction_use_track_default,
-        shortcut_ride_construction_slope_down,
-        shortcut_ride_construction_slope_up,
-        shortcut_ride_construction_chain_lift_toggle,
-        shortcut_ride_construction_bank_left,
-        shortcut_ride_construction_bank_right,
-        shortcut_ride_construction_previous_track,
-        shortcut_ride_construction_next_track,
-        shortcut_ride_construction_build_current,
-        shortcut_ride_construction_demolish_current,
-        shortcut_load_game,
-        shortcut_clear_scenery,
-        shortcut_gridlines_toggle,
-        shortcut_view_clipping,
-        shortcut_highlight_path_issues_toggle,
-        shortcut_open_tile_inspector,
-        shortcut_advance_to_next_tick,
-        shortcut_open_scenery_picker,
-        shortcut_scale_up,
-        shortcut_scale_down,
-        shortcut_insert_corrupt_element,
-        shortcut_copy_element,
-        shortcut_paste_element,
-        shortcut_remove_element,
-        shortcut_move_element_up,
-        shortcut_move_element_down,
-        shortcut_increase_x_coord,
-        shortcut_decrease_x_coord,
-        shortcut_increase_y_coord,
-        shortcut_decrease_y_coord,
-        shortcut_increase_element_height,
-        shortcut_decrease_element_height,
-        shortcut_toggle_clearance_checks,
+        ShortcutDebugPaintToggle,
+        ShortcutSeeThroughPathsToggle,
+        ShortcutRideConstructionTurnLeft,
+        ShortcutRideConstructionTurnRight,
+        ShortcutRideConstructionUseTrackDefault,
+        ShortcutRideConstructionSlopeDown,
+        ShortcutRideConstructionSlopeUp,
+        ShortcutRideConstructionChainLiftToggle,
+        ShortcutRideConstructionBankLeft,
+        ShortcutRideConstructionBankRight,
+        ShortcutRideConstructionPreviousTrack,
+        ShortcutRideConstructionNextTrack,
+        ShortcutRideConstructionBuildCurrent,
+        ShortcutRideConstructionDemolishCurrent,
+        ShortcutLoadGame,
+        ShortcutClearScenery,
+        ShortcutGridlinesToggle,
+        ShortcutViewClipping,
+        ShortcutHighlightPathIssuesToggle,
+        ShortcutOpenTileInspector,
+        ShortcutAdvanceToNextTick,
+        ShortcutOpenSceneryPicker,
+        ShortcutScaleUp,
+        ShortcutScaleDown,
+        ShortcutInsertCorruptElement,
+        ShortcutCopyElement,
+        ShortcutPasteElement,
+        ShortcutRemoveElement,
+        ShortcutMoveElementUp,
+        ShortcutMoveElementDown,
+        ShortcutIncreaseXCoord,
+        ShortcutDecreaseXCoord,
+        ShortcutIncreaseYCoord,
+        ShortcutDecreaseYCoord,
+        ShortcutIncreaseElementHeight,
+        ShortcutDecreaseElementHeight,
+        ShortcutToggleClearanceChecks,
     };
 } // anonymous namespace
 

--- a/src/openrct2-ui/input/KeyboardShortcuts.cpp
+++ b/src/openrct2-ui/input/KeyboardShortcuts.cpp
@@ -264,38 +264,38 @@ ScreenCoordsXY KeyboardShortcuts::GetKeyboardMapScroll(const uint8_t* keysState)
     return screenCoords;
 }
 
-void keyboard_shortcuts_reset()
+void KeyboardShortcutsReset()
 {
     _instance->Reset();
 }
 
-bool keyboard_shortcuts_load()
+bool KeyboardShortcutsLoad()
 {
     return _instance->Load();
 }
 
-bool keyboard_shortcuts_save()
+bool KeyboardShortcutsSave()
 {
     return _instance->Save();
 }
 
-void keyboard_shortcuts_set(int32_t key)
+void KeyboardShortcutsSet(int32_t key)
 {
     return _instance->Set(key);
 }
 
-Shortcut keyboard_shortcuts_get_from_key(int32_t key)
+Shortcut KeyboardShortcutsGetFromKey(int32_t key)
 {
     return _instance->GetFromKey(key);
 }
 
-void keyboard_shortcuts_format_string(char* buffer, size_t bufferSize, int32_t shortcut)
+void KeyboardShortcutsFormatString(char* buffer, size_t bufferSize, int32_t shortcut)
 {
     auto str = _instance->GetShortcutString(shortcut);
     String::Set(buffer, bufferSize, str.c_str());
 }
 
-ScreenCoordsXY get_keyboard_map_scroll(const uint8_t* keysState)
+ScreenCoordsXY GetKeyboardMapScroll(const uint8_t* keysState)
 {
     return _instance->GetKeyboardMapScroll(keysState);
 }

--- a/src/openrct2-ui/input/KeyboardShortcuts.h
+++ b/src/openrct2-ui/input/KeyboardShortcuts.h
@@ -158,14 +158,14 @@ namespace OpenRCT2
 // The current shortcut being changed.
 extern OpenRCT2::Input::Shortcut gKeyboardShortcutChangeId;
 
-void keyboard_shortcuts_reset();
-bool keyboard_shortcuts_load();
-bool keyboard_shortcuts_save();
-void keyboard_shortcuts_set(int32_t key);
-OpenRCT2::Input::Shortcut keyboard_shortcuts_get_from_key(int32_t key);
-void keyboard_shortcuts_format_string(char* buffer, size_t bufferSize, int32_t shortcut);
+void KeyboardShortcutsReset();
+bool KeyboardShortcutsLoad();
+bool KeyboardShortcutsSave();
+void KeyboardShortcutsSet(int32_t key);
+OpenRCT2::Input::Shortcut KeyboardShortcutsGetFromKey(int32_t key);
+void KeyboardShortcutsFormatString(char* buffer, size_t bufferSize, int32_t shortcut);
 
-void keyboard_shortcut_handle(int32_t key);
-void keyboard_shortcut_handle_command(OpenRCT2::Input::Shortcut shortcut);
+void KeyboardShortcutHandle(int32_t key);
+void KeyboardShortcutHandleCommand(OpenRCT2::Input::Shortcut shortcut);
 
-ScreenCoordsXY get_keyboard_map_scroll(const uint8_t* keysState);
+ScreenCoordsXY GetKeyboardMapScroll(const uint8_t* keysState);

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -33,14 +33,14 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Sprite.h>
 
-struct rct_mouse_data
+struct RCTMouseData
 {
     uint32_t x;
     uint32_t y;
     uint32_t state;
 };
 
-static rct_mouse_data _mouseInputQueue[64];
+static RCTMouseData _mouseInputQueue[64];
 static uint8_t _mouseInputQueueReadIndex = 0;
 static uint8_t _mouseInputQueueWriteIndex = 0;
 
@@ -61,40 +61,39 @@ ScreenCoordsXY gTooltipCursor;
 
 static int16_t _clickRepeatTicks;
 
-static int32_t game_get_next_input(ScreenCoordsXY& screenCoords);
-static void input_widget_over(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex);
-static void input_widget_over_change_check(
-    rct_windowclass windowClass, rct_windownumber windowNumber, rct_widgetindex widgetIndex);
-static void input_widget_over_flatbutton_invalidate();
-void process_mouse_over(const ScreenCoordsXY& screenCoords);
-void process_mouse_tool(const ScreenCoordsXY& screenCoords);
-void invalidate_scroll();
-static rct_mouse_data* get_mouse_input();
-void tile_element_right_click(int32_t type, TileElement* tileElement, const ScreenCoordsXY& screenCoords);
-static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t state);
-static void input_widget_left(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex);
-void input_state_widget_pressed(
+static int32_t GameGetNextInput(ScreenCoordsXY& screenCoords);
+static void InputWidgetOver(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex);
+static void InputWidgetOverChangeCheck(rct_windowclass windowClass, rct_windownumber windowNumber, rct_widgetindex widgetIndex);
+static void InputWidgetOverFlatbuttonInvalidate();
+void ProcessMouseOver(const ScreenCoordsXY& screenCoords);
+void ProcessMouseTool(const ScreenCoordsXY& screenCoords);
+void InvalidateScroll();
+static RCTMouseData* GetMouseInput();
+void TileElementRightClick(int32_t type, TileElement* tileElement, const ScreenCoordsXY& screenCoords);
+static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, int32_t state);
+static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex);
+void InputStateWidgetPressed(
     const ScreenCoordsXY& screenCoords, int32_t state, rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
-void set_cursor(CursorID cursor_id);
-static void input_window_position_continue(
+void SetCursor(CursorID cursor_id);
+static void InputWindowPositionContinue(
     rct_window* w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords);
-static void input_window_position_end(rct_window* w, const ScreenCoordsXY& screenCoords);
-static void input_window_resize_begin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void input_window_resize_continue(rct_window* w, const ScreenCoordsXY& screenCoords);
-static void input_window_resize_end();
-static void input_viewport_drag_begin(rct_window* w);
-static void input_viewport_drag_continue();
-static void input_viewport_drag_end();
-static void input_scroll_begin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void input_scroll_continue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void input_scroll_end();
-static void input_scroll_part_update_hthumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id);
-static void input_scroll_part_update_hleft(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void input_scroll_part_update_hright(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void input_scroll_part_update_vthumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id);
-static void input_scroll_part_update_vtop(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void input_scroll_part_update_vbottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void input_update_tooltip(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputWindowPositionEnd(rct_window* w, const ScreenCoordsXY& screenCoords);
+static void InputWindowResizeBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputWindowResizeContinue(rct_window* w, const ScreenCoordsXY& screenCoords);
+static void InputWindowResizeEnd();
+static void InputViewportDragBegin(rct_window* w);
+static void InputViewportDragContinue();
+static void InputViewportDragEnd();
+static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputScrollEnd();
+static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id);
+static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id);
+static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
 
 #pragma region Mouse input
 
@@ -102,7 +101,7 @@ static void input_update_tooltip(rct_window* w, rct_widgetindex widgetIndex, con
  *
  *  rct2: 0x006EA627
  */
-void game_handle_input()
+void GameHandleInput()
 {
     window_visit_each([](rct_window* w) { window_event_periodic_update_call(w); });
 
@@ -110,14 +109,14 @@ void game_handle_input()
 
     int32_t state;
     ScreenCoordsXY screenCoords;
-    while ((state = game_get_next_input(screenCoords)) != MOUSE_STATE_RELEASED)
+    while ((state = GameGetNextInput(screenCoords)) != MOUSE_STATE_RELEASED)
     {
-        game_handle_input_mouse(screenCoords, state & 0xFF);
+        GameHandleInputMouse(screenCoords, state & 0xFF);
     }
 
     if (_inputFlags & INPUT_FLAG_5)
     {
-        game_handle_input_mouse(screenCoords, state);
+        GameHandleInputMouse(screenCoords, state);
     }
     else
     {
@@ -126,9 +125,9 @@ void game_handle_input()
         screenCoords.x = std::clamp(screenCoords.x, 0, screenWidth - 1);
         screenCoords.y = std::clamp(screenCoords.y, 0, screenHeight - 1);
 
-        game_handle_input_mouse(screenCoords, state);
-        process_mouse_over(screenCoords);
-        process_mouse_tool(screenCoords);
+        GameHandleInputMouse(screenCoords, state);
+        ProcessMouseOver(screenCoords);
+        ProcessMouseTool(screenCoords);
     }
 
     window_visit_each([](rct_window* w) { window_event_unknown_08_call(w); });
@@ -138,9 +137,9 @@ void game_handle_input()
  *
  *  rct2: 0x006E83C7
  */
-static int32_t game_get_next_input(ScreenCoordsXY& screenCoords)
+static int32_t GameGetNextInput(ScreenCoordsXY& screenCoords)
 {
-    rct_mouse_data* input = get_mouse_input();
+    RCTMouseData* input = GetMouseInput();
     if (input == nullptr)
     {
         const CursorState* cursorState = context_get_cursor_state();
@@ -159,7 +158,7 @@ static int32_t game_get_next_input(ScreenCoordsXY& screenCoords)
  *
  *  rct2: 0x00407074
  */
-static rct_mouse_data* get_mouse_input()
+static RCTMouseData* GetMouseInput()
 {
     // Check if that location has been written to yet
     if (_mouseInputQueueReadIndex == _mouseInputQueueWriteIndex)
@@ -168,7 +167,7 @@ static rct_mouse_data* get_mouse_input()
     }
     else
     {
-        rct_mouse_data* result = &_mouseInputQueue[_mouseInputQueueReadIndex];
+        RCTMouseData* result = &_mouseInputQueue[_mouseInputQueueReadIndex];
         _mouseInputQueueReadIndex = (_mouseInputQueueReadIndex + 1) % std::size(_mouseInputQueue);
         return result;
     }
@@ -178,7 +177,7 @@ static rct_mouse_data* get_mouse_input()
  *
  *  rct2: 0x006E957F
  */
-static void input_scroll_drag_begin(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex)
+static void InputScrollDragBegin(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex)
 {
     _inputState = InputState::ScrollRight;
     gInputDragLast = screenCoords;
@@ -195,7 +194,7 @@ static void input_scroll_drag_begin(const ScreenCoordsXY& screenCoords, rct_wind
  * Based on (heavily changed)
  *  rct2: 0x006E9E0E,  0x006E9ED0
  */
-static void input_scroll_drag_continue(const ScreenCoordsXY& screenCoords, rct_window* w)
+static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, rct_window* w)
 {
     rct_widgetindex widgetIndex = _dragWidget.widget_index;
     uint8_t scrollIndex = _dragScrollIndex;
@@ -236,7 +235,7 @@ static void input_scroll_drag_continue(const ScreenCoordsXY& screenCoords, rct_w
  *
  *  rct2: 0x006E8ACB
  */
-static void input_scroll_right(const ScreenCoordsXY& screenCoords, int32_t state)
+static void InputScrollRight(const ScreenCoordsXY& screenCoords, int32_t state)
 {
     rct_window* w = window_find_by_number(_dragWidget.window_classification, _dragWidget.window_number);
     if (w == nullptr)
@@ -253,7 +252,7 @@ static void input_scroll_right(const ScreenCoordsXY& screenCoords, int32_t state
             if (screenCoords.x != 0 || screenCoords.y != 0)
             {
                 _ticksSinceDragStart = 1000;
-                input_scroll_drag_continue(screenCoords, w);
+                InputScrollDragContinue(screenCoords, w);
             }
             break;
         case MOUSE_STATE_RIGHT_RELEASE:
@@ -267,7 +266,7 @@ static void input_scroll_right(const ScreenCoordsXY& screenCoords, int32_t state
  *
  *  rct2: 0x006E8655
  */
-static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t state)
+static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, int32_t state)
 {
     rct_window* w;
     rct_widget* widget;
@@ -287,10 +286,10 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
             switch (state)
             {
                 case MOUSE_STATE_RELEASED:
-                    input_widget_over(screenCoords, w, widgetIndex);
+                    InputWidgetOver(screenCoords, w, widgetIndex);
                     break;
                 case MOUSE_STATE_LEFT_PRESS:
-                    input_widget_left(screenCoords, w, widgetIndex);
+                    InputWidgetLeft(screenCoords, w, widgetIndex);
                     break;
                 case MOUSE_STATE_RIGHT_PRESS:
                     window_close_by_class(WC_TOOLTIP);
@@ -307,11 +306,11 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
                             case WWT_VIEWPORT:
                                 if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_MANAGER | SCREEN_FLAGS_TITLE_DEMO)))
                                 {
-                                    input_viewport_drag_begin(w);
+                                    InputViewportDragBegin(w);
                                 }
                                 break;
                             case WWT_SCROLL:
-                                input_scroll_drag_begin(screenCoords, w, widgetIndex);
+                                InputScrollDragBegin(screenCoords, w, widgetIndex);
                                 break;
                         }
                     }
@@ -319,7 +318,7 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
             }
             break;
         case InputState::WidgetPressed:
-            input_state_widget_pressed(screenCoords, state, widgetIndex, w, widget);
+            InputStateWidgetPressed(screenCoords, state, widgetIndex, w, widget);
             break;
         case InputState::PositioningWindow:
             w = window_find_by_number(_dragWidget.window_classification, _dragWidget.window_number);
@@ -329,21 +328,21 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
             }
             else
             {
-                input_window_position_continue(w, gInputDragLast, screenCoords);
+                InputWindowPositionContinue(w, gInputDragLast, screenCoords);
                 if (state == MOUSE_STATE_LEFT_RELEASE)
                 {
-                    input_window_position_end(w, screenCoords);
+                    InputWindowPositionEnd(w, screenCoords);
                 }
             }
             break;
         case InputState::ViewportRight:
             if (state == MOUSE_STATE_RELEASED)
             {
-                input_viewport_drag_continue();
+                InputViewportDragContinue();
             }
             else if (state == MOUSE_STATE_RIGHT_RELEASE)
             {
-                input_viewport_drag_end();
+                InputViewportDragEnd();
                 if (_ticksSinceDragStart < 500)
                 {
                     // If the user pressed the right mouse button for less than 500 ticks, interpret as right click
@@ -352,7 +351,7 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
             }
             break;
         case InputState::DropdownActive:
-            input_state_widget_pressed(screenCoords, state, widgetIndex, w, widget);
+            InputStateWidgetPressed(screenCoords, state, widgetIndex, w, widget);
             break;
         case InputState::ViewportLeft:
             w = window_find_by_number(_dragWidget.window_classification, _dragWidget.window_number);
@@ -410,10 +409,10 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
             switch (state)
             {
                 case MOUSE_STATE_RELEASED:
-                    input_scroll_continue(w, widgetIndex, screenCoords);
+                    InputScrollContinue(w, widgetIndex, screenCoords);
                     break;
                 case MOUSE_STATE_LEFT_RELEASE:
-                    input_scroll_end();
+                    InputScrollEnd();
                     break;
             }
             break;
@@ -427,23 +426,23 @@ static void game_handle_input_mouse(const ScreenCoordsXY& screenCoords, int32_t 
             {
                 if (state == MOUSE_STATE_LEFT_RELEASE)
                 {
-                    input_window_resize_end();
+                    InputWindowResizeEnd();
                 }
                 if (state == MOUSE_STATE_RELEASED || state == MOUSE_STATE_LEFT_RELEASE)
                 {
-                    input_window_resize_continue(w, screenCoords);
+                    InputWindowResizeContinue(w, screenCoords);
                 }
             }
             break;
         case InputState::ScrollRight:
-            input_scroll_right(screenCoords, state);
+            InputScrollRight(screenCoords, state);
             break;
     }
 }
 
 #pragma region Window positioning / resizing
 
-void input_window_position_begin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+void InputWindowPositionBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     _inputState = InputState::PositioningWindow;
     gInputDragLast = screenCoords - w->windowPos;
@@ -452,7 +451,7 @@ void input_window_position_begin(rct_window* w, rct_widgetindex widgetIndex, con
     _dragWidget.widget_index = widgetIndex;
 }
 
-static void input_window_position_continue(
+static void InputWindowPositionContinue(
     rct_window* w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords)
 {
     int32_t snapProximity;
@@ -461,7 +460,7 @@ static void input_window_position_continue(
     window_move_and_snap(w, newScreenCoords - lastScreenCoords, snapProximity);
 }
 
-static void input_window_position_end(rct_window* w, const ScreenCoordsXY& screenCoords)
+static void InputWindowPositionEnd(rct_window* w, const ScreenCoordsXY& screenCoords)
 {
     _inputState = InputState::Normal;
     gTooltipTimeout = 0;
@@ -469,7 +468,7 @@ static void input_window_position_end(rct_window* w, const ScreenCoordsXY& scree
     window_event_moved_call(w, screenCoords);
 }
 
-static void input_window_resize_begin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputWindowResizeBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     _inputState = InputState::Resizing;
     gInputDragLast = screenCoords;
@@ -480,7 +479,7 @@ static void input_window_resize_begin(rct_window* w, rct_widgetindex widgetIndex
     _originalWindowHeight = w->height;
 }
 
-static void input_window_resize_continue(rct_window* w, const ScreenCoordsXY& screenCoords)
+static void InputWindowResizeContinue(rct_window* w, const ScreenCoordsXY& screenCoords)
 {
     if (screenCoords.y < static_cast<int32_t>(context_get_height()) - 2)
     {
@@ -492,7 +491,7 @@ static void input_window_resize_continue(rct_window* w, const ScreenCoordsXY& sc
     }
 }
 
-static void input_window_resize_end()
+static void InputWindowResizeEnd()
 {
     _inputState = InputState::Normal;
     gTooltipTimeout = 0;
@@ -503,7 +502,7 @@ static void input_window_resize_end()
 
 #pragma region Viewport dragging
 
-static void input_viewport_drag_begin(rct_window* w)
+static void InputViewportDragBegin(rct_window* w)
 {
     w->flags &= ~WF_SCROLLING_TO_LOCATION;
     _inputState = InputState::ViewportRight;
@@ -518,7 +517,7 @@ static void input_viewport_drag_begin(rct_window* w)
     // gInputFlags |= INPUT_FLAG_5;
 }
 
-static void input_viewport_drag_continue()
+static void InputViewportDragContinue()
 {
     rct_window* w;
     rct_viewport* viewport;
@@ -533,7 +532,7 @@ static void input_viewport_drag_continue()
     //        the session if the window no longer exists
     if (w == nullptr)
     {
-        input_viewport_drag_end();
+        InputViewportDragEnd();
         return;
     }
 
@@ -577,7 +576,7 @@ static void input_viewport_drag_continue()
     }
 }
 
-static void input_viewport_drag_end()
+static void InputViewportDragEnd()
 {
     _inputState = InputState::Reset;
     context_show_cursor();
@@ -587,7 +586,7 @@ static void input_viewport_drag_end()
 
 #pragma region Scroll bars
 
-static void input_scroll_begin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     rct_widget* widget;
 
@@ -659,7 +658,7 @@ static void input_scroll_begin(rct_window* w, rct_widgetindex widgetIndex, const
     window_invalidate_by_number(widgetIndex, w->classification);
 }
 
-static void input_scroll_continue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     rct_widget* widget;
     int32_t scroll_part, scroll_id;
@@ -670,7 +669,7 @@ static void input_scroll_continue(rct_window* w, rct_widgetindex widgetIndex, co
     if (w->classification != gPressedWidget.window_classification || w->number != gPressedWidget.window_number
         || widgetIndex != gPressedWidget.widget_index)
     {
-        invalidate_scroll();
+        InvalidateScroll();
         return;
     }
 
@@ -681,7 +680,7 @@ static void input_scroll_continue(rct_window* w, rct_widgetindex widgetIndex, co
     {
         int32_t originalTooltipCursorX = gTooltipCursor.x;
         gTooltipCursor.x = screenCoords.x;
-        input_scroll_part_update_hthumb(w, widgetIndex, screenCoords.x - originalTooltipCursorX, scroll_id);
+        InputScrollPartUpdateHThumb(w, widgetIndex, screenCoords.x - originalTooltipCursorX, scroll_id);
         return;
     }
 
@@ -689,13 +688,13 @@ static void input_scroll_continue(rct_window* w, rct_widgetindex widgetIndex, co
     {
         int32_t originalTooltipCursorY = gTooltipCursor.y;
         gTooltipCursor.y = screenCoords.y;
-        input_scroll_part_update_vthumb(w, widgetIndex, screenCoords.y - originalTooltipCursorY, scroll_id);
+        InputScrollPartUpdateVThumb(w, widgetIndex, screenCoords.y - originalTooltipCursorY, scroll_id);
         return;
     }
 
     if (scroll_part != _currentScrollArea)
     {
-        invalidate_scroll();
+        InvalidateScroll();
         return;
     }
 
@@ -705,31 +704,31 @@ static void input_scroll_continue(rct_window* w, rct_widgetindex widgetIndex, co
             window_event_scroll_mousedrag_call(w, scroll_id, newScreenCoords);
             break;
         case SCROLL_PART_HSCROLLBAR_LEFT:
-            input_scroll_part_update_hleft(w, widgetIndex, scroll_id);
+            InputScrollPartUpdateHLeft(w, widgetIndex, scroll_id);
             break;
         case SCROLL_PART_HSCROLLBAR_RIGHT:
-            input_scroll_part_update_hright(w, widgetIndex, scroll_id);
+            InputScrollPartUpdateHRight(w, widgetIndex, scroll_id);
             break;
         case SCROLL_PART_VSCROLLBAR_TOP:
-            input_scroll_part_update_vtop(w, widgetIndex, scroll_id);
+            InputScrollPartUpdateVTop(w, widgetIndex, scroll_id);
             break;
         case SCROLL_PART_VSCROLLBAR_BOTTOM:
-            input_scroll_part_update_vbottom(w, widgetIndex, scroll_id);
+            InputScrollPartUpdateVBottom(w, widgetIndex, scroll_id);
             break;
     }
 }
 
-static void input_scroll_end()
+static void InputScrollEnd()
 {
     _inputState = InputState::Reset;
-    invalidate_scroll();
+    InvalidateScroll();
 }
 
 /**
  *
  *  rct2: 0x006E98F2
  */
-static void input_scroll_part_update_hthumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id)
+static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id)
 {
     rct_widget* widget = &w->widgets[widgetIndex];
 
@@ -767,7 +766,7 @@ static void input_scroll_part_update_hthumb(rct_window* w, rct_widgetindex widge
  *
  *  rct2: 0x006E99A9
  */
-static void input_scroll_part_update_vthumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id)
+static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id)
 {
     assert(w != nullptr);
     rct_widget* widget = &w->widgets[widgetIndex];
@@ -806,7 +805,7 @@ static void input_scroll_part_update_vthumb(rct_window* w, rct_widgetindex widge
  *
  *  rct2: 0x006E9A60
  */
-static void input_scroll_part_update_hleft(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
     assert(w != nullptr);
     if (window_find_by_number(w->classification, w->number))
@@ -823,7 +822,7 @@ static void input_scroll_part_update_hleft(rct_window* w, rct_widgetindex widget
  *
  *  rct2: 0x006E9ABF
  */
-static void input_scroll_part_update_hright(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
     assert(w != nullptr);
     rct_widget* widget = &w->widgets[widgetIndex];
@@ -849,7 +848,7 @@ static void input_scroll_part_update_hright(rct_window* w, rct_widgetindex widge
  *
  *  rct2: 0x006E9C37
  */
-static void input_scroll_part_update_vtop(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
     assert(w != nullptr);
     if (window_find_by_number(w->classification, w->number))
@@ -866,7 +865,7 @@ static void input_scroll_part_update_vtop(rct_window* w, rct_widgetindex widgetI
  *
  *  rct2: 0x006E9C96
  */
-static void input_scroll_part_update_vbottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
     assert(w != nullptr);
     rct_widget* widget = &w->widgets[widgetIndex];
@@ -896,7 +895,7 @@ static void input_scroll_part_update_vbottom(rct_window* w, rct_widgetindex widg
  *
  *  rct2: 0x006E9253
  */
-static void input_widget_over(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex)
+static void InputWidgetOver(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex)
 {
     rct_windowclass windowClass = WC_NULL;
     rct_windownumber windowNumber = 0;
@@ -909,7 +908,7 @@ static void input_widget_over(const ScreenCoordsXY& screenCoords, rct_window* w,
         widget = &w->widgets[widgetIndex];
     }
 
-    input_widget_over_change_check(windowClass, windowNumber, widgetIndex);
+    InputWidgetOverChangeCheck(windowClass, windowNumber, widgetIndex);
 
     if (w != nullptr && widgetIndex != -1 && widget->type == WWT_SCROLL)
     {
@@ -922,12 +921,12 @@ static void input_widget_over(const ScreenCoordsXY& screenCoords, rct_window* w,
         else
         {
             window_event_scroll_mouseover_call(w, scrollId, newScreenCoords);
-            input_update_tooltip(w, widgetIndex, screenCoords);
+            InputUpdateTooltip(w, widgetIndex, screenCoords);
         }
     }
     else
     {
-        input_update_tooltip(w, widgetIndex, screenCoords);
+        InputUpdateTooltip(w, widgetIndex, screenCoords);
     }
 }
 
@@ -935,8 +934,7 @@ static void input_widget_over(const ScreenCoordsXY& screenCoords, rct_window* w,
  *
  *  rct2: 0x006E9269
  */
-static void input_widget_over_change_check(
-    rct_windowclass windowClass, rct_windownumber windowNumber, rct_widgetindex widgetIndex)
+static void InputWidgetOverChangeCheck(rct_windowclass windowClass, rct_windownumber windowNumber, rct_widgetindex widgetIndex)
 {
     // Prevents invalid widgets being clicked source of bug is elsewhere
     if (widgetIndex == -1)
@@ -947,7 +945,7 @@ static void input_widget_over_change_check(
         || widgetIndex != gHoverWidget.widget_index)
     {
         // Invalidate last widget cursor was on if widget is a flat button
-        input_widget_over_flatbutton_invalidate();
+        InputWidgetOverFlatbuttonInvalidate();
 
         // Set new cursor over widget
         gHoverWidget.window_classification = windowClass;
@@ -956,7 +954,7 @@ static void input_widget_over_change_check(
 
         // Invalidate new widget cursor is on if widget is a flat button
         if (windowClass != 255)
-            input_widget_over_flatbutton_invalidate();
+            InputWidgetOverFlatbuttonInvalidate();
     }
 }
 
@@ -964,7 +962,7 @@ static void input_widget_over_change_check(
  * Used to invalidate flat button widgets when the mouse leaves and enters them. This should be generalised so that all widgets
  * can use this in the future.
  */
-static void input_widget_over_flatbutton_invalidate()
+static void InputWidgetOverFlatbuttonInvalidate()
 {
     rct_window* w = window_find_by_number(gHoverWidget.window_classification, gHoverWidget.window_number);
     if (w != nullptr)
@@ -982,7 +980,7 @@ static void input_widget_over_flatbutton_invalidate()
  *
  *  rct2: 0x006E95F9
  */
-static void input_widget_left(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex)
+static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, rct_widgetindex widgetIndex)
 {
     rct_windowclass windowClass = WC_NULL;
     rct_windownumber windowNumber = 0;
@@ -1020,7 +1018,7 @@ static void input_widget_left(const ScreenCoordsXY& screenCoords, rct_window* w,
         case WWT_RESIZE:
             if (window_can_resize(w)
                 && (screenCoords.x >= w->windowPos.x + w->width - 19 && screenCoords.y >= w->windowPos.y + w->height - 19))
-                input_window_resize_begin(w, widgetIndex, screenCoords);
+                InputWindowResizeBegin(w, widgetIndex, screenCoords);
             break;
         case WWT_VIEWPORT:
             _inputState = InputState::ViewportLeft;
@@ -1038,10 +1036,10 @@ static void input_widget_left(const ScreenCoordsXY& screenCoords, rct_window* w,
             }
             break;
         case WWT_CAPTION:
-            input_window_position_begin(w, widgetIndex, screenCoords);
+            InputWindowPositionBegin(w, widgetIndex, screenCoords);
             break;
         case WWT_SCROLL:
-            input_scroll_begin(w, widgetIndex, screenCoords);
+            InputScrollBegin(w, widgetIndex, screenCoords);
             break;
         default:
             if (widget_is_enabled(w, widgetIndex) && !widget_is_disabled(w, widgetIndex))
@@ -1069,7 +1067,7 @@ static void input_widget_left(const ScreenCoordsXY& screenCoords, rct_window* w,
  *
  *  rct2: 0x006ED833
  */
-void process_mouse_over(const ScreenCoordsXY& screenCoords)
+void ProcessMouseOver(const ScreenCoordsXY& screenCoords)
 {
     rct_window* window;
 
@@ -1091,7 +1089,7 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
                     {
                         if (viewport_interaction_left_over(screenCoords))
                         {
-                            set_cursor(CursorID::HandPoint);
+                            SetCursor(CursorID::HandPoint);
                             return;
                         }
                         break;
@@ -1143,14 +1141,14 @@ void process_mouse_over(const ScreenCoordsXY& screenCoords)
     }
 
     viewport_interaction_right_over(screenCoords);
-    set_cursor(cursorId);
+    SetCursor(cursorId);
 }
 
 /**
  *
  *  rct2: 0x006ED801
  */
-void process_mouse_tool(const ScreenCoordsXY& screenCoords)
+void ProcessMouseTool(const ScreenCoordsXY& screenCoords)
 {
     if (_inputFlags & INPUT_FLAG_TOOL_ACTIVE)
     {
@@ -1167,7 +1165,7 @@ void process_mouse_tool(const ScreenCoordsXY& screenCoords)
  *
  *  rct2: 0x006E8DA7
  */
-void input_state_widget_pressed(
+void InputStateWidgetPressed(
     const ScreenCoordsXY& screenCoords, int32_t state, rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget)
 {
     rct_windowclass cursor_w_class;
@@ -1416,7 +1414,7 @@ void input_state_widget_pressed(
     }
 }
 
-static void input_update_tooltip(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     if (gTooltipWidget.window_classification == 255)
     {
@@ -1459,7 +1457,7 @@ static void input_update_tooltip(rct_window* w, rct_widgetindex widgetIndex, con
  *
  *  rct2: 0x00406CD2
  */
-int32_t get_next_key()
+int32_t GetNextKey()
 {
     uint8_t* keysPressed = const_cast<uint8_t*>(context_get_keys_pressed());
     for (int32_t i = 0; i < 221; i++)
@@ -1480,7 +1478,7 @@ int32_t get_next_key()
  *
  *  rct2: 0x006ED990
  */
-void set_cursor(CursorID cursor_id)
+void SetCursor(CursorID cursor_id)
 {
     assert(cursor_id != CursorID::Undefined);
     if (_inputState == InputState::Resizing)
@@ -1494,7 +1492,7 @@ void set_cursor(CursorID cursor_id)
  *
  *  rct2: 0x006E876D
  */
-void invalidate_scroll()
+void InvalidateScroll()
 {
     rct_window* w = window_find_by_number(gPressedWidget.window_classification, gPressedWidget.window_number);
     if (w != nullptr)
@@ -1508,7 +1506,7 @@ void invalidate_scroll()
 /**
  * rct2: 0x00406C96
  */
-void store_mouse_input(int32_t state, const ScreenCoordsXY& screenCoords)
+void StoreMouseInput(int32_t state, const ScreenCoordsXY& screenCoords)
 {
     uint32_t writeIndex = _mouseInputQueueWriteIndex;
     uint32_t nextWriteIndex = (writeIndex + 1) % std::size(_mouseInputQueue);
@@ -1516,7 +1514,7 @@ void store_mouse_input(int32_t state, const ScreenCoordsXY& screenCoords)
     // Check if the queue is full
     if (nextWriteIndex != _mouseInputQueueReadIndex)
     {
-        rct_mouse_data* item = &_mouseInputQueue[writeIndex];
+        RCTMouseData* item = &_mouseInputQueue[writeIndex];
         item->x = screenCoords.x;
         item->y = screenCoords.y;
         item->state = state;
@@ -1525,7 +1523,7 @@ void store_mouse_input(int32_t state, const ScreenCoordsXY& screenCoords)
     }
 }
 
-void game_handle_edge_scroll()
+void GameHandleEdgeScroll()
 {
     rct_window* mainWindow;
     int32_t scrollX, scrollY;
@@ -1556,15 +1554,15 @@ void game_handle_edge_scroll()
     else if (cursorState->position.y >= context_get_height() - 1)
         scrollY = 1;
 
-    input_scroll_viewport(ScreenCoordsXY(scrollX, scrollY));
+    InputScrollViewport(ScreenCoordsXY(scrollX, scrollY));
 }
 
-bool input_test_place_object_modifier(PLACE_OBJECT_MODIFIER modifier)
+bool InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER modifier)
 {
     return gInputPlaceObjectModifier & modifier;
 }
 
-void input_scroll_viewport(const ScreenCoordsXY& scrollScreenCoords)
+void InputScrollViewport(const ScreenCoordsXY& scrollScreenCoords)
 {
     rct_window* mainWindow = window_get_main();
     rct_viewport* viewport = mainWindow->viewport;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -715,7 +715,7 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
         WC_EDITOR_INVENTION_LIST_DRAG, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_SNAPPING);
     w->widgets = window_editor_inventions_list_drag_widgets;
     w->colours[1] = COLOUR_WHITE;
-    input_window_position_begin(w, 0, gTooltipCursor);
+    InputWindowPositionBegin(w, 0, gTooltipCursor);
 }
 
 /**

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -80,7 +80,7 @@ void window_map_tooltip_update_visibility()
     std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(rct_string_id));
 
     if (_cursorHoldDuration < 25 || stringId == STR_NONE
-        || input_test_place_object_modifier(
+        || InputTestPlaceObjectModifier(
             static_cast<PLACE_OBJECT_MODIFIER>(PLACE_OBJECT_MODIFIER_COPY_Z | PLACE_OBJECT_MODIFIER_SHIFT_Z))
         || window_find_by_class(WC_ERROR) != nullptr)
     {

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -231,8 +231,8 @@ static void window_shortcut_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             window_close(w);
             break;
         case WIDX_RESET:
-            keyboard_shortcuts_reset();
-            keyboard_shortcuts_save();
+            KeyboardShortcutsReset();
+            KeyboardShortcutsSave();
             w->Invalidate();
             break;
     }
@@ -357,7 +357,7 @@ static void window_shortcut_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         DrawTextEllipsised(dpi, { 0, y - 1 }, bindingOffset, format, ft, COLOUR_BLACK);
 
         char keybinding[128];
-        keyboard_shortcuts_format_string(keybinding, 128, static_cast<int32_t>(ShortcutList[i].ShortcutId));
+        KeyboardShortcutsFormatString(keybinding, 128, static_cast<int32_t>(ShortcutList[i].ShortcutId));
 
         if (strlen(keybinding) > 0)
         {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1194,7 +1194,7 @@ static void window_tile_inspector_tool_update(rct_window* w, rct_widgetindex wid
     CoordsXY mapCoords;
     TileElement* clickedElement = nullptr;
     bool mouseOnViewport = false;
-    if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z))
+    if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z))
     {
         auto info = get_map_coordinates_from_pos(screenCoords, ViewportInteractionFlags);
         clickedElement = info.Element;
@@ -1231,7 +1231,7 @@ static void window_tile_inspector_tool_update(rct_window* w, rct_widgetindex wid
 
 static void window_tile_inspector_update_selected_tile(rct_window* w, const ScreenCoordsXY& screenCoords)
 {
-    const bool ctrlIsHeldDown = input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z);
+    const bool ctrlIsHeldDown = InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z);
 
     // Mouse hasn't moved
     if (screenCoords.x == windowTileInspectorToolMouseX && screenCoords.y == windowTileInspectorToolMouseY

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1216,7 +1216,7 @@ static void sub_6E1F34(
     {
         if (!gSceneryCtrlPressed)
         {
-            if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z))
+            if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z))
             {
                 // CTRL pressed
                 auto flags = VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_RIDE
@@ -1233,7 +1233,7 @@ static void sub_6E1F34(
         }
         else
         {
-            if (!(input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z)))
+            if (!(InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z)))
             {
                 // CTRL not pressed
                 gSceneryCtrlPressed = false;
@@ -1242,7 +1242,7 @@ static void sub_6E1F34(
 
         if (!gSceneryShiftPressed)
         {
-            if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
+            if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
             {
                 // SHIFT pressed
                 gSceneryShiftPressed = true;
@@ -1253,7 +1253,7 @@ static void sub_6E1F34(
         }
         else
         {
-            if (input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
+            if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_SHIFT_Z))
             {
                 // SHIFT pressed
                 gSceneryShiftPressZOffset = (gSceneryShiftPressY - screenPos.y + 4);
@@ -2111,7 +2111,7 @@ static void top_toolbar_tool_update_scenery_clear(const ScreenCoordsXY& screenPo
  */
 static void top_toolbar_tool_update_land(const ScreenCoordsXY& screenPos)
 {
-    const bool mapCtrlPressed = input_test_place_object_modifier(PLACE_OBJECT_MODIFIER_COPY_Z);
+    const bool mapCtrlPressed = InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z);
 
     map_invalidate_selection_rect();
 

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -93,21 +93,21 @@ extern InputState _inputState;
 extern uint8_t _inputFlags;
 extern uint16_t _tooltipNotShownTicks;
 
-void input_window_position_begin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+void InputWindowPositionBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
 
 void title_handle_keyboard_input();
-void game_handle_input();
+void GameHandleInput();
 void game_handle_keyboard_input();
-void game_handle_edge_scroll();
-int32_t get_next_key();
+void GameHandleEdgeScroll();
+int32_t GetNextKey();
 
-void store_mouse_input(int32_t state, const ScreenCoordsXY& screenCoords);
+void StoreMouseInput(int32_t state, const ScreenCoordsXY& screenCoords);
 
 void input_set_flag(INPUT_FLAGS flag, bool on);
 bool input_test_flag(INPUT_FLAGS flag);
 void input_reset_flags();
 
-bool input_test_place_object_modifier(PLACE_OBJECT_MODIFIER modifier);
+bool InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER modifier);
 
 void input_set_state(InputState state);
 InputState input_get_state();
@@ -116,6 +116,6 @@ void reset_tooltip_not_shown();
 
 void input_reset_place_obj_modifier();
 
-void input_scroll_viewport(const ScreenCoordsXY& screenCoords);
+void InputScrollViewport(const ScreenCoordsXY& screenCoords);
 
 #endif


### PR DESCRIPTION
I saw a while back that someone said it might be a good idea to just go through and rename everything to Title Case in one go, so I figured I could try that, but I wanted to go folder by folder so it wouldn't be too much too fast.