### PR TITLE
[Plugin] Add track progress property to vehicles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Feature: [#13509] [Plugin] Add ability to format strings using OpenRCT2 string framework.
 - Feature: [#13512] [Plugin] Add item separators to list view.
 - Feature: [#13583] [Plugin] Add allowed_hosts to plugin section of config.
+- Feature: [#13593] [Plugin] Add ability to read and change the position of ride vehicles.
 - Feature: [#13614] Add terrain surfaces from RollerCoaster Tycoon 1.
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1064,6 +1064,11 @@ declare global {
          * Current status of the car or train.
          */
         status: VehicleStatus;
+		
+        /**
+         * The progress on the current track piece, in steps.
+         */
+        trackProgress: number;
 
         /**
          * List of peep IDs ordered by seat.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1085,7 +1085,7 @@ declare global {
          * position. A single visible step is about 8.000 to 14.000 in distance depending 
          * on the direction its moving in.
          */
-        move(distance: number): void;
+        travelBy(distance: number): void;
     }
 
     type VehicleStatus =

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1064,12 +1064,12 @@ declare global {
          * Current status of the car or train.
          */
         status: VehicleStatus;
-		
+
         /**
          * The progress on the current track piece, in steps.
          */
         readonly trackProgress: number;
-		
+
         /**
          * The currently projected remaining distance the car will travel.
          */
@@ -1079,13 +1079,13 @@ declare global {
          * List of peep IDs ordered by seat.
          */
         peeps: (number | null)[];
-				
+
         /**
          * Moves the vehicle forward or backwards along the track, relative to its current 
-		 * position. A single visible step is about 8.000 to 14.000 in distance depending 
-		 * on the direction its moving in.
+         * position. A single visible step is about 8.000 to 14.000 in distance depending 
+         * on the direction its moving in.
          */
-		move(distance: number): void;
+        move(distance: number): void;
     }
 
     type VehicleStatus =

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1068,12 +1068,24 @@ declare global {
         /**
          * The progress on the current track piece, in steps.
          */
-        trackProgress: number;
+        readonly trackProgress: number;
+		
+        /**
+         * The currently projected remaining distance the car will travel.
+         */
+        readonly remainingDistance: number;
 
         /**
          * List of peep IDs ordered by seat.
          */
         peeps: (number | null)[];
+				
+        /**
+         * Moves the vehicle forward or backwards along the track, relative to its current 
+		 * position. A single visible step is about 8.000 to 14.000 in distance depending 
+		 * on the direction its moving in.
+         */
+		move(distance: number): void;
     }
 
     type VehicleStatus =

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -825,16 +825,6 @@ void Vehicle::MoveRelativeDistance(int32_t distance)
     SetUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION);
     UpdateTrackMotion(nullptr);
     ClearUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION);
-
-    const Ride* curRide = GetRide();
-    const rct_vehicle_info* moveInfo = GetMoveInfo();
-
-    MoveTo({ TrackLocation.x + moveInfo->x, TrackLocation.y + moveInfo->y,
-             TrackLocation.z + moveInfo->z + RideTypeDescriptors[curRide->type].Heights.VehicleZOffset });
-
-    sprite_direction = moveInfo->direction;
-    bank_rotation = moveInfo->bank_rotation;
-    vehicle_sprite_type = moveInfo->vehicle_sprite_type;
 }
 
 Vehicle* try_get_vehicle(uint16_t spriteIndex)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -818,6 +818,44 @@ uint16_t Vehicle::GetTrackProgress() const
     return vehicle_get_move_info_size(TrackSubposition, track_type);
 }
 
+void Vehicle::SetRelativeTrackProgress(int16_t trackProgress)
+{
+    Ride* curRide = GetRide();
+
+    const uint16_t maximumProgress = GetTrackProgress();
+    const uint16_t trackType = GetTrackType();
+
+    if (trackProgress < 0)
+    {
+        uint16_t new_progress = 0;
+        if (UpdateTrackMotionBackwardsGetNewTrack(trackType, curRide, &new_progress))
+        {
+            SetRelativeTrackProgress(trackProgress + new_progress);
+        }
+        return;
+    }
+
+    if (trackProgress >= maximumProgress)
+    {
+        if (UpdateTrackMotionForwardsGetNewTrack(trackType, curRide, GetRideEntry()))
+        {
+            SetRelativeTrackProgress(trackProgress - maximumProgress);
+        }
+        return;
+    }
+
+    track_progress = trackProgress;
+
+    const rct_vehicle_info* moveInfo = GetMoveInfo();
+
+    MoveTo({ TrackLocation.x + moveInfo->x, TrackLocation.y + moveInfo->y,
+             TrackLocation.z + moveInfo->z + RideTypeDescriptors[curRide->type].Heights.VehicleZOffset });
+
+    sprite_direction = moveInfo->direction;
+    bank_rotation = moveInfo->bank_rotation;
+    vehicle_sprite_type = moveInfo->vehicle_sprite_type;
+}
+
 Vehicle* try_get_vehicle(uint16_t spriteIndex)
 {
     return TryGetEntity<Vehicle>(spriteIndex);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7650,7 +7650,7 @@ void Vehicle::UpdateReverserCarBogies()
  */
 bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, uint16_t* otherVehicleIndex)
 {
-    if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_COLLISION_DISABLED))
+    if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_COLLISION_DISABLED) || HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
         return false;
 
     auto vehicleEntry = Entry();

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -822,9 +822,9 @@ void Vehicle::MoveRelativeDistance(int32_t distance)
 {
     remaining_distance += distance;
 
-    SetUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION);
+    SetUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION | VEHICLE_UPDATE_FLAG_COLLISION_DISABLED);
     UpdateTrackMotion(nullptr);
