### PR TITLE
Close #13620: Add patrol area retrieval method for plugins

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -66,6 +66,17 @@ declare global {
     }
 
     /**
+     * a range of coordinates within the game client as a pair of map tile 
+     * x and y locations. These values will match what is show in the tile inspector.
+     */
+    interface TileRange {
+        x1: number;
+        y1: number;
+        x2: number; 
+        y2: number;
+    }
+
+    /**
      * A coordinate within the game.
      * Each in-game tile is a size of 32x32.
      */
@@ -1301,7 +1312,7 @@ declare global {
          * 64x64 possible patrol areas total. If no patrol area is set, this will return an array 
          * with every patrol coordinate as true, as the staff member can go anywhere.
          */
-        getPatrolArea(): CoordsXY[];
+        getPatrolArea(): TileRange[];
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1289,7 +1289,7 @@ declare global {
     /**
      * Represents a staff member.
      */
-    interface _Staff extends Peep {
+    interface Staff extends Peep {
         /**
          * The type of staff member, e.g. handyman, mechanic.
          */

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1277,10 +1277,19 @@ declare global {
         cash: number;
     }
 
+    interface PatrolArea {
+        staffId: number;
+        tiles: CoordsXY[];
+    
+        add(coords: CoordsXY[]): void;
+        remove(coords: CoordsXY[]): void;
+        contains(coord: CoordsXY): boolean;
+    }
+
     /**
      * Represents a staff member.
      */
-    interface Staff extends Peep {
+    interface _Staff extends Peep {
         /**
          * The type of staff member, e.g. handyman, mechanic.
          */
@@ -1312,7 +1321,7 @@ declare global {
          * 64x64 possible patrol areas total. If no patrol area is set, this will return an array 
          * with every patrol coordinate as true, as the staff member can go anywhere.
          */
-        getPatrolArea(): TileRange[];
+        getPatrolArea(): PatrolArea;
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1289,6 +1289,19 @@ declare global {
          * The enabled jobs the staff can do, e.g. sweep litter, water plants, inspect rides etc.
          */
         orders: number;
+        
+        /**
+         * The patrol area state of this staff member; true if a patrol area is set, false otherwise
+         */
+        hasPatrolArea: boolean;
+
+        /**
+         * Gets the current staff patrol area as an Array of CoordsXY of the patrol regions within
+         * this staf member's patrol area. Patrol regions are 4x4 sections of the map, so there are
+         * 64x64 possible patrol areas total. If no patrol area is set, this will return an array 
+         * with every patrol coordinate as true, as the staff member can go anywhere.
+         */
+        getPatrolArea(): CoordsXY[];
     }
 
     type StaffType = "handyman" | "mechanic" | "security" | "entertainer";

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -874,6 +874,7 @@ public:
     void UpdateStaff(uint32_t stepsToTake);
     void Tick128UpdateStaff();
     bool IsMechanic() const;
+    bool HasPatrolArea() const;
     bool IsPatrolAreaSet(const CoordsXY& coords) const;
     bool IsLocationInPatrol(const CoordsXY& loc) const;
     bool IsLocationOnPatrolEdge(const CoordsXY& loc) const;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -393,6 +393,11 @@ static bool staff_is_patrol_area_set(int32_t staffIndex, const CoordsXY& coords)
     return gStaffPatrolAreas[peepOffset + offset] & (1UL << bitIndex);
 }
 
+bool Staff::HasPatrolArea() const
+{
+    return gStaffModes[StaffId] == StaffMode::Patrol;
+}
+
 bool Staff::IsPatrolAreaSet(const CoordsXY& coords) const
 {
     return staff_is_patrol_area_set(StaffId, coords);

--- a/src/openrct2/scripting/Duktape.hpp
+++ b/src/openrct2/scripting/Duktape.hpp
@@ -381,14 +381,30 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    template<> inline DukValue ToDuk(duk_context* ctx, const TileRange& value)
+    template<> inline DukValue ToDuk(duk_context* ctx, const MapRange& value)
     {
-        DukObject dukTileRange(ctx);
-        dukTileRange.Set("x1", value.Point1.x);
-        dukTileRange.Set("y1", value.Point1.y);
-        dukTileRange.Set("x2", value.Point2.x);
-        dukTileRange.Set("y2", value.Point2.y);
-        return dukTileRange.Take();
+        DukObject dukMapRange(ctx);
+        dukMapRange.Set("x1", value.Point1.x);
+        dukMapRange.Set("y1", value.Point1.y);
+        dukMapRange.Set("x2", value.Point2.x);
+        dukMapRange.Set("y2", value.Point2.y);
+        return dukMapRange.Take();
+    }
+
+    template<> inline MapRange FromDuk(const DukValue& value)
+    {
+        MapRange result;
+        if (value.type() != DukValue::Type::OBJECT)
+        {
+            result.Point1.setNull();
+            result.Point2.setNull();
+            return result;
+        }
+        result.Point1.x = AsOrDefault(value["x1"], COORDS_NULL);
+        result.Point1.y = AsOrDefault(value["y1"], COORDS_NULL);
+        result.Point2.x = AsOrDefault(value["x2"], COORDS_NULL);
+        result.Point2.y = AsOrDefault(value["y1"], COORDS_NULL);
+        return result;
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/Duktape.hpp
+++ b/src/openrct2/scripting/Duktape.hpp
@@ -381,6 +381,16 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
+    template<> inline DukValue ToDuk(duk_context* ctx, const TileRange& value)
+    {
+        DukObject dukTileRange(ctx);
+        dukTileRange.Set("x1", value.Point1.x);
+        dukTileRange.Set("y1", value.Point1.y);
+        dukTileRange.Set("x2", value.Point2.x);
+        dukTileRange.Set("y2", value.Point2.y);
+        return dukTileRange.Take();
+    }
+
 } // namespace OpenRCT2::Scripting
 
 #endif

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1001,6 +1001,7 @@ namespace OpenRCT2::Scripting
             auto peep = GetPeep();
             return peep != nullptr ? peep->Intensity.GetMinimum() : 0;
         }
+
         void minIntensity_set(uint8_t value)
         {
             ThrowIfGameStateNotMutable();
@@ -1077,7 +1078,6 @@ namespace OpenRCT2::Scripting
         }
 
     private:
-
         static inline int32_t patrolRegionHeight(const MapRange& region)
         {
             return (region.GetY2() - region.GetY1()) / (COORDS_XY_STEP * 4);
@@ -1090,24 +1090,24 @@ namespace OpenRCT2::Scripting
 
         static inline void mergeIntoRegion(MapRange& target, const MapRange& toMerge)
         {
-            //printf(
+            // printf(
             //    "target %d %d %d %d\n", target.Point1.x / 128, target.Point1.y / 128, target.Point2.x / 128,
             //    target.Point2.y / 128);
-            //printf(
+            // printf(
             //    "toMerge %d %d %d %d\n", toMerge.Point1.x / 128, toMerge.Point1.y / 128, toMerge.Point2.x / 128,
             //    toMerge.Point2.y / 128);
             target.Point1.x = std::min(target.Point1.x, toMerge.Point1.x);
             target.Point1.y = std::min(target.Point1.y, toMerge.Point1.y);
             target.Point2.x = std::max(target.Point2.x, toMerge.Point2.x);
             target.Point2.y = std::max(target.Point2.y, toMerge.Point2.y);
-            //printf(
+            // printf(
             //    "merged %d %d %d %d\n\n", target.Point1.x / 128, target.Point1.y / 128, target.Point2.x / 128,
             //    target.Point2.y / 128);
         }
 
         void mergeRegions()
         {
-            // from top left, go across horizontal scanlines to create as many one
+            // from top left, go across horizontal scanlines to create as many
             // horizontally maximized regions; then go through vertical scanlines and merge
             // as many of the horizontal regions as possible into bigger rectangles; should
             // produce minimum possible number of rectangular regions (though not
@@ -1130,7 +1130,7 @@ namespace OpenRCT2::Scripting
                 auto initialY = topLeft.y / PATROL_REGION_STEP;
                 auto finalX = bottomRight.x / PATROL_REGION_STEP;
                 auto finalY = bottomRight.y / PATROL_REGION_STEP;
-                //printf("%d %d %d %d\n", initialX, initialY, finalX, finalY);
+                // printf("%d %d %d %d\n", initialX, initialY, finalX, finalY);
                 for (int32_t y = initialY; y < finalY; y++)
                 {
                     for (int32_t x = initialX; x < finalX; x++)
@@ -1139,7 +1139,7 @@ namespace OpenRCT2::Scripting
                     }
                 }
             }
-        
+
             // horizontal scanning
             for (int32_t y = 0; y < 64; y++)
             {
@@ -1217,7 +1217,7 @@ namespace OpenRCT2::Scripting
                         // aren't currently merging, start merging on this new region
                         currentRegion = nextRegion;
                         currentWidth = patrolRegionWidth(*currentRegion);
-                        //printf("new region width: %d\n", currentWidth);
+                        // printf("new region width: %d\n", currentWidth);
                         continue;
                     }
                     else if (nextRegion && currentRegion)
@@ -1225,7 +1225,7 @@ namespace OpenRCT2::Scripting
                         // check if height matches, and merge if so
                         if (patrolRegionWidth(*nextRegion) == currentWidth)
                         {
-                            mergeRegions(*currentRegion, *nextRegion);
+                            mergeIntoRegion(*currentRegion, *nextRegion);
                             patrolBitmask[y][x] = currentRegion;
                             mergedRegions.erase(nextRegion);
                             mergedRegions.insert(currentRegion);
@@ -1241,9 +1241,9 @@ namespace OpenRCT2::Scripting
             }
             // assemble new region vector
             _regions.clear();
-            for(auto& regionPtr : mergedRegions)
+            for (auto& regionPtr : mergedRegions)
             {
-                //printf(
+                // printf(
                 //    "Final region: %d %d %d %d\n", regionPtr->GetLeft() / PATROL_REGION_STEP,
                 //    regionPtr->GetTop() / PATROL_REGION_STEP, regionPtr->GetRight() / PATROL_REGION_STEP,
                 //    regionPtr->GetBottom() / PATROL_REGION_STEP);
@@ -1289,8 +1289,8 @@ namespace OpenRCT2::Scripting
         {
             for (auto& region : _regions)
             {
-                if (toCheck.x >= region.GetLeft() && toCheck.x < region.GetRight() &&
-                    toCheck.y >= region.GetTop() && toCheck.y < region.GetBottom())
+                if (toCheck.x >= region.GetLeft() && toCheck.x < region.GetRight() && toCheck.y >= region.GetTop()
+                    && toCheck.y < region.GetBottom())
                 {
                     return true;
                 }
@@ -1460,7 +1460,6 @@ namespace OpenRCT2::Scripting
                     // to only step by whole coordinate -> left shift by 7
                     if (staff->IsPatrolAreaSet({ x * PATROL_REGION_STEP, y_index }))
                     {
-                        //printf("%d %d in patrol area\n", x, y);
                         // patrol region is multiplied by 4 to return to tile coordinates
                         auto patrolRegion = MapRange(
                             { x * PATROL_REGION_STEP, y * PATROL_REGION_STEP },

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1215,7 +1215,7 @@ namespace OpenRCT2::Scripting
                     // to only step by whole coordinate -> left shift by 7
                     if (staff->IsLocationInPatrol({ x << 7, y_index }))
                     {
-                        patrolArea.push_back(ToDuk<CoordsXY>(ctx, {x, y}));
+                        patrolArea.push_back(ToDuk<CoordsXY>(ctx, { x, y }));
                     }
                 }
             }

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1072,6 +1072,8 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScStaff::colour_get, &ScStaff::colour_set, "colour");
             dukglue_register_property(ctx, &ScStaff::costume_get, &ScStaff::costume_set, "costume");
             dukglue_register_property(ctx, &ScStaff::orders_get, &ScStaff::orders_set, "orders");
+            dukglue_register_property(ctx, &ScStaff::has_patrolarea, nullptr, "hasPatrolArea");
+            dukglue_register_method(ctx, &ScStaff::getPatrolArea, "getPatrolArea");
         }
 
     private:
@@ -1187,6 +1189,37 @@ namespace OpenRCT2::Scripting
             {
                 peep->StaffOrders = value;
             }
+        }
+
+        bool has_patrolarea() const
+        {
+            auto staff = GetStaff();
+            return staff->HasPatrolArea();
+        }
+
+        std::vector<DukValue> getPatrolArea()
+        {
+            std::vector<DukValue> patrolArea;
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+            auto staff = GetStaff();
+            if (staff == nullptr)
+            {
+                return {};
+            }
+            for (int32_t y = 0; y < 64; y++)
+            {
+                auto y_index = y << 7;
+                for (int32_t x = 0; x < 64; x++)
+                {
+                    // multiply each by four to match the patrol area size, and by 32
+                    // to only step by whole coordinate -> left shift by 7
+                    if (staff->IsLocationInPatrol({ x << 7, y_index }))
+                    {
+                        patrolArea.push_back(ToDuk<CoordsXY>(ctx, {x, y}));
+                    }
+                }
+            }
+            return patrolArea;
         }
     };
 

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1215,7 +1215,9 @@ namespace OpenRCT2::Scripting
                     // to only step by whole coordinate -> left shift by 7
                     if (staff->IsLocationInPatrol({ x << 7, y_index }))
                     {
-                        patrolArea.push_back(ToDuk<CoordsXY>(ctx, { x, y }));
+                        // patrol region is multiplied by 4 to return to tile coordinates
+                        auto patrolRegion = TileRange({ x << 2, y << 2 }, { (x << 2) + 3, (y << 2) + 3 });
+                        patrolArea.push_back(ToDuk<TileRange>(ctx, patrolRegion));
                     }
                 }
             }

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -1088,7 +1088,7 @@ namespace OpenRCT2::Scripting
             return (region.GetX2() - region.GetX1()) / (COORDS_XY_STEP * 4);
         }
 
-        static inline void mergeRegions(MapRange& target, const MapRange& toMerge)
+        static inline void mergeIntoRegion(MapRange& target, const MapRange& toMerge)
         {
             //printf(
             //    "target %d %d %d %d\n", target.Point1.x / 128, target.Point1.y / 128, target.Point2.x / 128,
@@ -1174,7 +1174,7 @@ namespace OpenRCT2::Scripting
                         // check if height matches, and merge if so
                         if (patrolRegionHeight(*nextRegion) == currentHeight)
                         {
-                            mergeRegions(*currentRegion, *nextRegion);
+                            mergeIntoRegion(*currentRegion, *nextRegion);
                             patrolBitmask[y][x] = currentRegion;
                             mergedRegions.insert(currentRegion);
                             // skip to end of combined region

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -158,29 +158,6 @@ namespace OpenRCT2::Scripting
             return result;
         }
 
-        std::vector<std::vector<bool>> getStaffPatrolArea(int32_t id)
-        {
-            std::vector<std::vector<bool>> patrolArea;
-            auto spriteId = static_cast<uint16_t>(id);
-            auto staff = GetEntity<Staff>(spriteId);
-            if (staff == nullptr)
-            {
-                return {};
-            }
-            for (int32_t y = 0; y < 64; y++)
-            {
-                patrolArea.push_back({});
-                auto y_index = y << 7;
-                for (int32_t x = 0; x < 64; x++)
-                {
-                    // multiply each by four to match the patrol area size, and by 32
-                    // to only step by whole coordinate
-                    patrolArea[y].push_back(staff->IsLocationInPatrol({ x << 7, y_index }));
-                }
-            }
-            return patrolArea;
-        }
-
         static void Register(duk_context* ctx)
         {
             dukglue_register_property(ctx, &ScMap::size_get, nullptr, "size");
@@ -191,7 +168,6 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScMap::getTile, "getTile");
             dukglue_register_method(ctx, &ScMap::getEntity, "getEntity");
             dukglue_register_method(ctx, &ScMap::getAllEntities, "getAllEntities");
-            dukglue_register_method(ctx, &ScMap::getStaffPatrolArea, "getStaffPatrolArea");
         }
 
     private:

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -158,6 +158,29 @@ namespace OpenRCT2::Scripting
             return result;
         }
 
+        std::vector<std::vector<bool>> getStaffPatrolArea(int32_t id)
+        {
+            std::vector<std::vector<bool>> patrolArea;
+            auto spriteId = static_cast<uint16_t>(id);
+            auto staff = GetEntity<Staff>(spriteId);
+            if (staff == nullptr)
+            {
+                return {};
+            }
+            for (int32_t y = 0; y < 64; y++)
+            {
+                patrolArea.push_back({});
+                auto y_index = y << 7;
+                for (int32_t x = 0; x < 64; x++)
+                {
+                    // multiply each by four to match the patrol area size, and by 32
+                    // to only step by whole coordinate
+                    patrolArea[y].push_back(staff->IsLocationInPatrol({ x << 7, y_index }));
+                }
+            }
+            return patrolArea;
+        }
+
         static void Register(duk_context* ctx)
         {
             dukglue_register_property(ctx, &ScMap::size_get, nullptr, "size");
@@ -168,6 +191,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScMap::getTile, "getTile");
             dukglue_register_method(ctx, &ScMap::getEntity, "getEntity");
             dukglue_register_method(ctx, &ScMap::getAllEntities, "getAllEntities");
+            dukglue_register_method(ctx, &ScMap::getStaffPatrolArea, "getStaffPatrolArea");
         }
 
     private:

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -402,6 +402,7 @@ void ScriptEngine::Initialise()
 #    endif
     ScScenario::Register(ctx);
     ScScenarioObjective::Register(ctx);
