### PR TITLE
Move some game actions logic from header to source

### DIFF
--- a/src/openrct2/actions/BalloonPressAction.cpp
+++ b/src/openrct2/actions/BalloonPressAction.cpp
@@ -11,9 +11,19 @@
 
 #include "GameAction.h"
 
+BalloonPressAction::BalloonPressAction(uint16_t spriteIndex)
+    : _spriteIndex(spriteIndex)
+{
+}
+
 void BalloonPressAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("id", _spriteIndex);
+}
+
+uint16_t BalloonPressAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void BalloonPressAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/BalloonPressAction.h
+++ b/src/openrct2/actions/BalloonPressAction.h
@@ -18,16 +18,11 @@ DEFINE_GAME_ACTION(BalloonPressAction, GAME_COMMAND_BALLOON_PRESS, GameActions::
 
 public:
     BalloonPressAction() = default;
-    BalloonPressAction(uint16_t spriteIndex)
-        : _spriteIndex(spriteIndex)
-    {
-    }
+    BalloonPressAction(uint16_t spriteIndex);
+
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/BannerPlaceAction.cpp
@@ -15,12 +15,25 @@
 #include "../world/Scenery.h"
 #include "GameAction.h"
 
+BannerPlaceAction::BannerPlaceAction(const CoordsXYZD& loc, uint8_t bannerType, BannerIndex bannerIndex, uint8_t primaryColour)
+    : _loc(loc)
+    , _bannerType(bannerType)
+    , _bannerIndex(bannerIndex)
+    , _primaryColour(primaryColour)
+{
+}
+
 void BannerPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("object", _bannerType);
     visitor.Visit("primaryColour", _primaryColour);
     _bannerIndex = create_new_banner(0);
+}
+
+uint16_t BannerPlaceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void BannerPlaceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/BannerPlaceAction.h
+++ b/src/openrct2/actions/BannerPlaceAction.h
@@ -21,20 +21,11 @@ private:
 
 public:
     BannerPlaceAction() = default;
-    BannerPlaceAction(const CoordsXYZD& loc, uint8_t bannerType, BannerIndex bannerIndex, uint8_t primaryColour)
-        : _loc(loc)
-        , _bannerType(bannerType)
-        , _bannerIndex(bannerIndex)
-        , _primaryColour(primaryColour)
-    {
-    }
+    BannerPlaceAction(const CoordsXYZD& loc, uint8_t bannerType, BannerIndex bannerIndex, uint8_t primaryColour);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/BannerRemoveAction.cpp
+++ b/src/openrct2/actions/BannerRemoveAction.cpp
@@ -15,9 +15,19 @@
 #include "../world/Scenery.h"
 #include "GameAction.h"
 
+BannerRemoveAction::BannerRemoveAction(const CoordsXYZD& loc)
+    : _loc(loc)
+{
+}
+
 void BannerRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
+}
+
+uint16_t BannerRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void BannerRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/BannerRemoveAction.h
+++ b/src/openrct2/actions/BannerRemoveAction.h
@@ -18,17 +18,11 @@ private:
 
 public:
     BannerRemoveAction() = default;
-    BannerRemoveAction(const CoordsXYZD& loc)
-        : _loc(loc)
-    {
-    }
+    BannerRemoveAction(const CoordsXYZD& loc);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/BannerSetColourAction.cpp
+++ b/src/openrct2/actions/BannerSetColourAction.cpp
@@ -15,10 +15,21 @@
 #include "../world/Banner.h"
 #include "GameAction.h"
 
+BannerSetColourAction::BannerSetColourAction(const CoordsXYZD& loc, uint8_t primaryColour)
+    : _loc(loc)
+    , _primaryColour(primaryColour)
+{
+}
+
 void BannerSetColourAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("primaryColour", _primaryColour);
+}
+
+uint16_t BannerSetColourAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void BannerSetColourAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/BannerSetColourAction.h
+++ b/src/openrct2/actions/BannerSetColourAction.h
@@ -19,19 +19,11 @@ private:
 
 public:
     BannerSetColourAction() = default;
-
-    BannerSetColourAction(const CoordsXYZD& loc, uint8_t primaryColour)
-        : _loc(loc)
-        , _primaryColour(primaryColour)
-    {
-    }
+    BannerSetColourAction(const CoordsXYZD& loc, uint8_t primaryColour);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/BannerSetNameAction.cpp
+++ b/src/openrct2/actions/BannerSetNameAction.cpp
@@ -20,10 +20,21 @@
 #include "../world/Sprite.h"
 #include "GameAction.h"
 
+BannerSetNameAction::BannerSetNameAction(BannerIndex bannerIndex, const std::string& name)
+    : _bannerIndex(bannerIndex)
+    , _name(name)
+{
+}
+
 void BannerSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("id", _bannerIndex);
     visitor.Visit("name", _name);
+}
+
+uint16_t BannerSetNameAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void BannerSetNameAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/BannerSetNameAction.h
+++ b/src/openrct2/actions/BannerSetNameAction.h
@@ -19,18 +19,11 @@ private:
 
 public:
     BannerSetNameAction() = default;
-    BannerSetNameAction(BannerIndex bannerIndex, const std::string& name)
-        : _bannerIndex(bannerIndex)
-        , _name(name)
-    {
-    }
+    BannerSetNameAction(BannerIndex bannerIndex, const std::string& name);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/BannerSetStyleAction.cpp
+++ b/src/openrct2/actions/BannerSetStyleAction.cpp
@@ -16,11 +16,23 @@
 #include "../world/Banner.h"
 #include "GameAction.h"
 
+BannerSetStyleAction::BannerSetStyleAction(BannerSetStyleType type, uint8_t bannerIndex, uint8_t parameter)
+    : _type(type)
+    , _bannerIndex(bannerIndex)
+    , _parameter(parameter)
+{
+}
+
 void BannerSetStyleAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("id", _bannerIndex);
     visitor.Visit("type", _type);
     visitor.Visit("parameter", _parameter);
+}
+
+uint16_t BannerSetStyleAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void BannerSetStyleAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/BannerSetStyleAction.h
+++ b/src/openrct2/actions/BannerSetStyleAction.h
@@ -30,20 +30,11 @@ private:
 
 public:
     BannerSetStyleAction() = default;
