### PR TITLE
Fix #13611: Zero under decimal is not displayed

### DIFF
--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -341,6 +341,11 @@ namespace OpenRCT2
                 buffer[i++] = static_cast<char>('0' + (num % 10));
                 num /= 10;
             }
+            // handle case where value has fewer sig figs than required decimal places
+            while (num == 0 && i < TDecimalPlace && i < sizeof(buffer))
+            {
+                buffer[i++] = static_cast<char>('0');
+            }
 
             auto decSep = GetDecimalSeparator();
             AppendSeparator(buffer, i, decSep);

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -344,7 +344,7 @@ namespace OpenRCT2
             // handle case where value has fewer sig figs than required decimal places
             while (num == 0 && i < TDecimalPlace && i < sizeof(buffer))
             {
-                buffer[i++] = static_cast<char>('0');
+                buffer[i++] = '0';
             }
 
             auto decSep = GetDecimalSeparator();

--- a/test/tests/FormattingTests.cpp
+++ b/test/tests/FormattingTests.cpp
@@ -16,6 +16,8 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/localisation/StringIds.h>
+#include <string>
+#include <sstream>
 
 using namespace OpenRCT2;
 
@@ -335,4 +337,271 @@ TEST_F(FormattingTests, using_legacy_buffer_args)
     auto len = FormatStringLegacy(buffer, sizeof(buffer), STR_QUEUING_FOR, ft.Data());
     ASSERT_EQ(len, 23U);
     ASSERT_STREQ("Queuing for Boat Hire 2", buffer);
