### PR TITLE
Fix #13469: Exception thrown from plugin in context.subscribe

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.
 - Fix: [#13427] Newly created Go-Karts show "Race won by <blank>".
 - Fix: [#13454] Plug-ins do not load on Windows if the user directory contains non-ASCII characters.
+- Fix: [#13469] Exception thrown from plugin in context.subscribe.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
 

--- a/src/openrct2/scripting/ScContext.hpp
+++ b/src/openrct2/scripting/ScContext.hpp
@@ -156,21 +156,24 @@ namespace OpenRCT2::Scripting
 
         std::shared_ptr<ScDisposable> subscribe(const std::string& hook, const DukValue& callback)
         {
+            auto& scriptEngine = GetContext()->GetScriptEngine();
+            auto ctx = scriptEngine.GetContext();
+
             auto hookType = GetHookType(hook);
             if (hookType == HOOK_TYPE::UNDEFINED)
             {
-                throw DukException() << "Unknown hook type: " << hook;
+                duk_error(ctx, DUK_ERR_ERROR, "Unknown hook type");
             }
 
             if (!callback.is_function())
             {
-                throw DukException() << "Expected function for callback";
+                duk_error(ctx, DUK_ERR_ERROR, "Expected function for callback");
             }
 
             auto owner = _execInfo.GetCurrentPlugin();
             if (owner == nullptr)
             {
-                throw DukException() << "Not in a plugin context";
+                duk_error(ctx, DUK_ERR_ERROR, "Not in a plugin context");
             }
 
             auto cookie = _hookEngine.Subscribe(hookType, owner, callback);


### PR DESCRIPTION
Throw a JavaScript exception, not a C++ exception when invalid parameters are passed to subscribe.