### PR TITLE
Remove unnecessary parameter from Ride::Open

### DIFF
--- a/src/openrct2/actions/RideSetStatus.hpp
+++ b/src/openrct2/actions/RideSetStatus.hpp
@@ -110,7 +110,7 @@ public:
             }
             else if (_status == RIDE_STATUS_OPEN)
             {
-                if (!ride->Open(_status == RIDE_STATUS_OPEN, false))
+                if (!ride->Open(false))
                 {
                     res->Error = GameActions::Status::Unknown;
                     res->ErrorMessage = gGameCommandErrorText;
@@ -220,7 +220,7 @@ public:
                         return res;
                     }
                 }
-                else if (!ride->Open(_status == RIDE_STATUS_OPEN, true))
+                else if (!ride->Open(true))
                 {
                     res->Error = GameActions::Status::Unknown;
                     res->ErrorMessage = gGameCommandErrorText;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5241,7 +5241,7 @@ bool Ride::Test(int32_t newStatus, bool isApplying)
  *
  *  rct2: 0x006B4EEA
  */
-bool Ride::Open(int32_t goingToBeOpen, bool isApplying)
+bool Ride::Open(bool isApplying)
 {
     CoordsXYE trackElement, problematicTrackElement = {};
 
@@ -5266,7 +5266,7 @@ bool Ride::Open(int32_t goingToBeOpen, bool isApplying)
         return false;
     }
 
-    if (goingToBeOpen && isApplying)
+    if (isApplying)
     {
         ChainQueues();
         lifecycle_flags |= RIDE_LIFECYCLE_EVER_BEEN_OPENED;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -409,7 +409,7 @@ public:
 
     void StopGuestsQueuing();
 
-    bool Open(int32_t goingToBeOpen, bool isApplying);
+    bool Open(bool isApplying);
     bool Test(int32_t newStatus, bool isApplying);
 
     RideMode GetDefaultMode() const;


### PR DESCRIPTION
Similarly to my explanation in https://github.com/OpenRCT2/OpenRCT2/pull/13357#issuecomment-721413793 the parameter `goingToBeOpen` of `Ride::Open` will always be set to `true`, so it's redudndant and can be removed.

I've tracked down where this redundant parameter comes from: In d0a50c43f4b6c7d0fa24e5c7c6232807a3f54d05, opening and testing a ride were done by the same function (back then named `ride_is_valid_for_open`) and the parameter `goingToBeOpen` indicated whether the ride should be opened (`true`) or tested (`false`). 37221f0aaeb90a37f135e0ae884ca5bc69651deb then split up testing and opening into two different functions, from which on `goingToBeOpen` lost it's meaning.