### PR TITLE
Create calls for min/max cars per train

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2821,10 +2821,10 @@ static OpenRCT2String window_ride_vehicle_tooltip(
 
             auto ft = Formatter();
             ft.Increment(16);
-            ft.Add<uint16_t>(std::max(1, ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars);
+            ft.Add<uint16_t>(std::max(uint8_t(1), ride->GetMaxCarsPerTrain()) - rideEntry->zero_cars);
 
             rct_string_id stringId = RideComponentNames[RIDE_COMPONENT_TYPE_CAR].singular;
-            if ((ride->min_max_cars_per_train & 0xF) - rideEntry->zero_cars > 1)
+            if (ride->GetMaxCarsPerTrain() - rideEntry->zero_cars > 1)
             {
                 stringId = RideComponentNames[RIDE_COMPONENT_TYPE_CAR].plural;
             }

--- a/src/openrct2/actions/RideCreateAction.hpp
+++ b/src/openrct2/actions/RideCreateAction.hpp
@@ -309,7 +309,8 @@ public:
 
         ride->num_circuits = 1;
         ride->mode = ride->GetDefaultMode();
-        ride->min_max_cars_per_train = (rideEntry->min_cars_in_train << 4) | rideEntry->max_cars_in_train;
+        ride->SetMinCarsPerTrain(rideEntry->min_cars_in_train);
+        ride->SetMaxCarsPerTrain(rideEntry->max_cars_in_train);
         ride_set_vehicle_colours_to_random_preset(ride, _colour2);
         window_invalidate_by_class(WC_RIDE_LIST);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -836,7 +836,8 @@ private:
         dst->max_waiting_time = src->max_waiting_time;
         dst->operation_option = src->operation_option;
         dst->num_circuits = 1;
-        dst->min_max_cars_per_train = (rideEntry->min_cars_in_train << 4) | rideEntry->max_cars_in_train;
+        dst->SetMinCarsPerTrain(rideEntry->min_cars_in_train);
+        dst->SetMaxCarsPerTrain(rideEntry->max_cars_in_train);
 
         // RCT1 used 5mph / 8 km/h for every lift hill
         dst->lift_hill_speed = 5;

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -83,3 +83,25 @@ uint8_t OpenRCT2RideTypeToRCT2RideType(ObjectEntryIndex openrct2Type)
             return openrct2Type;
     }
 }
+
+uint8_t rct2_ride::GetMinCarsPerTrain() const
+{
+    return min_max_cars_per_train >> 4;
+}
+
+uint8_t rct2_ride::GetMaxCarsPerTrain() const
+{
+    return min_max_cars_per_train & 0xF;
+}
+
+void rct2_ride::SetMinCarsPerTrain(uint8_t newValue)
+{
+    min_max_cars_per_train &= ~0xF0;
+    min_max_cars_per_train |= (newValue << 4);
+}
+
+void rct2_ride::SetMaxCarsPerTrain(uint8_t newValue)
+{
+    min_max_cars_per_train &= ~0x0F;
+    min_max_cars_per_train |= newValue & 0x0F;
+}

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -318,6 +318,11 @@ struct rct2_ride
     uint16_t cable_lift;                                       // 0x1FE
     uint16_t queue_length[RCT12_MAX_STATIONS_PER_RIDE];        // 0x200
     uint8_t pad_208[0x58];                                     // 0x208
+
+    uint8_t GetMinCarsPerTrain() const;
+    uint8_t GetMaxCarsPerTrain() const;
+    void SetMinCarsPerTrain(uint8_t newValue);
+    void SetMaxCarsPerTrain(uint8_t newValue);
 };
 assert_struct_size(rct2_ride, 0x260);
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -606,7 +606,8 @@ void S6Exporter::ExportRide(rct2_ride* dst, const Ride* src)
     dst->proposed_num_vehicles = src->proposed_num_vehicles;
     dst->proposed_num_cars_per_train = src->proposed_num_cars_per_train;
     dst->max_trains = src->max_trains;