-
-    BannerSetStyleAction(BannerSetStyleType type, uint8_t bannerIndex, uint8_t parameter)
-        : _type(type)
-        , _bannerIndex(bannerIndex)
-        , _parameter(parameter)
-    {
-    }
+    BannerSetStyleAction(BannerSetStyleType type, uint8_t bannerIndex, uint8_t parameter);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -24,6 +24,12 @@
 
 #include <algorithm>
 
+ClearAction::ClearAction(MapRange range, ClearableItems itemsToClear)
+    : _range(range)
+    , _itemsToClear(itemsToClear)
+{
+}
+
 void ClearAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
@@ -199,4 +205,30 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
     } while (tileEdited);
 
     return totalCost;
+}
+
+void ClearAction::ResetClearLargeSceneryFlag()
+{
+    // TODO: Improve efficiency of this
+    for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
+    {
+        for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
+        {
+            auto tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+            do
+            {
+                if (tileElement == nullptr)
+                    break;
+                if (tileElement->GetType() == TILE_ELEMENT_TYPE_LARGE_SCENERY)
+                {
+                    tileElement->AsLargeScenery()->SetIsAccounted(false);
+                }
+            } while (!(tileElement++)->IsLastForTile());
+        }
+    }
+}
+
+bool ClearAction::MapCanClearAt(const CoordsXY& location)
+{
+    return (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode || map_is_location_owned_or_has_rights(location);
 }

--- a/src/openrct2/actions/ClearAction.h
+++ b/src/openrct2/actions/ClearAction.h
@@ -32,11 +32,7 @@ private:
 
 public:
     ClearAction() = default;
-    ClearAction(MapRange range, ClearableItems itemsToClear)
-        : _range(range)
-        , _itemsToClear(itemsToClear)
-    {
-    }
+    ClearAction(MapRange range, ClearableItems itemsToClear);
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;
@@ -51,30 +47,7 @@ private:
      * Function to clear the flag that is set to prevent cost duplication
      * when using the clear scenery tool with large scenery.
      */
-    static void ResetClearLargeSceneryFlag()
-    {
-        // TODO: Improve efficiency of this
-        for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
-        {
-            for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
-            {
-                auto tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
-                do
-                {
-                    if (tileElement == nullptr)
-                        break;
-                    if (tileElement->GetType() == TILE_ELEMENT_TYPE_LARGE_SCENERY)
-                    {
-                        tileElement->AsLargeScenery()->SetIsAccounted(false);
-                    }
-                } while (!(tileElement++)->IsLastForTile());
-            }
-        }
-    }
+    static void ResetClearLargeSceneryFlag();
 
-    static bool MapCanClearAt(const CoordsXY& location)
-    {
-        return (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode
-            || map_is_location_owned_or_has_rights(location);
-    }
+    static bool MapCanClearAt(const CoordsXY& location);
 };

--- a/src/openrct2/actions/ClimateSetAction.cpp
+++ b/src/openrct2/actions/ClimateSetAction.cpp
@@ -9,9 +9,19 @@
 
 #include "ClimateSetAction.h"
 
+ClimateSetAction::ClimateSetAction(ClimateType climate)
+    : _climate(climate)
+{
+}
+
 void ClimateSetAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("climate", _climate);
+}
+
+uint16_t ClimateSetAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void ClimateSetAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/ClimateSetAction.h
+++ b/src/openrct2/actions/ClimateSetAction.h
@@ -19,16 +19,11 @@ private:
 
 public:
     ClimateSetAction() = default;
-    ClimateSetAction(ClimateType climate)
-        : _climate(climate)
-    {
-    }
+    ClimateSetAction(ClimateType climate);
+
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/CustomAction.cpp
+++ b/src/openrct2/actions/CustomAction.cpp
@@ -13,6 +13,27 @@
 #    include "../Context.h"
 #    include "../scripting/ScriptEngine.h"
 
+CustomAction::CustomAction(const std::string& id, const std::string& json)
+    : _id(id)
+    , _json(json)
+{
+}
+
+std::string CustomAction::GetId() const
+{
+    return _id;
+}
+
+std::string CustomAction::GetJson() const
+{
+    return _json;
+}
+
+uint16_t CustomAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void CustomAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/CustomAction.h
+++ b/src/openrct2/actions/CustomAction.h
@@ -21,26 +21,12 @@ private:
 
 public:
     CustomAction() = default;
-    CustomAction(const std::string& id, const std::string& json)
-        : _id(id)
-        , _json(json)
-    {
-    }
+    CustomAction(const std::string& id, const std::string& json);
 
-    std::string GetId() const
-    {
-        return _id;
-    }
+    std::string GetId() const;
+    std::string GetJson() const;
 
-    std::string GetJson() const
-    {
-        return _json;
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
@@ -21,10 +21,21 @@
 #include "../world/Scenery.h"
 #include "../world/Wall.h"
 
+FootpathAdditionPlaceAction::FootpathAdditionPlaceAction(const CoordsXYZ& loc, ObjectEntryIndex pathItemType)
+    : _loc(loc)
+    , _pathItemType(pathItemType)
+{
+}
+
 void FootpathAdditionPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("object", _pathItemType);
+}
+
+uint16_t FootpathAdditionPlaceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void FootpathAdditionPlaceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/FootpathAdditionPlaceAction.h
+++ b/src/openrct2/actions/FootpathAdditionPlaceAction.h
@@ -19,18 +19,11 @@ private:
 
 public:
     FootpathAdditionPlaceAction() = default;
-    FootpathAdditionPlaceAction(const CoordsXYZ& loc, ObjectEntryIndex pathItemType)
-        : _loc(loc)
-        , _pathItemType(pathItemType)
-    {
-    }
+    FootpathAdditionPlaceAction(const CoordsXYZ& loc, ObjectEntryIndex pathItemType);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
@@ -20,9 +20,19 @@
 #include "../world/Park.h"
 #include "../world/Wall.h"
 
+FootpathAdditionRemoveAction::FootpathAdditionRemoveAction(const CoordsXYZ& loc)
+    : _loc(loc)
+{
+}
+
 void FootpathAdditionRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
