### PR TITLE
Make TileElement conversion preserve the const qualifier

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -991,7 +991,7 @@ void path_paint_box_support(
     paint_session* session, const TileElement* tileElement, int32_t height, PathSurfaceEntry* footpathEntry,
     PathRailingsEntry* railingEntry, bool hasSupports, uint32_t imageFlags, uint32_t sceneryImageFlags)
 {
-    PathElement* pathElement = tileElement->AsPath();
+    const PathElement* pathElement = tileElement->AsPath();
 
     // Rol edges around rotation
     uint8_t edges = ((tileElement->AsPath()->GetEdges() << session->CurrentRotation) & 0xF)
@@ -1141,7 +1141,7 @@ void path_paint_pole_support(
     paint_session* session, const TileElement* tileElement, int16_t height, PathSurfaceEntry* footpathEntry,
     PathRailingsEntry* railingEntry, bool hasSupports, uint32_t imageFlags, uint32_t sceneryImageFlags)
 {
-    PathElement* pathElement = tileElement->AsPath();
+    const PathElement* pathElement = tileElement->AsPath();
 
     // Rol edges around rotation
     uint8_t edges = ((tileElement->AsPath()->GetEdges() << session->CurrentRotation) & 0xF)

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -36,7 +36,7 @@ void scenery_paint(paint_session* session, uint8_t direction, int32_t height, co
     {
         return;
     }
-    SmallSceneryElement* sceneryElement = tileElement->AsSmallScenery();
+    const SmallSceneryElement* sceneryElement = tileElement->AsSmallScenery();
     session->InteractionType = VIEWPORT_INTERACTION_ITEM_SCENERY;
     LocationXYZ16 boxlength;
     LocationXYZ16 boxoffset;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -301,42 +301,76 @@ struct RCT12TileElementBase
 struct RCT12TileElement : public RCT12TileElementBase
 {
     uint8_t pad_04[4];
-    template<typename TType, RCT12TileElementType TClass> TType* as() const
+    template<typename TType, RCT12TileElementType TClass> const TType* as() const
     {
-        return static_cast<RCT12TileElementType>(GetType()) == TClass
-            ? reinterpret_cast<TType*>(const_cast<RCT12TileElement*>(this))
-            : nullptr;
+        return static_cast<RCT12TileElementType>(GetType()) == TClass ? reinterpret_cast<const TType*>(this) : nullptr;
+    }
+    template<typename TType, RCT12TileElementType TClass> TType* as()
+    {
+        return static_cast<RCT12TileElementType>(GetType()) == TClass ? reinterpret_cast<TType*>(this) : nullptr;
     }
 
-    RCT12SurfaceElement* AsSurface() const
+    const RCT12SurfaceElement* AsSurface() const
     {
         return as<RCT12SurfaceElement, RCT12TileElementType::Surface>();
     }
-    RCT12PathElement* AsPath() const
+    RCT12SurfaceElement* AsSurface()
+    {
+        return as<RCT12SurfaceElement, RCT12TileElementType::Surface>();
+    }
+    const RCT12PathElement* AsPath() const
     {
         return as<RCT12PathElement, RCT12TileElementType::Path>();
     }
-    RCT12TrackElement* AsTrack() const
+    RCT12PathElement* AsPath()
+    {
+        return as<RCT12PathElement, RCT12TileElementType::Path>();
+    }
+    const RCT12TrackElement* AsTrack() const
     {
         return as<RCT12TrackElement, RCT12TileElementType::Track>();
     }
-    RCT12SmallSceneryElement* AsSmallScenery() const
+    RCT12TrackElement* AsTrack()
+    {
+        return as<RCT12TrackElement, RCT12TileElementType::Track>();
+    }
+    const RCT12SmallSceneryElement* AsSmallScenery() const
     {
         return as<RCT12SmallSceneryElement, RCT12TileElementType::SmallScenery>();
     }
-    RCT12LargeSceneryElement* AsLargeScenery() const
+    RCT12SmallSceneryElement* AsSmallScenery()
+    {
+        return as<RCT12SmallSceneryElement, RCT12TileElementType::SmallScenery>();
+    }
+    const RCT12LargeSceneryElement* AsLargeScenery() const
     {
         return as<RCT12LargeSceneryElement, RCT12TileElementType::LargeScenery>();
     }
-    RCT12WallElement* AsWall() const
+    RCT12LargeSceneryElement* AsLargeScenery()
+    {
+        return as<RCT12LargeSceneryElement, RCT12TileElementType::LargeScenery>();
+    }
+    const RCT12WallElement* AsWall() const
     {
         return as<RCT12WallElement, RCT12TileElementType::Wall>();
     }
-    RCT12EntranceElement* AsEntrance() const
+    RCT12WallElement* AsWall()
+    {
+        return as<RCT12WallElement, RCT12TileElementType::Wall>();
+    }
+    const RCT12EntranceElement* AsEntrance() const
     {
         return as<RCT12EntranceElement, RCT12TileElementType::Entrance>();
     }
-    RCT12BannerElement* AsBanner() const
+    RCT12EntranceElement* AsEntrance()
+    {
+        return as<RCT12EntranceElement, RCT12TileElementType::Entrance>();
+    }
+    const RCT12BannerElement* AsBanner() const
+    {
+        return as<RCT12BannerElement, RCT12TileElementType::Banner>();
+    }
+    RCT12BannerElement* AsBanner()
     {
         return as<RCT12BannerElement, RCT12TileElementType::Banner>();
     }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1616,7 +1616,7 @@ void PathElement::SetQueueBannerDirection(uint8_t direction)
     type |= (direction << 6);
 }
 
-bool PathElement::ShouldDrawPathOverSupports()
+bool PathElement::ShouldDrawPathOverSupports() const
 {
     return (GetRailingEntry()->flags & RAILING_ENTRY_FLAG_DRAW_PATH_OVER_SUPPORTS);
 }

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -105,42 +105,77 @@ struct TileElement : public TileElementBase
     uint8_t pad_04[4];
     uint8_t pad_08[8];
 
-    template<typename TType, TileElementType TClass> TType* as() const
+    template<typename TType, TileElementType TClass> const TType* as() const
     {
-        return static_cast<TileElementType>(GetType()) == TClass ? reinterpret_cast<TType*>(const_cast<TileElement*>(this))
-                                                                 : nullptr;
+        return static_cast<TileElementType>(GetType()) == TClass ? reinterpret_cast<const TType*>(this) : nullptr;
+    }
+    template<typename TType, TileElementType TClass> TType* as()
+    {
+        return static_cast<TileElementType>(GetType()) == TClass ? reinterpret_cast<TType*>(this) : nullptr;
     }
 
 public:
-    SurfaceElement* AsSurface() const
+    const SurfaceElement* AsSurface() const
     {
         return as<SurfaceElement, TileElementType::Surface>();
     }
-    PathElement* AsPath() const
+    SurfaceElement* AsSurface()
+    {
+        return as<SurfaceElement, TileElementType::Surface>();
+    }
+    const PathElement* AsPath() const
     {
         return as<PathElement, TileElementType::Path>();
     }
-    TrackElement* AsTrack() const
+    PathElement* AsPath()
+    {
+        return as<PathElement, TileElementType::Path>();
+    }
+    const TrackElement* AsTrack() const
     {
         return as<TrackElement, TileElementType::Track>();
     }
-    SmallSceneryElement* AsSmallScenery() const
+    TrackElement* AsTrack()
+    {
+        return as<TrackElement, TileElementType::Track>();
+    }
+    const SmallSceneryElement* AsSmallScenery() const
     {
         return as<SmallSceneryElement, TileElementType::SmallScenery>();
     }
-    LargeSceneryElement* AsLargeScenery() const
+    SmallSceneryElement* AsSmallScenery()
+    {
+        return as<SmallSceneryElement, TileElementType::SmallScenery>();
+    }
+    const LargeSceneryElement* AsLargeScenery() const
     {
         return as<LargeSceneryElement, TileElementType::LargeScenery>();
     }
-    WallElement* AsWall() const
+    LargeSceneryElement* AsLargeScenery()
+    {
+        return as<LargeSceneryElement, TileElementType::LargeScenery>();
+    }
+    const WallElement* AsWall() const
     {
         return as<WallElement, TileElementType::Wall>();
     }
-    EntranceElement* AsEntrance() const
+    WallElement* AsWall()
+    {
+        return as<WallElement, TileElementType::Wall>();
+    }
+    const EntranceElement* AsEntrance() const
     {
         return as<EntranceElement, TileElementType::Entrance>();
     }
-    BannerElement* AsBanner() const
+    EntranceElement* AsEntrance()
+    {
+        return as<EntranceElement, TileElementType::Entrance>();
+    }
+    const BannerElement* AsBanner() const
+    {
+        return as<BannerElement, TileElementType::Banner>();
+    }
+    BannerElement* AsBanner()
     {
         return as<BannerElement, TileElementType::Banner>();
     }
@@ -274,7 +309,7 @@ public:
     uint8_t GetAdditionStatus() const;
     void SetAdditionStatus(uint8_t newStatus);
 
-    bool ShouldDrawPathOverSupports();
+    bool ShouldDrawPathOverSupports() const;
     void SetShouldDrawPathOverSupports(bool on);
 
     bool IsLevelCrossing(const CoordsXY& coords) const;


### PR DESCRIPTION
Currently, `TileElement` (and `RCT12TileElement`) conversion functions silently drop the `const` qualifiers of tile elements it's called on. This commit adds more conversion functions so `const` qualifiers are kept as they are during conversion.

Additionally this commit fixes some constness issues revealed by this change.