### PR TITLE
Close #13627: Refactor ItemTypeProperty to use strong enum

### DIFF
--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -19,7 +19,6 @@
 #include "../localisation/Localisation.h"
 #include "../management/Research.h"
 #include "../ride/Ride.h"
-#include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "../world/Location.hpp"
 #include "../world/Sprite.h"

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -38,12 +38,6 @@ namespace News
 
     constexpr size_t ItemTypeCount = static_cast<size_t>(News::ItemType::Count);
 
-    enum ItemTypeProperty : uint8_t
-    {
-        HasLocation = 1,
-        HasSubject = 2,
-    };
-
     enum ItemFlags : uint8_t
     {
         HasButton = 1 << 0,
@@ -67,29 +61,6 @@ namespace News
             return Type == News::ItemType::Null;
         }
 
-        constexpr uint8_t GetTypeProperties() const
-        {
-            switch (Type)
-            {
-                case News::ItemType::Blank:
-                    return News::ItemTypeProperty::HasLocation;
-                case News::ItemType::Money:
-                case News::ItemType::Research:
-                case News::ItemType::Peeps:
-                case News::ItemType::Award:
-                case News::ItemType::Graph:
-                    return News::ItemTypeProperty::HasSubject;
-                case News::ItemType::Ride:
-                case News::ItemType::PeepOnRide:
-                case News::ItemType::Peep:
-                    return News::ItemTypeProperty::HasLocation | News::ItemTypeProperty::HasSubject;
-                case News::ItemType::Null:
-                case News::ItemType::Count:
-                default:
-                    return 0;
-            }
-        }
-
         void SetFlags(uint8_t flag)
         {
             Flags |= flag;
@@ -97,12 +68,34 @@ namespace News
 
         constexpr bool TypeHasSubject() const
         {
-            return this->GetTypeProperties() & News::ItemTypeProperty::HasSubject;
+            switch (Type)
+            {
+                case News::ItemType::Money:
+                case News::ItemType::Research:
+                case News::ItemType::Peeps:
+                case News::ItemType::Award:
+                case News::ItemType::Graph:
+                case News::ItemType::Ride:
+                case News::ItemType::PeepOnRide:
+                case News::ItemType::Peep:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         constexpr bool TypeHasLocation() const
         {
-            return this->GetTypeProperties() & News::ItemTypeProperty::HasLocation;
+            switch (Type)
+            {
+                case News::ItemType::Blank:
+                case News::ItemType::Ride:
+                case News::ItemType::PeepOnRide:
+                case News::ItemType::Peep:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         constexpr bool HasButton() const noexcept

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../util/Util.h"
 
 #include <algorithm>
 #include <array>
@@ -38,6 +39,12 @@ namespace News
 
     constexpr size_t ItemTypeCount = static_cast<size_t>(News::ItemType::Count);
 
+    enum class ItemTypeProperty : uint8_t
+    {
+        HasLocation = 1,
+        HasSubject = 2,
+    };
+
     enum ItemFlags : uint8_t
     {
         HasButton = 1 << 0,
@@ -61,6 +68,29 @@ namespace News
             return Type == News::ItemType::Null;
         }
 
+        constexpr uint8_t GetTypeProperties() const
+        {
+            switch (Type)
+            {
+                case News::ItemType::Blank:
+                    return EnumValue(News::ItemTypeProperty::HasLocation);
+                case News::ItemType::Money:
+                case News::ItemType::Research:
+                case News::ItemType::Peeps:
+                case News::ItemType::Award:
+                case News::ItemType::Graph:
+                    return EnumValue(News::ItemTypeProperty::HasSubject);
+                case News::ItemType::Ride:
+                case News::ItemType::PeepOnRide:
+                case News::ItemType::Peep:
+                    return EnumValue(News::ItemTypeProperty::HasLocation) | EnumValue(News::ItemTypeProperty::HasSubject);
+                case News::ItemType::Null:
+                case News::ItemType::Count:
+                default:
+                    return 0;
+            }
+        }
+
         void SetFlags(uint8_t flag)
         {
             Flags |= flag;
@@ -68,34 +98,12 @@ namespace News
 
         constexpr bool TypeHasSubject() const
         {
-            switch (Type)
-            {
-                case News::ItemType::Money:
-                case News::ItemType::Research:
-                case News::ItemType::Peeps:
-                case News::ItemType::Award:
-                case News::ItemType::Graph:
-                case News::ItemType::Ride:
-                case News::ItemType::PeepOnRide:
-                case News::ItemType::Peep:
-                    return true;
-                default:
-                    return false;
-            }
+            return this->GetTypeProperties() & EnumValue(News::ItemTypeProperty::HasSubject);
         }
 
         constexpr bool TypeHasLocation() const
         {
-            switch (Type)
-            {
-                case News::ItemType::Blank:
-                case News::ItemType::Ride:
-                case News::ItemType::PeepOnRide:
-                case News::ItemType::Peep:
-                    return true;
-                default:
-                    return false;
-            }
+            return this->GetTypeProperties() & EnumValue(News::ItemTypeProperty::HasLocation);
         }
 
         constexpr bool HasButton() const noexcept


### PR DESCRIPTION
Close #13627: Refactor ItemTypeProperty to use strong enum
~~Close #13623: Refactor LightFXQualifier to use strong enum~~

The enum ItemTypeProperty was only being used to determine if a NewsItem Type has a subject and/or a location. There already exists a function TypeHasSubject() and TypeHasLocation() so I refactored those to return true for the correct Type. The enum becomes obsolete this way.

~~I also changed LightFXQualifier to a strong enum, same PR since it required no refactoring.~~