### PR TITLE
Mark possibly unused variable as maybe_unused

### DIFF
--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -348,7 +348,7 @@ namespace OpenRCT2
 
         // Whole digits
         [[maybe_unused]] auto digitSep = GetDigitSeparator();
-        size_t groupLen = 0;
+        [[maybe_unused]] size_t groupLen = 0;
         do
         {
             if constexpr (TDigitSep)


### PR DESCRIPTION
Ran into this when compiling x64 with VS 2019 Version 16.5.5.