### PR TITLE
Move remaining game actions logic from header to source

### DIFF
--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -25,12 +25,45 @@
 
 #include <algorithm>
 
+RideCreateGameActionResult::RideCreateGameActionResult()
+    : GameActions::Result(GameActions::Status::Ok, STR_NONE)
+{
+}
+
+RideCreateGameActionResult::RideCreateGameActionResult(GameActions::Status error, rct_string_id message)
+    : GameActions::Result(error, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, message)
+{
+}
+
+RideCreateAction::RideCreateAction(int32_t rideType, ObjectEntryIndex subType, int32_t colour1, int32_t colour2)
+    : _rideType(rideType)
+    , _subType(subType)
+    , _colour1(colour1)
+    , _colour2(colour2)
+{
+}
+
 void RideCreateAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("rideType", _rideType);
     visitor.Visit("rideObject", _subType);
     visitor.Visit("colour1", _colour1);
     visitor.Visit("colour2", _colour2);
+}
+
+int32_t RideCreateAction::GetRideType() const
+{
+    return _rideType;
+}
+
+int32_t RideCreateAction::GetRideObject() const
+{
+    return _subType;
+}
+
+uint16_t RideCreateAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideCreateAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideCreateAction.h
+++ b/src/openrct2/actions/RideCreateAction.h
@@ -14,14 +14,8 @@
 class RideCreateGameActionResult final : public GameActions::Result
 {
 public:
-    RideCreateGameActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_NONE)
-    {
-    }
-    RideCreateGameActionResult(GameActions::Status error, rct_string_id message)
-        : GameActions::Result(error, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, message)
-    {
-    }
+    RideCreateGameActionResult();
+    RideCreateGameActionResult(GameActions::Status error, rct_string_id message);
 
     ride_id_t rideIndex = RIDE_ID_NULL;
 };
@@ -36,31 +30,13 @@ private:
 
 public:
     RideCreateAction() = default;
-
-    RideCreateAction(int32_t rideType, ObjectEntryIndex subType, int32_t colour1, int32_t colour2)
-        : _rideType(rideType)
-        , _subType(subType)
-        , _colour1(colour1)
-        , _colour2(colour2)
-    {
-    }
+    RideCreateAction(int32_t rideType, ObjectEntryIndex subType, int32_t colour1, int32_t colour2);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    int32_t GetRideType() const
-    {
-        return _rideType;
-    }
-
-    int32_t GetRideObject() const
-    {
-        return _subType;
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    int32_t GetRideType() const;
+    int32_t GetRideObject() const;
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -29,10 +29,21 @@
 
 using namespace OpenRCT2;
 
+RideDemolishAction::RideDemolishAction(ride_id_t rideIndex, uint8_t modifyType)
+    : _rideIndex(rideIndex)
+    , _modifyType(modifyType)
+{
+}
+
 void RideDemolishAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("modifyType", _modifyType);
+}
+
+uint32_t RideDemolishAction::GetCooldownTime() const
+{
+    return 1000;
 }
 
 void RideDemolishAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideDemolishAction.h
+++ b/src/openrct2/actions/RideDemolishAction.h
@@ -19,18 +19,11 @@ private:
 
 public:
     RideDemolishAction() = default;
-    RideDemolishAction(ride_id_t rideIndex, uint8_t modifyType)
-        : _rideIndex(rideIndex)
-        , _modifyType(modifyType)
-    {
-    }
+    RideDemolishAction(ride_id_t rideIndex, uint8_t modifyType);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint32_t GetCooldownTime() const override
-    {
-        return 1000;
-    }
+    uint32_t GetCooldownTime() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.h
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.h
@@ -23,63 +23,16 @@ private:
 
 public:
     RideEntranceExitPlaceAction() = default;
-
     RideEntranceExitPlaceAction(
-        const CoordsXY& loc, Direction direction, ride_id_t rideIndex, StationIndex stationNum, bool isExit)
-        : _loc(loc)
-        , _direction(direction)
-        , _rideIndex(rideIndex)
-        , _stationNum(stationNum)
-        , _isExit(isExit)
-    {
-    }
+        const CoordsXY& loc, Direction direction, ride_id_t rideIndex, StationIndex stationNum, bool isExit);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;
     GameActions::Result::Ptr Execute() const override;
 
-    static GameActions::Result::Ptr TrackPlaceQuery(const CoordsXYZ& loc, const bool isExit)
-    {
-        auto errorTitle = isExit ? STR_CANT_BUILD_MOVE_EXIT_FOR_THIS_RIDE_ATTRACTION
-                                 : STR_CANT_BUILD_MOVE_ENTRANCE_FOR_THIS_RIDE_ATTRACTION;
-        if (!map_check_free_elements_and_reorganise(1))
-        {
-            return MakeResult(GameActions::Status::NoFreeElements, errorTitle);
-        }
-
-        if (!gCheatsSandboxMode && !map_is_location_owned(loc))
-        {
-            return MakeResult(GameActions::Status::NotOwned, errorTitle);
-        }
-
-        int16_t baseZ = loc.z;
-        int16_t clearZ = baseZ + (isExit ? RideExitHeight : RideEntranceHeight);
-        auto cost = MONEY32_UNDEFINED;
-        if (!map_can_construct_with_clear_at(
-                { loc, baseZ, clearZ }, &map_place_non_scenery_clear_func, { 0b1111, 0 }, 0, &cost, CREATE_CROSSING_MODE_NONE))
-        {
-            return MakeResult(GameActions::Status::NoClearance, errorTitle, gGameCommandErrorText, gCommonFormatArgs);
-        }
-
-        if (gMapGroundFlags & ELEMENT_IS_UNDERWATER)
-        {
-            return MakeResult(GameActions::Status::Disallowed, errorTitle, STR_RIDE_CANT_BUILD_THIS_UNDERWATER);
-        }
-
-        if (baseZ > MaxRideEntranceOrExitHeight)
-        {
-            return MakeResult(GameActions::Status::Disallowed, errorTitle, STR_TOO_HIGH);
-        }
-        auto res = MakeResult();
-        res->Position = { loc.ToTileCentre(), tile_element_height(loc) };
-        res->Expenditure = ExpenditureType::RideConstruction;
-        return res;
-    }
+    static GameActions::Result::Ptr TrackPlaceQuery(const CoordsXYZ& loc, const bool isExit);
 };

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
@@ -13,12 +13,26 @@
 #include "../ride/Station.h"
 #include "../world/Entrance.h"
 
+RideEntranceExitRemoveAction::RideEntranceExitRemoveAction(
+    const CoordsXY& loc, ride_id_t rideIndex, StationIndex stationNum, bool isExit)
+    : _loc(loc)
+    , _rideIndex(rideIndex)
+    , _stationNum(stationNum)
+    , _isExit(isExit)
+{
+}
+
 void RideEntranceExitRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("station", _stationNum);
     visitor.Visit("isExit", _isExit);
+}
+
+uint16_t RideEntranceExitRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void RideEntranceExitRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.h
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.h
@@ -21,21 +21,11 @@ private:
 
 public:
     RideEntranceExitRemoveAction() = default;
