### PR TITLE
Fix #13476: Clean up unneeded colour variables in TopToolbar.cpp

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -314,10 +314,6 @@ static ClearAction GetClearAction();
 static bool _landToolBlocked;
 static uint8_t _unkF64F0E;
 static int16_t _unkF64F0A;
-// rct2: 0x00F64F15
-static colour_t _secondaryColour;
-// rct2: 0x00F64F16
-static colour_t _tertiaryColour;
 
 /**
  * Creates the main game top toolbar window.
@@ -1223,7 +1219,7 @@ static void sub_6E1F34_update_screen_coords_and_buttons_pressed(bool canRaiseIte
 
 static void sub_6E1F34_small_scenery(
     const ScreenCoordsXY& sourceScreenPos, ObjectEntryIndex sceneryIndex, CoordsXY& gridPos, uint8_t* outQuadrant,
-    colour_t* outPrimaryColour, colour_t* outSecondaryColour, Direction* outRotation)
+    Direction* outRotation)
 {
     rct_window* w = window_find_by_class(WC_SCENERY);
 
@@ -1325,8 +1321,6 @@ static void sub_6E1F34_small_scenery(
         }
 
         *outQuadrant = quadrant ^ 2;
-        *outPrimaryColour = gWindowSceneryPrimaryColour;
-        *outSecondaryColour = gWindowScenerySecondaryColour;
         *outRotation = rotation;
 
         return;
@@ -1411,8 +1405,6 @@ static void sub_6E1F34_small_scenery(
     }
 
     *outQuadrant = 0;
-    *outPrimaryColour = gWindowSceneryPrimaryColour;
-    *outSecondaryColour = gWindowScenerySecondaryColour;
     *outRotation = rotation;
 }
 
@@ -1451,8 +1443,7 @@ static void sub_6E1F34_path_item(
 }
 
 static void sub_6E1F34_wall(
-    const ScreenCoordsXY& sourceScreenPos, ObjectEntryIndex sceneryIndex, CoordsXY& gridPos, colour_t* outPrimaryColour,
-    uint8_t* outEdges)
+    const ScreenCoordsXY& sourceScreenPos, ObjectEntryIndex sceneryIndex, CoordsXY& gridPos, uint8_t* outEdges)
 {
     rct_window* w = window_find_by_class(WC_SCENERY);
 
@@ -1532,21 +1523,16 @@ static void sub_6E1F34_wall(
     if (gridPos.isNull())
         return;
 
-    _secondaryColour = gWindowScenerySecondaryColour;
-    _tertiaryColour = gWindowSceneryTertiaryColour;
-
     if (gConfigGeneral.virtual_floor_style != VirtualFloorStyles::Off)
     {
         virtual_floor_set_height(gSceneryPlaceZ);
     }
 
-    *outPrimaryColour = gWindowSceneryPrimaryColour;
     *outEdges = edge;
 }
 
 static void sub_6E1F34_large_scenery(
-    const ScreenCoordsXY& sourceScreenPos, ObjectEntryIndex sceneryIndex, CoordsXY& gridPos, colour_t* outPrimaryColour,
-    colour_t* outSecondaryColour, Direction* outDirection)
+    const ScreenCoordsXY& sourceScreenPos, ObjectEntryIndex sceneryIndex, CoordsXY& gridPos, Direction* outDirection)
 {
     rct_window* w = window_find_by_class(WC_SCENERY);
 
@@ -1641,8 +1627,6 @@ static void sub_6E1F34_large_scenery(
         virtual_floor_set_height(gSceneryPlaceZ);
     }
 
-    *outPrimaryColour = gWindowSceneryPrimaryColour;
-    *outSecondaryColour = gWindowScenerySecondaryColour;
     *outDirection = rotation;
 }
 
@@ -1728,11 +1712,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
         case SCENERY_TYPE_SMALL:
         {
             uint8_t quadrant;
-            colour_t primaryColour;
-            colour_t secondaryColour;
             Direction rotation;
-            sub_6E1F34_small_scenery(
-                windowPos, selectedScenery, gridPos, &quadrant, &primaryColour, &secondaryColour, &rotation);
+            sub_6E1F34_small_scenery(windowPos, selectedScenery, gridPos, &quadrant, &rotation);
             if (gridPos.isNull())
                 return;
 
@@ -1803,7 +1784,7 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
                 {
                     auto smallSceneryPlaceAction = SmallSceneryPlaceAction(
                         { cur_grid_x, cur_grid_y, gSceneryPlaceZ, gSceneryPlaceRotation }, quadrant, selectedScenery,
-                        primaryColour, secondaryColour);
+                        gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
                     auto res = GameActions::Query(&smallSceneryPlaceAction);
                     success = res->Error;
                     if (res->Error == GameActions::Status::Ok)
@@ -1826,7 +1807,7 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
                 {
                     auto smallSceneryPlaceAction = SmallSceneryPlaceAction(
                         { cur_grid_x, cur_grid_y, gSceneryPlaceZ, gSceneryPlaceRotation }, quadrant, selectedScenery,
-                        primaryColour, secondaryColour);
+                        gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
 
                     smallSceneryPlaceAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {
                         if (result->Error == GameActions::Status::Ok)
@@ -1870,9 +1851,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
         }
         case SCENERY_TYPE_WALL:
         {
-            colour_t primaryColour;
             uint8_t edges;
-            sub_6E1F34_wall(windowPos, selectedScenery, gridPos, &primaryColour, &edges);
+            sub_6E1F34_wall(windowPos, selectedScenery, gridPos, &edges);
             if (gridPos.isNull())
                 return;
 
@@ -1885,7 +1865,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
             for (; zAttemptRange != 0; zAttemptRange--)
             {
                 auto wallPlaceAction = WallPlaceAction(
-                    selectedScenery, { gridPos, gSceneryPlaceZ }, edges, primaryColour, _secondaryColour, _tertiaryColour);
+                    selectedScenery, { gridPos, gSceneryPlaceZ }, edges, gWindowSceneryPrimaryColour,
+                    gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
 
                 auto res = GameActions::Query(&wallPlaceAction);
                 if (res->Error == GameActions::Status::Ok)
@@ -1908,7 +1889,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
             }
 
             auto wallPlaceAction = WallPlaceAction(
-                selectedScenery, { gridPos, gSceneryPlaceZ }, edges, primaryColour, _secondaryColour, _tertiaryColour);
+                selectedScenery, { gridPos, gSceneryPlaceZ }, edges, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour,
+                gWindowSceneryTertiaryColour);
 
             wallPlaceAction.SetCallback([](const GameAction* ga, const GameActions::Result* result) {
                 if (result->Error == GameActions::Status::Ok)
@@ -1921,10 +1903,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
         }
         case SCENERY_TYPE_LARGE:
         {
-            colour_t primaryColour;
-            colour_t secondaryColour;
             Direction direction;
-            sub_6E1F34_large_scenery(windowPos, selectedScenery, gridPos, &primaryColour, &secondaryColour, &direction);
+            sub_6E1F34_large_scenery(windowPos, selectedScenery, gridPos, &direction);
             if (gridPos.isNull())
                 return;
 
@@ -1938,7 +1918,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
             {
                 CoordsXYZD loc = { gridPos, gSceneryPlaceZ, direction };
 
-                auto sceneryPlaceAction = LargeSceneryPlaceAction(loc, selectedScenery, primaryColour, secondaryColour);
+                auto sceneryPlaceAction = LargeSceneryPlaceAction(
+                    loc, selectedScenery, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
 
                 auto res = GameActions::Query(&sceneryPlaceAction);
                 if (res->Error == GameActions::Status::Ok)
@@ -1962,7 +1943,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
 
             CoordsXYZD loc = { gridPos, gSceneryPlaceZ, direction };
 
-            auto sceneryPlaceAction = LargeSceneryPlaceAction(loc, selectedScenery, primaryColour, secondaryColour);
+            auto sceneryPlaceAction = LargeSceneryPlaceAction(
+                loc, selectedScenery, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
             sceneryPlaceAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {
                 if (result->Error == GameActions::Status::Ok)
                 {
@@ -2462,13 +2444,13 @@ static void top_toolbar_tool_update_water(const ScreenCoordsXY& screenPos)
  * On failure returns MONEY32_UNDEFINED
  * On success places ghost scenery and returns cost to place proper
  */
