### PR TITLE
Fix #13567: Added ability for peeps to stop eating certain food constanly

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -172,12 +172,34 @@ int32_t bitscanforward(int32_t source)
     int32_t success = __builtin_ffs(source);
     return success - 1;
 #else
-#    pragma message "Falling back to iterative bitscan forward, consider using intrinsics"
+#    pragma message("Falling back to iterative bitscan forward, consider using intrinsics")
     // This is a low-hanging optimisation boost, check if your compiler offers
     // any intrinsic.
     // cf. https://github.com/OpenRCT2/OpenRCT2/pull/2093
     for (int32_t i = 0; i < 32; i++)
         if (source & (1u << i))
+            return i;
+
+    return -1;
+#endif
+}
+
+int32_t bitscanforward(int64_t source)
+{
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && defined(_M_X64) // Visual Studio 2005
+    DWORD i;
+    uint8_t success = _BitScanForward64(&i, static_cast<uint64_t>(source));
+    return success != 0 ? i : -1;
+#elif defined(__GNUC__)
+    int32_t success = __builtin_ffsll(source);
+    return success - 1;
+#else
+#    pragma message("Falling back to iterative bitscan forward, consider using intrinsics")
+    // This is a low-hanging optimisation boost, check if your compiler offers
+    // any intrinsic.
+    // cf. https://github.com/OpenRCT2/OpenRCT2/pull/2093
+    for (int32_t i = 0; i < 64; i++)
+        if (source & (1ull << i))
             return i;
 
     return -1;

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -38,6 +38,7 @@ bool sse41_available();
 bool avx2_available();
 
 int32_t bitscanforward(int32_t source);
+int32_t bitscanforward(int64_t source);
 void bitcount_init();
 int32_t bitcount(uint32_t source);
 int32_t strcicmp(char const* a, char const* b);


### PR DESCRIPTION
Fix #13567: Added ability for peeps to stop eating certain food constanly

Incorrect assumption that bitscanforward iterated over 64 bits meant that food that was previously within the ExtraItemFlags would never get removed from the peeps inventory. bitscanforward function has been replaced with a 64bit version