-
-    RideEntranceExitRemoveAction(const CoordsXY& loc, ride_id_t rideIndex, StationIndex stationNum, bool isExit)
-        : _loc(loc)
-        , _rideIndex(rideIndex)
-        , _stationNum(stationNum)
-        , _isExit(isExit)
-    {
-    }
+    RideEntranceExitRemoveAction(const CoordsXY& loc, ride_id_t rideIndex, StationIndex stationNum, bool isExit);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetAppearanceAction.cpp
+++ b/src/openrct2/actions/RideSetAppearanceAction.cpp
@@ -21,12 +21,25 @@
 #include "../ui/WindowManager.h"
 #include "../world/Park.h"
 
+RideSetAppearanceAction::RideSetAppearanceAction(ride_id_t rideIndex, RideSetAppearanceType type, uint8_t value, uint32_t index)
+    : _rideIndex(rideIndex)
+    , _type(type)
+    , _value(value)
+    , _index(index)
+{
+}
+
 void RideSetAppearanceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("type", _type);
     visitor.Visit("value", _value);
     visitor.Visit("index", _index);
+}
+
+uint16_t RideSetAppearanceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetAppearanceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetAppearanceAction.h
+++ b/src/openrct2/actions/RideSetAppearanceAction.h
@@ -34,20 +34,11 @@ private:
 
 public:
     RideSetAppearanceAction() = default;
-    RideSetAppearanceAction(ride_id_t rideIndex, RideSetAppearanceType type, uint8_t value, uint32_t index)
-        : _rideIndex(rideIndex)
-        , _type(type)
-        , _value(value)
-        , _index(index)
-    {
-    }
+    RideSetAppearanceAction(ride_id_t rideIndex, RideSetAppearanceType type, uint8_t value, uint32_t index);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetColourSchemeAction.cpp
+++ b/src/openrct2/actions/RideSetColourSchemeAction.cpp
@@ -20,11 +20,23 @@
 #include "../world/Park.h"
 #include "../world/Sprite.h"
 
+RideSetColourSchemeAction::RideSetColourSchemeAction(const CoordsXYZD& location, int32_t trackType, uint16_t newColourScheme)
+    : _loc(location)
+    , _trackType(trackType)
+    , _newColourScheme(newColourScheme)
+{
+}
+
 void RideSetColourSchemeAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("trackType", _trackType);
     visitor.Visit("colourScheme", _newColourScheme);
+}
+
+uint16_t RideSetColourSchemeAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetColourSchemeAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetColourSchemeAction.h
+++ b/src/openrct2/actions/RideSetColourSchemeAction.h
@@ -20,19 +20,11 @@ private:
 
 public:
     RideSetColourSchemeAction() = default;
-    RideSetColourSchemeAction(const CoordsXYZD& location, int32_t trackType, uint16_t newColourScheme)
-        : _loc(location)
-        , _trackType(trackType)
-        , _newColourScheme(newColourScheme)
-    {
-    }
+    RideSetColourSchemeAction(const CoordsXYZD& location, int32_t trackType, uint16_t newColourScheme);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetNameAction.cpp
+++ b/src/openrct2/actions/RideSetNameAction.cpp
@@ -21,10 +21,21 @@
 #include "../ui/WindowManager.h"
 #include "../world/Park.h"
 
+RideSetNameAction::RideSetNameAction(ride_id_t rideIndex, const std::string& name)
+    : _rideIndex(rideIndex)
+    , _name(name)
+{
+}
+
 void RideSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("name", _name);
+}
+
+uint16_t RideSetNameAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetNameAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetNameAction.h
+++ b/src/openrct2/actions/RideSetNameAction.h
@@ -19,18 +19,11 @@ private:
 
 public:
     RideSetNameAction() = default;
-    RideSetNameAction(ride_id_t rideIndex, const std::string& name)
-        : _rideIndex(rideIndex)
-        , _name(name)
-    {
-    }
+    RideSetNameAction(ride_id_t rideIndex, const std::string& name);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/RideSetPriceAction.cpp
@@ -22,11 +22,23 @@
 #include "../world/Park.h"
 #include "../world/Sprite.h"
 
+RideSetPriceAction::RideSetPriceAction(ride_id_t rideIndex, money16 price, bool primaryPrice)
+    : _rideIndex(rideIndex)
+    , _price(price)
+    , _primaryPrice(primaryPrice)
+{
+}
+
 void RideSetPriceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("price", _price);
     visitor.Visit("isPrimaryPrice", _primaryPrice);
+}
+
+uint16_t RideSetPriceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetPriceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetPriceAction.h
+++ b/src/openrct2/actions/RideSetPriceAction.h
@@ -20,19 +20,11 @@ private:
 
 public:
     RideSetPriceAction() = default;
-    RideSetPriceAction(ride_id_t rideIndex, money16 price, bool primaryPrice)
-        : _rideIndex(rideIndex)
-        , _price(price)
-        , _primaryPrice(primaryPrice)
-    {
-    }
+    RideSetPriceAction(ride_id_t rideIndex, money16 price, bool primaryPrice);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -12,11 +12,23 @@
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 
+RideSetSettingAction::RideSetSettingAction(ride_id_t rideIndex, RideSetSetting setting, uint8_t value)
+    : _rideIndex(rideIndex)
+    , _setting(setting)
+    , _value(value)
+{
+}
+
 void RideSetSettingAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("setting", _setting);
     visitor.Visit("value", _value);
+}
+
+uint16_t RideSetSettingAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetSettingAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetSettingAction.h
+++ b/src/openrct2/actions/RideSetSettingAction.h
@@ -35,19 +35,11 @@ private:
 
 public:
     RideSetSettingAction() = default;
-    RideSetSettingAction(ride_id_t rideIndex, RideSetSetting setting, uint8_t value)
-        : _rideIndex(rideIndex)
-        , _setting(setting)
-        , _value(value)
-    {
-    }
+    RideSetSettingAction(ride_id_t rideIndex, RideSetSetting setting, uint8_t value);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/RideSetStatusAction.cpp
@@ -29,10 +29,21 @@ static rct_string_id _StatusErrorTitles[] = {
     STR_CANT_SIMULATE,
 };
 
+RideSetStatusAction::RideSetStatusAction(ride_id_t rideIndex, uint8_t status)
+    : _rideIndex(rideIndex)
+    , _status(status)
+{
+}
+
 void RideSetStatusAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("status", _status);
+}
+
+uint16_t RideSetStatusAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetStatusAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetStatusAction.h
+++ b/src/openrct2/actions/RideSetStatusAction.h
@@ -19,18 +19,11 @@ private:
 
 public:
     RideSetStatusAction() = default;
-    RideSetStatusAction(ride_id_t rideIndex, uint8_t status)
-        : _rideIndex(rideIndex)
-        , _status(status)
-    {
-    }
+    RideSetStatusAction(ride_id_t rideIndex, uint8_t status);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/RideSetVehicleAction.cpp
@@ -25,12 +25,29 @@
 #include "../util/Util.h"
 #include "../world/Park.h"
 
