### PR TITLE
Fix #13409: Peeps sometimes stray too far from the path centre

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.18/
 set(OBJECTS_SHA1 "4a3c32a0251c3babe014844f2c683fc32138b3f2")
 
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.22/replays.zip")
-set(REPLAYS_SHA1 "7591DB0A3842A7AC44FCBFF9A573C9CB3DDC56")
+set(REPLAYS_SHA1 "7591db0a3842a7ac44fcbfbff9a573c9cb3ddc56")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip")
 set(OBJECTS_SHA1 "4a3c32a0251c3babe014844f2c683fc32138b3f2")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.21/replays.zip")
-set(REPLAYS_SHA1 "23BF9B52D2D0BDBAF7E2DE4F35ED53F6A416539D")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.22/replays.zip")
+set(REPLAYS_SHA1 "7591DB0A3842A7AC44FCBFF9A573C9CB3DDC56")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Change: [#13346] Change FootpathScenery to FootpathAddition in all occurrences.
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.
+- Fix: [#13409] Clamp peep distances from path centers.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 
 0.3.2 (2020-11-01)

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip</ObjectsUrl>
     <ObjectsSha1>4a3c32a0251c3babe014844f2c683fc32138b3f2</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.21/replays.zip</ReplaysUrl>
-    <ReplaysSha1>23BF9B52D2D0BDBAF7E2DE4F35ED53F6A416539D</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.22/replays.zip</ReplaysUrl>
+    <ReplaysSha1>7591DB0A3842A7AC44FCBFF9A573C9CB3DDC56</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -49,7 +49,7 @@
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip</ObjectsUrl>
     <ObjectsSha1>4a3c32a0251c3babe014844f2c683fc32138b3f2</ObjectsSha1>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.22/replays.zip</ReplaysUrl>
-    <ReplaysSha1>7591DB0A3842A7AC44FCBFF9A573C9CB3DDC56</ReplaysSha1>
+    <ReplaysSha1>7591db0a3842a7ac44fcbfbff9a573c9cb3ddc56</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The debunch-peeps improvement did not account for the fact that peeps may change direction when they are only at the very edge of a tile - it's not entirely clear to me why this happens, but it does. The previous code would push these peeps back towards the center line over time, but the new behaviour allows them to keep walking along these very edge-y lines, which means they sometimes appear to be walking on the wrong sides of benches, railings, etc.

To fix the problem, do not simply keep the target coordinate constant for the direction the peep is moving in, but clamp it, so that peeps in these outlier positions will get pulled back to a more acceptable position within one tile. Peeps who are already debunched within the reasonable center area of the path are unaffected.