### PR TITLE
Fix #13644, #13102: Underflows in ride graph, temperature, cut-away view

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Feature: [#13583] [Plugin] Add allowed_hosts to plugin section of config.
 - Feature: [#13614] Add terrain surfaces from RollerCoaster Tycoon 1.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
+- Fix: [#13102] Underflow on height chart (Ride measurements).
 - Fix: [#13257] Rides that are exactly the minimum objective length are not counted.
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -768,16 +768,18 @@ namespace OpenRCT2
                 case FormatToken::Sprite:
                     anyArgs.push_back(ReadFromArgs<int32_t>(args));
                     break;
-                case FormatToken::Comma16:
                 case FormatToken::UInt16:
                 case FormatToken::MonthYear:
                 case FormatToken::Month:
                 case FormatToken::Velocity:
                 case FormatToken::DurationShort:
                 case FormatToken::DurationLong:
+                    anyArgs.push_back(ReadFromArgs<uint16_t>(args));
+                    break;
+                case FormatToken::Comma16:
                 case FormatToken::Length:
                 case FormatToken::Comma1dp16:
-                    anyArgs.push_back(ReadFromArgs<uint16_t>(args));
+                    anyArgs.push_back(ReadFromArgs<int16_t>(args));
                     break;
                 case FormatToken::StringId:
                 {


### PR DESCRIPTION
This silently reintroduces #1013. To fix that, we'll need to use 32 bits for length strings.