+constexpr static rct_string_id SetVehicleTypeErrorTitle[] = { STR_RIDE_SET_VEHICLE_SET_NUM_TRAINS_FAIL,
+                                                              STR_RIDE_SET_VEHICLE_SET_NUM_CARS_PER_TRAIN_FAIL,
+                                                              STR_RIDE_SET_VEHICLE_TYPE_FAIL };
+
+RideSetVehicleAction::RideSetVehicleAction(ride_id_t rideIndex, RideSetVehicleType type, uint8_t value, uint8_t colour)
+    : _rideIndex(rideIndex)
+    , _type(type)
+    , _value(value)
+    , _colour(colour)
+{
+}
+
 void RideSetVehicleAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("ride", _rideIndex);
     visitor.Visit("type", _type);
     visitor.Visit("value", _value);
     visitor.Visit("colour", _colour);
+}
+
+uint16_t RideSetVehicleAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void RideSetVehicleAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/RideSetVehicleAction.h
+++ b/src/openrct2/actions/RideSetVehicleAction.h
@@ -27,26 +27,13 @@ private:
     uint8_t _value{};
     uint8_t _colour{};
 
-    constexpr static rct_string_id SetVehicleTypeErrorTitle[] = { STR_RIDE_SET_VEHICLE_SET_NUM_TRAINS_FAIL,
-                                                                  STR_RIDE_SET_VEHICLE_SET_NUM_CARS_PER_TRAIN_FAIL,
-                                                                  STR_RIDE_SET_VEHICLE_TYPE_FAIL };
-
 public:
     RideSetVehicleAction() = default;
-    RideSetVehicleAction(ride_id_t rideIndex, RideSetVehicleType type, uint8_t value, uint8_t colour = 0)
-        : _rideIndex(rideIndex)
-        , _type(type)
-        , _value(value)
-        , _colour(colour)
-    {
-    }
+    RideSetVehicleAction(ride_id_t rideIndex, RideSetVehicleType type, uint8_t value, uint8_t colour = 0);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -37,11 +37,23 @@
 
 using ParametersRange = std::pair<std::pair<int32_t, int32_t>, std::pair<int32_t, int32_t>>;
 
+SetCheatAction::SetCheatAction(CheatType cheatType, int32_t param1, int32_t param2)
+    : _cheatType(static_cast<int32_t>(cheatType))
+    , _param1(param1)
+    , _param2(param2)
+{
+}
+
 void SetCheatAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("type", _cheatType);
     visitor.Visit("param1", _param1);
     visitor.Visit("param2", _param2);
+}
+
+uint16_t SetCheatAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void SetCheatAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/SetCheatAction.h
+++ b/src/openrct2/actions/SetCheatAction.h
@@ -22,19 +22,11 @@ private:
 
 public:
     SetCheatAction() = default;
-    SetCheatAction(CheatType cheatType, int32_t param1 = 0, int32_t param2 = 0)
-        : _cheatType(static_cast<int32_t>(cheatType))
-        , _param1(param1)
-        , _param2(param2)
-    {
-    }
+    SetCheatAction(CheatType cheatType, int32_t param1 = 0, int32_t param2 = 0);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SetParkEntranceFeeAction.cpp
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.cpp
@@ -15,6 +15,16 @@
 #include "../localisation/StringIds.h"
 #include "../world/Park.h"
 
+SetParkEntranceFeeAction::SetParkEntranceFeeAction(money16 fee)
+    : _fee(fee)
+{
+}
+
+uint16_t SetParkEntranceFeeAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void SetParkEntranceFeeAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/SetParkEntranceFeeAction.h
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.h
@@ -18,15 +18,9 @@ private:
 
 public:
     SetParkEntranceFeeAction() = default;
-    SetParkEntranceFeeAction(money16 fee)
-        : _fee(fee)
-    {
-    }
+    SetParkEntranceFeeAction(money16 fee);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SignSetNameAction.cpp
+++ b/src/openrct2/actions/SignSetNameAction.cpp
@@ -20,6 +20,17 @@
 
 #include <string>
 
+SignSetNameAction::SignSetNameAction(BannerIndex bannerIndex, const std::string& name)
+    : _bannerIndex(bannerIndex)
+    , _name(name)
+{
+}
+
+uint16_t SignSetNameAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void SignSetNameAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/SignSetNameAction.h
+++ b/src/openrct2/actions/SignSetNameAction.h
@@ -19,16 +19,9 @@ private:
 
 public:
     SignSetNameAction() = default;
-    SignSetNameAction(BannerIndex bannerIndex, const std::string& name)
-        : _bannerIndex(bannerIndex)
-        , _name(name)
-    {
-    }
+    SignSetNameAction(BannerIndex bannerIndex, const std::string& name);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SignSetStyleAction.cpp
+++ b/src/openrct2/actions/SignSetStyleAction.cpp
@@ -19,6 +19,19 @@
 #include "../world/Scenery.h"
 #include "../world/Sprite.h"
 
+SignSetStyleAction::SignSetStyleAction(BannerIndex bannerIndex, uint8_t mainColour, uint8_t textColour, bool isLarge)
+    : _bannerIndex(bannerIndex)
+    , _mainColour(mainColour)
+    , _textColour(textColour)
+    , _isLarge(isLarge)
+{
+}
+
+uint16_t SignSetStyleAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void SignSetStyleAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/SignSetStyleAction.h
+++ b/src/openrct2/actions/SignSetStyleAction.h
@@ -21,18 +21,9 @@ private:
 
 public:
     SignSetStyleAction() = default;
-    SignSetStyleAction(BannerIndex bannerIndex, uint8_t mainColour, uint8_t textColour, bool isLarge)
-        : _bannerIndex(bannerIndex)
-        , _mainColour(mainColour)
-        , _textColour(textColour)
-        , _isLarge(isLarge)
-    {
-    }
+    SignSetStyleAction(BannerIndex bannerIndex, uint8_t mainColour, uint8_t textColour, bool isLarge);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -28,6 +28,36 @@
 #include "GameAction.h"
 #include "SmallSceneryRemoveAction.h"
 
