### PR TITLE
Fix #13552: Highscore crash

### DIFF
--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -129,7 +129,7 @@ class ScenarioFileIndex final : public FileIndex<scenario_index_entry>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x58444953; // SIDX
-    static constexpr uint16_t VERSION = 4;
+    static constexpr uint16_t VERSION = 5;
     static constexpr auto PATTERN = "*.sc4;*.sc6;*.sea";
 
 public:

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -40,7 +40,7 @@ struct scenario_index_entry
     uint8_t objective_arg_1;
     int32_t objective_arg_2;
     int16_t objective_arg_3;
-    scenario_highscore_entry* highscore;
+    scenario_highscore_entry* highscore = nullptr;
 
     utf8 internal_name[64]; // Untranslated name
     utf8 name[64];          // Translated name


### PR DESCRIPTION
Fix #13552, #13547, #13546, #13545. #13544: Incorrect value for highscore pointer

This was causing an invalid pointer dereference