### PR TITLE
Create ObjectEntryDescriptor to properly handle mixed DAT and JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ set(CMAKE_MACOSX_RPATH 1)
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 
-set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip")
-set(OBJECTS_SHA1 "4a3c32a0251c3babe014844f2c683fc32138b3f2")
+set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip")
+set(OBJECTS_SHA1 "151424d24b1d49a167932b58319bedaa6ec368e9")
 
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.22/replays.zip")
 set(REPLAYS_SHA1 "7591db0a3842a7ac44fcbfbff9a573c9cb3ddc56")

--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -3908,7 +3908,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "version=\"1.0.18\"\nzipname=\"objects.zip\"\nliburl=\"https://github.com/OpenRCT2/objects/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/object\" || ! -e \"${SRCROOT}/objectsversion\" || $(head -n 1 \"${SRCROOT}/objectsversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/object\" ]]; then rm -r \"${SRCROOT}/data/object\"; fi\nmkdir -p \"${SRCROOT}/data/object\"\n\ncurl -L -o \"${SRCROOT}/data/object/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/object\" \"${SRCROOT}/data/object/$zipname\"\nrm \"${SRCROOT}/data/object/$zipname\"\n\necho $version > \"${SRCROOT}/objectsversion\"\nfi";
+			shellScript = "version=\"1.0.20\"\nzipname=\"objects.zip\"\nliburl=\"https://github.com/OpenRCT2/objects/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/object\" || ! -e \"${SRCROOT}/objectsversion\" || $(head -n 1 \"${SRCROOT}/objectsversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/object\" ]]; then rm -r \"${SRCROOT}/data/object\"; fi\nmkdir -p \"${SRCROOT}/data/object\"\n\ncurl -L -o \"${SRCROOT}/data/object/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/object\" \"${SRCROOT}/data/object/$zipname\"\nrm \"${SRCROOT}/data/object/$zipname\"\n\necho $version > \"${SRCROOT}/objectsversion\"\nfi";
 		};
 		C68B2D471EC790710020651C /* Download Libraries */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -46,8 +46,8 @@
     <GtestSha1>058b9df80244c03f1633cb06e9f70471a29ebb8e</GtestSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.18/objects.zip</ObjectsUrl>
-    <ObjectsSha1>4a3c32a0251c3babe014844f2c683fc32138b3f2</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip</ObjectsUrl>
+    <ObjectsSha1>151424d24b1d49a167932b58319bedaa6ec368e9</ObjectsSha1>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.22/replays.zip</ReplaysUrl>
     <ReplaysSha1>7591db0a3842a7ac44fcbfbff9a573c9cb3ddc56</ReplaysSha1>
   </PropertyGroup>

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,8 @@ let
   objects-src = pkgs.fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.0.18";
-    sha256 = "bf8a28b7ccebaf58e4e9eb2540534632830534cf0b3f73677521dc555878c682";
+    rev = "v1.0.20";
+    sha256 = "bc266ef589c60302105473499ac142dbf951847be15e65b692d165ce261aeae0";
   };
 
   title-sequences-src = pkgs.fetchFromGitHub {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -455,7 +455,7 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
         {
             for (const auto& sgEntry : item->SceneryGroupInfo.Entries)
             {
-                window_editor_object_selection_select_object(++isMasterObject, flags, &sgEntry);
+                window_editor_object_selection_select_object(++isMasterObject, flags, sgEntry);
             }
         }
 
@@ -494,7 +494,7 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
         {
             for (const auto& sgEntry : item->SceneryGroupInfo.Entries)
             {
-                if (!window_editor_object_selection_select_object(++isMasterObject, flags, &sgEntry))
+                if (!window_editor_object_selection_select_object(++isMasterObject, flags, sgEntry))
                 {
                     _maxObjectsWasHit = true;
                 }
@@ -535,6 +535,14 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
 {
     const ObjectRepositoryItem* item = object_repository_find_object_by_entry(entry);
     return window_editor_object_selection_select_object(isMasterObject, flags, item);
+}
+
+bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, const ObjectEntryDescriptor& entry)
+{
+    if (entry.Generation == ObjectGeneration::DAT)
+        return window_editor_object_selection_select_object(isMasterObject, flags, &entry.Entry);
+
+    return window_editor_object_selection_select_object(isMasterObject, flags, entry.Identifier);
 }
 
 bool editor_check_object_group_at_least_one_selected(ObjectType checkObjectType)

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -36,6 +36,7 @@ void finish_object_selection();
 bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, const ObjectRepositoryItem* item);
 bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, std::string_view identifier);
 bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, const rct_object_entry* entry);
+bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, const ObjectEntryDescriptor& entry);
 
 /**
  * Removes all unused objects from the object selection.

--- a/src/openrct2/core/IStream.cpp
+++ b/src/openrct2/core/IStream.cpp
@@ -9,6 +9,7 @@
 
 #include "IStream.hpp"
 
+#include "../object/Object.h"
 #include "Memory.hpp"
 #include "String.hpp"
 
@@ -59,6 +60,24 @@ namespace OpenRCT2
     void IStream::WriteString(const std::string& str)
     {
         WriteString(str.c_str());
+    }
+
+    ObjectEntryDescriptor IStream::ReadObjectEntryDescriptor()
+    {
+        auto generation = ReadValue<ObjectGeneration>();
+        if (generation == ObjectGeneration::DAT)
+            return ObjectEntryDescriptor(ReadValue<rct_object_entry>());
+
+        return ObjectEntryDescriptor(ReadStdString());
+    }
+
+    void IStream::WriteObjectEntryDescriptor(const ObjectEntryDescriptor& oed)
+    {
+        WriteValue<ObjectGeneration>(oed.Generation);
+        if (oed.Generation == ObjectGeneration::DAT)
+            WriteValue<rct_object_entry>(oed.Entry);
+        else
+            WriteString(oed.Identifier);
     }
 
 } // namespace OpenRCT2

--- a/src/openrct2/core/IStream.hpp
+++ b/src/openrct2/core/IStream.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../object/Object.h"
 #include "Memory.hpp"
 
 #include <istream>
@@ -206,6 +207,8 @@ namespace OpenRCT2
         std::string ReadStdString();
         void WriteString(const utf8* str);
         void WriteString(const std::string& string);
+        ObjectEntryDescriptor ReadObjectEntryDescriptor();
+        void WriteObjectEntryDescriptor(const ObjectEntryDescriptor& oed);
     };
 
 } // namespace OpenRCT2

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -52,7 +52,7 @@ struct ObjectRepositoryItem
     } RideInfo;
     struct
     {
-        std::vector<rct_object_entry> Entries;
+        std::vector<ObjectEntryDescriptor> Entries;
     } SceneryGroupInfo;
 
     ObjectSourceGame GetFirstSourceGame() const
@@ -75,6 +75,7 @@ struct IObjectRepository
     virtual const ObjectRepositoryItem* FindObjectLegacy(const std::string_view& legacyIdentifier) const abstract;
     virtual const ObjectRepositoryItem* FindObject(std::string_view identifier) const abstract;
     virtual const ObjectRepositoryItem* FindObject(const rct_object_entry* objectEntry) const abstract;
+    virtual const ObjectRepositoryItem* FindObject(const ObjectEntryDescriptor& oed) const abstract;
 
     virtual std::unique_ptr<Object> LoadObject(const ObjectRepositoryItem* ori) abstract;
     virtual void RegisterLoadedObject(const ObjectRepositoryItem* ori, Object* object) abstract;

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -75,7 +75,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
     _legacyType.entry_count = 0;
     for (const auto& objectEntry : _items)
     {
-        auto ori = objectRepository.FindObject(&objectEntry);
+        auto ori = objectRepository.FindObject(objectEntry);
         if (ori == nullptr)
             continue;
         if (ori->LoadedObject == nullptr)
@@ -98,14 +98,14 @@ void SceneryGroupObject::SetRepositoryItem(ObjectRepositoryItem* item) const
     item->SceneryGroupInfo.Entries = _items;
 }
 
-std::vector<rct_object_entry> SceneryGroupObject::ReadItems(IStream* stream)
+std::vector<ObjectEntryDescriptor> SceneryGroupObject::ReadItems(IStream* stream)
 {
-    auto items = std::vector<rct_object_entry>();
+    auto items = std::vector<ObjectEntryDescriptor>();
     while (stream->ReadValue<uint8_t>() != 0xFF)
     {
         stream->Seek(-1, STREAM_SEEK_CURRENT);
         auto entry = stream->ReadValue<rct_object_entry>();
-        items.push_back(entry);
+        items.push_back(ObjectEntryDescriptor(entry));
     }
     return items;
 }
@@ -166,13 +166,13 @@ EntertainerCostume SceneryGroupObject::ParseEntertainerCostume(const std::string
     return EntertainerCostume::Panda;
 }
 
-std::vector<rct_object_entry> SceneryGroupObject::ReadJsonEntries(json_t& jEntries)
+std::vector<ObjectEntryDescriptor> SceneryGroupObject::ReadJsonEntries(json_t& jEntries)
 {
-    std::vector<rct_object_entry> entries;
+    std::vector<ObjectEntryDescriptor> entries;
 
     for (auto& jEntry : jEntries)
     {
-        auto entry = ParseObjectEntry(Json::GetString(jEntry));
+        auto entry = ObjectEntryDescriptor(Json::GetString(jEntry));
         entries.push_back(entry);
     }
     return entries;

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -22,7 +22,7 @@ class SceneryGroupObject final : public Object
 {
 private:
     rct_scenery_group_entry _legacyType = {};
-    std::vector<rct_object_entry> _items;
+    std::vector<ObjectEntryDescriptor> _items;
 
 public:
     explicit SceneryGroupObject(const rct_object_entry& entry)
@@ -46,8 +46,8 @@ public:
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 
 private:
-    static std::vector<rct_object_entry> ReadItems(OpenRCT2::IStream* stream);
+    static std::vector<ObjectEntryDescriptor> ReadItems(OpenRCT2::IStream* stream);
     static uint32_t ReadJsonEntertainerCostumes(json_t& jCostumes);
     static EntertainerCostume ParseEntertainerCostume(const std::string& s);
-    static std::vector<rct_object_entry> ReadJsonEntries(json_t& jEntries);
+    static std::vector<ObjectEntryDescriptor> ReadJsonEntries(json_t& jEntries);
 };


### PR DESCRIPTION
ObjectEntryDescriptor contains an enum to tell whether the object is DAT or JSON, along with either a DAT header or JSON identifier.

In this PR, it is used for the list of objects in a scenery group. It is also useful for the new save format, allowing it to reference both old and new objects and allowing for a smooth transition from .DAT objects to JSON objects.