+SmallSceneryPlaceActionResult::SmallSceneryPlaceActionResult()
+    : GameActions::Result(GameActions::Status::Ok, STR_CANT_POSITION_THIS_HERE)
+{
+}
+
+SmallSceneryPlaceActionResult::SmallSceneryPlaceActionResult(GameActions::Status error)
+    : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE)
+{
+}
+
+SmallSceneryPlaceActionResult::SmallSceneryPlaceActionResult(GameActions::Status error, rct_string_id message)
+    : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message)
+{
+}
+
+SmallSceneryPlaceActionResult::SmallSceneryPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args)
+    : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message, args)
+{
+}
+
+SmallSceneryPlaceAction::SmallSceneryPlaceAction(
+    const CoordsXYZD& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
+    : _loc(loc)
+    , _quadrant(quadrant)
+    , _sceneryType(sceneryType)
+    , _primaryColour(primaryColour)
+    , _secondaryColour(secondaryColour)
+{
+}
+
 void SmallSceneryPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
@@ -35,6 +65,16 @@ void SmallSceneryPlaceAction::AcceptParameters(GameActionParameterVisitor& visit
     visitor.Visit("object", _sceneryType);
     visitor.Visit("primaryColour", _primaryColour);
     visitor.Visit("secondaryColour", _secondaryColour);
+}
+
+uint32_t SmallSceneryPlaceAction::GetCooldownTime() const
+{
+    return 20;
+}
+
+uint16_t SmallSceneryPlaceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void SmallSceneryPlaceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/SmallSceneryPlaceAction.h
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.h
@@ -15,22 +15,10 @@
 class SmallSceneryPlaceActionResult final : public GameActions::Result
 {
 public:
-    SmallSceneryPlaceActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_CANT_POSITION_THIS_HERE)
-    {
-    }
-    SmallSceneryPlaceActionResult(GameActions::Status error)
-        : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE)
-    {
-    }
-    SmallSceneryPlaceActionResult(GameActions::Status error, rct_string_id message)
-        : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message)
-    {
-    }
-    SmallSceneryPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args)
-        : GameActions::Result(error, STR_CANT_POSITION_THIS_HERE, message, args)
-    {
-    }
+    SmallSceneryPlaceActionResult();
+    SmallSceneryPlaceActionResult(GameActions::Status error);
+    SmallSceneryPlaceActionResult(GameActions::Status error, rct_string_id message);
+    SmallSceneryPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args);
 
     uint8_t GroundFlags{ 0 };
     TileElement* tileElement = nullptr;
@@ -47,27 +35,13 @@ private:
 
 public:
     SmallSceneryPlaceAction() = default;
-
     SmallSceneryPlaceAction(
-        const CoordsXYZD& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
-        : _loc(loc)
-        , _quadrant(quadrant)
-        , _sceneryType(sceneryType)
-        , _primaryColour(primaryColour)
-        , _secondaryColour(secondaryColour)
-    {
-    }
+        const CoordsXYZD& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
-    uint32_t GetCooldownTime() const override
-    {
-        return 20;
-    }
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint32_t GetCooldownTime() const override;
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.cpp
@@ -24,11 +24,23 @@
 #include "GameAction.h"
 #include "SmallSceneryPlaceAction.h"
 
+SmallSceneryRemoveAction::SmallSceneryRemoveAction(const CoordsXYZ& location, uint8_t quadrant, ObjectEntryIndex sceneryType)
+    : _loc(location)
+    , _quadrant(quadrant)
+    , _sceneryType(sceneryType)
+{
+}
+
 void SmallSceneryRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("object", _sceneryType);
     visitor.Visit("quadrant", _quadrant);
+}
+
+uint16_t SmallSceneryRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void SmallSceneryRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/SmallSceneryRemoveAction.h
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.h
@@ -21,20 +21,11 @@ private:
 
 public:
     SmallSceneryRemoveAction() = default;
-
-    SmallSceneryRemoveAction(const CoordsXYZ& location, uint8_t quadrant, ObjectEntryIndex sceneryType)
-        : _loc(location)
-        , _quadrant(quadrant)
-        , _sceneryType(sceneryType)
-    {
-    }
+    SmallSceneryRemoveAction(const CoordsXYZ& location, uint8_t quadrant, ObjectEntryIndex sceneryType);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SmallScenerySetColourAction.cpp
+++ b/src/openrct2/actions/SmallScenerySetColourAction.cpp
@@ -26,6 +26,21 @@
 #include "../world/Surface.h"
 #include "../world/TileElement.h"
 
+SmallScenerySetColourAction::SmallScenerySetColourAction(
+    const CoordsXYZ& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
+    : _loc(loc)
+    , _quadrant(quadrant)
+    , _sceneryType(sceneryType)
+    , _primaryColour(primaryColour)
+    , _secondaryColour(secondaryColour)
+{
+}
+
+uint16_t SmallScenerySetColourAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void SmallScenerySetColourAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/SmallScenerySetColourAction.h
+++ b/src/openrct2/actions/SmallScenerySetColourAction.h
@@ -22,21 +22,10 @@ private:
 
 public:
     SmallScenerySetColourAction() = default;
-
     SmallScenerySetColourAction(
-        const CoordsXYZ& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour)
-        : _loc(loc)
-        , _quadrant(quadrant)
-        , _sceneryType(sceneryType)
-        , _primaryColour(primaryColour)
-        , _secondaryColour(secondaryColour)
-    {
-    }
+        const CoordsXYZ& loc, uint8_t quadrant, ObjectEntryIndex sceneryType, uint8_t primaryColour, uint8_t secondaryColour);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -12,6 +12,16 @@
 #include "../interface/Window.h"
 #include "../peep/Peep.h"
 
+StaffFireAction::StaffFireAction(uint16_t spriteId)
+    : _spriteId(spriteId)
+{
+}
+
+uint16_t StaffFireAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void StaffFireAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/StaffFireAction.h
+++ b/src/openrct2/actions/StaffFireAction.h
@@ -19,15 +19,9 @@ private:
 
 public:
     StaffFireAction() = default;
-    StaffFireAction(uint16_t spriteId)
-        : _spriteId(spriteId)
-    {
-    }
+    StaffFireAction(uint16_t spriteId);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -26,12 +26,36 @@
 #include "../world/Park.h"
 #include "../world/Sprite.h"
 
+StaffHireNewActionResult::StaffHireNewActionResult()
+    : GameActions::Result(GameActions::Status::Ok, STR_CANT_HIRE_NEW_STAFF)
+{
+}
+
+StaffHireNewActionResult::StaffHireNewActionResult(GameActions::Status error, rct_string_id message)
+    : GameActions::Result(error, STR_CANT_HIRE_NEW_STAFF, message)
+{
+}
+
+StaffHireNewAction::StaffHireNewAction(
+    bool autoPosition, StaffType staffType, EntertainerCostume entertainerType, uint32_t staffOrders)
+    : _autoPosition(autoPosition)
+    , _staffType(static_cast<uint8_t>(staffType))
+    , _entertainerType(entertainerType)
+    , _staffOrders(staffOrders)
+{
+}
+
 void StaffHireNewAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("autoPosition", _autoPosition);
     visitor.Visit("staffType", _staffType);
     visitor.Visit("entertainerType", _entertainerType);
     visitor.Visit("staffOrders", _staffOrders);
+}
+
+uint16_t StaffHireNewAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void StaffHireNewAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/StaffHireNewAction.h
+++ b/src/openrct2/actions/StaffHireNewAction.h
@@ -24,14 +24,8 @@ static constexpr const PeepSpriteType spriteTypes[] = {
 class StaffHireNewActionResult final : public GameActions::Result
 {
 public:
-    StaffHireNewActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_CANT_HIRE_NEW_STAFF)
-    {
-    }
-    StaffHireNewActionResult(GameActions::Status error, rct_string_id message)
-        : GameActions::Result(error, STR_CANT_HIRE_NEW_STAFF, message)
-    {
-    }
+    StaffHireNewActionResult();
+    StaffHireNewActionResult(GameActions::Status error, rct_string_id message);
 
     uint32_t peepSriteIndex = SPRITE_INDEX_NULL;
 };
