### PR TITLE
Feature: Add allow_remote_hosts to plugin section of the config

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Feature: [#13495] [Plugin] Add properties for park value, guests and company value.
 - Feature: [#13509] [Plugin] Add ability to format strings using OpenRCT2 string framework.
 - Feature: [#13512] [Plugin] Add item separators to list view.
+- Feature: Add allow_remote_hosts to plugin section of the config
 - Change: [#13346] Change FootpathScenery to FootpathAddition in all occurrences.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
 - Fix: [#13257] Rides that are exactly the minimum objective length are not counted.

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -537,6 +537,7 @@ namespace Config
         {
             auto model = &gConfigPlugin;
             model->enable_hot_reloading = reader->GetBoolean("enable_hot_reloading", false);
+            model->allow_remote_hosts = reader->GetBoolean("allow_remote_hosts", false);
         }
     }
 
@@ -545,6 +546,7 @@ namespace Config
         auto model = &gConfigPlugin;
         writer->WriteSection("plugin");
         writer->WriteBoolean("enable_hot_reloading", model->enable_hot_reloading);
+        writer->WriteBoolean("allow_remote_hosts", model->allow_remote_hosts);
     }
 
     static bool SetDefaults()

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -204,6 +204,7 @@ struct FontConfiguration
 struct PluginConfiguration
 {
     bool enable_hot_reloading;
+    bool allow_remote_hosts;
 };
 
 enum SORT

--- a/src/openrct2/scripting/ScSocket.hpp
+++ b/src/openrct2/scripting/ScSocket.hpp
@@ -166,7 +166,7 @@ namespace OpenRCT2::Scripting
             {
                 duk_error(ctx, DUK_ERR_ERROR, "Socket is already connecting.");
             }
-            else if (!IsLocalhostAddress(host))
+            else if (!IsLocalhostAddress(host) && !gConfigPlugin.allow_remote_hosts)
             {
                 duk_error(ctx, DUK_ERR_ERROR, "For security reasons, only connecting to localhost is allowed.");
             }


### PR DESCRIPTION
Gives plugin developers more flexibility while continuing to prevent users from accidentally shooting themselves in the foot.