+    ScPatrolArea::Register(ctx);
     ScStaff::Register(ctx);
 
     dukglue_register_global(ctx, std::make_shared<ScCheats>(), "cheats");

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -729,6 +729,16 @@ struct MapRange : public RectRange<CoordsXY>
     }
 };
 
+struct TileRange : public RectRange<TileCoordsXY>
+{
+    using RectRange::RectRange;
+
+    TileRange(const MapRange& mapRange)
+        : RectRange(TileCoordsXY(mapRange.Point1), TileCoordsXY(mapRange.Point2))
+    {
+    }
+};
+
 /**
  * Represents a line on the screen
  */

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -17,6 +17,7 @@ constexpr const int16_t LOCATION_NULL = -32768;
 
 constexpr const int32_t COORDS_XY_STEP = 32;
 constexpr const int32_t COORDS_XY_HALF_TILE = (COORDS_XY_STEP / 2);
+constexpr const int32_t COORDS_XY_PATROL_STEP = 4;
 constexpr const int32_t COORDS_Z_STEP = 8;
 constexpr const int32_t COORDS_Z_PER_TINY_Z = 16;
 
@@ -726,16 +727,6 @@ struct MapRange : public RectRange<CoordsXY>
             std::min(GetLeft(), GetRight()), std::min(GetTop(), GetBottom()), std::max(GetLeft(), GetRight()),
             std::max(GetTop(), GetBottom()));
         return result;
-    }
-};
-
-struct TileRange : public RectRange<TileCoordsXY>
-{
-    using RectRange::RectRange;
-
-    TileRange(const MapRange& mapRange)
-        : RectRange(TileCoordsXY(mapRange.Point1), TileCoordsXY(mapRange.Point2))
-    {
     }
 };
 


### PR DESCRIPTION
 - allows a script engine plugin to conveniently get the staff patrol
   area matrix for a particular staff member
 - returns a javascript Array of Arrays of bools representing a 64x64
   grid
