### PR TITLE
Fix #13527: Read access violation in format_string

### DIFF
--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -588,7 +588,10 @@ namespace OpenRCT2
             case FormatToken::String:
                 if constexpr (std::is_same<T, const char*>())
                 {
-                    ss << arg;
+                    if (arg != nullptr)
+                    {
+                        ss << arg;
+                    }
                 }
                 else if constexpr (std::is_same<T, const std::string&>())
                 {


### PR DESCRIPTION
The issues all look like they are due to RCT1 path being nullptr.