### PR TITLE
Fix #12895: Prevent Mechanics from fixing just fixed rides

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,7 +3,7 @@
 - Feature: [#13057] Make GameAction flags accessible by plugins.
 - Feature: [#13376] Open custom window at specified tab.
 - Change: [#13346] Change FootpathScenery to FootpathAddition in all occurrences.
-- Fix: [#12895] Mechanics no longer are called to repair rides that were just re-opened
+- Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#13057] Make GameAction flags accessible by plugins.
 - Feature: [#13376] Open custom window at specified tab.
 - Change: [#13346] Change FootpathScenery to FootpathAddition in all occurrences.
+- Fix: [#12895] Mechanics no longer are called to repair rides that were just re-opened
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -2579,15 +2579,13 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride* r
 {
     if (!firstRun)
     {
-        ride->mechanic_status = RIDE_MECHANIC_STATUS_UNDEFINED;
-
         if (State == PeepState::Inspecting)
         {
             UpdateRideInspected(CurrentRide);
 
             StaffRidesInspected++;
             WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
-
+            ride->mechanic_status = RIDE_MECHANIC_STATUS_UNDEFINED;
             return true;
         }
 
@@ -2610,7 +2608,7 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride* r
     }
 
     ride_fix_breakdown(ride, steps);
-
+    ride->mechanic_status = RIDE_MECHANIC_STATUS_UNDEFINED;
     return true;
 }
 


### PR DESCRIPTION
The state machine for finishing repairs previously unset the ride's mechanic status prior to advancing to the next state (and before marking the ride as repaired). This caused the ride's `ride_mechanic_status_update` to trigger a new mechanic call when the ride's mechanic state was undefined and the ride state was still broken down, which previously occurred while the mechanic was performing the call action to reopen the ride.