+}
+
+TEST_F(FormattingTests, format_number_basic)
+{
+    std::stringstream ss;
+    // test basic integral conversion
+    FormatArgument<int32_t>(ss, FormatToken::UInt16, 123);
+    ASSERT_STREQ("123", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_basic_int32)
+{
+    std::stringstream ss;
+    // test that case fallthrough works
+    FormatArgument<int32_t>(ss, FormatToken::Int32, 123);
+    ASSERT_STREQ("123", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_negative)
+{
+    std::stringstream ss;
+    // test negative conversion
+    FormatArgument<int32_t>(ss, FormatToken::Int32, -123);
+    ASSERT_STREQ("-123", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_basic)
+{
+    std::stringstream ss;
+    // test separator formatter
+    // test base case separator formatter
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, 123);
+    ASSERT_STREQ("123", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_negative)
+{
+    std::stringstream ss;
+    // test separator formatter
+    // test base case separator formatter
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, -123);
+    ASSERT_STREQ("-123", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_large)
+{
+    std::stringstream ss;
+    // test larger value for separator formatter
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, 123456789);
+    ASSERT_STREQ("123,456,789", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_large_negative)
+{
+    std::stringstream ss;
+    // test larger value for separator formatter with negative
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, -123456789);
+    ASSERT_STREQ("-123,456,789", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_uneven)
+{
+    std::stringstream ss;
+    // test non-multiple of 3
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, 12345678);
+    ASSERT_STREQ("12,345,678", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_uneven_negative)
+{
+    std::stringstream ss;
+    // test non-multiple of 3 with negative
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, -12345678);
+    ASSERT_STREQ("-12,345,678", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma16_zero)
+{
+    std::stringstream ss;
+    // test zero
+    FormatArgument<int32_t>(ss, FormatToken::Comma16, 0);
+    ASSERT_STREQ("0", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_zero)
+{
+    std::stringstream ss;
+    // zero case
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, 0);
+    ASSERT_STREQ("0.0", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_leading_zero)
+{
+    std::stringstream ss;
+    // test leading zero
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, 5);
+    ASSERT_STREQ("0.5", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_leading_zero_negative)
+{
+    std::stringstream ss;
+    // test leading zero with negative value
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, -5);
+    ASSERT_STREQ("-0.5", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_small_value)
+{
+    std::stringstream ss;
+    // test small value
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, 75);
+    ASSERT_STREQ("7.5", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_small_value_negative)
+{
+    std::stringstream ss;
+    // test small value with negative
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, -75);
+    ASSERT_STREQ("-7.5", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_trailing_zeros)
+{
+    std::stringstream ss;
+    // test value with trailing zero, no commas
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, 1000);
+    ASSERT_STREQ("100.0", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_trailing_zeros_negative)
+{
+    std::stringstream ss;
+    // test value with trailing zero, no commas
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, -1000);
+    ASSERT_STREQ("-100.0", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_large_trailing_zeros)
+{
+    std::stringstream ss;
+    // test value with commas and trailing zeros
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, 10000000);
+    ASSERT_STREQ("1,000,000.0", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_large_trailing_zeros_negative)
+{
+    std::stringstream ss;
+    // test value with commas and trailing zeros
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, -10000000);
+    ASSERT_STREQ("-1,000,000.0", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_large_value)
+{
+    std::stringstream ss;
+    // test large value
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, 123456789);
+    ASSERT_STREQ("12,345,678.9", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma1dp16_large_value_negative)
+{
+    std::stringstream ss;
+    // test large value
+    FormatArgument<int32_t>(ss, FormatToken::Comma1dp16, -123456789);
+    ASSERT_STREQ("-12,345,678.9", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_zero)
+{
+    std::stringstream ss;
+    // zero case
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, 0);
+    ASSERT_STREQ("0.00", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_less_sig_figs)
+{
+    std::stringstream ss;
+    // test leading zero
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, 5);
+    ASSERT_STREQ("0.05", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_less_sig_figs_negative)
+{
+    std::stringstream ss;
+    // test leading zero
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, -5);
+    ASSERT_STREQ("-0.05", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_leading_zero)
+{
+    std::stringstream ss;
+    // test small value
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, 75);
+    ASSERT_STREQ("0.75", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_leading_zero_negative)
+{
+    std::stringstream ss;
+    // test small value
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, -75);
+    ASSERT_STREQ("-0.75", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_trailing_zeros)
+{
+    std::stringstream ss;
+    // test value with trailing zero, no commas
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, 1000);
+    ASSERT_STREQ("10.00", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_trailing_zeros_negative)
+{
+    std::stringstream ss;
+    // test value with trailing zero, no commas
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, -1000);
+    ASSERT_STREQ("-10.00", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_large_trailing_zeros)
+{
+    std::stringstream ss;
+    // test value with commas and trailing zeros
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, 10000000);
+    ASSERT_STREQ("100,000.00", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_large_trailing_zeros_negative)
+{
+    std::stringstream ss;
+    // test value with commas and trailing zeros
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, -10000000);
+    ASSERT_STREQ("-100,000.00", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_large_value)
+{
+    std::stringstream ss;
+    // test large value
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, 123456789);
+    ASSERT_STREQ("1,234,567.89", ss.str().c_str());
+}
+
+TEST_F(FormattingTests, format_number_comma2dp32_large_value_negative)
+{
+    std::stringstream ss;
+    // test large value
+    FormatArgument<int32_t>(ss, FormatToken::Comma2dp32, -123456789);
+    ASSERT_STREQ("-1,234,567.89", ss.str().c_str());
+
+    // extra note:
+    // for some reason the FormatArgument function contains constexpr
+    // checks for std::is_floating_point<T>, even though a template
+    // specialization for which that would ever be the case is never
+    // declared. As such the following line won't be able to find
+    // the necessary symbol to link with.
+    // FormatArgument<double>(ss, FormatToken::Comma1dp16, 12.372);
+
 }

--- a/test/tests/FormattingTests.cpp
+++ b/test/tests/FormattingTests.cpp
@@ -16,8 +16,8 @@
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/localisation/StringIds.h>
-#include <string>
 #include <sstream>
+#include <string>
 
 using namespace OpenRCT2;
 

--- a/test/tests/FormattingTests.cpp
+++ b/test/tests/FormattingTests.cpp
@@ -603,5 +603,4 @@ TEST_F(FormattingTests, format_number_comma2dp32_large_value_negative)
     // declared. As such the following line won't be able to find
     // the necessary symbol to link with.
     // FormatArgument<double>(ss, FormatToken::Comma1dp16, 12.372);
-
 }


### PR DESCRIPTION
The existing code does not properly handle the formatting conversion case for fixed point decimal values. If a fixed point integer representation has fewer significant figures than the required fixed point precision, no zeros are placed between the decimal place and the first sig fig. This causes ride intensity, nausea etc. to display incorrectly when very small values, e.g. a nausea value of 0.05 will be displayed as 0.5. 