-    dst->min_max_cars_per_train = src->min_max_cars_per_train;
+    dst->SetMinCarsPerTrain(src->GetMinCarsPerTrain());
+    dst->SetMaxCarsPerTrain(src->GetMaxCarsPerTrain());
     dst->min_waiting_time = src->min_waiting_time;
     dst->max_waiting_time = src->max_waiting_time;
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -627,7 +627,8 @@ public:
         dst->proposed_num_vehicles = src->proposed_num_vehicles;
         dst->proposed_num_cars_per_train = src->proposed_num_cars_per_train;
         dst->max_trains = src->max_trains;
-        dst->min_max_cars_per_train = src->min_max_cars_per_train;
+        dst->SetMinCarsPerTrain(src->GetMinCarsPerTrain());
+        dst->SetMaxCarsPerTrain(src->GetMaxCarsPerTrain());
         dst->min_waiting_time = src->min_waiting_time;
         dst->max_waiting_time = src->max_waiting_time;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6658,7 +6658,8 @@ void Ride::UpdateMaxVehicles()
     {
         int32_t trainLength;
         num_cars_per_train = std::max(rideEntry->min_cars_in_train, num_cars_per_train);
-        min_max_cars_per_train = rideEntry->max_cars_in_train | (rideEntry->min_cars_in_train << 4);
+        SetMinCarsPerTrain(rideEntry->min_cars_in_train);
+        SetMaxCarsPerTrain(rideEntry->max_cars_in_train);
 
         // Calculate maximum train length based on smallest station length
         auto stationNumTiles = ride_get_smallest_station_length(this);
@@ -6691,7 +6692,8 @@ void Ride::UpdateMaxVehicles()
         {
             newCarsPerTrain = std::min(maxCarsPerTrain, newCarsPerTrain);
         }
-        min_max_cars_per_train = maxCarsPerTrain | (rideEntry->min_cars_in_train << 4);
+        SetMaxCarsPerTrain(maxCarsPerTrain);
+        SetMinCarsPerTrain(rideEntry->min_cars_in_train);
 
         switch (mode)
         {
@@ -6769,7 +6771,8 @@ void Ride::UpdateMaxVehicles()
     else
     {
         max_trains = rideEntry->cars_per_flat_ride;
-        min_max_cars_per_train = rideEntry->max_cars_in_train | (rideEntry->min_cars_in_train << 4);
+        SetMinCarsPerTrain(rideEntry->min_cars_in_train);
+        SetMaxCarsPerTrain(rideEntry->max_cars_in_train);
         numCarsPerTrain = rideEntry->max_cars_in_train;
         maxNumTrains = rideEntry->cars_per_flat_ride;
     }
@@ -7618,4 +7621,26 @@ uint64_t Ride::GetAvailableModes() const
 const RideTypeDescriptor& Ride::GetRideTypeDescriptor() const
 {
     return RideTypeDescriptors[type];
+}
+
+uint8_t Ride::GetMinCarsPerTrain() const
+{
+    return min_max_cars_per_train >> 4;
+}
+
+uint8_t Ride::GetMaxCarsPerTrain() const
+{
+    return min_max_cars_per_train & 0xF;
+}
+
+void Ride::SetMinCarsPerTrain(uint8_t newValue)
+{
+    min_max_cars_per_train &= ~0xF0;
+    min_max_cars_per_train |= (newValue << 4);
+}
+
+void Ride::SetMaxCarsPerTrain(uint8_t newValue)
+{
+    min_max_cars_per_train &= ~0x0F;
+    min_max_cars_per_train |= newValue & 0x0F;
 }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -221,7 +221,11 @@ struct Ride
     uint8_t proposed_num_vehicles;
     uint8_t proposed_num_cars_per_train;
     uint8_t max_trains;
+
+private:
     uint8_t min_max_cars_per_train;
+
+public:
     uint8_t min_waiting_time;
     uint8_t max_waiting_time;
     union
@@ -443,6 +447,11 @@ public:
     TrackElement* GetOriginElement(StationIndex stationIndex) const;
 
     std::pair<RideMeasurement*, OpenRCT2String> GetMeasurement();
+
+    uint8_t GetMinCarsPerTrain() const;
+    uint8_t GetMaxCarsPerTrain() const;
+    void SetMinCarsPerTrain(uint8_t newValue);
+    void SetMaxCarsPerTrain(uint8_t newValue);
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
I also want to actually split the field later on. Not doing so now also means that this should pass the replay tests as-is.