### PR TITLE
Fix #13574: Object selection crashes if 'originalId' missing

### DIFF
--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -108,6 +108,12 @@ struct rct_object_entry
         return static_cast<ObjectType>(flags & 0x0F);
     }
 
+    void SetType(ObjectType newType)
+    {
+        flags &= ~0x0F;
+        flags |= (static_cast<uint8_t>(newType) & 0x0F);
+    }
+
     std::optional<uint8_t> GetSceneryType() const;
 
     ObjectSourceGame GetSourceGame() const

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -450,6 +450,8 @@ namespace ObjectFactory
                 originalName = originalId.substr(9, 8);
                 entry.checksum = std::stoul(originalId.substr(18, 8), nullptr, 16);
             }
+            // Always set, since originalId might be missing or incorrect.
+            entry.SetType(objectType);
             auto minLength = std::min<size_t>(8, originalName.length());
             std::memcpy(entry.name, originalName.c_str(), minLength);
 


### PR DESCRIPTION
Not sure if this should be in the changelog or not.