### PR TITLE
[WIP] macOS cmake updates for OpenRCT2.app target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,12 @@ if (CCache_FOUND)
     endif (OPENRCT2_USE_CCACHE)
 endif (CCache_FOUND)
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+if (APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+    include_directories(${CMAKE_SOURCE_DIR}/libxc/inc)
+    link_directories(${CMAKE_SOURCE_DIR}/libxc/lib)
+endif ()
 
 project(openrct2 CXX)
 
@@ -328,23 +333,6 @@ if (MACOS_BUNDLE)
     endif ()
 
     # TODO: make the above routine a function, use it for objects, title sequences, and languages
-
-    # not yet used, but link against the dylibs (and embed them)
-    message("search dir: ${MACOS_DYLIBS_DIR}")
-    find_library(
-        DYLIB_SDL2
-        libSDL2.dylib
-        PATHS ${MACOS_DYLIBS_DIR}/lib
-        HINTS ${MACOS_DYLIBS_DIR}/lib
-        NO_DEFAULT_PATH
-        NO_PACKAGE_ROOT_PATH
-        NO_CMAKE_PATH
-        NO_CMAKE_ENVIRONMENT_PATH
-        NO_CMAKE_SYSTEM_PATH
-        NO_SYSTEM_ENVIRONMENT_PATH
-        REQUIRED
-    )
-    message("Found libsdl2.dylib: ${DYLIB_SDL2}")
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,8 @@ if (MINGW)
 endif ()
 
 option(DISABLE_GUI "Don't build GUI. (Headless only.)")
-
+CMAKE_DEPENDENT_OPTION(MACOS_BUNDLE "Build macOS application bundle (OpenRCT2.app)" ON
+    "APPLE; NOT DISABLE_GUI" OFF)
 if (FORCE32)
     set(TARGET_M "-m32")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TARGET_M}")
@@ -297,7 +298,7 @@ if (MINGW)
 endif ()
 
 # if we'll build a macOS app bundle, we need to pull dependencies
-if (NOT DISABLE_GUI AND APPLE)
+if (MACOS_BUNDLE)
     # update dylibs
     set(MACOS_DYLIBS_VERSION "26")
     set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v26-x64-macos-dylibs.zip")
@@ -451,89 +452,3 @@ if (NOT DISABLE_GUI)
 endif()
 install(FILES "distribution/linux/openrct2-mimeinfo.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages/" RENAME "openrct2.xml")
 install(DIRECTORY "distribution/man/" DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" FILES_MATCHING PATTERN "*.6")
-
-if(NOT DISABLE_GUI AND APPLE)
-    set(OUTPUT_NAME "OpenRCT2")
-    set(MACOS_APP_NAME "${OUTPUT_NAME}.app")
-    set(BUNDLE_FRAMEWORK_DIR "${MACOS_APP_NAME}/Contents/Frameworks")
-    set(BUNDLE_RESOURCE_DIR "${MACOS_APP_NAME}/Contents/Resources")
-    set(SOURCE_DATA_DIR "${ROOT_DIR}/data")
-    set(SOURCE_ICON_DIR "${ROOT_DIR}/resources/logo")
-    set(ICON_TARGET "${ROOT_DIR}/distribution/macos/Assets.xcassets")
-    set(ICON_OUTPUT "${ICON_TARGET}/AppIcon.iconset")
-    file(GLOB SOURCE_ICON_DIR "${SOURCE_ICON_DIR}/*.png")
-    file(COPY ${SOURCE_ICON_DIR} DESTINATION "${ICON_OUTPUT}")
-    add_custom_command(OUTPUT
-        ${ICON_TARGET}/AppIcon.icns
-        COMMAND iconutil -c icns AppIcon.iconset
-        WORKING_DIRECTORY ${ICON_TARGET})
-
-    target_sources(${PROJECT} PRIVATE ${ICON_TARGET})
-    set_source_files_properties(${ICON_TARGET} PROPERTIES
-        MACOSX_PACKAGE_LOCATION Resources
-    )
-
-    # execute_process(COMMAND xcrun --show-sdk-path 
-    #     OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
-    #     OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    # Add distribution sources
-    target_sources(${PROJECT}
-        PUBLIC distribution/readme.txt
-        PUBLIC distribution/changelog.txt
-        PUBLIC g2.dat
-        PUBLIC ${ICON_OUTPUT}
-        PUBLIC ${SOURCE_DATA_DIR}/language
-        PUBLIC ${SOURCE_DATA_DIR}/object
-        PUBLIC ${SOURCE_DATA_DIR}/sequence
-        )
-    if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
-        target_sources(${PROJECT} PRIVATE ${ICON_TARGET}/AppIcon.icns)
-        set_source_files_properties(${ICON_TARGET}/AppIcon.icns PROPERTIES
-            MACOSX_PACKAGE_LOCATION Resources
-        )
-    endif ()
-
-    # Specify the resources to move to the bundle
-    set(BUNDLE_RESOURCES
-        distribution/readme.txt
-        distribution/changelog.txt
-        g2.dat
-        # ${ICON_OUTPUT}
-        ${SOURCE_DATA_DIR}/language
-        ${SOURCE_DATA_DIR}/object
-        ${SOURCE_DATA_DIR}/sequence
-        )
-
-
-    if(${OPENRCT2_BRANCH} EQUAL master)
-        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG}")
-    else()
-        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG} ${OPENRCT2_BRANCH}")
-    endif()
-
-    set(MACOSX_BUNDLE_COPYRIGHT "OpenRCT2 is licensed under the GNU General Public License version 3")
-    set(MACOSX_BUNDLE_ICON_FILE "AppIcon")
-    set(MACOSX_BUNDLE_GUI_IDENTIFIER "io.openrct2.OpenRCT2")
-    set(MACOSX_BUNDLE_BUNDLE_VERSION "${OPENRCT2_COMMIT_SHA1_SHORT}")
-
-    # Copy DYLIBS
-    file(GLOB MACOS_DYLIBS_LIBS "${MACOS_DYLIBS_DIR}/lib/*.dylib")
-    file(MAKE_DIRECTORY "${BUNDLE_FRAMEWORK_DIR}")
-    file(COPY ${MACOS_DYLIBS_LIBS} DESTINATION "${BUNDLE_FRAMEWORK_DIR}")
-
-    # copy data
-    file(COPY ${SOURCE_DATA_DIR}/language DESTINATION "${BUNDLE_RESOURCE_DIR}")
-    file(COPY ${SOURCE_DATA_DIR}/object DESTINATION "${BUNDLE_RESOURCE_DIR}")
-    file(COPY ${SOURCE_DATA_DIR}/sequence DESTINATION "${BUNDLE_RESOURCE_DIR}")
-
-
-    # Create as a bundle
-    set_target_properties(${PROJECT} PROPERTIES
-        MACOSX_BUNDLE ON
-        OUTPUT_NAME ${OUTPUT_NAME}
-        MACOSX_BUNDLE_BUNDLE_NAME ${OUTPUT_NAME}
-        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/Info.plist
-        XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
-        RESOURCE "${BUNDLE_RESOURCES}")
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ if (CCache_FOUND)
     endif (OPENRCT2_USE_CCACHE)
 endif (CCache_FOUND)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+
 project(openrct2 CXX)
 
 include(cmake/platform.cmake)