+}
+
+uint16_t FootpathAdditionRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void FootpathAdditionRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/FootpathAdditionRemoveAction.h
+++ b/src/openrct2/actions/FootpathAdditionRemoveAction.h
@@ -18,16 +18,11 @@ private:
 
 public:
     FootpathAdditionRemoveAction() = default;
-    FootpathAdditionRemoveAction(const CoordsXYZ& loc)
-        : _loc(loc)
-    {
-    }
+    FootpathAdditionRemoveAction(const CoordsXYZ& loc);
+
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -22,12 +22,25 @@
 #include "../world/Surface.h"
 #include "../world/Wall.h"
 
+FootpathPlaceAction::FootpathPlaceAction(const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, Direction direction)
+    : _loc(loc)
+    , _slope(slope)
+    , _type(type)
+    , _direction(direction)
+{
+}
+
 void FootpathPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("object", _type);
     visitor.Visit("direction", _direction);
     visitor.Visit("slope", _slope);
+}
+
+uint16_t FootpathPlaceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void FootpathPlaceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/FootpathPlaceAction.h
+++ b/src/openrct2/actions/FootpathPlaceAction.h
@@ -22,20 +22,11 @@ private:
 
 public:
     FootpathPlaceAction() = default;
-    FootpathPlaceAction(const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, Direction direction = INVALID_DIRECTION)
-        : _loc(loc)
-        , _slope(slope)
-        , _type(type)
-        , _direction(direction)
-    {
-    }
+    FootpathPlaceAction(const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, Direction direction = INVALID_DIRECTION);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.cpp
@@ -21,11 +21,25 @@
 #include "../world/Surface.h"
 #include "../world/Wall.h"
 
+FootpathPlaceFromTrackAction::FootpathPlaceFromTrackAction(
+    const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, uint8_t edges)
+    : _loc(loc)
+    , _slope(slope)
+    , _type(type)
+    , _edges(edges)
+{
+}
+
 void FootpathPlaceFromTrackAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
 
     stream << DS_TAG(_loc) << DS_TAG(_slope) << DS_TAG(_type) << DS_TAG(_edges);
+}
+
+uint16_t FootpathPlaceFromTrackAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 GameActions::Result::Ptr FootpathPlaceFromTrackAction::Query() const

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.h
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.h
@@ -21,18 +21,9 @@ private:
 
 public:
     FootpathPlaceFromTrackAction() = default;
-    FootpathPlaceFromTrackAction(const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, uint8_t edges)
-        : _loc(loc)
-        , _slope(slope)
-        , _type(type)
-        , _edges(edges)
-    {
-    }
+    FootpathPlaceFromTrackAction(const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, uint8_t edges);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/FootpathRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathRemoveAction.cpp
@@ -21,9 +21,19 @@
 #include "../world/Wall.h"
 #include "BannerRemoveAction.h"
 
+FootpathRemoveAction::FootpathRemoveAction(const CoordsXYZ& location)
+    : _loc(location)
+{
+}
+
 void FootpathRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
+}
+
+uint16_t FootpathRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void FootpathRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/FootpathRemoveAction.h
+++ b/src/openrct2/actions/FootpathRemoveAction.h
@@ -19,17 +19,11 @@ private:
 
 public:
     FootpathRemoveAction() = default;
-    FootpathRemoveAction(const CoordsXYZ& location)
-        : _loc(location)
-    {
-    }
+    FootpathRemoveAction(const CoordsXYZ& location);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/GuestSetFlagsAction.cpp
+++ b/src/openrct2/actions/GuestSetFlagsAction.cpp
@@ -12,10 +12,21 @@
 #include "../Context.h"
 #include "../OpenRCT2.h"
 
+GuestSetFlagsAction::GuestSetFlagsAction(uint16_t peepId, uint32_t flags)
+    : _peepId(peepId)
+    , _newFlags(flags)
+{
+}
+
 void GuestSetFlagsAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("peep", _peepId);
     visitor.Visit("flags", _newFlags);
+}
+
+uint16_t GuestSetFlagsAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void GuestSetFlagsAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/GuestSetFlagsAction.h
+++ b/src/openrct2/actions/GuestSetFlagsAction.h
@@ -20,18 +20,11 @@ private:
 
 public:
     GuestSetFlagsAction() = default;
-    GuestSetFlagsAction(uint16_t peepId, uint32_t flags)
-        : _peepId(peepId)
-        , _newFlags(flags)
-    {
-    }
+    GuestSetFlagsAction(uint16_t peepId, uint32_t flags);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/GuestSetNameAction.cpp
+++ b/src/openrct2/actions/GuestSetNameAction.cpp
@@ -20,10 +20,31 @@
 #include "../world/Park.h"
 #include "../world/Sprite.h"
 
+GuestSetNameAction::GuestSetNameAction(uint16_t spriteIndex, const std::string& name)
+    : _spriteIndex(spriteIndex)
+    , _name(name)
+{
+}
+
+uint16_t GuestSetNameAction::GetSpriteIndex() const
+{
+    return _spriteIndex;
+}
+
+std::string GuestSetNameAction::GetGuestName() const
+{
+    return _name;
+}
+
 void GuestSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("peep", _spriteIndex);
     visitor.Visit("name", _name);
+}
+
+uint16_t GuestSetNameAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void GuestSetNameAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/GuestSetNameAction.h
+++ b/src/openrct2/actions/GuestSetNameAction.h
@@ -20,27 +20,14 @@ private:
 
 public:
     GuestSetNameAction() = default;
-    GuestSetNameAction(uint16_t spriteIndex, const std::string& name)
-        : _spriteIndex(spriteIndex)
-        , _name(name)
-    {
-    }
+    GuestSetNameAction(uint16_t spriteIndex, const std::string& name);
 
-    uint16_t GetSpriteIndex() const
-    {
-        return _spriteIndex;
-    }
+    uint16_t GetSpriteIndex() const;
+    std::string GetGuestName() const;
 