@@ -46,20 +40,11 @@ private:
 
 public:
     StaffHireNewAction() = default;
-    StaffHireNewAction(bool autoPosition, StaffType staffType, EntertainerCostume entertainerType, uint32_t staffOrders)
-        : _autoPosition(autoPosition)
-        , _staffType(static_cast<uint8_t>(staffType))
-        , _entertainerType(entertainerType)
-        , _staffOrders(staffOrders)
-    {
-    }
+    StaffHireNewAction(bool autoPosition, StaffType staffType, EntertainerCostume entertainerType, uint32_t staffOrders);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/StaffSetColourAction.cpp
+++ b/src/openrct2/actions/StaffSetColourAction.cpp
@@ -19,6 +19,17 @@
 #include "../windows/Intent.h"
 #include "../world/Sprite.h"
 
+StaffSetColourAction::StaffSetColourAction(StaffType staffType, uint8_t colour)
+    : _staffType(static_cast<uint8_t>(staffType))
+    , _colour(colour)
+{
+}
+
+uint16_t StaffSetColourAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void StaffSetColourAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/StaffSetColourAction.h
+++ b/src/openrct2/actions/StaffSetColourAction.h
@@ -19,16 +19,9 @@ private:
 
 public:
     StaffSetColourAction() = default;
-    StaffSetColourAction(StaffType staffType, uint8_t colour)
-        : _staffType(static_cast<uint8_t>(staffType))
-        , _colour(colour)
-    {
-    }
+    StaffSetColourAction(StaffType staffType, uint8_t colour);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/StaffSetCostumeAction.cpp
+++ b/src/openrct2/actions/StaffSetCostumeAction.cpp
@@ -15,6 +15,37 @@
 #include "../localisation/StringIds.h"
 #include "../windows/Intent.h"
 
+/** rct2: 0x00982134 */
+constexpr const bool peep_slow_walking_types[] = {
+    false, // PeepSpriteType::Normal
+    false, // PeepSpriteType::Handyman
+    false, // PeepSpriteType::Mechanic
+    false, // PeepSpriteType::Security
+    false, // PeepSpriteType::EntertainerPanda
+    false, // PeepSpriteType::EntertainerTiger
+    false, // PeepSpriteType::EntertainerElephant
+    false, // PeepSpriteType::EntertainerRoman
+    false, // PeepSpriteType::EntertainerGorilla
+    false, // PeepSpriteType::EntertainerSnowman
+    false, // PeepSpriteType::EntertainerKnight
+    true,  // PeepSpriteType::EntertainerAstronaut
+    false, // PeepSpriteType::EntertainerBandit
+    false, // PeepSpriteType::EntertainerSheriff
+    true,  // PeepSpriteType::EntertainerPirate
+    true,  // PeepSpriteType::Balloon
+};
+
+StaffSetCostumeAction::StaffSetCostumeAction(uint16_t spriteIndex, EntertainerCostume costume)
+    : _spriteIndex(spriteIndex)
+    , _costume(costume)
+{
+}
+
+uint16_t StaffSetCostumeAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void StaffSetCostumeAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/StaffSetCostumeAction.h
+++ b/src/openrct2/actions/StaffSetCostumeAction.h
@@ -13,26 +13,6 @@
 #include "../world/Sprite.h"
 #include "GameAction.h"
 
