### PR TITLE
Refactor MISC_SPRITE to strong enum

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -937,7 +937,7 @@ declare global {
     }
 
     type EntityType =
-        "car" | "duck" | "peep";
+        "car" | "duck" | "peep" | "steam_particle" | "money_effect" | "crashed_vehicle_particle" | "explosion_cloud" | "crash_splash" | "explosion_flare" | "jumping_fountain_water" | "balloon" | "jumping_fountain_snow";
 
     /**
      * Represents an object "entity" on the map that can typically moves and has a sub-tile coordinate.

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -195,15 +195,15 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                 case SpriteIdentifier::Misc:
                     if (game_is_not_paused())
                     {
-                        switch (entity->type)
+                        switch (static_cast<MiscSpriteType>(entity->type))
                         {
-                            case SPRITE_MISC_BALLOON:
+                            case MiscSpriteType::Balloon:
                             {
                                 auto balloonPress = BalloonPressAction(entity->sprite_index);
                                 GameActions::Execute(&balloonPress);
                             }
                             break;
-                            case SPRITE_MISC_DUCK:
+                            case MiscSpriteType::Duck:
                             {
                                 auto duck = entity->As<Duck>();
                                 if (duck != nullptr)
@@ -212,6 +212,8 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                                 }
                             }
                             break;
+                            default:
+                                break;
                         }
                     }
                     break;

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -195,15 +195,15 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                 case SpriteIdentifier::Misc:
                     if (game_is_not_paused())
                     {
-                        switch (static_cast<MiscSpriteType>(entity->type))
+                        switch (static_cast<MiscEntityType>(entity->type))
                         {
-                            case MiscSpriteType::Balloon:
+                            case MiscEntityType::Balloon:
                             {
                                 auto balloonPress = BalloonPressAction(entity->sprite_index);
                                 GameActions::Execute(&balloonPress);
                             }
                             break;
-                            case MiscSpriteType::Duck:
+                            case MiscEntityType::Duck:
                             {
                                 auto duck = entity->As<Duck>();
                                 if (duck != nullptr)

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -92,21 +92,21 @@ struct GameStateSnapshot_t
                 case SpriteIdentifier::Misc:
                 {
                     ds << sprite.generic.type;
-                    switch (static_cast<MiscSpriteType>(sprite.generic.type))
+                    switch (static_cast<MiscEntityType>(sprite.generic.type))
                     {
-                        case MiscSpriteType::MoneyEffect:
+                        case MiscEntityType::MoneyEffect:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(MoneyEffect)]>(sprite.money_effect);
                             break;
-                        case MiscSpriteType::Balloon:
+                        case MiscEntityType::Balloon:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(Balloon)]>(sprite.balloon);
                             break;
-                        case MiscSpriteType::Duck:
+                        case MiscEntityType::Duck:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(Duck)]>(sprite.duck);
                             break;
-                        case MiscSpriteType::JumpingFountainWater:
+                        case MiscEntityType::JumpingFountainWater:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(JumpingFountain)]>(sprite.jumping_fountain);
                             break;
-                        case MiscSpriteType::SteamParticle:
+                        case MiscEntityType::SteamParticle:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(SteamParticle)]>(sprite.steam_particle);
                             break;
                         default:
@@ -494,32 +494,32 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
                     CompareSpriteDataGeneric(spriteBase.generic, spriteCmp.generic, changeData);
-                    switch (static_cast<MiscSpriteType>(spriteBase.generic.type))
+                    switch (static_cast<MiscEntityType>(spriteBase.generic.type))
                     {
-                        case MiscSpriteType::SteamParticle:
+                        case MiscEntityType::SteamParticle:
                             CompareSpriteDataSteamParticle(spriteBase.steam_particle, spriteCmp.steam_particle, changeData);
                             break;
-                        case MiscSpriteType::MoneyEffect:
+                        case MiscEntityType::MoneyEffect:
                             CompareSpriteDataMoneyEffect(spriteBase.money_effect, spriteCmp.money_effect, changeData);
                             break;
-                        case MiscSpriteType::CrashedVehicleParticle:
+                        case MiscEntityType::CrashedVehicleParticle:
                             CompareSpriteDataVehicleCrashParticle(
                                 spriteBase.crashed_vehicle_particle, spriteCmp.crashed_vehicle_particle, changeData);
                             break;
-                        case MiscSpriteType::ExplosionCloud:
-                        case MiscSpriteType::CrashSplash:
-                        case MiscSpriteType::ExplosionFlare:
+                        case MiscEntityType::ExplosionCloud:
+                        case MiscEntityType::CrashSplash:
+                        case MiscEntityType::ExplosionFlare:
                             // SpriteGeneric
                             break;
-                        case MiscSpriteType::JumpingFountainWater:
-                        case MiscSpriteType::JumpingFountainSnow:
+                        case MiscEntityType::JumpingFountainWater:
+                        case MiscEntityType::JumpingFountainSnow:
                             CompareSpriteDataJumpingFountain(
                                 spriteBase.jumping_fountain, spriteCmp.jumping_fountain, changeData);
                             break;
-                        case MiscSpriteType::Balloon:
+                        case MiscEntityType::Balloon:
                             CompareSpriteDataBalloon(spriteBase.balloon, spriteCmp.balloon, changeData);
                             break;
-                        case MiscSpriteType::Duck:
+                        case MiscEntityType::Duck:
                             CompareSpriteDataDuck(spriteBase.duck, spriteCmp.duck, changeData);
                             break;
                         default:
@@ -594,7 +594,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         return res;
     }
 
-    static const char* GetSpriteIdentifierName(SpriteIdentifier spriteIdentifier, MiscSpriteType miscIdentifier)
+    static const char* GetSpriteIdentifierName(SpriteIdentifier spriteIdentifier, MiscEntityType miscIdentifier)
     {
         switch (spriteIdentifier)
         {
@@ -609,25 +609,25 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             case SpriteIdentifier::Misc:
                 switch (miscIdentifier)
                 {
-                    case MiscSpriteType::SteamParticle:
+                    case MiscEntityType::SteamParticle:
                         return "Misc: Steam Particle";
-                    case MiscSpriteType::MoneyEffect:
+                    case MiscEntityType::MoneyEffect:
                         return "Misc: Money effect";
-                    case MiscSpriteType::CrashedVehicleParticle:
+                    case MiscEntityType::CrashedVehicleParticle:
                         return "Misc: Crash Vehicle Particle";
-                    case MiscSpriteType::ExplosionCloud:
+                    case MiscEntityType::ExplosionCloud:
                         return "Misc: Explosion Cloud";
-                    case MiscSpriteType::CrashSplash:
+                    case MiscEntityType::CrashSplash:
                         return "Misc: Crash Splash";
-                    case MiscSpriteType::ExplosionFlare:
+                    case MiscEntityType::ExplosionFlare:
                         return "Misc: Explosion Flare";
-                    case MiscSpriteType::JumpingFountainWater:
+                    case MiscEntityType::JumpingFountainWater:
                         return "Misc: Jumping fountain water";
-                    case MiscSpriteType::Balloon:
+                    case MiscEntityType::Balloon:
                         return "Misc: Balloon";
-                    case MiscSpriteType::Duck:
+                    case MiscEntityType::Duck:
                         return "Misc: Duck";
-                    case MiscSpriteType::JumpingFountainSnow:
+                    case MiscEntityType::JumpingFountainSnow:
                         return "Misc: Jumping fountain snow";
                     default:
                         break;
@@ -656,7 +656,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                 continue;
 
             const char* typeName = GetSpriteIdentifierName(
-                change.spriteIdentifier, static_cast<MiscSpriteType>(change.miscIdentifier));
+                change.spriteIdentifier, static_cast<MiscEntityType>(change.miscIdentifier));
 
             if (change.changeType == GameStateSpriteChange_t::ADDED)
             {

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -92,22 +92,24 @@ struct GameStateSnapshot_t
                 case SpriteIdentifier::Misc:
                 {
                     ds << sprite.generic.type;
-                    switch (sprite.generic.type)
+                    switch (static_cast<MiscSpriteType>(sprite.generic.type))
                     {
-                        case SPRITE_MISC_MONEY_EFFECT:
+                        case MiscSpriteType::MoneyEffect:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(MoneyEffect)]>(sprite.money_effect);
                             break;
-                        case SPRITE_MISC_BALLOON:
+                        case MiscSpriteType::Balloon:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(Balloon)]>(sprite.balloon);
                             break;
-                        case SPRITE_MISC_DUCK:
+                        case MiscSpriteType::Duck:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(Duck)]>(sprite.duck);
                             break;
-                        case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
+                        case MiscSpriteType::JumpingFountainWater:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(JumpingFountain)]>(sprite.jumping_fountain);
                             break;
-                        case SPRITE_MISC_STEAM_PARTICLE:
+                        case MiscSpriteType::SteamParticle:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(SteamParticle)]>(sprite.steam_particle);
+                            break;
+                        default:
                             break;
                     }
                     break;
@@ -492,33 +494,35 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
                     CompareSpriteDataGeneric(spriteBase.generic, spriteCmp.generic, changeData);
-                    switch (spriteBase.generic.type)
+                    switch (static_cast<MiscSpriteType>(spriteBase.generic.type))
                     {
-                        case SPRITE_MISC_STEAM_PARTICLE:
+                        case MiscSpriteType::SteamParticle:
                             CompareSpriteDataSteamParticle(spriteBase.steam_particle, spriteCmp.steam_particle, changeData);
                             break;
-                        case SPRITE_MISC_MONEY_EFFECT:
+                        case MiscSpriteType::MoneyEffect:
                             CompareSpriteDataMoneyEffect(spriteBase.money_effect, spriteCmp.money_effect, changeData);
                             break;
-                        case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+                        case MiscSpriteType::CrashedVehicleParticle:
                             CompareSpriteDataVehicleCrashParticle(
                                 spriteBase.crashed_vehicle_particle, spriteCmp.crashed_vehicle_particle, changeData);
                             break;
-                        case SPRITE_MISC_EXPLOSION_CLOUD:
-                        case SPRITE_MISC_CRASH_SPLASH:
-                        case SPRITE_MISC_EXPLOSION_FLARE:
+                        case MiscSpriteType::ExplosionCloud:
+                        case MiscSpriteType::CrashSplash:
+                        case MiscSpriteType::ExplosionFlare:
                             // SpriteGeneric
                             break;
-                        case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
-                        case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
+                        case MiscSpriteType::JumpingFountainWater:
+                        case MiscSpriteType::JumpingFountainSnow:
                             CompareSpriteDataJumpingFountain(
                                 spriteBase.jumping_fountain, spriteCmp.jumping_fountain, changeData);
                             break;
-                        case SPRITE_MISC_BALLOON:
+                        case MiscSpriteType::Balloon:
                             CompareSpriteDataBalloon(spriteBase.balloon, spriteCmp.balloon, changeData);
                             break;
-                        case SPRITE_MISC_DUCK:
+                        case MiscSpriteType::Duck:
                             CompareSpriteDataDuck(spriteBase.duck, spriteCmp.duck, changeData);
+                            break;
+                        default:
                             break;
                     }
                     break;
@@ -590,7 +594,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         return res;
     }
 
-    static const char* GetSpriteIdentifierName(SpriteIdentifier spriteIdentifier, uint8_t miscIdentifier)
+    static const char* GetSpriteIdentifierName(SpriteIdentifier spriteIdentifier, MiscSpriteType miscIdentifier)
     {
         switch (spriteIdentifier)
         {
@@ -605,26 +609,28 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             case SpriteIdentifier::Misc:
                 switch (miscIdentifier)
                 {
-                    case SPRITE_MISC_STEAM_PARTICLE:
+                    case MiscSpriteType::SteamParticle:
                         return "Misc: Steam Particle";
-                    case SPRITE_MISC_MONEY_EFFECT:
+                    case MiscSpriteType::MoneyEffect:
                         return "Misc: Money effect";
-                    case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+                    case MiscSpriteType::CrashedVehicleParticle:
                         return "Misc: Crash Vehicle Particle";
-                    case SPRITE_MISC_EXPLOSION_CLOUD:
+                    case MiscSpriteType::ExplosionCloud:
                         return "Misc: Explosion Cloud";
-                    case SPRITE_MISC_CRASH_SPLASH:
+                    case MiscSpriteType::CrashSplash:
                         return "Misc: Crash Splash";
-                    case SPRITE_MISC_EXPLOSION_FLARE:
+                    case MiscSpriteType::ExplosionFlare:
                         return "Misc: Explosion Flare";
-                    case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
+                    case MiscSpriteType::JumpingFountainWater:
                         return "Misc: Jumping fountain water";
-                    case SPRITE_MISC_BALLOON:
+                    case MiscSpriteType::Balloon:
                         return "Misc: Balloon";
-                    case SPRITE_MISC_DUCK:
+                    case MiscSpriteType::Duck:
                         return "Misc: Duck";
-                    case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
+                    case MiscSpriteType::JumpingFountainSnow:
                         return "Misc: Jumping fountain snow";
+                    default:
+                        break;
                 }
                 return "Misc";
         }
@@ -649,7 +655,8 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             if (change.changeType == GameStateSpriteChange_t::EQUAL)
                 continue;
 
-            const char* typeName = GetSpriteIdentifierName(change.spriteIdentifier, change.miscIdentifier);
+            const char* typeName = GetSpriteIdentifierName(
+                change.spriteIdentifier, static_cast<MiscSpriteType>(change.miscIdentifier));
 
             if (change.changeType == GameStateSpriteChange_t::ADDED)
             {

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -33,9 +33,9 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
 {
     rct_drawpixelinfo* dpi = &session->DPI;
 
-    switch (misc->type)
+    switch (static_cast<MiscSpriteType>(misc->type))
     {
-        case SPRITE_MISC_STEAM_PARTICLE: // 0
+        case MiscSpriteType::SteamParticle: // 0
         {
             auto particle = misc->As<SteamParticle>();
             if (particle == nullptr)
@@ -45,7 +45,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_MONEY_EFFECT: // 1
+        case MiscSpriteType::MoneyEffect: // 1
         {
             if (dpi->zoom_level > 0)
             {
@@ -61,7 +61,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE: // 2
+        case MiscSpriteType::CrashedVehicleParticle: // 2
         {
             if (dpi->zoom_level > 0)
             {
@@ -77,7 +77,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_EXPLOSION_CLOUD: // 3
+        case MiscSpriteType::ExplosionCloud: // 3
         {
             auto particle = misc->As<ExplosionCloud>();
             if (particle == nullptr)
@@ -87,7 +87,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_CRASH_SPLASH: // 4
+        case MiscSpriteType::CrashSplash: // 4
         {
             auto crashSplash = misc->As<CrashSplashParticle>();
             if (crashSplash == nullptr)
@@ -97,7 +97,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_EXPLOSION_FLARE: // 5
+        case MiscSpriteType::ExplosionFlare: // 5
         {
             // Like a flare
             auto flare = misc->As<ExplosionFlare>();
@@ -108,8 +108,8 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_JUMPING_FOUNTAIN_WATER: // 6
-        case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:  // 9
+        case MiscSpriteType::JumpingFountainWater: // 6
+        case MiscSpriteType::JumpingFountainSnow:  // 9
         {
             if (dpi->zoom_level > 0)
             {
@@ -134,7 +134,9 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
                 isAntiClockwise = !isAntiClockwise;
             }
 
-            uint32_t baseImageId = (jumpingFountain->type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW) ? 23037 : 22973;
+            uint32_t baseImageId = (static_cast<MiscSpriteType>(jumpingFountain->type) == MiscSpriteType::JumpingFountainSnow)
+                ? 23037
+                : 22973;
             uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;
             constexpr std::array<CoordsXY, 2> antiClockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, -3 },
                                                                              CoordsXY{ 0, -3 } };
@@ -146,7 +148,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_BALLOON: // 7
+        case MiscSpriteType::Balloon: // 7
         {
             auto balloon = misc->As<Balloon>();
             if (balloon == nullptr)
@@ -162,7 +164,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case SPRITE_MISC_DUCK:
+        case MiscSpriteType::Duck:
             if (dpi->zoom_level <= 1)
             {
                 const Duck* duck = misc->As<Duck>();

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -33,9 +33,9 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
 {
     rct_drawpixelinfo* dpi = &session->DPI;
 
-    switch (static_cast<MiscSpriteType>(misc->type))
+    switch (static_cast<MiscEntityType>(misc->type))
     {
-        case MiscSpriteType::SteamParticle: // 0
+        case MiscEntityType::SteamParticle: // 0
         {
             auto particle = misc->As<SteamParticle>();
             if (particle == nullptr)
@@ -45,7 +45,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::MoneyEffect: // 1
+        case MiscEntityType::MoneyEffect: // 1
         {
             if (dpi->zoom_level > 0)
             {
@@ -61,7 +61,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::CrashedVehicleParticle: // 2
+        case MiscEntityType::CrashedVehicleParticle: // 2
         {
             if (dpi->zoom_level > 0)
             {
@@ -77,7 +77,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::ExplosionCloud: // 3
+        case MiscEntityType::ExplosionCloud: // 3
         {
             auto particle = misc->As<ExplosionCloud>();
             if (particle == nullptr)
@@ -87,7 +87,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::CrashSplash: // 4
+        case MiscEntityType::CrashSplash: // 4
         {
             auto crashSplash = misc->As<CrashSplashParticle>();
             if (crashSplash == nullptr)
@@ -97,7 +97,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::ExplosionFlare: // 5
+        case MiscEntityType::ExplosionFlare: // 5
         {
             // Like a flare
             auto flare = misc->As<ExplosionFlare>();
@@ -108,8 +108,8 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::JumpingFountainWater: // 6
-        case MiscSpriteType::JumpingFountainSnow:  // 9
+        case MiscEntityType::JumpingFountainWater: // 6
+        case MiscEntityType::JumpingFountainSnow:  // 9
         {
             if (dpi->zoom_level > 0)
             {
@@ -134,7 +134,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
                 isAntiClockwise = !isAntiClockwise;
             }
 
-            uint32_t baseImageId = (static_cast<MiscSpriteType>(jumpingFountain->type) == MiscSpriteType::JumpingFountainSnow)
+            uint32_t baseImageId = (static_cast<MiscEntityType>(jumpingFountain->type) == MiscEntityType::JumpingFountainSnow)
                 ? 23037
                 : 22973;
             uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;
@@ -148,7 +148,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::Balloon: // 7
+        case MiscEntityType::Balloon: // 7
         {
             auto balloon = misc->As<Balloon>();
             if (balloon == nullptr)
@@ -164,7 +164,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
             break;
         }
 
-        case MiscSpriteType::Duck:
+        case MiscEntityType::Duck:
             if (dpi->zoom_level <= 1)
             {
                 const Duck* duck = misc->As<Duck>();

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1691,31 +1691,33 @@ private:
 
                 dst->MoveTo({ src->x, src->y, src->z });
 
-                switch (src->type)
+                switch (static_cast<MiscSpriteType>(src->type))
                 {
-                    case SPRITE_MISC_STEAM_PARTICLE:
+                    case MiscSpriteType::SteamParticle:
                         ImportSteamParticle(dst->As<SteamParticle>(), reinterpret_cast<RCT12SpriteSteamParticle*>(src));
                         break;
-                    case SPRITE_MISC_MONEY_EFFECT:
+                    case MiscSpriteType::MoneyEffect:
                         ImportMoneyEffect(dst->As<MoneyEffect>(), reinterpret_cast<RCT12SpriteMoneyEffect*>(src));
                         break;
-                    case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+                    case MiscSpriteType::CrashedVehicleParticle:
                         break;
-                    case SPRITE_MISC_EXPLOSION_CLOUD:
+                    case MiscSpriteType::ExplosionCloud:
                         break;
-                    case SPRITE_MISC_CRASH_SPLASH:
+                    case MiscSpriteType::CrashSplash:
                         break;
-                    case SPRITE_MISC_EXPLOSION_FLARE:
+                    case MiscSpriteType::ExplosionFlare:
                         break;
-                    case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
+                    case MiscSpriteType::JumpingFountainWater:
                         ImportJumpingFountainWater(
                             dst->As<JumpingFountain>(), reinterpret_cast<RCT12SpriteJumpingFountain*>(src));
                         break;
-                    case SPRITE_MISC_BALLOON:
+                    case MiscSpriteType::Balloon:
                         ImportBalloon(dst->As<Balloon>(), reinterpret_cast<RCT12SpriteBalloon*>(src));
                         break;
-                    case SPRITE_MISC_DUCK:
+                    case MiscSpriteType::Duck:
                         ImportDuck(dst->As<Duck>(), reinterpret_cast<RCT12SpriteDuck*>(src));
+                        break;
+                    default:
                         break;
                 }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1691,30 +1691,30 @@ private:
 
                 dst->MoveTo({ src->x, src->y, src->z });
 
-                switch (static_cast<MiscSpriteType>(src->type))
+                switch (static_cast<MiscEntityType>(src->type))
                 {
-                    case MiscSpriteType::SteamParticle:
+                    case MiscEntityType::SteamParticle:
                         ImportSteamParticle(dst->As<SteamParticle>(), reinterpret_cast<RCT12SpriteSteamParticle*>(src));
                         break;
-                    case MiscSpriteType::MoneyEffect:
+                    case MiscEntityType::MoneyEffect:
                         ImportMoneyEffect(dst->As<MoneyEffect>(), reinterpret_cast<RCT12SpriteMoneyEffect*>(src));
                         break;
-                    case MiscSpriteType::CrashedVehicleParticle:
+                    case MiscEntityType::CrashedVehicleParticle:
                         break;
-                    case MiscSpriteType::ExplosionCloud:
+                    case MiscEntityType::ExplosionCloud:
                         break;
-                    case MiscSpriteType::CrashSplash:
+                    case MiscEntityType::CrashSplash:
                         break;
-                    case MiscSpriteType::ExplosionFlare:
+                    case MiscEntityType::ExplosionFlare:
                         break;
-                    case MiscSpriteType::JumpingFountainWater:
+                    case MiscEntityType::JumpingFountainWater:
                         ImportJumpingFountainWater(
                             dst->As<JumpingFountain>(), reinterpret_cast<RCT12SpriteJumpingFountain*>(src));
                         break;
-                    case MiscSpriteType::Balloon:
+                    case MiscEntityType::Balloon:
                         ImportBalloon(dst->As<Balloon>(), reinterpret_cast<RCT12SpriteBalloon*>(src));
                         break;
-                    case MiscSpriteType::Duck:
+                    case MiscEntityType::Duck:
                         ImportDuck(dst->As<Duck>(), reinterpret_cast<RCT12SpriteDuck*>(src));
                         break;
                     default:

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1251,9 +1251,9 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
-    switch (static_cast<MiscSpriteType>(cdst->type))
+    switch (static_cast<MiscEntityType>(cdst->type))
     {
-        case MiscSpriteType::SteamParticle:
+        case MiscEntityType::SteamParticle:
         {
             auto src = static_cast<const SteamParticle*>(csrc);
             auto dst = static_cast<RCT12SpriteSteamParticle*>(cdst);
@@ -1261,7 +1261,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->frame = src->frame;
             break;
         }
-        case MiscSpriteType::MoneyEffect:
+        case MiscEntityType::MoneyEffect:
         {
             auto src = static_cast<const MoneyEffect*>(csrc);
             auto dst = static_cast<RCT12SpriteMoneyEffect*>(cdst);
@@ -1273,7 +1273,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->wiggle = src->Wiggle;
             break;
         }
-        case MiscSpriteType::CrashedVehicleParticle:
+        case MiscEntityType::CrashedVehicleParticle:
         {
             auto src = static_cast<const VehicleCrashParticle*>(csrc);
             auto dst = static_cast<RCT12SpriteCrashedVehicleParticle*>(cdst);
@@ -1291,17 +1291,17 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->acceleration_z = src->acceleration_z;
             break;
         }
-        case MiscSpriteType::ExplosionCloud:
-        case MiscSpriteType::ExplosionFlare:
-        case MiscSpriteType::CrashSplash:
+        case MiscEntityType::ExplosionCloud:
+        case MiscEntityType::ExplosionFlare:
+        case MiscEntityType::CrashSplash:
         {
             auto src = static_cast<const SpriteGeneric*>(csrc);
             auto dst = static_cast<RCT12SpriteParticle*>(cdst);
             dst->frame = src->frame;
             break;
         }
-        case MiscSpriteType::JumpingFountainWater:
-        case MiscSpriteType::JumpingFountainSnow:
+        case MiscEntityType::JumpingFountainWater:
+        case MiscEntityType::JumpingFountainSnow:
         {
             auto* src = static_cast<const JumpingFountain*>(csrc);
             auto* dst = static_cast<RCT12SpriteJumpingFountain*>(cdst);
@@ -1314,7 +1314,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->iteration = src->Iteration;
             break;
         }
-        case MiscSpriteType::Balloon:
+        case MiscEntityType::Balloon:
         {
             auto src = static_cast<const Balloon*>(csrc);
             auto dst = static_cast<RCT12SpriteBalloon*>(cdst);
@@ -1324,7 +1324,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->colour = src->colour;
             break;
         }
-        case MiscSpriteType::Duck:
+        case MiscEntityType::Duck:
         {
             auto src = static_cast<const Duck*>(csrc);
             auto dst = static_cast<RCT12SpriteDuck*>(cdst);

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1251,9 +1251,9 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
-    switch (cdst->type)
+    switch (static_cast<MiscSpriteType>(cdst->type))
     {
-        case SPRITE_MISC_STEAM_PARTICLE:
+        case MiscSpriteType::SteamParticle:
         {
             auto src = static_cast<const SteamParticle*>(csrc);
             auto dst = static_cast<RCT12SpriteSteamParticle*>(cdst);
@@ -1261,7 +1261,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->frame = src->frame;
             break;
         }
-        case SPRITE_MISC_MONEY_EFFECT:
+        case MiscSpriteType::MoneyEffect:
         {
             auto src = static_cast<const MoneyEffect*>(csrc);
             auto dst = static_cast<RCT12SpriteMoneyEffect*>(cdst);
@@ -1273,7 +1273,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->wiggle = src->Wiggle;
             break;
         }
-        case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+        case MiscSpriteType::CrashedVehicleParticle:
         {
             auto src = static_cast<const VehicleCrashParticle*>(csrc);
             auto dst = static_cast<RCT12SpriteCrashedVehicleParticle*>(cdst);
@@ -1291,17 +1291,17 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->acceleration_z = src->acceleration_z;
             break;
         }
-        case SPRITE_MISC_EXPLOSION_CLOUD:
-        case SPRITE_MISC_EXPLOSION_FLARE:
-        case SPRITE_MISC_CRASH_SPLASH:
+        case MiscSpriteType::ExplosionCloud:
+        case MiscSpriteType::ExplosionFlare:
+        case MiscSpriteType::CrashSplash:
         {
             auto src = static_cast<const SpriteGeneric*>(csrc);
             auto dst = static_cast<RCT12SpriteParticle*>(cdst);
             dst->frame = src->frame;
             break;
         }
-        case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
-        case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
+        case MiscSpriteType::JumpingFountainWater:
+        case MiscSpriteType::JumpingFountainSnow:
         {
             auto* src = static_cast<const JumpingFountain*>(csrc);
             auto* dst = static_cast<RCT12SpriteJumpingFountain*>(cdst);
@@ -1314,7 +1314,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->iteration = src->Iteration;
             break;
         }
-        case SPRITE_MISC_BALLOON:
+        case MiscSpriteType::Balloon:
         {
             auto src = static_cast<const Balloon*>(csrc);
             auto dst = static_cast<RCT12SpriteBalloon*>(cdst);
@@ -1324,7 +1324,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
             dst->colour = src->colour;
             break;
         }
-        case SPRITE_MISC_DUCK:
+        case MiscSpriteType::Duck:
         {
             auto src = static_cast<const Duck*>(csrc);
             auto dst = static_cast<RCT12SpriteDuck*>(cdst);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1538,9 +1538,9 @@ public:
     void ImportSpriteMisc(SpriteBase* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        switch (cdst->type)
+        switch (static_cast<MiscSpriteType>(cdst->type))
         {
-            case SPRITE_MISC_STEAM_PARTICLE:
+            case MiscSpriteType::SteamParticle:
             {
                 auto src = static_cast<const RCT12SpriteSteamParticle*>(csrc);
                 auto dst = static_cast<SteamParticle*>(cdst);
@@ -1548,7 +1548,7 @@ public:
                 dst->frame = src->frame;
                 break;
             }
-            case SPRITE_MISC_MONEY_EFFECT:
+            case MiscSpriteType::MoneyEffect:
             {
                 auto src = static_cast<const RCT12SpriteMoneyEffect*>(csrc);
                 auto dst = static_cast<MoneyEffect*>(cdst);
@@ -1560,7 +1560,7 @@ public:
                 dst->Wiggle = src->wiggle;
                 break;
             }
-            case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+            case MiscSpriteType::CrashedVehicleParticle:
             {
                 auto src = static_cast<const RCT12SpriteCrashedVehicleParticle*>(csrc);
                 auto dst = static_cast<VehicleCrashParticle*>(cdst);
@@ -1578,17 +1578,17 @@ public:
                 dst->acceleration_z = src->acceleration_z;
                 break;
             }
-            case SPRITE_MISC_EXPLOSION_CLOUD:
-            case SPRITE_MISC_EXPLOSION_FLARE:
-            case SPRITE_MISC_CRASH_SPLASH:
+            case MiscSpriteType::ExplosionCloud:
+            case MiscSpriteType::ExplosionFlare:
+            case MiscSpriteType::CrashSplash:
             {
                 auto src = static_cast<const RCT12SpriteParticle*>(csrc);
                 auto dst = static_cast<SpriteGeneric*>(cdst);
                 dst->frame = src->frame;
                 break;
             }
-            case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
-            case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
+            case MiscSpriteType::JumpingFountainWater:
+            case MiscSpriteType::JumpingFountainSnow:
             {
                 auto* src = static_cast<const RCT12SpriteJumpingFountain*>(csrc);
                 auto* dst = static_cast<JumpingFountain*>(cdst);
@@ -1600,7 +1600,7 @@ public:
                 dst->Iteration = src->iteration;
                 break;
             }
-            case SPRITE_MISC_BALLOON:
+            case MiscSpriteType::Balloon:
             {
                 auto src = static_cast<const RCT12SpriteBalloon*>(csrc);
                 auto dst = static_cast<Balloon*>(cdst);
@@ -1610,7 +1610,7 @@ public:
                 dst->colour = src->colour;
                 break;
             }
-            case SPRITE_MISC_DUCK:
+            case MiscSpriteType::Duck:
             {
                 auto src = static_cast<const RCT12SpriteDuck*>(csrc);
                 auto dst = static_cast<Duck*>(cdst);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1538,9 +1538,9 @@ public:
     void ImportSpriteMisc(SpriteBase* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        switch (static_cast<MiscSpriteType>(cdst->type))
+        switch (static_cast<MiscEntityType>(cdst->type))
         {
-            case MiscSpriteType::SteamParticle:
+            case MiscEntityType::SteamParticle:
             {
                 auto src = static_cast<const RCT12SpriteSteamParticle*>(csrc);
                 auto dst = static_cast<SteamParticle*>(cdst);
@@ -1548,7 +1548,7 @@ public:
                 dst->frame = src->frame;
                 break;
             }
-            case MiscSpriteType::MoneyEffect:
+            case MiscEntityType::MoneyEffect:
             {
                 auto src = static_cast<const RCT12SpriteMoneyEffect*>(csrc);
                 auto dst = static_cast<MoneyEffect*>(cdst);
@@ -1560,7 +1560,7 @@ public:
                 dst->Wiggle = src->wiggle;
                 break;
             }
-            case MiscSpriteType::CrashedVehicleParticle:
+            case MiscEntityType::CrashedVehicleParticle:
             {
                 auto src = static_cast<const RCT12SpriteCrashedVehicleParticle*>(csrc);
                 auto dst = static_cast<VehicleCrashParticle*>(cdst);
@@ -1578,17 +1578,17 @@ public:
                 dst->acceleration_z = src->acceleration_z;
                 break;
             }
-            case MiscSpriteType::ExplosionCloud:
-            case MiscSpriteType::ExplosionFlare:
-            case MiscSpriteType::CrashSplash:
+            case MiscEntityType::ExplosionCloud:
+            case MiscEntityType::ExplosionFlare:
+            case MiscEntityType::CrashSplash:
             {
                 auto src = static_cast<const RCT12SpriteParticle*>(csrc);
                 auto dst = static_cast<SpriteGeneric*>(cdst);
                 dst->frame = src->frame;
                 break;
             }
-            case MiscSpriteType::JumpingFountainWater:
-            case MiscSpriteType::JumpingFountainSnow:
+            case MiscEntityType::JumpingFountainWater:
+            case MiscEntityType::JumpingFountainSnow:
             {
                 auto* src = static_cast<const RCT12SpriteJumpingFountain*>(csrc);
                 auto* dst = static_cast<JumpingFountain*>(cdst);
@@ -1600,7 +1600,7 @@ public:
                 dst->Iteration = src->iteration;
                 break;
             }
-            case MiscSpriteType::Balloon:
+            case MiscEntityType::Balloon:
             {
                 auto src = static_cast<const RCT12SpriteBalloon*>(csrc);
                 auto dst = static_cast<Balloon*>(cdst);
@@ -1610,7 +1610,7 @@ public:
                 dst->colour = src->colour;
                 break;
             }
-            case MiscSpriteType::Duck:
+            case MiscEntityType::Duck:
             {
                 auto src = static_cast<const RCT12SpriteDuck*>(csrc);
                 auto dst = static_cast<Duck*>(cdst);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7253,7 +7253,7 @@ static void steam_particle_create(const CoordsXYZ& coords)
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
         steam->sprite_identifier = SpriteIdentifier::Misc;
-        steam->type = EnumValue(MiscSpriteType::SteamParticle);
+        steam->type = EnumValue(MiscEntityType::SteamParticle);
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7253,7 +7253,7 @@ static void steam_particle_create(const CoordsXYZ& coords)
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
         steam->sprite_identifier = SpriteIdentifier::Misc;
-        steam->type = SPRITE_MISC_STEAM_PARTICLE;
+        steam->type = EnumValue(MiscSpriteType::SteamParticle);
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,12 +57,30 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (static_cast<MiscSpriteType>(entity->type))
+                        switch (static_cast<MiscEntityType>(entity->type))
                         {
-                            case MiscSpriteType::Balloon:
+                            case MiscEntityType::SteamParticle:
+                                return "steam_particle";
+                            case MiscEntityType::MoneyEffect:
+                                return "money_effect";
+                            case MiscEntityType::CrashedVehicleParticle:
+                                return "crashed_vehicle_particle";
+                            case MiscEntityType::ExplosionCloud:
+                                return "explosion_cloud";
+                            case MiscEntityType::CrashSplash:
+                                return "crash_splash";
+                            case MiscEntityType::ExplosionFlare:
+                                return "explosion_flare";
+                            case MiscEntityType::JumpingFountainWater:
+                                return "jumping_fountain_water";
+                            case MiscEntityType::Balloon:
                                 return "balloon";
-                            case MiscSpriteType::Duck:
+                            case MiscEntityType::Duck:
                                 return "duck";
+                            case MiscEntityType::JumpingFountainSnow:
+                                return "jumping_fountain_snow";
+                            default:
+                                break;
                         }
                         break;
                     case SpriteIdentifier::Litter:

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,11 +57,11 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (entity->type)
+                        switch (static_cast<MiscSpriteType>(entity->type))
                         {
-                            case SPRITE_MISC_BALLOON:
+                            case MiscSpriteType::Balloon:
                                 return "balloon";
-                            case SPRITE_MISC_DUCK:
+                            case MiscSpriteType::Duck:
                                 return "duck";
                         }
                         break;

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -103,7 +103,7 @@ namespace OpenRCT2::Scripting
             if (type == "balloon")
             {
                 targetList = EntityListId::Misc;
-                targetType = EnumValue(MiscSpriteType::Balloon);
+                targetType = EnumValue(MiscEntityType::Balloon);
             }
             if (type == "car")
             {
@@ -116,7 +116,7 @@ namespace OpenRCT2::Scripting
             else if (type == "duck")
             {
                 targetList = EntityListId::Misc;
-                targetType = EnumValue(MiscSpriteType::Duck);
+                targetType = EnumValue(MiscEntityType::Duck);
             }
             else if (type == "peep")
             {

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -103,7 +103,7 @@ namespace OpenRCT2::Scripting
             if (type == "balloon")
             {
                 targetList = EntityListId::Misc;
-                targetType = SPRITE_MISC_BALLOON;
+                targetType = EnumValue(MiscSpriteType::Balloon);
             }
             if (type == "car")
             {
@@ -116,7 +116,7 @@ namespace OpenRCT2::Scripting
             else if (type == "duck")
             {
                 targetList = EntityListId::Misc;
-                targetType = SPRITE_MISC_DUCK;
+                targetType = EnumValue(MiscSpriteType::Duck);
             }
             else if (type == "peep")
             {

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -16,7 +16,7 @@
 
 template<> bool SpriteBase::Is<Balloon>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_BALLOON;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::Balloon;
 }
 
 void Balloon::Update()
@@ -85,7 +85,7 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (sprite == nullptr)
         return;
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.type = SPRITE_MISC_BALLOON;
+    sprite->generic.type = EnumValue(MiscSpriteType::Balloon);
     auto balloon = sprite->generic.As<Balloon>();
     if (balloon == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -16,7 +16,7 @@
 
 template<> bool SpriteBase::Is<Balloon>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::Balloon;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::Balloon;
 }
 
 void Balloon::Update()
@@ -85,7 +85,7 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (sprite == nullptr)
         return;
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.type = EnumValue(MiscSpriteType::Balloon);
+    sprite->generic.type = EnumValue(MiscEntityType::Balloon);
     auto balloon = sprite->generic.As<Balloon>();
     if (balloon == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -68,7 +68,7 @@ static constexpr const uint8_t * DuckAnimations[] =
 
 template<> bool SpriteBase::Is<Duck>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::Duck;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::Duck;
 }
 
 void Duck::Invalidate()
@@ -298,7 +298,7 @@ void create_duck(const CoordsXY& pos)
     targetPos.y += offsetXY;
 
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.type = EnumValue(MiscSpriteType::Duck);
+    sprite->generic.type = EnumValue(MiscEntityType::Duck);
     auto duck = sprite->generic.As<Duck>();
     if (duck == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -68,7 +68,7 @@ static constexpr const uint8_t * DuckAnimations[] =
 
 template<> bool SpriteBase::Is<Duck>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_DUCK;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::Duck;
 }
 
 void Duck::Invalidate()
@@ -298,7 +298,7 @@ void create_duck(const CoordsXY& pos)
     targetPos.y += offsetXY;
 
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.type = SPRITE_MISC_DUCK;
+    sprite->generic.type = EnumValue(MiscSpriteType::Duck);
     auto duck = sprite->generic.As<Duck>();
     if (duck == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -72,8 +72,9 @@ const uint8_t _fountainPatternFlags[] = {
 
 template<> bool SpriteBase::Is<JumpingFountain>() const
 {
+    const auto miscType = static_cast<MiscSpriteType>(type);
     return sprite_identifier == SpriteIdentifier::Misc
-        && (type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW || type == SPRITE_MISC_JUMPING_FOUNTAIN_WATER);
+        && (miscType == MiscSpriteType::JumpingFountainSnow || miscType == MiscSpriteType::JumpingFountainWater);
 }
 
 void JumpingFountain::StartAnimation(const int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement)
@@ -139,8 +140,8 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->sprite_identifier = SpriteIdentifier::Misc;
         jumpingFountain->MoveTo(newLoc);
-        jumpingFountain->type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? SPRITE_MISC_JUMPING_FOUNTAIN_SNOW
-                                                                      : SPRITE_MISC_JUMPING_FOUNTAIN_WATER;
+        jumpingFountain->type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? EnumValue(MiscSpriteType::JumpingFountainSnow)
+                                                                      : EnumValue(MiscSpriteType::JumpingFountainWater);
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
     }
@@ -161,9 +162,9 @@ void JumpingFountain::Update()
     Invalidate0();
     frame++;
 
-    switch (type)
+    switch (static_cast<MiscSpriteType>(type))
     {
-        case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
+        case MiscSpriteType::JumpingFountainWater:
             if (frame == 11 && (FountainFlags & FOUNTAIN_FLAG::FAST))
             {
                 AdvanceAnimation();
@@ -173,11 +174,13 @@ void JumpingFountain::Update()
                 AdvanceAnimation();
             }
             break;
-        case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
+        case MiscSpriteType::JumpingFountainSnow:
             if (frame == 16)
             {
                 AdvanceAnimation();
             }
+            break;
+        default:
             break;
     }
 
@@ -189,8 +192,9 @@ void JumpingFountain::Update()
 
 int32_t JumpingFountain::GetType() const
 {
-    const int32_t fountainType = type == SPRITE_MISC_JUMPING_FOUNTAIN_SNOW ? JUMPING_FOUNTAIN_TYPE_SNOW
-                                                                           : JUMPING_FOUNTAIN_TYPE_WATER;
+    const int32_t fountainType = static_cast<MiscSpriteType>(type) == MiscSpriteType::JumpingFountainSnow
+        ? JUMPING_FOUNTAIN_TYPE_SNOW
+        : JUMPING_FOUNTAIN_TYPE_WATER;
     return fountainType;
 }
 

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -72,9 +72,9 @@ const uint8_t _fountainPatternFlags[] = {
 
 template<> bool SpriteBase::Is<JumpingFountain>() const
 {
-    const auto miscType = static_cast<MiscSpriteType>(type);
+    const auto miscType = static_cast<MiscEntityType>(type);
     return sprite_identifier == SpriteIdentifier::Misc
-        && (miscType == MiscSpriteType::JumpingFountainSnow || miscType == MiscSpriteType::JumpingFountainWater);
+        && (miscType == MiscEntityType::JumpingFountainSnow || miscType == MiscEntityType::JumpingFountainWater);
 }
 
 void JumpingFountain::StartAnimation(const int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement)
@@ -140,8 +140,8 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->sprite_identifier = SpriteIdentifier::Misc;
         jumpingFountain->MoveTo(newLoc);
-        jumpingFountain->type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? EnumValue(MiscSpriteType::JumpingFountainSnow)
-                                                                      : EnumValue(MiscSpriteType::JumpingFountainWater);
+        jumpingFountain->type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? EnumValue(MiscEntityType::JumpingFountainSnow)
+                                                                      : EnumValue(MiscEntityType::JumpingFountainWater);
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
     }
@@ -162,9 +162,9 @@ void JumpingFountain::Update()
     Invalidate0();
     frame++;
 
-    switch (static_cast<MiscSpriteType>(type))
+    switch (static_cast<MiscEntityType>(type))
     {
-        case MiscSpriteType::JumpingFountainWater:
+        case MiscEntityType::JumpingFountainWater:
             if (frame == 11 && (FountainFlags & FOUNTAIN_FLAG::FAST))
             {
                 AdvanceAnimation();
@@ -174,7 +174,7 @@ void JumpingFountain::Update()
                 AdvanceAnimation();
             }
             break;
-        case MiscSpriteType::JumpingFountainSnow:
+        case MiscEntityType::JumpingFountainSnow:
             if (frame == 16)
             {
                 AdvanceAnimation();
@@ -192,7 +192,7 @@ void JumpingFountain::Update()
 
 int32_t JumpingFountain::GetType() const
 {
-    const int32_t fountainType = static_cast<MiscSpriteType>(type) == MiscSpriteType::JumpingFountainSnow
+    const int32_t fountainType = static_cast<MiscEntityType>(type) == MiscEntityType::JumpingFountainSnow
         ? JUMPING_FOUNTAIN_TYPE_SNOW
         : JUMPING_FOUNTAIN_TYPE_WATER;
     return fountainType;

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -20,7 +20,7 @@ static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }
 
 template<> bool SpriteBase::Is<MoneyEffect>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::MoneyEffect;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::MoneyEffect;
 }
 
 /**
@@ -43,7 +43,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SpriteIdentifier::Misc;
     moneyEffect->MoveTo(effectPos);
-    moneyEffect->type = EnumValue(MiscSpriteType::MoneyEffect);
+    moneyEffect->type = EnumValue(MiscEntityType::MoneyEffect);
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;
 

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -20,7 +20,7 @@ static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }
 
 template<> bool SpriteBase::Is<MoneyEffect>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_MONEY_EFFECT;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::MoneyEffect;
 }
 
 /**
@@ -43,7 +43,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SpriteIdentifier::Misc;
     moneyEffect->MoveTo(effectPos);
-    moneyEffect->type = SPRITE_MISC_MONEY_EFFECT;
+    moneyEffect->type = EnumValue(MiscSpriteType::MoneyEffect);
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;
 

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -16,12 +16,13 @@
 
 template<> bool SpriteBase::Is<VehicleCrashParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_CRASHED_VEHICLE_PARTICLE;
+    return sprite_identifier == SpriteIdentifier::Misc
+        && static_cast<MiscSpriteType>(type) == MiscSpriteType::CrashedVehicleParticle;
 }
 
 template<> bool SpriteBase::Is<CrashSplashParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_CRASH_SPLASH;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::CrashSplash;
 }
 /**
  *
@@ -39,7 +40,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(vehiclePos);
-        sprite->type = SPRITE_MISC_CRASHED_VEHICLE_PARTICLE;
+        sprite->type = EnumValue(MiscSpriteType::CrashedVehicleParticle);
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -129,7 +130,7 @@ void crash_splash_create(const CoordsXYZ& splashPos)
         sprite->sprite_height_positive = 16;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
-        sprite->type = SPRITE_MISC_CRASH_SPLASH;
+        sprite->type = EnumValue(MiscSpriteType::CrashSplash);
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -17,12 +17,12 @@
 template<> bool SpriteBase::Is<VehicleCrashParticle>() const
 {
     return sprite_identifier == SpriteIdentifier::Misc
-        && static_cast<MiscSpriteType>(type) == MiscSpriteType::CrashedVehicleParticle;
+        && static_cast<MiscEntityType>(type) == MiscEntityType::CrashedVehicleParticle;
 }
 
 template<> bool SpriteBase::Is<CrashSplashParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::CrashSplash;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::CrashSplash;
 }
 /**
  *
@@ -40,7 +40,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(vehiclePos);
-        sprite->type = EnumValue(MiscSpriteType::CrashedVehicleParticle);
+        sprite->type = EnumValue(MiscEntityType::CrashedVehicleParticle);
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -130,7 +130,7 @@ void crash_splash_create(const CoordsXYZ& splashPos)
         sprite->sprite_height_positive = 16;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
-        sprite->type = EnumValue(MiscSpriteType::CrashSplash);
+        sprite->type = EnumValue(MiscEntityType::CrashSplash);
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -65,17 +65,17 @@ template<> bool SpriteBase::Is<Litter>() const
 
 template<> bool SpriteBase::Is<SteamParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::SteamParticle;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::SteamParticle;
 }
 
 template<> bool SpriteBase::Is<ExplosionFlare>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::ExplosionFlare;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::ExplosionFlare;
 }
 
 template<> bool SpriteBase::Is<ExplosionCloud>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::ExplosionCloud;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::ExplosionCloud;
 }
 
 uint16_t GetEntityListCount(EntityListId list)
@@ -557,7 +557,7 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
         sprite->sprite_height_positive = 34;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
-        sprite->type = EnumValue(MiscSpriteType::ExplosionCloud);
+        sprite->type = EnumValue(MiscEntityType::ExplosionCloud);
         sprite->frame = 0;
     }
 }
@@ -590,7 +590,7 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
-        sprite->type = EnumValue(MiscSpriteType::ExplosionFlare);
+        sprite->type = EnumValue(MiscEntityType::ExplosionFlare);
         sprite->frame = 0;
     }
 }
@@ -615,34 +615,34 @@ void ExplosionFlare::Update()
  */
 static void sprite_misc_update(SpriteBase* sprite)
 {
-    switch (static_cast<MiscSpriteType>(sprite->type))
+    switch (static_cast<MiscEntityType>(sprite->type))
     {
-        case MiscSpriteType::SteamParticle:
+        case MiscEntityType::SteamParticle:
             sprite->As<SteamParticle>()->Update();
             break;
-        case MiscSpriteType::MoneyEffect:
+        case MiscEntityType::MoneyEffect:
             sprite->As<MoneyEffect>()->Update();
             break;
-        case MiscSpriteType::CrashedVehicleParticle:
+        case MiscEntityType::CrashedVehicleParticle:
             sprite->As<VehicleCrashParticle>()->Update();
             break;
-        case MiscSpriteType::ExplosionCloud:
+        case MiscEntityType::ExplosionCloud:
             sprite->As<ExplosionCloud>()->Update();
             break;
-        case MiscSpriteType::CrashSplash:
+        case MiscEntityType::CrashSplash:
             sprite->As<CrashSplashParticle>()->Update();
             break;
-        case MiscSpriteType::ExplosionFlare:
+        case MiscEntityType::ExplosionFlare:
             sprite->As<ExplosionFlare>()->Update();
             break;
-        case MiscSpriteType::JumpingFountainWater:
-        case MiscSpriteType::JumpingFountainSnow:
+        case MiscEntityType::JumpingFountainWater:
+        case MiscEntityType::JumpingFountainSnow:
             sprite->As<JumpingFountain>()->Update();
             break;
-        case MiscSpriteType::Balloon:
+        case MiscEntityType::Balloon:
             sprite->As<Balloon>()->Update();
             break;
-        case MiscSpriteType::Duck:
+        case MiscEntityType::Duck:
             sprite->As<Duck>()->Update();
             break;
         default:

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -65,17 +65,17 @@ template<> bool SpriteBase::Is<Litter>() const
 
 template<> bool SpriteBase::Is<SteamParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_STEAM_PARTICLE;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::SteamParticle;
 }
 
 template<> bool SpriteBase::Is<ExplosionFlare>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_EXPLOSION_FLARE;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::ExplosionFlare;
 }
 
 template<> bool SpriteBase::Is<ExplosionCloud>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && type == SPRITE_MISC_EXPLOSION_CLOUD;
