### PR TITLE
Fix #13517: Bad formatting of chat messages

### DIFF
--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -42,6 +42,5 @@ void chat_history_add(const char* src);
 void chat_input(ChatInput input);
 
 int32_t chat_string_wrapped_get_height(void* args, int32_t width);
-int32_t chat_history_draw_string(rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& screenCoords, int32_t width);
 
 #endif

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
* Bump network version which was the main cause of the problem.
* Ensure each chat line starts with some format codes.