-/** rct2: 0x00982134 */
-constexpr const bool peep_slow_walking_types[] = {
-    false, // PeepSpriteType::Normal
-    false, // PeepSpriteType::Handyman
-    false, // PeepSpriteType::Mechanic
-    false, // PeepSpriteType::Security
-    false, // PeepSpriteType::EntertainerPanda
-    false, // PeepSpriteType::EntertainerTiger
-    false, // PeepSpriteType::EntertainerElephant
-    false, // PeepSpriteType::EntertainerRoman
-    false, // PeepSpriteType::EntertainerGorilla
-    false, // PeepSpriteType::EntertainerSnowman
-    false, // PeepSpriteType::EntertainerKnight
-    true,  // PeepSpriteType::EntertainerAstronaut
-    false, // PeepSpriteType::EntertainerBandit
-    false, // PeepSpriteType::EntertainerSheriff
-    true,  // PeepSpriteType::EntertainerPirate
-    true,  // PeepSpriteType::Balloon
-};
-
 DEFINE_GAME_ACTION(StaffSetCostumeAction, GAME_COMMAND_SET_STAFF_COSTUME, GameActions::Result)
 {
 private:
@@ -41,16 +21,9 @@ private:
 
 public:
     StaffSetCostumeAction() = default;
-    StaffSetCostumeAction(uint16_t spriteIndex, EntertainerCostume costume)
-        : _spriteIndex(spriteIndex)
-        , _costume(costume)
-    {
-    }
+    StaffSetCostumeAction(uint16_t spriteIndex, EntertainerCostume costume);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/StaffSetNameAction.cpp
+++ b/src/openrct2/actions/StaffSetNameAction.cpp
@@ -20,6 +20,17 @@
 #include "../windows/Intent.h"
 #include "../world/Park.h"
 
+StaffSetNameAction::StaffSetNameAction(uint16_t spriteIndex, const std::string& name)
+    : _spriteIndex(spriteIndex)
+    , _name(name)
+{
+}
+
+uint16_t StaffSetNameAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void StaffSetNameAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/StaffSetNameAction.h
+++ b/src/openrct2/actions/StaffSetNameAction.h
@@ -20,17 +20,9 @@ private:
 
 public:
     StaffSetNameAction() = default;
-    StaffSetNameAction(uint16_t spriteIndex, const std::string& name)
-        : _spriteIndex(spriteIndex)
-        , _name(name)
-    {
-    }
+    StaffSetNameAction(uint16_t spriteIndex, const std::string& name);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
-
+    uint16_t GetActionFlags() const override;
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;
     GameActions::Result::Ptr Execute() const override;

--- a/src/openrct2/actions/StaffSetOrdersAction.cpp
+++ b/src/openrct2/actions/StaffSetOrdersAction.cpp
@@ -16,6 +16,17 @@
 #include "../peep/Staff.h"
 #include "../windows/Intent.h"
 
+StaffSetOrdersAction::StaffSetOrdersAction(uint16_t spriteIndex, uint8_t ordersId)
+    : _spriteIndex(spriteIndex)
+    , _ordersId(ordersId)
+{
+}
+
+uint16_t StaffSetOrdersAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void StaffSetOrdersAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/StaffSetOrdersAction.h
+++ b/src/openrct2/actions/StaffSetOrdersAction.h
@@ -20,16 +20,9 @@ private:
 
 public:
     StaffSetOrdersAction() = default;
-    StaffSetOrdersAction(uint16_t spriteIndex, uint8_t ordersId)
-        : _spriteIndex(spriteIndex)
-        , _ordersId(ordersId)
-    {
-    }
+    StaffSetOrdersAction(uint16_t spriteIndex, uint8_t ordersId);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
@@ -13,6 +13,17 @@
 #include "../peep/Peep.h"
 #include "../peep/Staff.h"
 
+StaffSetPatrolAreaAction::StaffSetPatrolAreaAction(uint16_t spriteId, const CoordsXY& loc)
+    : _spriteId(spriteId)
+    , _loc(loc)
+{
+}
+
+uint16_t StaffSetPatrolAreaAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void StaffSetPatrolAreaAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.h
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.h
@@ -20,16 +20,9 @@ private:
 
 public:
     StaffSetPatrolAreaAction() = default;
-    StaffSetPatrolAreaAction(uint16_t spriteId, const CoordsXY& loc)
-        : _spriteId(spriteId)
-        , _loc(loc)
-    {
-    }
+    StaffSetPatrolAreaAction(uint16_t spriteId, const CoordsXY& loc);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -19,6 +19,13 @@
 #include "../world/Surface.h"
 #include "../world/TileElement.h"
 
+SurfaceSetStyleAction::SurfaceSetStyleAction(MapRange range, ObjectEntryIndex surfaceStyle, ObjectEntryIndex edgeStyle)
+    : _range(range)
+    , _surfaceStyle(surfaceStyle)
+    , _edgeStyle(edgeStyle)
+{
+}
+
 void SurfaceSetStyleAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/SurfaceSetStyleAction.h
+++ b/src/openrct2/actions/SurfaceSetStyleAction.h
@@ -20,13 +20,7 @@ private:
 
 public:
     SurfaceSetStyleAction() = default;
-
-    SurfaceSetStyleAction(MapRange range, ObjectEntryIndex surfaceStyle, ObjectEntryIndex edgeStyle)
-        : _range(range)
-        , _surfaceStyle(surfaceStyle)
-        , _edgeStyle(edgeStyle)
-    {
-    }
+    SurfaceSetStyleAction(MapRange range, ObjectEntryIndex surfaceStyle, ObjectEntryIndex edgeStyle);
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/TileModifyAction.cpp
+++ b/src/openrct2/actions/TileModifyAction.cpp
@@ -11,6 +11,21 @@
 
 #include "../world/TileInspector.h"
 
+TileModifyAction::TileModifyAction(
+    CoordsXY loc, TileModifyType setting, uint32_t value1, uint32_t value2, TileElement pasteElement)
+    : _loc(loc)
+    , _setting(setting)
+    , _value1(value1)
+    , _value2(value2)
+    , _pasteElement(pasteElement)
+{
+}
+
+uint16_t TileModifyAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void TileModifyAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/TileModifyAction.h
+++ b/src/openrct2/actions/TileModifyAction.h
@@ -53,19 +53,9 @@ private:
 public:
     TileModifyAction() = default;
     TileModifyAction(
-        CoordsXY loc, TileModifyType setting, uint32_t value1 = 0, uint32_t value2 = 0, TileElement pasteElement = {})
-        : _loc(loc)
-        , _setting(setting)
-        , _value1(value1)
-        , _value2(value2)
-        , _pasteElement(pasteElement)
-    {
-    }
+        CoordsXY loc, TileModifyType setting, uint32_t value1 = 0, uint32_t value2 = 0, TileElement pasteElement = {});
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -27,6 +27,51 @@ static int32_t place_virtual_track(
     return place_virtual_track(const_cast<TrackDesign*>(&td6), ptdOperation, placeScenery, ride, loc);
 }
 
+TrackDesignActionResult::TrackDesignActionResult()
+    : GameActions::Result(GameActions::Status::Ok, STR_NONE)
+{
+}
+
+TrackDesignActionResult::TrackDesignActionResult(GameActions::Status error)
+    : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_NONE)
+{
+}
+
+TrackDesignActionResult::TrackDesignActionResult(GameActions::Status error, rct_string_id title, rct_string_id message)
+    : GameActions::Result(error, title, message)
+{
+}
+
+TrackDesignActionResult::TrackDesignActionResult(GameActions::Status error, rct_string_id message)
+    : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, message)
+{
+}
+
+TrackDesignAction::TrackDesignAction(const CoordsXYZD& location, const TrackDesign& td)
+    : _loc(location)
+    , _td(td)
+{
+}
+
+void TrackDesignAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit(_loc);
+    // TODO visit the track design (it has a lot of sub fields)
+}
+
+uint16_t TrackDesignAction::GetActionFlags() const
+{
+    return GameActionBase::GetActionFlags();
+}
+
+void TrackDesignAction::Serialise(DataSerialiser& stream)
+{
+    GameAction::Serialise(stream);
+
+    stream << DS_TAG(_loc);
+    _td.Serialise(stream);
+}
+
 GameActions::Result::Ptr TrackDesignAction::Query() const
 {
     auto res = MakeResult();

--- a/src/openrct2/actions/TrackDesignAction.h
+++ b/src/openrct2/actions/TrackDesignAction.h
@@ -15,22 +15,10 @@
 class TrackDesignActionResult final : public GameActions::Result
 {
 public:
-    TrackDesignActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_NONE)
-    {
-    }
-    TrackDesignActionResult(GameActions::Status error)
-        : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_NONE)
-    {
-    }
-    TrackDesignActionResult(GameActions::Status error, rct_string_id title, rct_string_id message)
-        : GameActions::Result(error, title, message)
-    {
-    }
-    TrackDesignActionResult(GameActions::Status error, rct_string_id message)
-        : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, message)
-    {
-    }
+    TrackDesignActionResult();
+    TrackDesignActionResult(GameActions::Status error);
+    TrackDesignActionResult(GameActions::Status error, rct_string_id title, rct_string_id message);
+    TrackDesignActionResult(GameActions::Status error, rct_string_id message);
 
     ride_id_t rideIndex = RIDE_ID_NULL;
 };
@@ -43,31 +31,13 @@ private:
 
 public:
     TrackDesignAction() = default;
+    TrackDesignAction(const CoordsXYZD& location, const TrackDesign& td);
 
-    TrackDesignAction(const CoordsXYZD& location, const TrackDesign& td)
-        : _loc(location)
-        , _td(td)
-    {
-    }
+    void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    void AcceptParameters(GameActionParameterVisitor & visitor) override
-    {
-        visitor.Visit(_loc);
-        // TODO visit the track design (it has a lot of sub fields)
-    }
+    uint16_t GetActionFlags() const override;
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameActionBase::GetActionFlags();
-    }
-
-    void Serialise(DataSerialiser & stream) override
-    {
-        GameAction::Serialise(stream);
-
-        stream << DS_TAG(_loc);
-        _td.Serialise(stream);
-    }
+    void Serialise(DataSerialiser & stream) override;
 
     GameActions::Result::Ptr Query() const override;
     GameActions::Result::Ptr Execute() const override;

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -19,6 +19,41 @@
 #include "../world/Surface.h"
 #include "RideSetSettingAction.h"
 