-static money32 try_place_ghost_small_scenery(
-    CoordsXYZD loc, uint8_t quadrant, ObjectEntryIndex entryIndex, colour_t primaryColour, colour_t secondaryColour)
+static money32 try_place_ghost_small_scenery(CoordsXYZD loc, uint8_t quadrant, ObjectEntryIndex entryIndex)
 {
     scenery_remove_ghost_tool_placement();
 
     // 6e252b
-    auto smallSceneryPlaceAction = SmallSceneryPlaceAction(loc, quadrant, entryIndex, primaryColour, secondaryColour);
+    auto smallSceneryPlaceAction = SmallSceneryPlaceAction(
+        loc, quadrant, entryIndex, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
     smallSceneryPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
     auto res = GameActions::Execute(&smallSceneryPlaceAction);
     auto sspar = dynamic_cast<SmallSceneryPlaceActionResult*>(res.get());
@@ -2519,12 +2501,13 @@ static money32 try_place_ghost_path_addition(CoordsXYZ loc, ObjectEntryIndex ent
     return res->Cost;
 }
 
-static money32 try_place_ghost_wall(CoordsXYZ loc, uint8_t edge, ObjectEntryIndex entryIndex, colour_t primaryColour)
+static money32 try_place_ghost_wall(CoordsXYZ loc, uint8_t edge, ObjectEntryIndex entryIndex)
 {
     scenery_remove_ghost_tool_placement();
 
     // 6e26b0
-    auto wallPlaceAction = WallPlaceAction(entryIndex, loc, edge, primaryColour, _secondaryColour, _tertiaryColour);
+    auto wallPlaceAction = WallPlaceAction(
+        entryIndex, loc, edge, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
     wallPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND);
     wallPlaceAction.SetCallback([=](const GameAction* ga, const WallPlaceActionResult* result) {
         if (result->Error != GameActions::Status::Ok)
@@ -2543,13 +2526,13 @@ static money32 try_place_ghost_wall(CoordsXYZ loc, uint8_t edge, ObjectEntryInde
     return res->Cost;
 }
 
-static money32 try_place_ghost_large_scenery(
-    CoordsXYZD loc, ObjectEntryIndex entryIndex, colour_t primaryColour, colour_t secondaryColour)
+static money32 try_place_ghost_large_scenery(CoordsXYZD loc, ObjectEntryIndex entryIndex)
 {
     scenery_remove_ghost_tool_placement();
 
     // 6e25a7
-    auto sceneryPlaceAction = LargeSceneryPlaceAction(loc, entryIndex, primaryColour, secondaryColour);
+    auto sceneryPlaceAction = LargeSceneryPlaceAction(
+        loc, entryIndex, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
     sceneryPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND);
     auto res = GameActions::Execute(&sceneryPlaceAction);
     auto lspar = dynamic_cast<LargeSceneryPlaceActionResult*>(res.get());
@@ -2639,11 +2622,9 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
         {
             CoordsXY mapTile = {};
             uint8_t quadrant;
-            colour_t primaryColour, secondaryColour;
             Direction rotation;
 
-            sub_6E1F34_small_scenery(
-                screenPos, selection.EntryIndex, mapTile, &quadrant, &primaryColour, &secondaryColour, &rotation);
+            sub_6E1F34_small_scenery(screenPos, selection.EntryIndex, mapTile, &quadrant, &rotation);
 
             if (mapTile.isNull())
             {
@@ -2704,8 +2685,7 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
 
             for (; attemptsLeft != 0; attemptsLeft--)
             {
-                cost = try_place_ghost_small_scenery(
-                    { mapTile, gSceneryPlaceZ, rotation }, quadrant, selection.EntryIndex, primaryColour, secondaryColour);
+                cost = try_place_ghost_small_scenery({ mapTile, gSceneryPlaceZ, rotation }, quadrant, selection.EntryIndex);
 
                 if (cost != MONEY32_UNDEFINED)
                     break;
@@ -2753,10 +2733,9 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
         case SCENERY_TYPE_WALL:
         {
             CoordsXY mapTile = {};
-            colour_t primaryColour;
             uint8_t edge;
 
-            sub_6E1F34_wall(screenPos, selection.EntryIndex, mapTile, &primaryColour, &edge);
+            sub_6E1F34_wall(screenPos, selection.EntryIndex, mapTile, &edge);
 
             if (mapTile.isNull())
             {
@@ -2794,7 +2773,7 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
             cost = 0;
             for (; attemptsLeft != 0; attemptsLeft--)
             {
-                cost = try_place_ghost_wall({ mapTile, gSceneryPlaceZ }, edge, selection.EntryIndex, primaryColour);
+                cost = try_place_ghost_wall({ mapTile, gSceneryPlaceZ }, edge, selection.EntryIndex);
 
                 if (cost != MONEY32_UNDEFINED)
                     break;
@@ -2807,10 +2786,9 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
         case SCENERY_TYPE_LARGE:
         {
             CoordsXY mapTile = {};
-            colour_t primaryColour, secondaryColour;
             Direction direction;
 
-            sub_6E1F34_large_scenery(screenPos, selection.EntryIndex, mapTile, &primaryColour, &secondaryColour, &direction);
+            sub_6E1F34_large_scenery(screenPos, selection.EntryIndex, mapTile, &direction);
 
             if (mapTile.isNull())
             {
@@ -2859,8 +2837,7 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
             cost = 0;
             for (; attemptsLeft != 0; attemptsLeft--)
             {
-                cost = try_place_ghost_large_scenery(
-                    { mapTile, gSceneryPlaceZ, direction }, selection.EntryIndex, primaryColour, secondaryColour);
+                cost = try_place_ghost_large_scenery({ mapTile, gSceneryPlaceZ, direction }, selection.EntryIndex);
 
                 if (cost != MONEY32_UNDEFINED)
                     break;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -2444,13 +2444,13 @@ static void top_toolbar_tool_update_water(const ScreenCoordsXY& screenPos)
  * On failure returns MONEY32_UNDEFINED
  * On success places ghost scenery and returns cost to place proper
  */
-static money32 try_place_ghost_small_scenery(CoordsXYZD loc, uint8_t quadrant, ObjectEntryIndex entryIndex)
+static money32 try_place_ghost_small_scenery(
+    CoordsXYZD loc, uint8_t quadrant, ObjectEntryIndex entryIndex, colour_t primaryColour, colour_t secondaryColour)
 {
     scenery_remove_ghost_tool_placement();
 
     // 6e252b
-    auto smallSceneryPlaceAction = SmallSceneryPlaceAction(
-        loc, quadrant, entryIndex, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
+    auto smallSceneryPlaceAction = SmallSceneryPlaceAction(loc, quadrant, entryIndex, primaryColour, secondaryColour);
     smallSceneryPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
     auto res = GameActions::Execute(&smallSceneryPlaceAction);
     auto sspar = dynamic_cast<SmallSceneryPlaceActionResult*>(res.get());
@@ -2501,13 +2501,14 @@ static money32 try_place_ghost_path_addition(CoordsXYZ loc, ObjectEntryIndex ent
     return res->Cost;
 }
 
-static money32 try_place_ghost_wall(CoordsXYZ loc, uint8_t edge, ObjectEntryIndex entryIndex)
+static money32 try_place_ghost_wall(
+    CoordsXYZ loc, uint8_t edge, ObjectEntryIndex entryIndex, colour_t primaryColour, colour_t secondaryColour,
+    colour_t tertiaryColour)
 {
     scenery_remove_ghost_tool_placement();
 
     // 6e26b0
-    auto wallPlaceAction = WallPlaceAction(
-        entryIndex, loc, edge, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
+    auto wallPlaceAction = WallPlaceAction(entryIndex, loc, edge, primaryColour, secondaryColour, tertiaryColour);
     wallPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND);
     wallPlaceAction.SetCallback([=](const GameAction* ga, const WallPlaceActionResult* result) {
         if (result->Error != GameActions::Status::Ok)
@@ -2526,13 +2527,13 @@ static money32 try_place_ghost_wall(CoordsXYZ loc, uint8_t edge, ObjectEntryInde
     return res->Cost;
 }
 
-static money32 try_place_ghost_large_scenery(CoordsXYZD loc, ObjectEntryIndex entryIndex)
+static money32 try_place_ghost_large_scenery(
+    CoordsXYZD loc, ObjectEntryIndex entryIndex, colour_t primaryColour, colour_t secondaryColour)
 {
     scenery_remove_ghost_tool_placement();
 
     // 6e25a7
-    auto sceneryPlaceAction = LargeSceneryPlaceAction(
-        loc, entryIndex, gWindowSceneryPrimaryColour, gWindowScenerySecondaryColour);
+    auto sceneryPlaceAction = LargeSceneryPlaceAction(loc, entryIndex, primaryColour, secondaryColour);
     sceneryPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND);
     auto res = GameActions::Execute(&sceneryPlaceAction);
     auto lspar = dynamic_cast<LargeSceneryPlaceActionResult*>(res.get());
@@ -2685,7 +2686,9 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
 
             for (; attemptsLeft != 0; attemptsLeft--)
             {
-                cost = try_place_ghost_small_scenery({ mapTile, gSceneryPlaceZ, rotation }, quadrant, selection.EntryIndex);
+                cost = try_place_ghost_small_scenery(
+                    { mapTile, gSceneryPlaceZ, rotation }, quadrant, selection.EntryIndex, gWindowSceneryPrimaryColour,
+                    gWindowScenerySecondaryColour);
 
                 if (cost != MONEY32_UNDEFINED)
                     break;
@@ -2773,7 +2776,9 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
             cost = 0;
             for (; attemptsLeft != 0; attemptsLeft--)
             {
-                cost = try_place_ghost_wall({ mapTile, gSceneryPlaceZ }, edge, selection.EntryIndex);
+                cost = try_place_ghost_wall(
+                    { mapTile, gSceneryPlaceZ }, edge, selection.EntryIndex, gWindowSceneryPrimaryColour,
+                    gWindowScenerySecondaryColour, gWindowSceneryTertiaryColour);
 
                 if (cost != MONEY32_UNDEFINED)
                     break;
@@ -2837,7 +2842,9 @@ static void top_toolbar_tool_update_scenery(const ScreenCoordsXY& screenPos)
             cost = 0;
             for (; attemptsLeft != 0; attemptsLeft--)
             {
-                cost = try_place_ghost_large_scenery({ mapTile, gSceneryPlaceZ, direction }, selection.EntryIndex);
+                cost = try_place_ghost_large_scenery(
+                    { mapTile, gSceneryPlaceZ, direction }, selection.EntryIndex, gWindowSceneryPrimaryColour,
+                    gWindowScenerySecondaryColour);
 
                 if (cost != MONEY32_UNDEFINED)
                     break;


### PR DESCRIPTION
I also removed the _secondaryColour and _tertiaryColour variables. I don't think we had a need for them they seemed to just match the global values.