-    std::string GetGuestName() const
-    {
-        return _name;
-    }
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LandBuyRightsAction.cpp
+++ b/src/openrct2/actions/LandBuyRightsAction.cpp
@@ -25,6 +25,23 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+LandBuyRightsAction::LandBuyRightsAction(const MapRange& range, LandBuyRightSetting setting)
+    : _range(range)
+    , _setting(setting)
+{
+}
+
+LandBuyRightsAction::LandBuyRightsAction(const CoordsXY& coord, LandBuyRightSetting setting)
+    : _range(coord.x, coord.y, coord.x, coord.y)
+    , _setting(setting)
+{
+}
+
+uint16_t LandBuyRightsAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void LandBuyRightsAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LandBuyRightsAction.h
+++ b/src/openrct2/actions/LandBuyRightsAction.h
@@ -28,23 +28,10 @@ private:
 
 public:
     LandBuyRightsAction() = default;
+    LandBuyRightsAction(const MapRange& range, LandBuyRightSetting setting);
+    LandBuyRightsAction(const CoordsXY& coord, LandBuyRightSetting setting);
 
-    LandBuyRightsAction(const MapRange& range, LandBuyRightSetting setting)
-        : _range(range)
-        , _setting(setting)
-    {
-    }
-
-    LandBuyRightsAction(const CoordsXY& coord, LandBuyRightSetting setting)
-        : _range(coord.x, coord.y, coord.x, coord.y)
-        , _setting(setting)
-    {
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LandLowerAction.cpp
+++ b/src/openrct2/actions/LandLowerAction.cpp
@@ -24,6 +24,18 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+LandLowerAction::LandLowerAction(const CoordsXY& coords, MapRange range, uint8_t selectionType)
+    : _coords(coords)
+    , _range(range)
+    , _selectionType(selectionType)
+{
+}
+
+uint16_t LandLowerAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void LandLowerAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LandLowerAction.h
+++ b/src/openrct2/actions/LandLowerAction.h
@@ -20,17 +20,9 @@ private:
 
 public:
     LandLowerAction() = default;
-    LandLowerAction(const CoordsXY& coords, MapRange range, uint8_t selectionType)
-        : _coords(coords)
-        , _range(range)
-        , _selectionType(selectionType)
-    {
-    }
+    LandLowerAction(const CoordsXY& coords, MapRange range, uint8_t selectionType);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LandRaiseAction.cpp
+++ b/src/openrct2/actions/LandRaiseAction.cpp
@@ -25,6 +25,18 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+LandRaiseAction::LandRaiseAction(const CoordsXY& coords, MapRange range, uint8_t selectionType)
+    : _coords(coords)
+    , _range(range)
+    , _selectionType(selectionType)
+{
+}
+
+uint16_t LandRaiseAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void LandRaiseAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LandRaiseAction.h
+++ b/src/openrct2/actions/LandRaiseAction.h
@@ -20,17 +20,9 @@ private:
 
 public:
     LandRaiseAction() = default;
-    LandRaiseAction(const CoordsXY& coords, MapRange range, uint8_t selectionType)
-        : _coords(coords)
-        , _range(range)
-        , _selectionType(selectionType)
-    {
-    }
+    LandRaiseAction(const CoordsXY& coords, MapRange range, uint8_t selectionType);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -23,6 +23,18 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+LandSetHeightAction::LandSetHeightAction(const CoordsXY& coords, uint8_t height, uint8_t style)
+    : _coords(coords)
+    , _height(height)
+    , _style(style)
+{
+}
+
+uint16_t LandSetHeightAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::EditorOnly;
+}
+
 void LandSetHeightAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
@@ -371,4 +383,17 @@ void LandSetHeightAction::SetSurfaceHeight(TileElement* surfaceElement) const
     }
 
     map_invalidate_tile_full(_coords);
+}
+
+int32_t LandSetHeightAction::map_set_land_height_clear_func(
+    TileElement** tile_element, [[maybe_unused]] const CoordsXY& coords, [[maybe_unused]] uint8_t flags,
+    [[maybe_unused]] money32* price)
+{
+    if ((*tile_element)->GetType() == TILE_ELEMENT_TYPE_SURFACE)
+        return 0;
+
+    if ((*tile_element)->GetType() == TILE_ELEMENT_TYPE_SMALL_SCENERY)
+        return 0;
+
+    return 1;
 }

--- a/src/openrct2/actions/LandSetHeightAction.h
+++ b/src/openrct2/actions/LandSetHeightAction.h
@@ -20,17 +20,9 @@ private:
 
 public:
     LandSetHeightAction() = default;
-    LandSetHeightAction(const CoordsXY& coords, uint8_t height, uint8_t style)
-        : _coords(coords)
-        , _height(height)
-        , _style(style)
-    {
-    }
+    LandSetHeightAction(const CoordsXY& coords, uint8_t height, uint8_t style);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::EditorOnly;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;
@@ -53,14 +45,5 @@ private:
      */
     static int32_t map_set_land_height_clear_func(
         TileElement * *tile_element, [[maybe_unused]] const CoordsXY& coords, [[maybe_unused]] uint8_t flags,
-        [[maybe_unused]] money32* price)
-    {
-        if ((*tile_element)->GetType() == TILE_ELEMENT_TYPE_SURFACE)
-            return 0;
-
-        if ((*tile_element)->GetType() == TILE_ELEMENT_TYPE_SMALL_SCENERY)
-            return 0;
-
-        return 1;
-    }
+        [[maybe_unused]] money32* price);
 };

--- a/src/openrct2/actions/LandSetRightsAction.cpp
+++ b/src/openrct2/actions/LandSetRightsAction.cpp
@@ -25,6 +25,25 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+LandSetRightsAction::LandSetRightsAction(const MapRange& range, LandSetRightSetting setting, uint8_t ownership)
+    : _range(range)
+    , _setting(setting)
+    , _ownership(ownership)
+{
+}
+
+LandSetRightsAction::LandSetRightsAction(const CoordsXY& coord, LandSetRightSetting setting, uint8_t ownership)
+    : _range(coord.x, coord.y, coord.x, coord.y)
+    , _setting(setting)
+    , _ownership(ownership)
+{
+}
+
+uint16_t LandSetRightsAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::EditorOnly;
+}
+
 void LandSetRightsAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LandSetRightsAction.h
+++ b/src/openrct2/actions/LandSetRightsAction.h
@@ -30,25 +30,10 @@ private:
 
 public:
     LandSetRightsAction() = default;