+TrackPlaceActionResult::TrackPlaceActionResult()
+    : GameActions::Result(GameActions::Status::Ok, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE)
+{
+}
+
+TrackPlaceActionResult::TrackPlaceActionResult(GameActions::Status error)
+    : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE)
+{
+}
+
+TrackPlaceActionResult::TrackPlaceActionResult(GameActions::Status error, rct_string_id message)
+    : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, message)
+{
+}
+
+TrackPlaceActionResult::TrackPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args)
+    : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, message, args)
+{
+}
+
+TrackPlaceAction::TrackPlaceAction(
+    NetworkRideId_t rideIndex, int32_t trackType, const CoordsXYZD& origin, int32_t brakeSpeed, int32_t colour,
+    int32_t seatRotation, int32_t liftHillAndAlternativeState, bool fromTrackDesign)
+    : _rideIndex(rideIndex)
+    , _trackType(trackType)
+    , _origin(origin)
+    , _brakeSpeed(brakeSpeed)
+    , _colour(colour)
+    , _seatRotation(seatRotation)
+    , _trackPlaceFlags(liftHillAndAlternativeState)
+    , _fromTrackDesign(fromTrackDesign)
+{
+    _origin.direction &= 3;
+}
+
 void TrackPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_origin);
@@ -29,6 +64,11 @@ void TrackPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
     visitor.Visit("seatRotation", _seatRotation);
     visitor.Visit("trackPlaceFlags", _trackPlaceFlags);
     visitor.Visit("isFromTrackDesign", _fromTrackDesign);
+}
+
+uint16_t TrackPlaceAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void TrackPlaceAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/TrackPlaceAction.h
+++ b/src/openrct2/actions/TrackPlaceAction.h
@@ -14,22 +14,10 @@
 class TrackPlaceActionResult final : public GameActions::Result
 {
 public:
-    TrackPlaceActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE)
-    {
-    }
-    TrackPlaceActionResult(GameActions::Status error)
-        : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE)
-    {
-    }
-    TrackPlaceActionResult(GameActions::Status error, rct_string_id message)
-        : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, message)
-    {
-    }
-    TrackPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args)
-        : GameActions::Result(error, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, message, args)
-    {
-    }
+    TrackPlaceActionResult();
+    TrackPlaceActionResult(GameActions::Status error);
+    TrackPlaceActionResult(GameActions::Status error, rct_string_id message);
+    TrackPlaceActionResult(GameActions::Status error, rct_string_id message, uint8_t* args);
 
     uint8_t GroundFlags{ 0 };
 };
@@ -50,25 +38,11 @@ public:
     TrackPlaceAction() = default;
     TrackPlaceAction(
         NetworkRideId_t rideIndex, int32_t trackType, const CoordsXYZD& origin, int32_t brakeSpeed, int32_t colour,
-        int32_t seatRotation, int32_t liftHillAndAlternativeState, bool fromTrackDesign)
-        : _rideIndex(rideIndex)
-        , _trackType(trackType)
-        , _origin(origin)
-        , _brakeSpeed(brakeSpeed)
-        , _colour(colour)
-        , _seatRotation(seatRotation)
-        , _trackPlaceFlags(liftHillAndAlternativeState)
-        , _fromTrackDesign(fromTrackDesign)
-    {
-        _origin.direction &= 3;
-    }
+        int32_t seatRotation, int32_t liftHillAndAlternativeState, bool fromTrackDesign);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override final
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override final;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -19,11 +19,24 @@
 #include "../world/Surface.h"
 #include "RideSetSettingAction.h"
 
+TrackRemoveAction::TrackRemoveAction(int32_t trackType, int32_t sequence, const CoordsXYZD& origin)
+    : _trackType(trackType)
+    , _sequence(sequence)
+    , _origin(origin)
+{
+    _origin.direction &= 3;
+}
+
 void TrackRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_origin);
     visitor.Visit("trackType", _trackType);
     visitor.Visit("sequence", _sequence);
+}
+
+uint16_t TrackRemoveAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
 }
 
 void TrackRemoveAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/TrackRemoveAction.h
+++ b/src/openrct2/actions/TrackRemoveAction.h
@@ -20,20 +20,11 @@ private:
 
 public:
     TrackRemoveAction() = default;
-    TrackRemoveAction(int32_t trackType, int32_t sequence, const CoordsXYZD& origin)
-        : _trackType(trackType)
-        , _sequence(sequence)
-        , _origin(origin)
-    {
-        _origin.direction &= 3;
-    }
+    TrackRemoveAction(int32_t trackType, int32_t sequence, const CoordsXYZD& origin);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override final
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override final;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -11,11 +11,23 @@
 
 #include "../management/Finance.h"
 
+TrackSetBrakeSpeedAction::TrackSetBrakeSpeedAction(const CoordsXYZ& loc, track_type_t trackType, uint8_t brakeSpeed)
+    : _loc(loc)
+    , _trackType(trackType)
+    , _brakeSpeed(brakeSpeed)
+{
+}
+
 void TrackSetBrakeSpeedAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("trackType", _trackType);
     visitor.Visit("brakeSpeed", _brakeSpeed);
+}
+
+uint16_t TrackSetBrakeSpeedAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
 }
 
 void TrackSetBrakeSpeedAction::Serialise(DataSerialiser& stream)

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.h
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.h
@@ -20,19 +20,11 @@ private:
 
 public:
     TrackSetBrakeSpeedAction() = default;
-    TrackSetBrakeSpeedAction(const CoordsXYZ& loc, track_type_t trackType, uint8_t brakeSpeed)
-        : _loc(loc)
-        , _trackType(trackType)
-        , _brakeSpeed(brakeSpeed)
-    {
-    }
+    TrackSetBrakeSpeedAction(const CoordsXYZ& loc, track_type_t trackType, uint8_t brakeSpeed);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override final
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override final;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/WallPlaceAction.h
+++ b/src/openrct2/actions/WallPlaceAction.h
@@ -17,25 +17,10 @@
 class WallPlaceActionResult final : public GameActions::Result
 {
 public:
-    WallPlaceActionResult()
-        : GameActions::Result(GameActions::Status::Ok, STR_CANT_BUILD_PARK_ENTRANCE_HERE)
-    {
-    }
-
-    WallPlaceActionResult(GameActions::Status err)
-        : GameActions::Result(err, STR_CANT_BUILD_PARK_ENTRANCE_HERE)
-    {
-    }
-
-    WallPlaceActionResult(GameActions::Status err, rct_string_id msg)
-        : GameActions::Result(err, STR_CANT_BUILD_PARK_ENTRANCE_HERE, msg)
-    {
-    }
-
-    WallPlaceActionResult(GameActions::Status error, rct_string_id msg, uint8_t* args)
-        : GameActions::Result(error, STR_CANT_BUILD_PARK_ENTRANCE_HERE, msg, args)
-    {
-    }
+    WallPlaceActionResult();
+    WallPlaceActionResult(GameActions::Status err);
+    WallPlaceActionResult(GameActions::Status err, rct_string_id msg);
+    WallPlaceActionResult(GameActions::Status error, rct_string_id msg, uint8_t* args);
 
     TileElement* tileElement = nullptr;
 };
