### PR TITLE
Fix #13427: Newly created Go-Karts show "Race won by <blank>"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#13454] Plug-ins do not load on Windows if the user directory contains non-ASCII characters.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
+- Fix: [#13427] Newly created Go-Karts show "Race won by <blank>".
 
 0.3.2 (2020-11-01)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,10 +7,10 @@
 - Fix: [#13257] Rides that are exactly the minimum objective length are not counted.
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.
+- Fix: [#13427] Newly created Go-Karts show "Race won by <blank>".
 - Fix: [#13454] Plug-ins do not load on Windows if the user directory contains non-ASCII characters.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
-- Fix: [#13427] Newly created Go-Karts show "Race won by <blank>".
 
 0.3.2 (2020-11-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -839,7 +839,9 @@ void Ride::FormatStatusTo(Formatter& ft) const
     {
         ft.Add<rct_string_id>(STR_TEST_RUN);
     }
-    else if (mode == RideMode::Race && !(lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING))
+    else if (
+        mode == RideMode::Race && !(lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+        && race_winner != SPRITE_INDEX_NULL)
     {
         auto peep = GetEntity<Peep>(race_winner);
         if (peep != nullptr)


### PR DESCRIPTION
Fix #13427. This was caused in the fix for issue #12497 0f78d452.

race_winner is null when the ride switches from closed to open. The fix for issue #12497 accidentally changed the logic here in an attempt to prevent a duplicate check. This resulted in "Race won by" displaying any time a ride switches from closed to open (not just the first time). This message remained until the ride actually started. For example it would jump up to say "7 people on the ride" immediately even if peeps are entering the ride slowly.

In vanilla for a ride that changed from closed to open the message says "0 people on the ride" and counts as peeps enter the ride. I tested and this fix seems to behave the same as vanilla. 