+    LandSetRightsAction(const MapRange& range, LandSetRightSetting setting, uint8_t ownership = 0);
+    LandSetRightsAction(const CoordsXY& coord, LandSetRightSetting setting, uint8_t ownership = 0);
 
-    LandSetRightsAction(const MapRange& range, LandSetRightSetting setting, uint8_t ownership = 0)
-        : _range(range)
-        , _setting(setting)
-        , _ownership(ownership)
-    {
-    }
-
-    LandSetRightsAction(const CoordsXY& coord, LandSetRightSetting setting, uint8_t ownership = 0)
-        : _range(coord.x, coord.y, coord.x, coord.y)
-        , _setting(setting)
-        , _ownership(ownership)
-    {
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::EditorOnly;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LandSmoothAction.cpp
+++ b/src/openrct2/actions/LandSmoothAction.cpp
@@ -26,6 +26,19 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+LandSmoothAction::LandSmoothAction(const CoordsXY& coords, MapRange range, uint8_t selectionType, bool isLowering)
+    : _coords(coords)
+    , _range(range)
+    , _selectionType(selectionType)
+    , _isLowering(isLowering)
+{
+}
+
+uint16_t LandSmoothAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void LandSmoothAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LandSmoothAction.h
+++ b/src/openrct2/actions/LandSmoothAction.h
@@ -23,18 +23,9 @@ private:
 
 public:
     LandSmoothAction() = default;
-    LandSmoothAction(const CoordsXY& coords, MapRange range, uint8_t selectionType, bool isLowering)
-        : _coords(coords)
-        , _range(range)
-        , _selectionType(selectionType)
-        , _isLowering(isLowering)
-    {
-    }
+    LandSmoothAction(const CoordsXY& coords, MapRange range, uint8_t selectionType, bool isLowering);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -17,6 +17,43 @@
 #include "../world/MapAnimation.h"
 #include "../world/Surface.h"
 
+LargeSceneryPlaceActionResult::LargeSceneryPlaceActionResult()
+    : GameActions::Result(GameActions::Status::Ok, STR_CANT_POSITION_THIS_HERE)
+{
+}
+
+LargeSceneryPlaceActionResult::LargeSceneryPlaceActionResult(GameActions::Status error)
+    : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE)
+{
+}
+
+LargeSceneryPlaceActionResult::LargeSceneryPlaceActionResult(GameActions::Status error, rct_string_id message)
+    : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message)
+{
+}
+
+LargeSceneryPlaceActionResult::LargeSceneryPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args)
+    : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message, args)
+{
+}
+
+LargeSceneryPlaceAction::LargeSceneryPlaceAction(
+    const CoordsXYZD& loc, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
+    : _loc(loc)
+    , _sceneryType(sceneryType)
+    , _primaryColour(primaryColour)
+    , _secondaryColour(secondaryColour)
+{
+    rct_scenery_entry* sceneryEntry = get_large_scenery_entry(_sceneryType);
+    if (sceneryEntry != nullptr)
+    {
+        if (sceneryEntry->large_scenery.scrolling_mode != SCROLLING_MODE_NONE)
+        {
+            _bannerId = create_new_banner(0);
+        }
+    }
+}
+
 void LargeSceneryPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
@@ -31,6 +68,11 @@ void LargeSceneryPlaceAction::AcceptParameters(GameActionParameterVisitor& visit
             _bannerId = create_new_banner(0);
         }
     }
+}
+
+uint16_t LargeSceneryPlaceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void LargeSceneryPlaceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/LargeSceneryPlaceAction.h
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.h
@@ -16,22 +16,10 @@
 class LargeSceneryPlaceActionResult final : public GameActions::Result
 {
 public:
-    LargeSceneryPlaceActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_CANT_POSITION_THIS_HERE)
-    {
-    }
-    LargeSceneryPlaceActionResult(GameActions::Status error)
-        : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE)
-    {
-    }
-    LargeSceneryPlaceActionResult(GameActions::Status error, rct_string_id message)
-        : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message)
-    {
-    }
-    LargeSceneryPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args)
-        : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message, args)
-    {
-    }
+    LargeSceneryPlaceActionResult();
+    LargeSceneryPlaceActionResult(GameActions::Status error);
+    LargeSceneryPlaceActionResult(GameActions::Status error, rct_string_id message);
+    LargeSceneryPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args);
 
     uint8_t GroundFlags{ 0 };
     TileElement* tileElement = nullptr;
@@ -49,28 +37,12 @@ private:
 public:
     LargeSceneryPlaceAction() = default;
 
