### PR TITLE
Implement ToUpper for WinNT 5.1

### DIFF
--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -731,8 +731,9 @@ namespace String
             return String::ToUtf8(dstW);
         }
 #    else
-        log_warning("String::ToUpper not supported");
-        return std::string(src);
+        std::string dst = std::string(src);
+        std::transform(dst.begin(), dst.end(), dst.begin(), [](unsigned char c) { return std::toupper(c); });
+        return dst;
 #    endif
 #else
         icu::UnicodeString str = icu::UnicodeString::fromUTF8(std::string(src));


### PR DESCRIPTION
Salvaged from https://github.com/OpenRCT2/OpenRCT2/pull/13391.