-    ClearUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION);
+    ClearUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION | VEHICLE_UPDATE_FLAG_COLLISION_DISABLED);
 }
 
 Vehicle* try_get_vehicle(uint16_t spriteIndex)
@@ -7640,7 +7640,7 @@ void Vehicle::UpdateReverserCarBogies()
  */
 bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, uint16_t* otherVehicleIndex)
 {
-    if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_COLLISION_DISABLED) || HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
+    if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_COLLISION_DISABLED))
         return false;
 
     auto vehicleEntry = Entry();

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -818,34 +818,15 @@ uint16_t Vehicle::GetTrackProgress() const
     return vehicle_get_move_info_size(TrackSubposition, track_type);
 }
 
-void Vehicle::SetRelativeTrackProgress(int16_t trackProgress)
+void Vehicle::MoveRelativeDistance(int32_t distance)
 {
-    Ride* curRide = GetRide();
+    remaining_distance += distance;
 
-    const uint16_t maximumProgress = GetTrackProgress();
-    const uint16_t trackType = GetTrackType();
+    SetUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION);
+    UpdateTrackMotion(nullptr);
+    ClearUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION);
 
-    if (trackProgress < 0)
-    {
-        uint16_t new_progress = 0;
-        if (UpdateTrackMotionBackwardsGetNewTrack(trackType, curRide, &new_progress))
-        {
-            SetRelativeTrackProgress(trackProgress + new_progress);
-        }
-        return;
-    }
-
-    if (trackProgress >= maximumProgress)
-    {
-        if (UpdateTrackMotionForwardsGetNewTrack(trackType, curRide, GetRideEntry()))
-        {
-            SetRelativeTrackProgress(trackProgress - maximumProgress);
-        }
-        return;
-    }
-
-    track_progress = trackProgress;
-
+    const Ride* curRide = GetRide();
     const rct_vehicle_info* moveInfo = GetMoveInfo();
 
     MoveTo({ TrackLocation.x + moveInfo->x, TrackLocation.y + moveInfo->y,

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -334,6 +334,12 @@ struct Vehicle : SpriteBase
     Vehicle* TrainHead() const;
     Vehicle* TrainTail() const;
     void EnableCollisionsForTrain();
+    /**
+     * Sets the track progress relative to the current track element.
+     * If the value is higher than the maximum, it will move to the next track piece.
+     * If the value is negative, the vehicle will move to the previous track piece.
+     */
+    void SetRelativeTrackProgress(int16_t trackProgress);
 
     uint16_t GetTrackType() const
     {

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -335,11 +335,9 @@ struct Vehicle : SpriteBase
     Vehicle* TrainTail() const;
     void EnableCollisionsForTrain();
     /**
-     * Sets the track progress relative to the current track element.
-     * If the value is higher than the maximum, it will move to the next track piece.
-     * If the value is negative, the vehicle will move to the previous track piece.
+     * Instantly moves the specific car forward or backwards along the track.
      */
-    void SetRelativeTrackProgress(int16_t trackProgress);
+    void MoveRelativeDistance(int32_t distance);
 
     uint16_t GetTrackType() const
     {

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -243,6 +243,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScVehicle::bankRotation_get, &ScVehicle::bankRotation_set, "bankRotation");
             dukglue_register_property(ctx, &ScVehicle::colours_get, &ScVehicle::colours_set, "colours");
             dukglue_register_property(ctx, &ScVehicle::trackLocation_get, &ScVehicle::trackLocation_set, "trackLocation");
+            dukglue_register_property(ctx, &ScVehicle::trackProgress_get, &ScVehicle::trackProgress_set, "trackProgress");            
             dukglue_register_property(
                 ctx, &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set, "poweredAcceleration");
             dukglue_register_property(ctx, &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set, "poweredMaxSpeed");
@@ -515,6 +516,23 @@ namespace OpenRCT2::Scripting
                 vehicle->TrackLocation = CoordsXYZ(coords.x, coords.y, coords.z);
                 vehicle->track_direction &= ~3;
                 vehicle->track_direction |= coords.direction & 3;
+            }
+        }
+                
+        int16_t trackProgress_get() const
+        {
+            auto vehicle = GetVehicle();
+            return vehicle != nullptr ? vehicle->track_progress : 0;
+        }
+        void trackProgress_set(int16_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            auto vehicle = GetVehicle();
+            if (vehicle != nullptr)
+            {
+                vehicle->Invalidate2();
+                vehicle->SetRelativeTrackProgress(value);
+                vehicle->Invalidate2();
             }
         }
 

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -243,12 +243,14 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScVehicle::bankRotation_get, &ScVehicle::bankRotation_set, "bankRotation");
             dukglue_register_property(ctx, &ScVehicle::colours_get, &ScVehicle::colours_set, "colours");
             dukglue_register_property(ctx, &ScVehicle::trackLocation_get, &ScVehicle::trackLocation_set, "trackLocation");