-    LargeSceneryPlaceAction(const CoordsXYZD& loc, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
-        : _loc(loc)
-        , _sceneryType(sceneryType)
-        , _primaryColour(primaryColour)
-        , _secondaryColour(secondaryColour)
-    {
-        rct_scenery_entry* sceneryEntry = get_large_scenery_entry(_sceneryType);
-        if (sceneryEntry != nullptr)
-        {
-            if (sceneryEntry->large_scenery.scrolling_mode != SCROLLING_MODE_NONE)
-            {
-                _bannerId = create_new_banner(0);
-            }
-        }
-    }
+    LargeSceneryPlaceAction(
+        const CoordsXYZD& loc, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -22,10 +22,21 @@
 #include "../world/SmallScenery.h"
 #include "../world/Sprite.h"
 
+LargeSceneryRemoveAction::LargeSceneryRemoveAction(const CoordsXYZD& location, uint16_t tileIndex)
+    : _loc(location)
+    , _tileIndex(tileIndex)
+{
+}
+
 void LargeSceneryRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("tileIndex", _tileIndex);
+}
+
+uint16_t LargeSceneryRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void LargeSceneryRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/LargeSceneryRemoveAction.h
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.h
@@ -19,19 +19,11 @@ private:
 
 public:
     LargeSceneryRemoveAction() = default;
-
-    LargeSceneryRemoveAction(const CoordsXYZD& location, uint16_t tileIndex)
-        : _loc(location)
-        , _tileIndex(tileIndex)
-    {
-    }
+    LargeSceneryRemoveAction(const CoordsXYZD& location, uint16_t tileIndex);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LargeScenerySetColourAction.cpp
+++ b/src/openrct2/actions/LargeScenerySetColourAction.cpp
@@ -13,6 +13,20 @@
 #include "../management/Finance.h"
 #include "../world/Scenery.h"
 
+LargeScenerySetColourAction::LargeScenerySetColourAction(
+    const CoordsXYZD& loc, uint8_t tileIndex, uint8_t primaryColour, uint8_t secondaryColour)
+    : _loc(loc)
+    , _tileIndex(tileIndex)
+    , _primaryColour(primaryColour)
+    , _secondaryColour(secondaryColour)
+{
+}
+
+uint16_t LargeScenerySetColourAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void LargeScenerySetColourAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LargeScenerySetColourAction.h
+++ b/src/openrct2/actions/LargeScenerySetColourAction.h
@@ -21,19 +21,9 @@ private:
 
 public:
     LargeScenerySetColourAction() = default;
+    LargeScenerySetColourAction(const CoordsXYZD& loc, uint8_t tileIndex, uint8_t primaryColour, uint8_t secondaryColour);
 
-    LargeScenerySetColourAction(const CoordsXYZD& loc, uint8_t tileIndex, uint8_t primaryColour, uint8_t secondaryColour)
-        : _loc(loc)
-        , _tileIndex(tileIndex)
-        , _primaryColour(primaryColour)
-        , _secondaryColour(secondaryColour)
-    {
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/LoadOrQuitAction.cpp
+++ b/src/openrct2/actions/LoadOrQuitAction.cpp
@@ -12,6 +12,17 @@
 #include "../Context.h"
 #include "../OpenRCT2.h"
 
+LoadOrQuitAction::LoadOrQuitAction(LoadOrQuitModes mode, PromptMode savePromptMode)
+    : _mode(mode)
+    , _savePromptMode(savePromptMode)
+{
+}
+
+uint16_t LoadOrQuitAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void LoadOrQuitAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/LoadOrQuitAction.h
+++ b/src/openrct2/actions/LoadOrQuitAction.h
@@ -25,16 +25,9 @@ private:
 
 public:
     LoadOrQuitAction() = default;
-    LoadOrQuitAction(LoadOrQuitModes mode, PromptMode savePromptMode = PromptMode::SaveBeforeLoad)
-        : _mode(mode)
-        , _savePromptMode(savePromptMode)
-    {
-    }
+    LoadOrQuitAction(LoadOrQuitModes mode, PromptMode savePromptMode = PromptMode::SaveBeforeLoad);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -12,6 +12,13 @@
 #include "../ride/RideData.h"
 #include "../ride/TrackData.h"
 
+MazePlaceTrackAction::MazePlaceTrackAction(const CoordsXYZ& location, NetworkRideId_t rideIndex, uint16_t mazeEntry)
+    : _loc(location)
+    , _rideIndex(rideIndex)
+    , _mazeEntry(mazeEntry)
+{
+}
+
 void MazePlaceTrackAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);

--- a/src/openrct2/actions/MazePlaceTrackAction.h
+++ b/src/openrct2/actions/MazePlaceTrackAction.h
@@ -19,13 +19,7 @@ private:
 
 public:
     MazePlaceTrackAction() = default;
-
-    MazePlaceTrackAction(const CoordsXYZ& location, NetworkRideId_t rideIndex, uint16_t mazeEntry)
-        : _loc(location)
-        , _rideIndex(rideIndex)
-        , _mazeEntry(mazeEntry)
-    {
-    }
+    MazePlaceTrackAction(const CoordsXYZ& location, NetworkRideId_t rideIndex, uint16_t mazeEntry);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -21,6 +21,15 @@
 #include "../world/Footpath.h"
 #include "../world/Park.h"
 
+MazeSetTrackAction::MazeSetTrackAction(
+    const CoordsXYZD& location, bool initialPlacement, NetworkRideId_t rideIndex, uint8_t mode)
+    : _loc(location)
+    , _initialPlacement(initialPlacement)
+    , _rideIndex(rideIndex)
+    , _mode(mode)
+{
+}
+
 void MazeSetTrackAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);

--- a/src/openrct2/actions/MazeSetTrackAction.h
+++ b/src/openrct2/actions/MazeSetTrackAction.h
@@ -47,13 +47,7 @@ private:
 
 public:
     MazeSetTrackAction() = default;
-    MazeSetTrackAction(const CoordsXYZD& location, bool initialPlacement, NetworkRideId_t rideIndex, uint8_t mode)
-        : _loc(location)
-        , _initialPlacement(initialPlacement)
-        , _rideIndex(rideIndex)
-        , _mode(mode)
-    {
-    }
+    MazeSetTrackAction(const CoordsXYZD& location, bool initialPlacement, NetworkRideId_t rideIndex, uint8_t mode);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/NetworkModifyGroupAction.cpp
+++ b/src/openrct2/actions/NetworkModifyGroupAction.cpp
@@ -12,6 +12,21 @@
 #include "../network/network.h"
 #include "../util/Util.h"
 
+NetworkModifyGroupAction::NetworkModifyGroupAction(
+    ModifyGroupType type, uint8_t groupId, const std::string name, uint32_t permissionIndex, PermissionState permissionState)
+    : _type(type)
+    , _groupId(groupId)
+    , _name(name)
+    , _permissionIndex(permissionIndex)
+    , _permissionState(permissionState)
+{
+}
+
+uint16_t NetworkModifyGroupAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void NetworkModifyGroupAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/NetworkModifyGroupAction.h
+++ b/src/openrct2/actions/NetworkModifyGroupAction.h
@@ -40,22 +40,11 @@ private:
 
 public:
     NetworkModifyGroupAction() = default;
-
     NetworkModifyGroupAction(
         ModifyGroupType type, uint8_t groupId = std::numeric_limits<uint8_t>::max(), const std::string name = "",
-        uint32_t permissionIndex = 0, PermissionState permissionState = PermissionState::Count)
-        : _type(type)
-        , _groupId(groupId)
-        , _name(name)
-        , _permissionIndex(permissionIndex)
-        , _permissionState(permissionState)
-    {
-    }
+        uint32_t permissionIndex = 0, PermissionState permissionState = PermissionState::Count);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkEntranceRemoveAction.cpp
+++ b/src/openrct2/actions/ParkEntranceRemoveAction.cpp
@@ -14,6 +14,16 @@
 #include "../world/Entrance.h"
 #include "../world/Park.h"
 
