### PR TITLE
Implement #13384: Expose all TileElement data to plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#13057] Make GameAction flags accessible by plugins.
 - Feature: [#13078] [Plugin] Add colour picker widget.
 - Feature: [#13376] Open custom window at specified tab.
+- Feature: [#13384] [Plugin] Expose all TileElement data.
 - Feature: [#13398] Add pause button to the Track Designer.
 - Feature: [#13495] [Plugin] Add properties for park value, guests and company value.
 - Feature: [#13509] [Plugin] Add ability to format strings using OpenRCT2 string framework.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -540,8 +540,11 @@ declare global {
     interface BaseTileElement {
         type: TileElementType;
         baseHeight: number;
+        baseZ: number;
         clearanceHeight: number;
+        clearanceZ: number;
         occupiedQuadrants: number;
+        isGhost: boolean;
         isHidden: boolean; /** Take caution when changing this field, it may invalidate TileElements you have stored in your script. */
     }
 
@@ -559,65 +562,87 @@ declare global {
     }
 
     interface FootpathElement extends BaseTileElement {
-        footpathType: number;
-        edgesAndCorners: number;
+        object: number;
+
+        edges: number;
+        corners: number;
         slopeDirection: number | null;
         isBlockedByVehicle: boolean;
         isWide: boolean;
 
         isQueue: boolean;
         queueBannerDirection: number | null;
-        ride: number;
-        station: number;
+        ride: number | null;
+        station: number | null;
 
         addition: number | null;
-        isAdditionBroken: boolean;
-
-        direction: Direction;
+        additionStatus: number | null;
+        isAdditionBroken: boolean | null;
+        isAdditionGhost: boolean | null;
     }
 
     interface TrackElement extends BaseTileElement {
-        trackType: number;
-        sequence: number;
-        ride: number;
-        station: number;
-        hasChainLift: boolean;
         direction: Direction;
+        trackType: number;
+        sequence: number | null;
+        mazeEntry: number | null;
+
+        colourScheme: number | null;
+        seatRotation: number | null;
+
+        ride: number;
+        station: number | null;
+
+        brakeBoosterSpeed: number | null;
+        hasChainLift: boolean;
+        isInverted: boolean;
+        hasCableLift: boolean;
     }
 
     interface SmallSceneryElement extends BaseTileElement {
+        direction: Direction;
         object: number;
         primaryColour: number;
         secondaryColour: number;
-        direction: Direction;
         quadrant: number;
-    }
-
-    interface EntranceElement extends BaseTileElement {
-        object: number;
-        sequence: number;
-        ride: number;
-        station: number;
+        age: number;
     }
 
     interface WallElement extends BaseTileElement {
-        object: number;
         direction: Direction;
-    }
-
-    interface LargeSceneryElement extends BaseTileElement {
         object: number;
         primaryColour: number;
         secondaryColour: number;
+        tertiaryColour: number;
+        bannerIndex: number | null;
+        slope: Direction;
+    }
+
+    interface EntranceElement extends BaseTileElement {
+        direction: Direction;
+        object: number;
+        ride: number;
+        station: number;
+        sequence: number;
+        footpathObject: number;
+    }
+
+    interface LargeSceneryElement extends BaseTileElement {
+        direction: Direction;
+        object: number;
+        primaryColour: number;
+        secondaryColour: number;
+        bannerIndex: number | null;
+        sequence: number;
     }
 
     interface BannerElement extends BaseTileElement {
+        direction: Direction;
+        bannerIndex: number;
     }
 
     interface CorruptElement extends BaseTileElement {
     }
-
-    type TileElement = SurfaceElement | FootpathElement | TrackElement;
 
     /**
      * Represents a tile containing tile elements on the map. This is a fixed handle
@@ -629,7 +654,7 @@ declare global {
         /** The y position in tiles. */
         readonly y: number;
         /** Gets an array of all the tile elements on this tile. */
-        readonly elements: TileElement[];
+        readonly elements: BaseTileElement[];
         /** Gets the number of tile elements on this tile. */
         readonly numElements: number;
         /**
@@ -640,11 +665,11 @@ declare global {
         data: Uint8Array;
 
         /** Gets the tile element at the given index on this tile. */
-        getElement(index: number): TileElement;
+        getElement(index: number): BaseTileElement;
         /** Gets the tile element at the given index on this tile. */
         getElement<T extends BaseTileElement>(index: number): T;
         /** Inserts a new tile element at the given index on this tile. */
-        insertElement(index: number): TileElement;
+        insertElement(index: number): BaseTileElement;
         /** Removes the tile element at the given index from this tile. */
         removeElement(index: number): void;
     }

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -44,7 +44,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 17;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 18;
 
 struct ExpressionStringifier final
 {


### PR DESCRIPTION
#### Adds the following fields:
TileElement.isGhost
TileElement.baseZ (= baseHeight * 8)
TileElement.clearanceZ (= clearanceHeight * 8)
Footpath.edges
Footpath.corners
Track.mazeEntry
Track.colourScheme
Track.seatRotation
Track.brakeBoosterSpeed ( = stored value * 2)
Track.isInverted
Track.hasCableLift
Wall.slope
Wall.primaryColour
Wall.secondaryColour
Wall.tertiaryColour
Wall.bannerIndex
LargeScenery.bannerIndex
LargeScenery.sequence
Banner.bannerIndex
Banner.direction

#### Removes the following fields:
Footpath.edgesAndCorners (replaced by Footpath.edges and Footpath.corners)
Footpath.railings (unused)
Footpath.direction (unused)

#### Changes to openrct2.d.ts
- adds/removes above fields
- removes FootpathElement->footpathType (unused / mistake?)
- adds nullable types where needed
- removes type TileElement (wrongly used and superfluous / mistake?)

#### Other changes:
- API returns null values for all fields that do not make sense for that element, e.g. corners for Walls.
- Banner.position is merged into TileElement.direction, as they have the same semantic meaning. (Note that above this change only affect the plugin API and nothing else.)
- Increased API version.