@@ -294,6 +296,58 @@ if (MINGW)
    add_definitions(-fstack-protector-strong)
 endif ()
 
+# if we'll build a macOS app bundle, we need to pull dependencies
+if (NOT DISABLE_GUI AND APPLE)
+    # update dylibs
+    set(MACOS_DYLIBS_VERSION "26")
+    set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v26-x64-macos-dylibs.zip")
+    set(MACOS_DYLIBS_DIR "${ROOT_DIR}/libxc")
+    set(MACOS_DYLIBS_URL "https://github.com/OpenRCT2/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
+    if (NOT EXISTS ${MACOS_DYLIBS_DIR})
+        set(DOWNLOAD_DYLIBS 1)
+    else ()
+        file(READ "${MACOS_DYLIBS_DIR}/libversion" MACOS_DYLIBS_CACHED_VERSION)
+        if (NOT ${MACOS_DYLIBS_CACHED_VERSION} STREQUAL ${MACOS_DYLIBS_VERSION})
+        message("Cached macOS dylibs out of date")
+        set(DOWNLOAD_DYLIBS 1)
+        endif ()
+    endif ()
+    if (DOWNLOAD_DYLIBS)
+        message("Downloading macOS dylibs")
+        file(DOWNLOAD "${MACOS_DYLIBS_URL}" "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
+        file(ARCHIVE_EXTRACT
+            INPUT "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}"
+            DESTINATION "${MACOS_DYLIBS_DIR}"
+        )
+        file(WRITE
+            "${MACOS_DYLIBS_DIR}/libversion"
+            "${MACOS_DYLIBS_VERSION}"
+        )
+        file(REMOVE "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
+    endif ()
+
+    # TODO: make the above routine a function, use it for objects, title sequences, and languages
+
+    # not yet used, but link against the dylibs (and embed them)
+    message("search dir: ${MACOS_DYLIBS_DIR}")
+    find_library(
+        DYLIB_SDL2
+        libSDL2.dylib
+        PATHS ${MACOS_DYLIBS_DIR}/lib
+        HINTS ${MACOS_DYLIBS_DIR}/lib
+        NO_DEFAULT_PATH
+        NO_PACKAGE_ROOT_PATH
+        NO_CMAKE_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        REQUIRED
+    )
+    message("Found libsdl2.dylib: ${DYLIB_SDL2}")
+
+endif()
+
+
 # Include sub-projects
 include("${ROOT_DIR}/src/openrct2/CMakeLists.txt" NO_POLICY_SCOPE)
 include("${ROOT_DIR}/src/openrct2-cli/CMakeLists.txt" NO_POLICY_SCOPE)
@@ -315,6 +369,7 @@ else ()
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif ()
+add_dependencies(${PROJECT} openrct2-cli)
 add_custom_target(g2 DEPENDS ${PROJECT} g2.dat)
 
 # Include tests
@@ -398,82 +453,29 @@ install(FILES "distribution/linux/openrct2-mimeinfo.xml" DESTINATION "${CMAKE_IN
 install(DIRECTORY "distribution/man/" DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" FILES_MATCHING PATTERN "*.6")
 
 if(NOT DISABLE_GUI AND APPLE)
-    # update dylibs
-    set(MACOS_DYLIBS_VERSION "26")
-    set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v26-x64-macos-dylibs.zip")
-    set(MACOS_DYLIBS_DIR "${ROOT_DIR}/libxc")
-    set(MACOS_DYLIBS_URL "https://github.com/OpenRCT2/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
-    if (NOT EXISTS ${MACOS_DYLIBS_DIR})
-        set(DOWNLOAD_DYLIBS 1)
-    else ()
-        file(READ "${MACOS_DYLIBS_DIR}/libversion" MACOS_DYLIBS_CACHED_VERSION)
-        if (NOT ${MACOS_DYLIBS_CACHED_VERSION} STREQUAL ${MACOS_DYLIBS_VERSION})
-           message("Cached macOS dylibs out of date")
-           set(DOWNLOAD_DYLIBS 1)
-        endif ()
-    endif ()
-    if (DOWNLOAD_DYLIBS)
-        message("Downloading macOS dylibs")
-        file(DOWNLOAD "${MACOS_DYLIBS_URL}" "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
-        file(ARCHIVE_EXTRACT
-            INPUT "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}"
-            DESTINATION "${MACOS_DYLIBS_DIR}"
-        )
-        file(WRITE
-            "${MACOS_DYLIBS_DIR}/libversion"
-            "${MACOS_DYLIBS_VERSION}"
-        )
-        file(REMOVE "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
-    endif ()
-
-    # TODO: make the above routine a function, use it for objects, title sequences, and languages
-
-    # not yet used, but link against the dylibs (and embed them)
-    find_library(
-        DYLIB_SDL2
-        libSDL2.dylib
-        PATH ${MACOS_DYLIBS_DIR}
-        PATH_SUFFIXES lib
-        REQUIRED
-    )
-
-
-    set(BUNDLE_RESOURCE "${PROJECT}.app/Contents/Resources")
+    set(OUTPUT_NAME "OpenRCT2")
+    set(MACOS_APP_NAME "${OUTPUT_NAME}.app")
+    set(BUNDLE_FRAMEWORK_DIR "${MACOS_APP_NAME}/Contents/Frameworks")
+    set(BUNDLE_RESOURCE_DIR "${MACOS_APP_NAME}/Contents/Resources")
     set(SOURCE_DATA_DIR "${ROOT_DIR}/data")
     set(SOURCE_ICON_DIR "${ROOT_DIR}/resources/logo")
     set(ICON_TARGET "${ROOT_DIR}/distribution/macos/Assets.xcassets")
-    set(ICON_OUTPUT "${ICON_TARGET}/AppIcon.appiconset")
-
+    set(ICON_OUTPUT "${ICON_TARGET}/AppIcon.iconset")
+    file(GLOB SOURCE_ICON_DIR "${SOURCE_ICON_DIR}/*.png")
+    file(COPY ${SOURCE_ICON_DIR} DESTINATION "${ICON_OUTPUT}")
     add_custom_command(OUTPUT
-        ${ICON_OUTPUT}/icon_16x16.png
-        ${ICON_OUTPUT}/icon_16x16@2x.png
-        ${ICON_OUTPUT}/icon_32x32.png
-        ${ICON_OUTPUT}/icon_32x32@2x.png
-        ${ICON_OUTPUT}/icon_128x128.png
-        ${ICON_OUTPUT}/icon_128x128@2x.png
-        ${ICON_OUTPUT}/icon_256x256.png
-        ${ICON_OUTPUT}/icon_256x256@2x.png
-        ${ICON_OUTPUT}/icon_512x512.png
-        ${ICON_OUTPUT}/icon_512x512@2x.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x16.png ${ICON_OUTPUT}/icon_16x16.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x32.png ${ICON_OUTPUT}/icon_16x16@2x.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x32.png ${ICON_OUTPUT}/icon_32x32.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x64.png ${ICON_OUTPUT}/icon_32x32@2x.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x128.png ${ICON_OUTPUT}/icon_128x128.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x256.png ${ICON_OUTPUT}/icon_128x128@2x.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x256.png ${ICON_OUTPUT}/icon_256x256.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x512.png ${ICON_OUTPUT}/icon_256x256@2x.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x512.png ${ICON_OUTPUT}/icon_512x512.png
-        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x1024.png ${ICON_OUTPUT}/icon_512x512@2x.png
-        WORKING_DIRECTORY ${SOURCE_ICON_DIR})
+        ${ICON_TARGET}/AppIcon.icns
+        COMMAND iconutil -c icns AppIcon.iconset
+        WORKING_DIRECTORY ${ICON_TARGET})
 
     target_sources(${PROJECT} PRIVATE ${ICON_TARGET})
     set_source_files_properties(${ICON_TARGET} PROPERTIES
         MACOSX_PACKAGE_LOCATION Resources
     )
 
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "macOS 10.13")
-    execute_process(COMMAND ${CMAKE_COMMAND} -E xcrun --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
+    # execute_process(COMMAND xcrun --show-sdk-path 
+    #     OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+    #     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     # Add distribution sources
     target_sources(${PROJECT}
@@ -483,14 +485,21 @@ if(NOT DISABLE_GUI AND APPLE)
         PUBLIC ${ICON_OUTPUT}
         PUBLIC ${SOURCE_DATA_DIR}/language
         PUBLIC ${SOURCE_DATA_DIR}/object
-        PUBLIC ${SOURCE_DATA_DIR}/sequence)
+        PUBLIC ${SOURCE_DATA_DIR}/sequence
+        )
+    if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
+        target_sources(${PROJECT} PRIVATE ${ICON_TARGET}/AppIcon.icns)
+        set_source_files_properties(${ICON_TARGET}/AppIcon.icns PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources
+        )
+    endif ()
 
     # Specify the resources to move to the bundle
     set(BUNDLE_RESOURCES
         distribution/readme.txt
         distribution/changelog.txt
         g2.dat
-        ${ICON_OUTPUT}
+        # ${ICON_OUTPUT}
         ${SOURCE_DATA_DIR}/language
         ${SOURCE_DATA_DIR}/object
         ${SOURCE_DATA_DIR}/sequence
@@ -506,12 +515,24 @@ if(NOT DISABLE_GUI AND APPLE)
     set(MACOSX_BUNDLE_COPYRIGHT "OpenRCT2 is licensed under the GNU General Public License version 3")
     set(MACOSX_BUNDLE_ICON_FILE "AppIcon")
     set(MACOSX_BUNDLE_GUI_IDENTIFIER "io.openrct2.OpenRCT2")
-    set(MACOSX_BUNDLE_BUNDLE_NAME "OpenRCT2")
     set(MACOSX_BUNDLE_BUNDLE_VERSION "${OPENRCT2_COMMIT_SHA1_SHORT}")
+
+    # Copy DYLIBS
+    file(GLOB MACOS_DYLIBS_LIBS "${MACOS_DYLIBS_DIR}/lib/*.dylib")
+    file(MAKE_DIRECTORY "${BUNDLE_FRAMEWORK_DIR}")
+    file(COPY ${MACOS_DYLIBS_LIBS} DESTINATION "${BUNDLE_FRAMEWORK_DIR}")
+
+    # copy data
+    file(COPY ${SOURCE_DATA_DIR}/language DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/object DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/sequence DESTINATION "${BUNDLE_RESOURCE_DIR}")
+
 
     # Create as a bundle
     set_target_properties(${PROJECT} PROPERTIES
         MACOSX_BUNDLE ON
+        OUTPUT_NAME ${OUTPUT_NAME}
+        MACOSX_BUNDLE_BUNDLE_NAME ${OUTPUT_NAME}
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/Info.plist
         XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
         RESOURCE "${BUNDLE_RESOURCES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,11 +302,19 @@ if(NOT DISABLE_GUI)
 endif()
 
 # g2
-add_custom_command(
-    OUTPUT g2.dat
-    COMMAND ./openrct2-cli sprite build \"${CMAKE_BINARY_DIR}/g2.dat\" \"${ROOT_DIR}/resources/g2/sprites.json\"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
+if (${CMAKE_GENERATOR} STREQUAL "Xcode")
+    add_custom_command(
+        OUTPUT g2.dat
+        COMMAND "./$(CONFIGURATION)/openrct2-cli" sprite build \"${CMAKE_BINARY_DIR}/g2.dat\" \"${ROOT_DIR}/resources/g2/sprites.json\"
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+else ()
+    add_custom_command(
+        OUTPUT g2.dat
+        COMMAND "./openrct2-cli" sprite build \"${CMAKE_BINARY_DIR}/g2.dat\" \"${ROOT_DIR}/resources/g2/sprites.json\"
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+endif ()
 add_custom_target(g2 DEPENDS ${PROJECT} g2.dat)
 
 # Include tests
@@ -388,3 +396,123 @@ if (NOT DISABLE_GUI)
 endif()
 install(FILES "distribution/linux/openrct2-mimeinfo.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages/" RENAME "openrct2.xml")
 install(DIRECTORY "distribution/man/" DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" FILES_MATCHING PATTERN "*.6")
+
+if(NOT DISABLE_GUI AND APPLE)
+    # update dylibs
+    set(MACOS_DYLIBS_VERSION "26")
+    set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v26-x64-macos-dylibs.zip")
+    set(MACOS_DYLIBS_DIR "${ROOT_DIR}/libxc")
+    set(MACOS_DYLIBS_URL "https://github.com/OpenRCT2/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
+    if (NOT EXISTS ${MACOS_DYLIBS_DIR})
+        set(DOWNLOAD_DYLIBS 1)
+    else ()
+        file(READ "${MACOS_DYLIBS_DIR}/libversion" MACOS_DYLIBS_CACHED_VERSION)
+        if (NOT ${MACOS_DYLIBS_CACHED_VERSION} STREQUAL ${MACOS_DYLIBS_VERSION})
+           message("Cached macOS dylibs out of date")
+           set(DOWNLOAD_DYLIBS 1)
+        endif ()
+    endif ()
+    if (DOWNLOAD_DYLIBS)
+        message("Downloading macOS dylibs")
+        file(DOWNLOAD "${MACOS_DYLIBS_URL}" "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
+        file(ARCHIVE_EXTRACT
+            INPUT "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}"
+            DESTINATION "${MACOS_DYLIBS_DIR}"
+        )
+        file(WRITE
+            "${MACOS_DYLIBS_DIR}/libversion"
+            "${MACOS_DYLIBS_VERSION}"
+        )
+        file(REMOVE "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
+    endif ()
+
+    # TODO: make the above routine a function, use it for objects, title sequences, and languages
+
+    # not yet used, but link against the dylibs (and embed them)
+    find_library(
+        DYLIB_SDL2
+        libSDL2.dylib
+        PATH ${MACOS_DYLIBS_DIR}
+        PATH_SUFFIXES lib
+        REQUIRED
+    )
+
+
+    set(BUNDLE_RESOURCE "${PROJECT}.app/Contents/Resources")
+    set(SOURCE_DATA_DIR "${ROOT_DIR}/data")
+    set(SOURCE_ICON_DIR "${ROOT_DIR}/resources/logo")
+    set(ICON_TARGET "${ROOT_DIR}/distribution/macos/Assets.xcassets")
+    set(ICON_OUTPUT "${ICON_TARGET}/AppIcon.appiconset")
+
+    add_custom_command(OUTPUT
+        ${ICON_OUTPUT}/icon_16x16.png
+        ${ICON_OUTPUT}/icon_16x16@2x.png
+        ${ICON_OUTPUT}/icon_32x32.png
+        ${ICON_OUTPUT}/icon_32x32@2x.png
+        ${ICON_OUTPUT}/icon_128x128.png
+        ${ICON_OUTPUT}/icon_128x128@2x.png
+        ${ICON_OUTPUT}/icon_256x256.png
+        ${ICON_OUTPUT}/icon_256x256@2x.png
+        ${ICON_OUTPUT}/icon_512x512.png
+        ${ICON_OUTPUT}/icon_512x512@2x.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x16.png ${ICON_OUTPUT}/icon_16x16.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x32.png ${ICON_OUTPUT}/icon_16x16@2x.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x32.png ${ICON_OUTPUT}/icon_32x32.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x64.png ${ICON_OUTPUT}/icon_32x32@2x.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x128.png ${ICON_OUTPUT}/icon_128x128.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x256.png ${ICON_OUTPUT}/icon_128x128@2x.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x256.png ${ICON_OUTPUT}/icon_256x256.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x512.png ${ICON_OUTPUT}/icon_256x256@2x.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x512.png ${ICON_OUTPUT}/icon_512x512.png
+        COMMAND cp -r ${SOURCE_ICON_DIR}/icon_x1024.png ${ICON_OUTPUT}/icon_512x512@2x.png
+        WORKING_DIRECTORY ${SOURCE_ICON_DIR})
+
+    target_sources(${PROJECT} PRIVATE ${ICON_TARGET})
+    set_source_files_properties(${ICON_TARGET} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+    )
+
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "macOS 10.13")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E xcrun --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
+
+    # Add distribution sources
+    target_sources(${PROJECT}
+        PUBLIC distribution/readme.txt
+        PUBLIC distribution/changelog.txt
+        PUBLIC g2.dat
+        PUBLIC ${ICON_OUTPUT}
+        PUBLIC ${SOURCE_DATA_DIR}/language
+        PUBLIC ${SOURCE_DATA_DIR}/object
+        PUBLIC ${SOURCE_DATA_DIR}/sequence)
+
+    # Specify the resources to move to the bundle
+    set(BUNDLE_RESOURCES
+        distribution/readme.txt
+        distribution/changelog.txt
+        g2.dat
+        ${ICON_OUTPUT}
+        ${SOURCE_DATA_DIR}/language
+        ${SOURCE_DATA_DIR}/object
+        ${SOURCE_DATA_DIR}/sequence
+        )
+
+
+    if(${OPENRCT2_BRANCH} EQUAL master)
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG}")
+    else()
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG} ${OPENRCT2_BRANCH}")
+    endif()
+
+    set(MACOSX_BUNDLE_COPYRIGHT "OpenRCT2 is licensed under the GNU General Public License version 3")
+    set(MACOSX_BUNDLE_ICON_FILE "AppIcon")
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "io.openrct2.OpenRCT2")
+    set(MACOSX_BUNDLE_BUNDLE_NAME "OpenRCT2")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${OPENRCT2_COMMIT_SHA1_SHORT}")
+
+    # Create as a bundle
+    set_target_properties(${PROJECT} PROPERTIES
+        MACOSX_BUNDLE ON
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/Info.plist
+        XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
+        RESOURCE "${BUNDLE_RESOURCES}")
+endif()

--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -3,13 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
+	<string>${OUTPUT_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -17,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>ORCT</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>OpenRCT2 is licensed under the GNU General Public License version 3</string>
 	<key>CFBundleAllowMixedLocalizations</key>

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -2,7 +2,11 @@
 set -e
 
 # Ensure we are in root directory
-basedir="$(readlink -f `dirname $0`/..)"
+if [[ $(uname) == "Darwin" ]]; then
+    basedir="$(perl -MCwd=abs_path -le 'print abs_path readlink(shift);' `dirname $0`/..)"
+else
+    basedir="$(readlink -f `dirname $0`/..)"
+fi
 cd $basedir/bin
 
 # Scan objects first so that does not happen within a test

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -45,12 +45,8 @@ SET_CHECK_CXX_FLAGS(${PROJECT})
 ipo_set_target_properties(${PROJECT})
 
 message("sdl2 flags ${SDL2_LDFLAGS}")
-if (APPLE)
-    target_link_libraries(${PROJECT} ${MACOS_DYLIBS_DIR}/lib/libSDL2.dylib)
-    # set(SDL2_LDFLAGS "-L${MACOS_DYLIBS_DIR}/lib;-lSDL2")
-else ()
-    target_link_libraries(${PROJECT} ${SDL2_LDFLAGS})
-endif ()
+
+target_link_libraries(${PROJECT} ${SDL2_LDFLAGS})
 target_link_libraries(${PROJECT} "libopenrct2"
                                  ${SPEEX_LDFLAGS})
 target_link_platform_libraries(${PROJECT})
@@ -127,3 +123,132 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     get_target_property(OPENRCT2_INCLUDE_DIRS ${PROJECT} INCLUDE_DIRECTORIES)
     set_target_properties(${PROJECT}-headers-check PROPERTIES INCLUDE_DIRECTORIES "${OPENRCT2_INCLUDE_DIRS}")
 endif ()
+
+if(MACOS_BUNDLE)
+    project(OpenRCT2.app CXX)
+    add_executable(${PROJECT_NAME} ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
+    SET_CHECK_CXX_FLAGS(${PROJECT_NAME})
+    ipo_set_target_properties(${PROJECT_NAME})
+
+    target_link_libraries(${PROJECT_NAME} ${MACOS_DYLIBS_DIR}/lib/libSDL2.dylib)
+    target_link_libraries(${PROJECT_NAME} ${SDL2_LDFLAGS})
+    target_link_libraries(${PROJECT_NAME} "libopenrct2"
+                                     ${SPEEX_LDFLAGS})
+    target_link_platform_libraries(${PROJECT_NAME})
+    
+    if (NOT DISABLE_OPENGL)
+        target_link_libraries(${PROJECT_NAME} ${OPENGL_LIBRARY})
+    endif ()
+    # Defines
+    if (DISABLE_OPENGL)
+        add_definitions(-DDISABLE_OPENGL)
+    else ()
+    # Makes OpenGL function get queried in run-time rather than linked-in
+        add_definitions(-DOPENGL_NO_LINK)
+    endif ()
+    
+    # Includes
+    target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/.."
+                                                  ${SPEEX_INCLUDE_DIRS})
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${SDL2_INCLUDE_DIRS}
+                                                         "${CMAKE_CURRENT_LIST_DIR}/../thirdparty")
+    
+    # Add headers check to verify all headers carry their dependencies.
+    # Only valid for Clang for now:
+    # - GCC 8 does not support -Wno-pragma-once-outside-header
+    # - Other compilers status unknown
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        set(OPENRCT2_HEADERS_CHECK ${OPENRCT2_UI_HEADERS})
+        # OpenGLAPIProc.h is not meant to be included directly.
+        list(REMOVE_ITEM OPENRCT2_HEADERS_CHECK "${CMAKE_CURRENT_LIST_DIR}/drawing/engines/opengl/OpenGLAPIProc.h")
+        add_library(${PROJECT_NAME}-headers-check OBJECT ${OPENRCT2_HEADERS_CHECK})
+        set_target_properties(${PROJECT_NAME}-headers-check PROPERTIES LINKER_LANGUAGE CXX)
+        set_source_files_properties(${OPENRCT2_HEADERS_CHECK} PROPERTIES LANGUAGE CXX)
+        add_definitions("-x c++ -Wno-pragma-once-outside-header -Wno-unused-const-variable")
+        get_target_property(OPENRCT2_INCLUDE_DIRS ${PROJECT_NAME} INCLUDE_DIRECTORIES)
+        set_target_properties(${PROJECT_NAME}-headers-check PROPERTIES INCLUDE_DIRECTORIES "${OPENRCT2_INCLUDE_DIRS}")
+    endif ()
+    set(OUTPUT_NAME "OpenRCT2")
+    set(MACOS_APP_NAME "${OUTPUT_NAME}.app")
+    set(BUNDLE_FRAMEWORK_DIR "${MACOS_APP_NAME}/Contents/Frameworks")
+    set(BUNDLE_RESOURCE_DIR "${MACOS_APP_NAME}/Contents/Resources")
+    set(SOURCE_DATA_DIR "${ROOT_DIR}/data")
+    set(SOURCE_ICON_DIR "${ROOT_DIR}/resources/logo")
+    set(ICON_TARGET "${ROOT_DIR}/distribution/macos/Assets.xcassets")
+    set(ICON_OUTPUT "${ICON_TARGET}/AppIcon.iconset")
+    file(GLOB SOURCE_ICON_DIR "${SOURCE_ICON_DIR}/*.png")
+    file(COPY ${SOURCE_ICON_DIR} DESTINATION "${ICON_OUTPUT}")
+    add_custom_command(OUTPUT
+        ${ICON_TARGET}/AppIcon.icns
+        COMMAND iconutil -c icns AppIcon.iconset
+        WORKING_DIRECTORY ${ICON_TARGET})
+
+    target_sources(${PROJECT_NAME} PRIVATE ${ICON_TARGET})
+    set_source_files_properties(${ICON_TARGET} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources
+    )
+
+    # execute_process(COMMAND xcrun --show-sdk-path 
+    #     OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+    #     OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    # Add distribution sources
+    target_sources(${PROJECT_NAME}
+        PUBLIC distribution/readme.txt
+        PUBLIC distribution/changelog.txt
+        PUBLIC g2.dat
+        PUBLIC ${ICON_OUTPUT}
+        PUBLIC ${SOURCE_DATA_DIR}/language
+        PUBLIC ${SOURCE_DATA_DIR}/object
+        PUBLIC ${SOURCE_DATA_DIR}/sequence
+        )
+    if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
+        target_sources(${PROJECT_NAME} PRIVATE ${ICON_TARGET}/AppIcon.icns)
+        set_source_files_properties(${ICON_TARGET}/AppIcon.icns PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources
+        )
+    endif ()
+
+    # Specify the resources to move to the bundle
+    set(BUNDLE_RESOURCES
+        distribution/readme.txt
+        distribution/changelog.txt
+        g2.dat
+        # ${ICON_OUTPUT}
+        ${SOURCE_DATA_DIR}/language
+        ${SOURCE_DATA_DIR}/object
+        ${SOURCE_DATA_DIR}/sequence
+        )
+
+
+    if(${OPENRCT2_BRANCH} EQUAL master)
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG}")
+    else()
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG} ${OPENRCT2_BRANCH}")
+    endif()
+
+    set(MACOSX_BUNDLE_COPYRIGHT "OpenRCT2 is licensed under the GNU General Public License version 3")
+    set(MACOSX_BUNDLE_ICON_FILE "AppIcon")
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "io.openrct2.OpenRCT2")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${OPENRCT2_COMMIT_SHA1_SHORT}")
+
+    # Copy DYLIBS
+    file(GLOB MACOS_DYLIBS_LIBS "${MACOS_DYLIBS_DIR}/lib/*.dylib")
+    file(MAKE_DIRECTORY "${BUNDLE_FRAMEWORK_DIR}")
+    file(COPY ${MACOS_DYLIBS_LIBS} DESTINATION "${BUNDLE_FRAMEWORK_DIR}")
+
+    # copy data
+    file(COPY ${SOURCE_DATA_DIR}/language DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/object DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/sequence DESTINATION "${BUNDLE_RESOURCE_DIR}")
+
+
+    # Create as a bundle
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE ON
+        OUTPUT_NAME ${OUTPUT_NAME}
+        MACOSX_BUNDLE_BUNDLE_NAME ${OUTPUT_NAME}
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/Info.plist
+        XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
+        RESOURCE "${BUNDLE_RESOURCES}")
+endif()

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -43,12 +43,18 @@ project(${PROJECT} CXX)
 add_executable(${PROJECT} ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
 SET_CHECK_CXX_FLAGS(${PROJECT})
 ipo_set_target_properties(${PROJECT})
+find_library(
+        DYLIB_SPEEXDSP
+        speexdsp
+        PATHS ${MACOS_DYLIBS_DIR}/lib
+        NO_DEFAULT_PATH
+        REQUIRED
+    )
 
-message("sdl2 flags ${SDL2_LDFLAGS}")
-
-target_link_libraries(${PROJECT} ${SDL2_LDFLAGS})
+target_link_libraries(${PROJECT} ${DYLIB_SPEEXDSP})
 target_link_libraries(${PROJECT} "libopenrct2"
-                                 ${SPEEX_LDFLAGS})
+                                 ${SDL2_LDFLAGS})
+                                # ${SPEEX_LDFLAGS})
 target_link_platform_libraries(${PROJECT})
 
 if (NOT DISABLE_OPENGL)
@@ -130,10 +136,25 @@ if(MACOS_BUNDLE)
     SET_CHECK_CXX_FLAGS(${PROJECT_NAME})
     ipo_set_target_properties(${PROJECT_NAME})
 
-    target_link_libraries(${PROJECT_NAME} ${MACOS_DYLIBS_DIR}/lib/libSDL2.dylib)
-    target_link_libraries(${PROJECT_NAME} ${SDL2_LDFLAGS})
-    target_link_libraries(${PROJECT_NAME} "libopenrct2"
-                                     ${SPEEX_LDFLAGS})
+    find_library(
+        DYLIB_SDL2
+        SDL2
+        PATHS ${MACOS_DYLIBS_DIR}/lib
+        NO_DEFAULT_PATH
+        REQUIRED
+    )
+
+    find_library(
+        DYLIB_SPEEXDSP
+        speexdsp
+        PATHS ${MACOS_DYLIBS_DIR}/lib
+        NO_DEFAULT_PATH
+        REQUIRED
+    )
+
+    target_link_libraries(${PROJECT_NAME} ${DYLIB_SDL2})
+    target_link_libraries(${PROJECT_NAME} ${DYLIB_SPEEXDSP})
+    target_link_libraries(${PROJECT_NAME} "libopenrct2")
     target_link_platform_libraries(${PROJECT_NAME})
     
     if (NOT DISABLE_OPENGL)

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -44,10 +44,16 @@ add_executable(${PROJECT} ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
 SET_CHECK_CXX_FLAGS(${PROJECT})
 ipo_set_target_properties(${PROJECT})
 
+
+if (APPLE)
+    target_link_libraries(${PROJECT} ${MACOS_DYLIBS_DIR}/lib/libSDL2.dylib)
+    # set(SDL2_LDFLAGS "-L${MACOS_DYLIBS_DIR}/lib;-lSDL2")
+endif ()
+message("sdl2 flags ${SDL2_LDFLAGS}")
 target_link_libraries(${PROJECT} "libopenrct2"
-                                 ${SDL2_LDFLAGS}
+                                #  ${SDL2_LDFLAGS}
                                  ${SPEEX_LDFLAGS})
-target_link_platform_libraries(${PROJECT})
+# target_link_platform_libraries(${PROJECT})
 
 if (NOT DISABLE_OPENGL)
     if (WIN32)

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -44,16 +44,16 @@ add_executable(${PROJECT} ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
 SET_CHECK_CXX_FLAGS(${PROJECT})
 ipo_set_target_properties(${PROJECT})
 
-
+message("sdl2 flags ${SDL2_LDFLAGS}")
 if (APPLE)
     target_link_libraries(${PROJECT} ${MACOS_DYLIBS_DIR}/lib/libSDL2.dylib)
     # set(SDL2_LDFLAGS "-L${MACOS_DYLIBS_DIR}/lib;-lSDL2")
+else ()
+    target_link_libraries(${PROJECT} ${SDL2_LDFLAGS})
 endif ()
-message("sdl2 flags ${SDL2_LDFLAGS}")
 target_link_libraries(${PROJECT} "libopenrct2"
-                                #  ${SDL2_LDFLAGS}
                                  ${SPEEX_LDFLAGS})
-# target_link_platform_libraries(${PROJECT})
+target_link_platform_libraries(${PROJECT})
 
 if (NOT DISABLE_OPENGL)
     if (WIN32)


### PR DESCRIPTION
Continuing the work started in #8650 and discussion in #13558....

Currently, cmake on macOS will build an executable only (`./openrct2`) while the Xcode project is setup to build `OpenRCT2.app`. This updates the cmake project definition to build `OpenRCT2.app` on macOS instead of the CLI executable. Before this is merged, the app bundle should be fully contained (libraries and required objects/languages/etc).

Yet to do:
- [ ] Reconcile the differences in the dependency (title sequences, objects, etc) management in cmake and the current Xcode project (cmake just checks for directory existence, Xcode tracks specific versions)
- [ ] Move dependency download/unpack to build phase instead of install phase for macOS only (since they need to be bundled into the .app file....or figure out if cmake install phase can end up in the app bundle)
- [ ] Fix library links to use rpath
- [ ] Update CI to use generated Xcode project? Or update to use make directly? Or both!
- [ ] Add tests to the macOS target. If the tests will run on macOS, then they should be used in CI somewhere.

Already done:
- [x] Xcode project generation
- [x] App icon (set properly both in GNU make and Xcode)
- [x] Copying (but not linking) of dependent libraries
- [x] g2.dat generation
- [x] Copying of objects/lanaguages/title sequences (but they currently must already exist in ./data)
- [x] changed minimum macOS target to 10.14 (cmake can only support one version for all targets, so the mix of 10.13 and 10.14 that the current Xcode project has needs to be rounded up.)

### Build methods
Two build methods seem to work (but I haven't tested this in a clean workspace yet):
make:
```
cmake ..
make
```
This will create OpenRCT2.app in the directory the command is run from.

Xcode:
```
cmake -G "Xcode" ..
xcodebuild
```
This generates an Xcode project file from cmake, which can then be used to build. It can also be used for development/editing as well...just run that cmake step when checking out the repo and then open the generated Xcode project. I'll note that the auto-generation does not preserve the directory structure that is set up in the current project, but sources for each target are clearly visible and can be edited. When building, the default configuration is "Debug", so the target is available in Debug/OpenRCT2.app (of course, Release could be specified via the appropriate argument).

### Library linking
Existing Xcode project:
```
❯ otool -L Release/OpenRCT2.app/Contents/MacOS/OpenRCT2
Release/OpenRCT2.app/Contents/MacOS/OpenRCT2:
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1770.106.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	@rpath/libcrypto.dylib (compatibility version 1.1.0, current version 1.1.0)
	@rpath/libduktape.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libicudata.dylib (compatibility version 64.0.0, current version 64.2.0)
	@rpath/libicuuc.dylib (compatibility version 64.0.0, current version 64.2.0)
	@rpath/libpng16.dylib (compatibility version 54.0.0, current version 54.0.0)
	@rpath/libSDL2.dylib (compatibility version 13.0.0, current version 13.0.0)
	@rpath/libfreetype.dylib (compatibility version 24.0.0, current version 24.1.0)
	@rpath/libspeexdsp.dylib (compatibility version 7.0.0, current version 7.1.0)
	@rpath/libzip.dylib (compatibility version 5.0.0, current version 5.1.0)
        ...
```
The libraries from [OpenRCT2/Dependencies](https://github.com/OpenRCT2/Dependencies) are all linked with rpath. By default, the Frameworks folder inside the app bundle is part of the search path (which already has the dylibs copied), as is the standard library directories.

Cmake defaults to linking against the library versions it discovers. Here is a similar excerpt from the current build:
```
otool -L OpenRCT2.app/Contents/MacOS/OpenRCT2
OpenRCT2.app/Contents/MacOS/OpenRCT2:
	@rpath/libSDL2.dylib (compatibility version 13.0.0, current version 13.0.0)
	/usr/local/opt/speexdsp/lib/libspeexdsp.1.dylib (compatibility version 7.0.0, current version 7.1.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
	/usr/local/opt/duktape/lib/libduktape.206.so (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 54.0.0, current version 54.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
       ...
```
Notice that only `libSDL2` was linked with rpath. This PR shows the changes required to accomplish that, although I do want to continue to look for a better way/explore alternatives.

@LRFLEW @Gymnasiast comments/discussion is very welcome.