+ParkEntranceRemoveAction::ParkEntranceRemoveAction(const CoordsXYZ& loc)
+    : _loc(loc)
+{
+}
+
+uint16_t ParkEntranceRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::EditorOnly;
+}
+
 void ParkEntranceRemoveAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/ParkEntranceRemoveAction.h
+++ b/src/openrct2/actions/ParkEntranceRemoveAction.h
@@ -18,16 +18,9 @@ private:
 
 public:
     ParkEntranceRemoveAction() = default;
+    ParkEntranceRemoveAction(const CoordsXYZ& loc);
 
-    ParkEntranceRemoveAction(const CoordsXYZ& loc)
-        : _loc(loc)
-    {
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::EditorOnly;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/ParkMarketingAction.cpp
@@ -21,6 +21,18 @@
 
 #include <iterator>
 
+ParkMarketingAction::ParkMarketingAction(int32_t type, int32_t item, int32_t numWeeks)
+    : _type(type)
+    , _item(item)
+    , _numWeeks(numWeeks)
+{
+}
+
+uint16_t ParkMarketingAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void ParkMarketingAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/ParkMarketingAction.h
+++ b/src/openrct2/actions/ParkMarketingAction.h
@@ -20,17 +20,9 @@ private:
 
 public:
     ParkMarketingAction() = default;
-    ParkMarketingAction(int32_t type, int32_t item, int32_t numWeeks)
-        : _type(type)
-        , _item(item)
-        , _numWeeks(numWeeks)
-    {
-    }
+    ParkMarketingAction(int32_t type, int32_t item, int32_t numWeeks);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -17,6 +17,18 @@
 #include "../ui/WindowManager.h"
 #include "../windows/Intent.h"
 
+ParkSetDateAction::ParkSetDateAction(int32_t year, int32_t month, int32_t day)
+    : _year(year)
+    , _month(month)
+    , _day(day)
+{
+}
+
+uint16_t ParkSetDateAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void ParkSetDateAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/ParkSetDateAction.h
+++ b/src/openrct2/actions/ParkSetDateAction.h
@@ -20,17 +20,9 @@ private:
 
 public:
     ParkSetDateAction() = default;
-    ParkSetDateAction(int32_t year, int32_t month, int32_t day)
-        : _year(year)
-        , _month(month)
-        , _day(day)
-    {
-    }
+    ParkSetDateAction(int32_t year, int32_t month, int32_t day);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkSetLoanAction.cpp
+++ b/src/openrct2/actions/ParkSetLoanAction.cpp
@@ -17,6 +17,16 @@
 #include "../ui/WindowManager.h"
 #include "../windows/Intent.h"
 
+ParkSetLoanAction::ParkSetLoanAction(money32 value)
+    : _value(value)
+{
+}
+
+uint16_t ParkSetLoanAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void ParkSetLoanAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/ParkSetLoanAction.h
+++ b/src/openrct2/actions/ParkSetLoanAction.h
@@ -18,15 +18,9 @@ private:
 
 public:
     ParkSetLoanAction() = default;
-    ParkSetLoanAction(money32 value)
-        : _value(value)
-    {
-    }
+    ParkSetLoanAction(money32 value);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkSetNameAction.cpp
+++ b/src/openrct2/actions/ParkSetNameAction.cpp
@@ -22,9 +22,19 @@
 #include "../windows/Intent.h"
 #include "../world/Park.h"
 
+ParkSetNameAction::ParkSetNameAction(const std::string& name)
+    : _name(name)
+{
+}
+
 void ParkSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("name", _name);
+}
+
+uint16_t ParkSetNameAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void ParkSetNameAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/ParkSetNameAction.h
+++ b/src/openrct2/actions/ParkSetNameAction.h
@@ -18,17 +18,11 @@ private:
 
 public:
     ParkSetNameAction() = default;
-    ParkSetNameAction(const std::string& name)
-        : _name(name)
-    {
-    }
+    ParkSetNameAction(const std::string& name);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/ParkSetParameterAction.cpp
@@ -14,6 +14,17 @@
 #include "../util/Util.h"
 #include "../world/Park.h"
 
+ParkSetParameterAction::ParkSetParameterAction(ParkParameter parameter, uint64_t value)
+    : _parameter(parameter)
+    , _value(value)
+{
+}
+
+uint16_t ParkSetParameterAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void ParkSetParameterAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/ParkSetParameterAction.h
+++ b/src/openrct2/actions/ParkSetParameterAction.h
@@ -29,16 +29,9 @@ private:
 
 public:
     ParkSetParameterAction() = default;
-    ParkSetParameterAction(ParkParameter parameter, uint64_t value = 0)
-        : _parameter(parameter)
-        , _value(value)
-    {
-    }
+    ParkSetParameterAction(ParkParameter parameter, uint64_t value = 0);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/ParkSetResearchFundingAction.cpp
+++ b/src/openrct2/actions/ParkSetResearchFundingAction.cpp
@@ -17,6 +17,17 @@
 #include "../ui/WindowManager.h"
 #include "../windows/Intent.h"
 
+ParkSetResearchFundingAction::ParkSetResearchFundingAction(uint32_t priorities, uint8_t fundingAmount)
+    : _priorities(priorities)
+    , _fundingAmount(fundingAmount)
+{
+}
+
+uint16_t ParkSetResearchFundingAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void ParkSetResearchFundingAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/ParkSetResearchFundingAction.h
+++ b/src/openrct2/actions/ParkSetResearchFundingAction.h
@@ -20,16 +20,9 @@ private:
 
 public:
     ParkSetResearchFundingAction() = default;
-    ParkSetResearchFundingAction(uint32_t priorities, uint8_t fundingAmount)
-        : _priorities(priorities)
-        , _fundingAmount(fundingAmount)
-    {
-    }
+    ParkSetResearchFundingAction(uint32_t priorities, uint8_t fundingAmount);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/PauseToggleAction.cpp
+++ b/src/openrct2/actions/PauseToggleAction.cpp
@@ -9,6 +9,16 @@
 
 #include "PauseToggleAction.h"
 
