### PR TITLE
Fix #13489: Mechanics continue heading to inspect broken down rides

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -162,6 +162,7 @@ The following people are not part of the development team, but have been contrib
 * Roger Seekell (rpstester)
 * Ben Johnston (gsckoco)
 * (evilclownattack)
+* Adam Bloom (adam-bloom)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#13454] Plug-ins do not load on Windows if the user directory contains non-ASCII characters.
 - Fix: [#13469] Exception thrown from plugin in context.subscribe.
 - Fix: [#13477] Plug-in widget tooltips do not work.
+- Fix: [#13489] Mechanics continue heading to inspect broken down rides.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
If a mechanic is already heading to a ride when it breaks down (for an inspection), the mechanic would continue to head for the ride for inspection, but would repair the ride when they arrived. With this change, the mechanic will receive a page for a repair and replace "heading for inspection" with "responding to breakdown" in the mechanic status.

Starting state:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/3771193/100552997-37cabe00-3248-11eb-8f84-334c1aa06863.png">

Before:
<img width="677" alt="image" src="https://user-images.githubusercontent.com/3771193/100553037-75c7e200-3248-11eb-9558-4dda895a9fe1.png">

After:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/3771193/100553007-474a0700-3248-11eb-96de-62947edbf871.png">
<img width="689" alt="image" src="https://user-images.githubusercontent.com/3771193/100553012-4dd87e80-3248-11eb-9e69-9487a1fb5232.png">
