### PR TITLE
Fix #11438: Crash when decreasing map size

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1738,28 +1738,48 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
                     break;
             }
             auto parkEntranceRemoveAction = ParkEntranceRemoveAction(CoordsXYZ{ seqLoc, element->GetBaseZ() });
-            GameActions::Execute(&parkEntranceRemoveAction);
+            auto result = GameActions::Execute(&parkEntranceRemoveAction);
+            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+            if (result->Error != GameActions::Status::Ok)
+            {
+                tile_element_remove(element);
+            }
             break;
         }
         case TILE_ELEMENT_TYPE_WALL:
         {
             CoordsXYZD wallLocation = { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() };
             auto wallRemoveAction = WallRemoveAction(wallLocation);
-            GameActions::Execute(&wallRemoveAction);
+            auto result = GameActions::Execute(&wallRemoveAction);
+            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+            if (result->Error != GameActions::Status::Ok)
+            {
+                tile_element_remove(element);
+            }
         }
         break;
         case TILE_ELEMENT_TYPE_LARGE_SCENERY:
         {
             auto removeSceneryAction = LargeSceneryRemoveAction(
                 { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() }, element->AsLargeScenery()->GetSequenceIndex());
-            GameActions::Execute(&removeSceneryAction);
+            auto result = GameActions::Execute(&removeSceneryAction);
+            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+            if (result->Error != GameActions::Status::Ok)
+            {
+                tile_element_remove(element);
+            }
         }
         break;
         case TILE_ELEMENT_TYPE_BANNER:
         {
             auto bannerRemoveAction = BannerRemoveAction(
                 { loc.x, loc.y, element->GetBaseZ(), element->AsBanner()->GetPosition() });
-            GameActions::Execute(&bannerRemoveAction);
+            auto result = GameActions::Execute(&bannerRemoveAction);
+            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+            if (result->Error != GameActions::Status::Ok)
+            {
+                tile_element_remove(element);
+            }
             break;
         }
         default:


### PR DESCRIPTION
The issue was caused by the code trying to remove a park entrance element that was not one that it knew about. It therefore refused to remove the tile element, caused code further upstream to get into an infinite loop.

Since `clear_element_at` is only called from functions that either clear the map completely or clear all the out of range elements, I figured that forcibly removing them was not too much of a problem.