### PR TITLE
Add ride category to plugin API

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -775,6 +775,12 @@ declare global {
         type: number;
 
         /**
+         * The category of a ride. Same as the tab from ride building window.
+         * (e.g. Transport, Gentle, Coaster, Thrill, Water, Shop)
+         */
+        readonly category: RideCategory;
+
+        /**
          * Whether the ride is a ride, shop or facility.
          */
         readonly classification: RideClassification;
@@ -905,6 +911,8 @@ declare global {
          */
         value: number;
     }
+
+    type RideCategory = "transport" | "gentle" | "rollercoaster" | "thrill" | "water" | "shop" | "";
 
     type RideClassification = "ride" | "stall" | "facility";
 

--- a/src/openrct2/scripting/ScRide.hpp
+++ b/src/openrct2/scripting/ScRide.hpp
@@ -14,6 +14,7 @@
 #    include "../Context.h"
 #    include "../common.h"
 #    include "../ride/Ride.h"
+#    include "../ride/RideData.h"
 #    include "Duktape.hpp"
 #    include "ScObject.hpp"
 #    include "ScriptEngine.h"
@@ -224,6 +225,35 @@ namespace OpenRCT2::Scripting
                         return "stall";
                     case RideClassification::KioskOrFacility:
                         return "facility";
+                }
+            }
+            return "";
+        }
+
+        std::string category_get() const
+        {
+            auto ride = GetRide();
+            if (ride != nullptr)
+            {
+                for (auto rideType : ride->GetRideEntry()->ride_type)
+                {
+                    switch (RideTypeDescriptors[rideType].Category)
+                    {
+                        case RIDE_CATEGORY_TRANSPORT:
+                            return "transport";
+                        case RIDE_CATEGORY_GENTLE:
+                            return "gentle";
+                        case RIDE_CATEGORY_ROLLERCOASTER:
+                            return "rollercoaster";
+                        case RIDE_CATEGORY_THRILL:
+                            return "thrill";
+                        case RIDE_CATEGORY_WATER:
+                            return "water";
+                        case RIDE_CATEGORY_SHOP:
+                            return "shop";
+                        case RIDE_CATEGORY_NONE:
+                            return "";
+                    }
                 }
             }
             return "";
@@ -652,6 +682,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScRide::object_get, nullptr, "object");
             dukglue_register_property(ctx, &ScRide::type_get, nullptr, "type");
             dukglue_register_property(ctx, &ScRide::classification_get, nullptr, "classification");
+            dukglue_register_property(ctx, &ScRide::category_get, nullptr, "category");
             dukglue_register_property(ctx, &ScRide::name_get, &ScRide::name_set, "name");
             dukglue_register_property(ctx, &ScRide::status_get, nullptr, "status");
             dukglue_register_property(ctx, &ScRide::lifecycleFlags_get, &ScRide::lifecycleFlags_set, "lifecycleFlags");


### PR DESCRIPTION
This is a small change. I want to have different behavior for different ride categories for my plugin, so I added it.

One quirk I saw: there can be up to `RCT2_MAX_RIDE_TYPES_PER_RIDE_ENTRY` (3) ride types per ride entry, but in every case I tested, I got `[realCategory, "transport", "transport"]` (e.g. `["water", "transport", "transport"]` or `["shop", "transport", "transport"]` or `["transport", "transport", "transport"]`) so I just took the 1st category. This is the logic in `category_get`.