### PR TITLE
Add individual vehicle motion update flag

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -8688,7 +8688,10 @@ void Vehicle::UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* ri
 
     _vehicleUnkF64E10 = 1;
     acceleration = dword_9A2970[vehicle_sprite_type];
-    remaining_distance = _vehicleVelocityF64E0C + remaining_distance;
+    if (!HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
+    {
+        remaining_distance = _vehicleVelocityF64E0C + remaining_distance;
+    }
     if (remaining_distance >= 0 && remaining_distance < 0x368A)
     {
         goto loc_6DCE02;
@@ -9231,6 +9234,12 @@ int32_t Vehicle::UpdateTrackMotionMiniGolf(int32_t* outStation)
         {
             _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_ON_LIFT_HILL;
         }
+        if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
+        {
+            if (outStation != nullptr)
+                *outStation = _vehicleStationIndex;
+            return _vehicleMotionTrackFlags;
+        }
         if (_vehicleVelocityF64E08 >= 0)
         {
             vehicle = GetEntity<Vehicle>(vehicle->next_vehicle_on_train);
@@ -9506,7 +9515,10 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         car->acceleration = dword_9A2970[car->vehicle_sprite_type];
         _vehicleUnkF64E10 = 1;
 
-        car->remaining_distance += _vehicleVelocityF64E0C;
+        if (!car->HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
+        {
+            car->remaining_distance += _vehicleVelocityF64E0C;
+        }
 
         car->sound2_flags &= ~VEHICLE_SOUND2_FLAGS_LIFT_HILL;
         unk_F64E20.x = car->x;
@@ -9567,6 +9579,12 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         if (car->HasUpdateFlag(VEHICLE_UPDATE_FLAG_ON_LIFT_HILL))
         {
             _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_ON_LIFT_HILL;
+        }
+        if (car->HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
+        {
+            if (outStation != nullptr)
+                *outStation = _vehicleStationIndex;
+            return _vehicleMotionTrackFlags;
         }
         if (_vehicleVelocityF64E08 >= 0)
         {

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -530,7 +530,9 @@ enum : uint32_t
     VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES = (1 << 11), // Used on rides where trains can run for extended periods of time,
                                                           // i.e. the Flying, Lay-down and Multi-dimension RCs.
     VEHICLE_UPDATE_FLAG_12 = (1 << 12),
-    VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE = (1 << 13) // After passing a rotation toggle track piece this will enable
+    VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE = (1 << 13), // After passing a rotation toggle track piece this will enable
+    VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION = (1 << 14), // OpenRCT2 Flag: Used to override UpdateMotion to move the position of
+                                                         // an individual car on a train
 };
 
 enum : uint32_t


### PR DESCRIPTION
This can be used in conjunction with #13593 to change the placement of vehicles on a track.

Example use:
```
        veh->remaining_distance += distanceToMove;
        veh->SetUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR);
        veh->UpdateTrackMotion(nullptr);
        veh->ClearUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR);
```
remaining_distance is internal distance units.  Issue at present is that velocity of the vehicle is also applied. Unsure if that is useful or not. If not can easily fix that by changing how the override of the update code works.