-            dukglue_register_property(ctx, &ScVehicle::trackProgress_get, &ScVehicle::trackProgress_set, "trackProgress");
+            dukglue_register_property(ctx, &ScVehicle::trackProgress_get, nullptr, "trackProgress");
+            dukglue_register_property(ctx, &ScVehicle::remainingDistance_get, nullptr, "remainingDistance");
             dukglue_register_property(
                 ctx, &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set, "poweredAcceleration");
             dukglue_register_property(ctx, &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set, "poweredMaxSpeed");
             dukglue_register_property(ctx, &ScVehicle::status_get, &ScVehicle::status_set, "status");
             dukglue_register_property(ctx, &ScVehicle::peeps_get, nullptr, "peeps");
+            dukglue_register_method(ctx, &ScVehicle::move, "move");
         }
 
     private:
@@ -519,21 +521,16 @@ namespace OpenRCT2::Scripting
             }
         }
 
-        int16_t trackProgress_get() const
+        uint16_t trackProgress_get() const
         {
             auto vehicle = GetVehicle();
             return vehicle != nullptr ? vehicle->track_progress : 0;
         }
-        void trackProgress_set(int16_t value)
+
+        int32_t remainingDistance_get() const
         {
-            ThrowIfGameStateNotMutable();
             auto vehicle = GetVehicle();
-            if (vehicle != nullptr)
-            {
-                vehicle->Invalidate2();
-                vehicle->SetRelativeTrackProgress(value);
-                vehicle->Invalidate2();
-            }
+            return vehicle != nullptr ? vehicle->remaining_distance : 0;
         }
 
         uint8_t poweredAcceleration_get() const