+    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscSpriteType>(type) == MiscSpriteType::ExplosionCloud;
 }
 
 uint16_t GetEntityListCount(EntityListId list)
@@ -557,7 +557,7 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
         sprite->sprite_height_positive = 34;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
-        sprite->type = SPRITE_MISC_EXPLOSION_CLOUD;
+        sprite->type = EnumValue(MiscSpriteType::ExplosionCloud);
         sprite->frame = 0;
     }
 }
@@ -590,7 +590,7 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
-        sprite->type = SPRITE_MISC_EXPLOSION_FLARE;
+        sprite->type = EnumValue(MiscSpriteType::ExplosionFlare);
         sprite->frame = 0;
     }
 }
@@ -615,35 +615,37 @@ void ExplosionFlare::Update()
  */
 static void sprite_misc_update(SpriteBase* sprite)
 {
-    switch (sprite->type)
+    switch (static_cast<MiscSpriteType>(sprite->type))
     {
-        case SPRITE_MISC_STEAM_PARTICLE:
+        case MiscSpriteType::SteamParticle:
             sprite->As<SteamParticle>()->Update();
             break;
-        case SPRITE_MISC_MONEY_EFFECT:
+        case MiscSpriteType::MoneyEffect:
             sprite->As<MoneyEffect>()->Update();
             break;
-        case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+        case MiscSpriteType::CrashedVehicleParticle:
             sprite->As<VehicleCrashParticle>()->Update();
             break;
-        case SPRITE_MISC_EXPLOSION_CLOUD:
+        case MiscSpriteType::ExplosionCloud:
             sprite->As<ExplosionCloud>()->Update();
             break;
-        case SPRITE_MISC_CRASH_SPLASH:
+        case MiscSpriteType::CrashSplash:
             sprite->As<CrashSplashParticle>()->Update();
             break;
-        case SPRITE_MISC_EXPLOSION_FLARE:
+        case MiscSpriteType::ExplosionFlare:
             sprite->As<ExplosionFlare>()->Update();
             break;
-        case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
-        case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
+        case MiscSpriteType::JumpingFountainWater:
+        case MiscSpriteType::JumpingFountainSnow:
             sprite->As<JumpingFountain>()->Update();
             break;
-        case SPRITE_MISC_BALLOON:
+        case MiscSpriteType::Balloon:
             sprite->As<Balloon>()->Update();
             break;
-        case SPRITE_MISC_DUCK:
+        case MiscSpriteType::Duck:
             sprite->As<Duck>()->Update();
+            break;
+        default:
             break;
     }
 }

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -172,18 +172,18 @@ struct rct_sprite_checksum
 
 #pragma pack(pop)
 
