### PR TITLE
Enhanced track designer with ability to add/remove scenery and footpaths

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#13510] [Plugin] list view scroll resets when items is set.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.
+- Improved: [#13587] Allow up to 128 ride objects to be selected in track designer.
 - Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
 
 0.3.2 (2020-11-01)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Feature: [#13509] [Plugin] Add ability to format strings using OpenRCT2 string framework.
 - Feature: [#13512] [Plugin] Add item separators to list view.
 - Feature: [#13583] Add allowed_hosts to plugin section of config.
+- Feature: [#13587] Enhanced track designer with ability to add/remove scenery and footpaths.
 - Change: [#13346] Change FootpathScenery to FootpathAddition in all occurrences.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
 - Fix: [#13257] Rides that are exactly the minimum objective length are not counted.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1001,8 +1001,6 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
 
         int32_t numSelected = _numSelectedObjectsForType[EnumValue(get_selected_object_type(w))];
         int32_t totalSelectable = object_entry_group_counts[EnumValue(get_selected_object_type(w))];
-        if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-            totalSelectable = 4;
 
         auto ft = Formatter();
         ft.Add<uint16_t>(numSelected);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5343,11 +5343,7 @@ static void window_ride_measurements_mousedown(rct_window* w, rct_widgetindex wi
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1],
         Dropdown::Flag::StayOpen, 2);
     gDropdownDefaultIndex = 0;
-    if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-    {
-        Dropdown::SetDisabled(1, true);
-    }
-    else if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_TRACK))
+    if (!ride_type_has_flag(ride->type, RIDE_TYPE_FLAG_HAS_TRACK))
     {
         // Disable saving without scenery if we're a flat ride
         Dropdown::SetDisabled(0, true);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -675,7 +675,7 @@ static void window_top_toolbar_invalidate(rct_window* w)
 
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
-        window_top_toolbar_widgets[WIDX_RIDES].type = WindowWidgetType::Empty;
+        //window_top_toolbar_widgets[WIDX_RIDES].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_PARK].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_STAFF].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_GUESTS].type = WindowWidgetType::Empty;
@@ -686,22 +686,28 @@ static void window_top_toolbar_invalidate(rct_window* w)
 
         if (gS6Info.editor_step != EDITOR_STEP_LANDSCAPE_EDITOR)
         {
-            window_top_toolbar_widgets[WIDX_MAP].type = WindowWidgetType::Empty;
+            //window_top_toolbar_widgets[WIDX_MAP].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_LAND].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_WATER].type = WindowWidgetType::Empty;
-            window_top_toolbar_widgets[WIDX_SCENERY].type = WindowWidgetType::Empty;
-            window_top_toolbar_widgets[WIDX_PATH].type = WindowWidgetType::Empty;
-            window_top_toolbar_widgets[WIDX_CLEAR_SCENERY].type = WindowWidgetType::Empty;
+            //window_top_toolbar_widgets[WIDX_SCENERY].type = WindowWidgetType::Empty;
+            //window_top_toolbar_widgets[WIDX_PATH].type = WindowWidgetType::Empty;
+            //window_top_toolbar_widgets[WIDX_CLEAR_SCENERY].type = WindowWidgetType::Empty;
         }
 
         if (gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         {
+            window_top_toolbar_widgets[WIDX_RIDES].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WindowWidgetType::Empty;
         }
 
         if (gS6Info.editor_step != EDITOR_STEP_LANDSCAPE_EDITOR && gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)
         {
+            window_top_toolbar_widgets[WIDX_MAP].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_SCENERY].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_PATH].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_CLEAR_SCENERY].type = WindowWidgetType::Empty;
+
             window_top_toolbar_widgets[WIDX_ZOOM_OUT].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_ZOOM_IN].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_ROTATE].type = WindowWidgetType::Empty;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -675,7 +675,6 @@ static void window_top_toolbar_invalidate(rct_window* w)
 
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
-        //window_top_toolbar_widgets[WIDX_RIDES].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_PARK].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_STAFF].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_GUESTS].type = WindowWidgetType::Empty;
@@ -686,12 +685,8 @@ static void window_top_toolbar_invalidate(rct_window* w)
 
         if (gS6Info.editor_step != EDITOR_STEP_LANDSCAPE_EDITOR)
         {
-            //window_top_toolbar_widgets[WIDX_MAP].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_LAND].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_WATER].type = WindowWidgetType::Empty;
-            //window_top_toolbar_widgets[WIDX_SCENERY].type = WindowWidgetType::Empty;
-            //window_top_toolbar_widgets[WIDX_PATH].type = WindowWidgetType::Empty;
-            //window_top_toolbar_widgets[WIDX_CLEAR_SCENERY].type = WindowWidgetType::Empty;
         }
 
         if (gS6Info.editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER)

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -496,10 +496,6 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
 
         ObjectType objectType = item->ObjectEntry.GetType();
         uint16_t maxObjects = object_entry_group_counts[EnumValue(objectType)];
-        if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER && objectType == ObjectType::Ride)
-        {
-            maxObjects = 4;
-        }
 
         if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
         {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -37,6 +37,7 @@ static void setup_in_use_selection_flags();
 static void setup_track_designer_objects();
 static void setup_track_manager_objects();
 static void window_editor_object_selection_select_default_objects();
+static void select_designer_objects();
 
 /**
  *
@@ -75,6 +76,7 @@ static void setup_track_designer_objects()
 {
     int32_t numObjects = static_cast<int32_t>(object_repository_get_items_count());
     const ObjectRepositoryItem* items = object_repository_get_items();
+    select_designer_objects();
     for (int32_t i = 0; i < numObjects; i++)
     {
         uint8_t* selectionFlags = &_objectSelectionFlags[i];
@@ -353,6 +355,21 @@ static void window_editor_object_selection_select_default_objects()
     }
 }
 
+static void select_designer_objects()
+{
+    if (_numSelectedObjectsForType[0] == 0)
+    {
+        for (auto designerSelectedObject : DesignerSelectedObjects)
+        {
+            window_editor_object_selection_select_object(
+                0,
+                INPUT_FLAG_EDITOR_OBJECT_SELECT | INPUT_FLAG_EDITOR_OBJECT_1
+                    | INPUT_FLAG_EDITOR_OBJECT_SELECT_OBJECTS_IN_SCENERY_GROUP,
+                designerSelectedObject);
+        }
+    }
+}
+
 /**
  *
  *  rct2: 0x006AA770
@@ -479,7 +496,7 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
 
         ObjectType objectType = item->ObjectEntry.GetType();
         uint16_t maxObjects = object_entry_group_counts[EnumValue(objectType)];
-        if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
+        if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER && objectType == ObjectType::Ride)
         {
             maxObjects = 4;
         }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -37,7 +37,7 @@ static void setup_in_use_selection_flags();
 static void setup_track_designer_objects();
 static void setup_track_manager_objects();
 static void window_editor_object_selection_select_default_objects();
-static void select_designer_objects();
+static void SelectDesignerObjects();
 
 /**
  *
@@ -76,7 +76,7 @@ static void setup_track_designer_objects()
 {
     int32_t numObjects = static_cast<int32_t>(object_repository_get_items_count());
     const ObjectRepositoryItem* items = object_repository_get_items();
-    select_designer_objects();
+    SelectDesignerObjects();
     for (int32_t i = 0; i < numObjects; i++)
     {
         uint8_t* selectionFlags = &_objectSelectionFlags[i];
@@ -355,7 +355,7 @@ static void window_editor_object_selection_select_default_objects()
     }
 }
 
-static void select_designer_objects()
+static void SelectDesignerObjects()
 {
     if (_numSelectedObjectsForType[0] == 0)
     {

--- a/src/openrct2/object/DefaultObjects.cpp
+++ b/src/openrct2/object/DefaultObjects.cpp
@@ -49,3 +49,22 @@ const std::string_view DefaultSelectedObjects[] = {
     "rct2.scgsnow",  // Snow and Ice Theming
     "rct2.scgwater", // Water Feature Theming
 };
+
+const std::string_view DesignerSelectedObjects[] = {
+    // An initial default selection + all standard footpaths
+    "rct2.scgtrees", // Scenery: Trees
+    "rct2.scgshrub", // Scenery: Shrubs and Ornaments
+    "rct2.scggardn", // Scenery: Gardens
+    "rct2.scgfence", // Scenery: Fences and Walls
+    "rct2.scgwalls", // Scenery: Walls and Roofs
+    "rct2.scgpathx", // Scenery: Signs and Items for Footpaths
+    "rct2.wtrcyan",  // Water: Natural Water
+    "rct2.pkent1",   // Park Entrance: Traditional Park Entrance
+    "rct2.tarmac",   // Footpath: Tarmac
+    "rct2.tarmacg",  // Footpath: Green Tarmac Footpath
+    "rct2.tarmacb",  // Footpath: Brown Tarmac Footpath
+    "rct2.pathspce", // Footpath: Space Style Footpath
+    "rct2.pathcrzy", // Footpath: Crazy Paving Footpath
+    "rct2.pathdirt", // Footpath: Dirt Footpath
+    "rct2.pathash",  // Footpath: Ash Footpath
+};

--- a/src/openrct2/object/DefaultObjects.h
+++ b/src/openrct2/object/DefaultObjects.h
@@ -12,3 +12,4 @@
 #include "Object.h"
 
 extern const std::string_view DefaultSelectedObjects[33];
+extern const std::string_view DesignerSelectedObjects[15];


### PR DESCRIPTION
Enhance the track designer for feature parity with Rollercoaster Tycoon Classic (RCTC). RCTC features the ability to add scenery and footpaths, unlike vanilla RCT2.

Includes:
* Re-enabled buttons: Ride List, Map, Scenery, Path, Clear Scenery
* Add all standard footpaths and core scenery objects to the object selection
    
The max limit of 4 rides has been removed (up to 128 rides can now be selected), and only a minimum set of scenery is enabled. I wish to add all of the standard scenery groups, but this would exceed the max limit of 19 scenery groups. Since I don't know which other scenery groups should be enabled, besides the core ones, I'll just leave the selection at the core set.
