### PR TITLE
Check if platform has a file picker

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3652,6 +3652,7 @@ STR_6395    :Maintenance
 STR_6396    :Disable screensaver and monitor power saving
 STR_6397    :{SMALLFONT}{BLACK}If checked, screensaver and other monitor power saving features will be inhibited while OpenRCT2 is running.
 STR_6398    :File contains unsupported ride types. Please update to a newer version of OpenRCT2.
+STR_6399    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 in order to work. Please set the "game_path" variable in config.ini to the directory where you installed RollerCoaster Tycoon 2, then restart OpenRCT2.
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -70,6 +70,11 @@ namespace OpenRCT2::Ui
         {
             STUB();
         }
+
+        bool HasFilePicker() const override
+        {
+            return false;
+        }
     };
 
     IPlatformUiContext* CreatePlatformUiContext()

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -250,6 +250,12 @@ namespace OpenRCT2::Ui
             return result;
         }
 
+        bool HasFilePicker() const override
+        {
+            std::string dummy;
+            return GetDialogApp(&dummy) != DIALOG_TYPE::NONE;
+        }
+
     private:
         static DIALOG_TYPE GetDialogApp(std::string* executablePath)
         {

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -197,6 +197,11 @@ namespace OpenRCT2::Ui
             return result;
         }
 
+        bool HasFilePicker() const override
+        {
+            return true;
+        }
+
     private:
         HWND GetHWND(SDL_Window* window)
         {

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -624,6 +624,11 @@ public:
         return _platformUiContext->ShowDirectoryDialog(_window, title);
     }
 
+    bool HasFilePicker() const override
+    {
+        return _platformUiContext->HasFilePicker();
+    }
+
     IWindowManager* GetWindowManager() override
     {
         return _windowManager;

--- a/src/openrct2-ui/UiContext.h
+++ b/src/openrct2-ui/UiContext.h
@@ -38,6 +38,8 @@ namespace OpenRCT2
             virtual void OpenURL(const std::string& url) abstract;
             virtual std::string ShowFileDialog(SDL_Window* window, const FileDialogDesc& desc) abstract;
             virtual std::string ShowDirectoryDialog(SDL_Window* window, const std::string& title) abstract;
+
+            virtual bool HasFilePicker() const abstract;
         };
 
         std::unique_ptr<IUiContext> CreateUiContext(const std::shared_ptr<IPlatformEnvironment>& env);

--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -156,6 +156,11 @@ namespace OpenRCT2::Ui
             }
         }
 
+        bool HasFilePicker() const override
+        {
+            return true;
+        }
+
     private:
         static int32_t Execute(const std::string& command, std::string* output = nullptr)
         {

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -30,6 +30,7 @@
 #include <openrct2/ride/TrackDesign.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/title/TitleScreen.h>
+#include <openrct2/ui/UiContext.h>
 #include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
@@ -252,7 +253,8 @@ rct_window* window_loadsave_open(int32_t type, const char* defaultName, loadsave
         return nullptr;
 
     // Bypass the lot?
-    if (gConfigGeneral.use_native_browse_dialog)
+    auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
+    if (gConfigGeneral.use_native_browse_dialog && hasFilePicker)
     {
         if (browse(isSave, path, sizeof(path)))
         {
@@ -273,6 +275,13 @@ rct_window* window_loadsave_open(int32_t type, const char* defaultName, loadsave
         w->min_height = WH / 2;
         w->max_width = WW * 2;
         w->max_height = WH * 2;
+
+        if (!hasFilePicker)
+        {
+            w->enabled_widgets &= ~(1 << WIDX_BROWSE);
+            w->disabled_widgets |= (1 << WIDX_BROWSE);
+            window_loadsave_widgets[WIDX_BROWSE].type = WWT_EMPTY;
+        }
     }
 
     const char* pattern = getFilterPatternByType(type, isSave);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -575,6 +575,13 @@ static void window_options_common_invalidate_before(rct_window* w)
     window_options_set_pressed_tab(w);
 
     w->disabled_widgets = 0;
+    auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
+    if (!hasFilePicker)
+    {
+        w->enabled_widgets &= ~WIDX_ALWAYS_NATIVE_LOADSAVE;
+        w->disabled_widgets |= WIDX_ALWAYS_NATIVE_LOADSAVE;
+        w->widgets[WIDX_ALWAYS_NATIVE_LOADSAVE].type = WWT_EMPTY;
+    }
 }
 
 static void window_options_common_invalidate_after(rct_window* w)

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -794,12 +794,18 @@ bool config_find_or_browse_install_directory()
             return false;
         }
 
+        auto uiContext = GetContext()->GetUiContext();
+        if (!uiContext->HasFilePicker())
+        {
+            uiContext->ShowMessageBox(format_string(STR_NEEDS_RCT2_FILES_MANUAL, nullptr));
+            return false;
+        }
+
         try
         {
             const char* g1DatPath = PATH_SEPARATOR "Data" PATH_SEPARATOR "g1.dat";
             while (true)
             {
-                auto uiContext = GetContext()->GetUiContext();
                 uiContext->ShowMessageBox(format_string(STR_NEEDS_RCT2_FILES, nullptr));
 
                 std::string installPath = uiContext->ShowDirectoryDialog(format_string(STR_PICK_RCT2_DIR, nullptr));

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3903,6 +3903,9 @@ enum
     STR_DISABLE_SCREENSAVER_TIP = 6397,
 
     STR_FILE_CONTAINS_UNSUPPORTED_RIDE_TYPES = 6398,
+
+    STR_NEEDS_RCT2_FILES_MANUAL = 6399,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -198,6 +198,11 @@ namespace OpenRCT2::Ui
         {
             delete _windowManager;
         }
+
+        bool HasFilePicker() const override
+        {
+            return false;
+        }
     };
 
     std::shared_ptr<IUiContext> CreateDummyUiContext()

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -117,6 +117,7 @@ namespace OpenRCT2
             virtual void OpenURL(const std::string& url) abstract;
             virtual std::string ShowFileDialog(const FileDialogDesc& desc) abstract;
             virtual std::string ShowDirectoryDialog(const std::string& title) abstract;
+            virtual bool HasFilePicker() const abstract;
 
             // Input
             virtual const CursorState* GetCursorState() abstract;


### PR DESCRIPTION
Hides buttons and options related to using the native file picker if the OS does not provide one. This avoids some footshooting on Android and barebones Linux and BSD installs.