### PR TITLE
Close #13386: Show a (hardcoded) GUI error message if en-GB.txt cannot be loaded

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -364,6 +364,8 @@ namespace OpenRCT2
                 catch (const std::exception& eFallback)
                 {
                     log_fatal("Failed to open fallback language: %s", eFallback.what());
+                    auto uiContext = GetContext()->GetUiContext();
+                    uiContext->ShowMessageBox("Failed to load language file!\nYour installation may be damaged.");
                     return false;
                 }
             }

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -17,7 +17,6 @@
 #include "../core/String.hpp"
 #include "../core/StringBuilder.h"
 #include "../core/StringReader.h"
-#include "../ui/UiContext.h"
 #include "Language.h"
 #include "Localisation.h"
 
@@ -88,9 +87,6 @@ public:
         {
             Memory::Free(fileData);
             log_error("Unable to open %s: %s", path, ex.what());
-            auto uiContext = OpenRCT2::GetContext()->GetUiContext();
-            uiContext->ShowMessageBox(
-                "Missing language file: " + static_cast<std::string>(path) + "\n\nYour installation may be damaged.");
             return nullptr;
         }
 

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -9,7 +9,6 @@
 
 #include "LanguagePack.h"
 
-#include "../Context.h"
 #include "../common.h"
 #include "../core/FileStream.h"
 #include "../core/Memory.hpp"

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -9,6 +9,7 @@
 
 #include "LanguagePack.h"
 
+#include "../Context.h"
 #include "../common.h"
 #include "../core/FileStream.h"
 #include "../core/Memory.hpp"
@@ -16,6 +17,7 @@
 #include "../core/String.hpp"
 #include "../core/StringBuilder.h"
 #include "../core/StringReader.h"
+#include "../ui/UiContext.h"
 #include "Language.h"
 #include "Localisation.h"
 
@@ -86,6 +88,9 @@ public:
         {
             Memory::Free(fileData);
             log_error("Unable to open %s: %s", path, ex.what());
+            auto uiContext = OpenRCT2::GetContext()->GetUiContext();
+            uiContext->ShowMessageBox(
+                "Missing language file: " + static_cast<std::string>(path) + "\n\nYour installation may be damaged.");
             return nullptr;
         }
 


### PR DESCRIPTION
That's my idea how it could be done.

Drawbacks:
 - Message is shown twice (as is the message in console)
 - I don't know if this method is good for Android, I followed code in `Drawing.Sprite.cpp` file.

Small things:
 - Icon shown in message box suggests an information (that is also valid for other error messages using this code)