### PR TITLE
Close #12455: Refactor MOUSE_STATE to use strong enum

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -401,7 +401,7 @@ public:
                     switch (e.button.button)
                     {
                         case SDL_BUTTON_LEFT:
-                            StoreMouseInput(MOUSE_STATE_LEFT_PRESS, mousePos);
+                            StoreMouseInput(MouseState::LeftPress, mousePos);
                             _cursorState.left = CURSOR_PRESSED;
                             _cursorState.old = 1;
                             break;
@@ -409,7 +409,7 @@ public:
                             _cursorState.middle = CURSOR_PRESSED;
                             break;
                         case SDL_BUTTON_RIGHT:
-                            StoreMouseInput(MOUSE_STATE_RIGHT_PRESS, mousePos);
+                            StoreMouseInput(MouseState::RightPress, mousePos);
                             _cursorState.right = CURSOR_PRESSED;
                             _cursorState.old = 2;
                             break;
@@ -428,7 +428,7 @@ public:
                     switch (e.button.button)
                     {
                         case SDL_BUTTON_LEFT:
-                            StoreMouseInput(MOUSE_STATE_LEFT_RELEASE, mousePos);
+                            StoreMouseInput(MouseState::LeftRelease, mousePos);
                             _cursorState.left = CURSOR_RELEASED;
                             _cursorState.old = 3;
                             break;
@@ -436,7 +436,7 @@ public:
                             _cursorState.middle = CURSOR_RELEASED;
                             break;
                         case SDL_BUTTON_RIGHT:
-                            StoreMouseInput(MOUSE_STATE_RIGHT_RELEASE, mousePos);
+                            StoreMouseInput(MouseState::RightRelease, mousePos);
                             _cursorState.right = CURSOR_RELEASED;
                             _cursorState.old = 4;
                             break;
@@ -461,13 +461,13 @@ public:
 
                     if (_cursorState.touchIsDouble)
                     {
-                        StoreMouseInput(MOUSE_STATE_RIGHT_PRESS, fingerPos);
+                        StoreMouseInput(MouseState::RightPress, fingerPos);
                         _cursorState.right = CURSOR_PRESSED;
                         _cursorState.old = 2;
                     }
                     else
                     {
-                        StoreMouseInput(MOUSE_STATE_LEFT_PRESS, fingerPos);
+                        StoreMouseInput(MouseState::LeftPress, fingerPos);
                         _cursorState.left = CURSOR_PRESSED;
                         _cursorState.old = 1;
                     }
@@ -482,13 +482,13 @@ public:
 
                     if (_cursorState.touchIsDouble)
                     {
-                        StoreMouseInput(MOUSE_STATE_RIGHT_RELEASE, fingerPos);
+                        StoreMouseInput(MouseState::RightRelease, fingerPos);
                         _cursorState.right = CURSOR_RELEASED;
                         _cursorState.old = 4;
                     }
                     else
                     {
-                        StoreMouseInput(MOUSE_STATE_LEFT_RELEASE, fingerPos);
+                        StoreMouseInput(MouseState::LeftRelease, fingerPos);
                         _cursorState.left = CURSOR_RELEASED;
                         _cursorState.old = 3;
                     }

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -259,10 +259,13 @@ static void InputScrollRight(const ScreenCoordsXY& screenCoords, MouseState stat
             _inputState = InputState::Reset;
             context_show_cursor();
             break;
-        default:
-        {
-            // Do nothing. Workaround for compilation errors.
-        }
+        case MouseState::LeftPress:
+        case MouseState::LeftRelease:
+        case MouseState::RightPress:
+            //Take no action
+            //In this switch only right button release is relevant
+            //Function handles only right button
+            break;
     }
 }
 
@@ -319,10 +322,11 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                         }
                     }
                     break;
-                default:
-                {
-                    // Do nothing. Workaround for compilation errors.
-                }
+                case MouseState::LeftRelease:
+                case MouseState::RightRelease:
+                    //Take no action
+                    //In this switch only button presses are relevant
+                    break;
             }
             break;
         case InputState::WidgetPressed:
@@ -411,10 +415,12 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                         }
                     }
                     break;
-                default:
-                {
-                    // Do nothing. Workaround for compilation errors.
-                }
+                case MouseState::LeftPress:
+                case MouseState::RightPress:
+                case MouseState::RightRelease:
+                    //Take no action
+                    //In this switch only left button release is relevant
+                    break;
             }
             break;
         case InputState::ScrollLeft:
@@ -426,10 +432,12 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                 case MouseState::LeftRelease:
                     InputScrollEnd();
                     break;
-                default:
-                {
-                    // Do nothing. Workaround for compilation errors.
-                }
+                case MouseState::LeftPress:
+                case MouseState::RightPress:
+                case MouseState::RightRelease:
+                    //Take no action
+                    //In this switch only left button release is relevant
+                    break;
             }
             break;
         case InputState::Resizing:

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -262,9 +262,7 @@ static void InputScrollRight(const ScreenCoordsXY& screenCoords, MouseState stat
         case MouseState::LeftPress:
         case MouseState::LeftRelease:
         case MouseState::RightPress:
-            //Take no action
-            //In this switch only right button release is relevant
-            //Function handles only right button
+            // Function only handles right button, so it's the only one relevant
             break;
     }
 }
@@ -324,8 +322,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                     break;
                 case MouseState::LeftRelease:
                 case MouseState::RightRelease:
-                    //Take no action
-                    //In this switch only button presses are relevant
+                    // In this switch only button presses are relevant
                     break;
             }
             break;
@@ -418,8 +415,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                 case MouseState::LeftPress:
                 case MouseState::RightPress:
                 case MouseState::RightRelease:
-                    //Take no action
-                    //In this switch only left button release is relevant
+                    // In this switch only left button release is relevant
                     break;
             }
             break;
@@ -435,8 +431,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                 case MouseState::LeftPress:
                 case MouseState::RightPress:
                 case MouseState::RightRelease:
-                    //Take no action
-                    //In this switch only left button release is relevant
+                    // In this switch only left button release is relevant
                     break;
             }
             break;

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -37,13 +37,13 @@ enum INPUT_FLAGS
     INPUT_FLAG_VIEWPORT_SCROLLING = (1 << 7)
 };
 
-enum MOUSE_STATE
+enum class MouseState : uint32_t
 {
-    MOUSE_STATE_RELEASED,
-    MOUSE_STATE_LEFT_PRESS,
-    MOUSE_STATE_LEFT_RELEASE,
-    MOUSE_STATE_RIGHT_PRESS,
-    MOUSE_STATE_RIGHT_RELEASE
+    Released,
+    LeftPress,
+    LeftRelease,
+    RightPress,
+    RightRelease
 };
 
 enum class InputState
@@ -101,7 +101,7 @@ void game_handle_keyboard_input();
 void GameHandleEdgeScroll();
 int32_t GetNextKey();
 
-void StoreMouseInput(int32_t state, const ScreenCoordsXY& screenCoords);
+void StoreMouseInput(MouseState state, const ScreenCoordsXY& screenCoords);
 
 void input_set_flag(INPUT_FLAGS flag, bool on);
 bool input_test_flag(INPUT_FLAGS flag);


### PR DESCRIPTION
In file `src/openrct2-ui/input/MouseInput.cpp` on line 114 there are two static casts.

`GameHandleInputMouse(screenCoords, static_cast<MouseState>(static_cast<uint32_t>(state) & 0xFF));`

I do not have any other idea how to write this line.
The function signature has been changed from:
`static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, uint32_t state)`
to:
`static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState state)`