@@ -609,6 +606,18 @@ namespace OpenRCT2::Scripting
                 result.resize(len);
             }
             return result;
+        }
+
+        void move(int32_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            auto vehicle = GetVehicle();
+            if (vehicle != nullptr)
+            {
+                vehicle->Invalidate2();
+                vehicle->MoveRelativeDistance(value);
+                vehicle->Invalidate2();
+            }
         }
     };
 

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -243,7 +243,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScVehicle::bankRotation_get, &ScVehicle::bankRotation_set, "bankRotation");
             dukglue_register_property(ctx, &ScVehicle::colours_get, &ScVehicle::colours_set, "colours");
             dukglue_register_property(ctx, &ScVehicle::trackLocation_get, &ScVehicle::trackLocation_set, "trackLocation");
-            dukglue_register_property(ctx, &ScVehicle::trackProgress_get, &ScVehicle::trackProgress_set, "trackProgress");            
+            dukglue_register_property(ctx, &ScVehicle::trackProgress_get, &ScVehicle::trackProgress_set, "trackProgress");
             dukglue_register_property(
                 ctx, &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set, "poweredAcceleration");
             dukglue_register_property(ctx, &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set, "poweredMaxSpeed");
@@ -518,7 +518,7 @@ namespace OpenRCT2::Scripting
                 vehicle->track_direction |= coords.direction & 3;
             }
         }
-                
+
         int16_t trackProgress_get() const
         {
             auto vehicle = GetVehicle();

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -614,9 +614,7 @@ namespace OpenRCT2::Scripting
             auto vehicle = GetVehicle();
             if (vehicle != nullptr)
             {
-                vehicle->Invalidate2();
                 vehicle->MoveRelativeDistance(value);
-                vehicle->Invalidate2();
             }
         }
     };

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -250,7 +250,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set, "poweredMaxSpeed");
             dukglue_register_property(ctx, &ScVehicle::status_get, &ScVehicle::status_set, "status");
             dukglue_register_property(ctx, &ScVehicle::peeps_get, nullptr, "peeps");
-            dukglue_register_method(ctx, &ScVehicle::move, "move");
+            dukglue_register_method(ctx, &ScVehicle::travelBy, "travelBy");
         }
 
     private:
@@ -608,7 +608,7 @@ namespace OpenRCT2::Scripting
             return result;
         }
 
-        void move(int32_t value)
+        void travelBy(int32_t value)
         {
             ThrowIfGameStateNotMutable();
             auto vehicle = GetVehicle();

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -44,7 +44,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 15;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 16;
 
 struct ExpressionStringifier final
 {


### PR DESCRIPTION
Hey all, this is my draft attempt at adding a property for track progress to vehicles for plugins. This would be very useful for my RideVehicleEditor plugin to adjust spacing between vehicles, and maybe others can find some usefulness in it as well!

- Track progress can be read and set for Car-instances.
- ~~If the chosen value is beyond the maximum amount of the current track piece, the vehicle will go to the relative position on the next track piece.~~
- If the chosen value is negative, the vehicle will go to the relative position on the previous track piece.

What I'm still planning to do:
- [x] ~~Clamp track progress at the end of tracks (for non-complete circuits).~~
- [x] ~~Sometimes if it jumps to the next or previous track, the position is off by 1.~~
- [x] ~~Test it thoroughly to make sure it doesn't crash or mess up the game somehow (so far it doesn't seem to).~~
- [x] Run clang-format.

Update 21 dec:
- After talking with Duncan, the proposed implementation has been changed to modify the vehicles 'remaining distance' instead.
- Duncan provided the related #13607 update flag which this implementation uses.
- The 'track progress' setter has been removed and replaced by a 'move' method which moves the car a relative distance in either forward or backwards along the track.

A screenshot of it working ingame:
![afbeelding](https://user-images.githubusercontent.com/20048660/102265665-b3e72600-3f17-11eb-9313-6728a7903235.png)

Right now it works surprisingly well and I haven't really found any issues so far. 

I'd love to hear feedback though. This is my first pull request and I'm not even sure if this is the best approach for it. Please let me know if this is something that would fit into the source code and if there is anything I should change.