+uint16_t PauseToggleAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
+GameActions::Result::Ptr PauseToggleAction::Query() const
+{
+    return std::make_unique<GameActions::Result>();
+}
+
 GameActions::Result::Ptr PauseToggleAction::Execute() const
 {
     pause_toggle();

--- a/src/openrct2/actions/PauseToggleAction.h
+++ b/src/openrct2/actions/PauseToggleAction.h
@@ -18,16 +18,9 @@ DEFINE_GAME_ACTION(PauseToggleAction, GAME_COMMAND_TOGGLE_PAUSE, GameActions::Re
 public:
     PauseToggleAction() = default;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
-    GameActions::Result::Ptr Query() const override
-    {
-        return std::make_unique<GameActions::Result>();
-    }
-
+    GameActions::Result::Ptr Query() const override;
     GameActions::Result::Ptr Execute() const override;
 };
 // clang-format on

--- a/src/openrct2/actions/PeepPickupAction.cpp
+++ b/src/openrct2/actions/PeepPickupAction.cpp
@@ -13,6 +13,19 @@
 #include "../network/network.h"
 #include "../util/Util.h"
 
+PeepPickupAction::PeepPickupAction(PeepPickupType type, uint32_t spriteId, const CoordsXYZ& loc, NetworkPlayerId_t owner)
+    : _type(type)
+    , _spriteId(spriteId)
+    , _loc(loc)
+    , _owner(owner)
+{
+}
+
+uint16_t PeepPickupAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void PeepPickupAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/PeepPickupAction.h
+++ b/src/openrct2/actions/PeepPickupAction.h
@@ -30,18 +30,9 @@ private:
 
 public:
     PeepPickupAction() = default;
-    PeepPickupAction(PeepPickupType type, uint32_t spriteId, const CoordsXYZ& loc, NetworkPlayerId_t owner)
-        : _type(type)
-        , _spriteId(spriteId)
-        , _loc(loc)
-        , _owner(owner)
-    {
-    }
+    PeepPickupAction(PeepPickupType type, uint32_t spriteId, const CoordsXYZ& loc, NetworkPlayerId_t owner);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/PlaceParkEntranceAction.cpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.cpp
@@ -21,6 +21,16 @@
 #include "../world/Sprite.h"
 #include "../world/Surface.h"
 
+PlaceParkEntranceAction::PlaceParkEntranceAction(const CoordsXYZD& location)
+    : _loc(location)
+{
+}
+
+uint16_t PlaceParkEntranceAction::GetActionFlags() const
+{
+    return GameActionBase::GetActionFlags() | GameActions::Flags::EditorOnly;
+}
+
 void PlaceParkEntranceAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/PlaceParkEntranceAction.h
+++ b/src/openrct2/actions/PlaceParkEntranceAction.h
@@ -18,15 +18,9 @@ private:
 
 public:
     PlaceParkEntranceAction() = default;
-    PlaceParkEntranceAction(const CoordsXYZD& location)
-        : _loc(location)
-    {
-    }
+    PlaceParkEntranceAction(const CoordsXYZD& location);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameActionBase::GetActionFlags() | GameActions::Flags::EditorOnly;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/PlacePeepSpawnAction.cpp
+++ b/src/openrct2/actions/PlacePeepSpawnAction.cpp
@@ -18,6 +18,16 @@
 #include "../world/Park.h"
 #include "../world/Surface.h"
 
+PlacePeepSpawnAction::PlacePeepSpawnAction(const CoordsXYZD& location)
+    : _location(location)
+{
+}
+
+uint16_t PlacePeepSpawnAction::GetActionFlags() const
+{
+    return GameActionBase::GetActionFlags() | GameActions::Flags::EditorOnly | GameActions::Flags::AllowWhilePaused;
+}
+
 void PlacePeepSpawnAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/PlacePeepSpawnAction.h
+++ b/src/openrct2/actions/PlacePeepSpawnAction.h
@@ -18,15 +18,9 @@ private:
 
 public:
     PlacePeepSpawnAction() = default;
-    PlacePeepSpawnAction(const CoordsXYZD& location)
-        : _location(location)
-    {
-    }
+    PlacePeepSpawnAction(const CoordsXYZD& location);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameActionBase::GetActionFlags() | GameActions::Flags::EditorOnly | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/PlayerKickAction.cpp
+++ b/src/openrct2/actions/PlayerKickAction.cpp
@@ -11,6 +11,16 @@
 
 #include "../network/network.h"
 
+PlayerKickAction::PlayerKickAction(NetworkPlayerId_t playerId)
+    : _playerId(playerId)
+{
+}
+
+uint16_t PlayerKickAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void PlayerKickAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/PlayerKickAction.h
+++ b/src/openrct2/actions/PlayerKickAction.h
@@ -19,15 +19,9 @@ private:
 public:
     PlayerKickAction() = default;
 
-    PlayerKickAction(NetworkPlayerId_t playerId)
-        : _playerId(playerId)
-    {
-    }
+    PlayerKickAction(NetworkPlayerId_t playerId);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/PlayerSetGroupAction.cpp
+++ b/src/openrct2/actions/PlayerSetGroupAction.cpp
@@ -11,6 +11,17 @@
 
 #include "../network/network.h"
 
+PlayerSetGroupAction::PlayerSetGroupAction(NetworkPlayerId_t playerId, uint8_t groupId)
+    : _playerId(playerId)
+    , _groupId(groupId)
+{
+}
+
+uint16_t PlayerSetGroupAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void PlayerSetGroupAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/PlayerSetGroupAction.h
+++ b/src/openrct2/actions/PlayerSetGroupAction.h
@@ -19,17 +19,9 @@ private:
 
 public:
     PlayerSetGroupAction() = default;
+    PlayerSetGroupAction(NetworkPlayerId_t playerId, uint8_t groupId);
 
-    PlayerSetGroupAction(NetworkPlayerId_t playerId, uint8_t groupId)
-        : _playerId(playerId)
-        , _groupId(groupId)
-    {
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;


### PR DESCRIPTION
A follow-up of #13548 to make sure everything is defined inside the `cpp` file, preventing further compilation