-enum
+enum class MiscSpriteType : uint8_t
 {
-    SPRITE_MISC_STEAM_PARTICLE,
-    SPRITE_MISC_MONEY_EFFECT,
-    SPRITE_MISC_CRASHED_VEHICLE_PARTICLE,
-    SPRITE_MISC_EXPLOSION_CLOUD,
-    SPRITE_MISC_CRASH_SPLASH,
-    SPRITE_MISC_EXPLOSION_FLARE,
-    SPRITE_MISC_JUMPING_FOUNTAIN_WATER,
-    SPRITE_MISC_BALLOON,
-    SPRITE_MISC_DUCK,
-    SPRITE_MISC_JUMPING_FOUNTAIN_SNOW
+    SteamParticle,
+    MoneyEffect,
+    CrashedVehicleParticle,
+    ExplosionCloud,
+    CrashSplash,
+    ExplosionFlare,
+    JumpingFountainWater,
+    Balloon,
+    Duck,
+    JumpingFountainSnow
 };
 
 enum

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -172,7 +172,7 @@ struct rct_sprite_checksum
 
 #pragma pack(pop)
 
-enum class MiscSpriteType : uint8_t
+enum class MiscEntityType : uint8_t
 {
     SteamParticle,
     MoneyEffect,

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -419,26 +419,28 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
                 CompareSpriteDataLitter(left.litter, right.litter);
                 break;
             case SpriteIdentifier::Misc:
-                switch (static_cast<MiscSpriteType>(left.generic.type))
+                switch (static_cast<MiscEntityType>(left.generic.type))
                 {
-                    case MiscSpriteType::SteamParticle:
+                    case MiscEntityType::SteamParticle:
                         CompareSpriteDataSteamParticle(left.steam_particle, right.steam_particle);
                         break;
-                    case MiscSpriteType::MoneyEffect:
+                    case MiscEntityType::MoneyEffect:
                         CompareSpriteDataMoneyEffect(left.money_effect, right.money_effect);
                         break;
-                    case MiscSpriteType::CrashedVehicleParticle:
+                    case MiscEntityType::CrashedVehicleParticle:
                         CompareSpriteDataCrashedVehicleParticle(left.crashed_vehicle_particle, right.crashed_vehicle_particle);
                         break;
-                    case MiscSpriteType::JumpingFountainSnow:
-                    case MiscSpriteType::JumpingFountainWater:
+                    case MiscEntityType::JumpingFountainSnow:
+                    case MiscEntityType::JumpingFountainWater:
                         CompareSpriteDataJumpingFountain(left.jumping_fountain, right.jumping_fountain);
                         break;
-                    case MiscSpriteType::Balloon:
+                    case MiscEntityType::Balloon:
                         CompareSpriteDataBalloon(left.balloon, right.balloon);
                         break;
-                    case MiscSpriteType::Duck:
+                    case MiscEntityType::Duck:
                         CompareSpriteDataDuck(left.duck, right.duck);
+                        break;
+                    default:
                         break;
                 }
                 break;

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -419,25 +419,25 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
                 CompareSpriteDataLitter(left.litter, right.litter);
                 break;
             case SpriteIdentifier::Misc:
-                switch (left.generic.type)
+                switch (static_cast<MiscSpriteType>(left.generic.type))
                 {
-                    case SPRITE_MISC_STEAM_PARTICLE:
+                    case MiscSpriteType::SteamParticle:
                         CompareSpriteDataSteamParticle(left.steam_particle, right.steam_particle);
                         break;
-                    case SPRITE_MISC_MONEY_EFFECT:
+                    case MiscSpriteType::MoneyEffect:
                         CompareSpriteDataMoneyEffect(left.money_effect, right.money_effect);
                         break;
-                    case SPRITE_MISC_CRASHED_VEHICLE_PARTICLE:
+                    case MiscSpriteType::CrashedVehicleParticle:
                         CompareSpriteDataCrashedVehicleParticle(left.crashed_vehicle_particle, right.crashed_vehicle_particle);
                         break;
-                    case SPRITE_MISC_JUMPING_FOUNTAIN_SNOW:
-                    case SPRITE_MISC_JUMPING_FOUNTAIN_WATER:
+                    case MiscSpriteType::JumpingFountainSnow:
+                    case MiscSpriteType::JumpingFountainWater:
                         CompareSpriteDataJumpingFountain(left.jumping_fountain, right.jumping_fountain);
                         break;
-                    case SPRITE_MISC_BALLOON:
+                    case MiscSpriteType::Balloon:
                         CompareSpriteDataBalloon(left.balloon, right.balloon);
                         break;
-                    case SPRITE_MISC_DUCK:
+                    case MiscSpriteType::Duck:
                         CompareSpriteDataDuck(left.duck, right.duck);
                         break;
                 }


### PR DESCRIPTION
I had to keep the type of ```type``` as its has a different representation based on the entity type.