### PR TITLE
Close #13359: Make GameAction flags optional in plugin API.

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1866,7 +1866,7 @@ declare global {
         widgets?: Widget[];
         colours?: number[];
         tabs?: WindowTabDesc[];
-        tabIndex: number;
+        tabIndex?: number;
 
         onClose?: () => void;
         onUpdate?: () => void;

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -43,7 +43,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 10;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 11;
 
 struct ExpressionStringifier final
 {
@@ -1130,7 +1130,10 @@ std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& ac
         DukValue argsCopy = args;
         DukToGameActionParameterVisitor visitor(std::move(argsCopy));
         action->AcceptParameters(visitor);
-        action->AcceptFlags(visitor);
+        if (args["flags"].type() == DukValue::Type::NUMBER)
+        {
+            action->AcceptFlags(visitor);
+        }
         return action;
     }
     else


### PR DESCRIPTION
Also marks `WindowDesc->tabIndex` as optional in the .d.ts file.