@@ -53,33 +38,13 @@ private:
 
 public:
     WallPlaceAction() = default;
-
     WallPlaceAction(
         ObjectEntryIndex wallType, const CoordsXYZ& loc, uint8_t edge, int32_t primaryColour, int32_t secondaryColour,
-        int32_t tertiaryColour)
-        : _wallType(wallType)
-        , _loc(loc)
-        , _edge(edge)
-        , _primaryColour(primaryColour)
-        , _secondaryColour(secondaryColour)
-        , _tertiaryColour(tertiaryColour)
-    {
-        rct_scenery_entry* sceneryEntry = get_wall_entry(_wallType);
-        if (sceneryEntry != nullptr)
-        {
-            if (sceneryEntry->wall.scrolling_mode != SCROLLING_MODE_NONE)
-            {
-                _bannerId = create_new_banner(0);
-            }
-        }
-    }
+        int32_t tertiaryColour);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 
-    uint16_t GetActionFlags() const override final
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override final;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;
@@ -103,25 +68,5 @@ private:
      * Gets whether the given track type can have a wall placed on the edge of the given direction.
      * Some thin tracks for example are allowed to have walls either side of the track, but wider tracks can not.
      */
-    static bool TrackIsAllowedWallEdges(uint8_t rideType, uint8_t trackType, uint8_t trackSequence, uint8_t direction)
-    {
-        if (!ride_type_has_flag(rideType, RIDE_TYPE_FLAG_TRACK_NO_WALLS))
-        {
-            if (ride_type_has_flag(rideType, RIDE_TYPE_FLAG_FLAT_RIDE))
-            {
-                if (FlatRideTrackSequenceElementAllowedWallEdges[trackType][trackSequence] & (1 << direction))
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                if (TrackSequenceElementAllowedWallEdges[trackType][trackSequence] & (1 << direction))
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+    static bool TrackIsAllowedWallEdges(uint8_t rideType, uint8_t trackType, uint8_t trackSequence, uint8_t direction);
 };

--- a/src/openrct2/actions/WallRemoveAction.cpp
+++ b/src/openrct2/actions/WallRemoveAction.cpp
@@ -18,6 +18,11 @@
 #include "../world/Location.hpp"
 #include "../world/Wall.h"
 
+WallRemoveAction::WallRemoveAction(const CoordsXYZD& loc)
+    : _loc(loc)
+{
+}
+
 void WallRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);

--- a/src/openrct2/actions/WallRemoveAction.h
+++ b/src/openrct2/actions/WallRemoveAction.h
@@ -18,10 +18,7 @@ private:
 
 public:
     WallRemoveAction() = default;
-    WallRemoveAction(const CoordsXYZD& loc)
-        : _loc(loc)
-    {
-    }
+    WallRemoveAction(const CoordsXYZD& loc);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/WallSetColourAction.cpp
+++ b/src/openrct2/actions/WallSetColourAction.cpp
@@ -20,6 +20,20 @@
 #include "../world/SmallScenery.h"
 #include "../world/Surface.h"
 
+WallSetColourAction::WallSetColourAction(
+    const CoordsXYZD& loc, int32_t primaryColour, int32_t secondaryColour, int32_t tertiaryColour)
+    : _loc(loc)
+    , _primaryColour(primaryColour)
+    , _secondaryColour(secondaryColour)
+    , _tertiaryColour(tertiaryColour)
+{
+}
+
+uint16_t WallSetColourAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
+}
+
 void WallSetColourAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/WallSetColourAction.h
+++ b/src/openrct2/actions/WallSetColourAction.h
@@ -21,19 +21,9 @@ private:
 
 public:
     WallSetColourAction() = default;
+    WallSetColourAction(const CoordsXYZD& loc, int32_t primaryColour, int32_t secondaryColour, int32_t tertiaryColour);
 
-    WallSetColourAction(const CoordsXYZD& loc, int32_t primaryColour, int32_t secondaryColour, int32_t tertiaryColour)
-        : _loc(loc)
-        , _primaryColour(primaryColour)
-        , _secondaryColour(secondaryColour)
-        , _tertiaryColour(tertiaryColour)
-    {
-    }
-
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/WaterLowerAction.cpp
+++ b/src/openrct2/actions/WaterLowerAction.cpp
@@ -13,6 +13,16 @@
 #include "../audio/audio.h"
 #include "WaterSetHeightAction.h"
 
+WaterLowerAction::WaterLowerAction(MapRange range)
+    : _range(range)
+{
+}
+
+uint16_t WaterLowerAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void WaterLowerAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/WaterLowerAction.h
+++ b/src/openrct2/actions/WaterLowerAction.h
@@ -18,15 +18,9 @@ private:
 
 public:
     WaterLowerAction() = default;
-    WaterLowerAction(MapRange range)
-        : _range(range)
-    {
-    }
+    WaterLowerAction(MapRange range);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/WaterRaiseAction.cpp
+++ b/src/openrct2/actions/WaterRaiseAction.cpp
@@ -13,6 +13,16 @@
 #include "../audio/audio.h"
 #include "WaterSetHeightAction.h"
 
+WaterRaiseAction::WaterRaiseAction(MapRange range)
+    : _range(range)
+{
+}
+
+uint16_t WaterRaiseAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void WaterRaiseAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/WaterRaiseAction.h
+++ b/src/openrct2/actions/WaterRaiseAction.h
@@ -18,15 +18,9 @@ private:
 
 public:
     WaterRaiseAction() = default;
-    WaterRaiseAction(MapRange range)
-        : _range(range)
-    {
-    }
+    WaterRaiseAction(MapRange range);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;

--- a/src/openrct2/actions/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/WaterSetHeightAction.cpp
@@ -14,6 +14,17 @@
 #include "../world/Park.h"
 #include "../world/Surface.h"
 
+WaterSetHeightAction::WaterSetHeightAction(const CoordsXY& coords, uint8_t height)
+    : _coords(coords)
+    , _height(height)
+{
+}
+
+uint16_t WaterSetHeightAction::GetActionFlags() const
+{
+    return GameAction::GetActionFlags();
+}
+
 void WaterSetHeightAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);

--- a/src/openrct2/actions/WaterSetHeightAction.h
+++ b/src/openrct2/actions/WaterSetHeightAction.h
@@ -19,16 +19,9 @@ private:
 
 public:
     WaterSetHeightAction() = default;
-    WaterSetHeightAction(const CoordsXY& coords, uint8_t height)
-        : _coords(coords)
-        , _height(height)
-    {
-    }
+    WaterSetHeightAction(const CoordsXY& coords, uint8_t height);
 
-    uint16_t GetActionFlags() const override
-    {
-        return GameAction::GetActionFlags();
-    }
+    uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;
     GameActions::Result::Ptr Query() const override;


### PR DESCRIPTION
A follow-up of #13548 and #13571 to make sure everything is defined inside the `cpp` file, preventing further compilation