### PR TITLE
Simplify object invalidation automatically when possible

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1601,7 +1601,7 @@ static int32_t cc_mp_desync(InteractiveConsole& console, const arguments_t& argv
                 if (peeps.size() > 1)
                     peep = peeps[util_rand() % peeps.size() - 1];
                 peep->TshirtColour = util_rand() & 0xFF;
-                peep->Invalidate0();
+                peep->Invalidate();
             }
             break;
         }

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -331,13 +331,6 @@ Staff* Peep::AsStaff()
     return AssignedPeepType == PeepType::Staff ? static_cast<Staff*>(this) : nullptr;
 }
 
-void Peep::MoveTo(const CoordsXYZ& newLocation)
-{
-    Invalidate(); // Invalidate current position.
-    SpriteBase::MoveTo(newLocation);
-    Invalidate(); // Invalidate new position.
-}
-
 uint8_t Peep::GetNextDirection() const
 {
     return NextFlags & PEEP_NEXT_FLAG_DIRECTION_MASK;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -331,11 +331,6 @@ Staff* Peep::AsStaff()
     return AssignedPeepType == PeepType::Staff ? static_cast<Staff*>(this) : nullptr;
 }
 
-void Peep::Invalidate()
-{
-    Invalidate2();
-}
-
 void Peep::MoveTo(const CoordsXYZ& newLocation)
 {
     Invalidate(); // Invalidate current position.

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -735,7 +735,6 @@ public: // Peep
     std::optional<CoordsXY> UpdateAction();
     void SetState(PeepState new_state);
     void Remove();
-    void Invalidate();
     void UpdateCurrentActionSpriteType();
     void SwitchToSpecialSprite(uint8_t special_sprite_id);
     void StateReset();

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -738,7 +738,6 @@ public: // Peep
     void UpdateCurrentActionSpriteType();
     void SwitchToSpecialSprite(uint8_t special_sprite_id);
     void StateReset();
-    void MoveTo(const CoordsXYZ& newLocation);
     uint8_t GetNextDirection() const;
     bool GetNextIsSloped() const;
     bool GetNextIsSurface() const;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1421,7 +1421,6 @@ private:
         dst->sprite_height_positive = spriteBounds->sprite_height_positive;
 
         dst->MoveTo({ src->x, src->y, src->z });
-        dst->Invalidate();
 
         dst->sprite_direction = src->sprite_direction;
 
@@ -1663,7 +1662,6 @@ private:
                 litter->sprite_height_negative = srcLitter->sprite_height_negative;
 
                 litter->MoveTo({ srcLitter->x, srcLitter->y, srcLitter->z });
-                litter->Invalidate();
             }
         }
     }
@@ -1722,7 +1720,6 @@ private:
                 }
 
                 dst->MoveTo({ src->x, src->y, src->z });
-                dst->Invalidate();
             }
         }
     }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1421,7 +1421,7 @@ private:
         dst->sprite_height_positive = spriteBounds->sprite_height_positive;
 
         dst->MoveTo({ src->x, src->y, src->z });
-        dst->Invalidate2();
+        dst->Invalidate();
 
         dst->sprite_direction = src->sprite_direction;
 
@@ -1663,7 +1663,7 @@ private:
                 litter->sprite_height_negative = srcLitter->sprite_height_negative;
 
                 litter->MoveTo({ srcLitter->x, srcLitter->y, srcLitter->z });
-                litter->Invalidate2();
+                litter->Invalidate();
             }
         }
     }
@@ -1722,7 +1722,7 @@ private:
                 }
 
                 dst->MoveTo({ src->x, src->y, src->z });
-                dst->Invalidate2();
+                dst->Invalidate();
             }
         }
     }

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -431,8 +431,6 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
                 }
             }
             vehicle->MoveTo(unk_F64E20);
-
-            vehicle->Invalidate();
         }
         vehicle->acceleration /= _vehicleUnkF64E10;
         if (_vehicleVelocityF64E08 >= 0)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -832,11 +832,6 @@ Vehicle* try_get_vehicle(uint16_t spriteIndex)
     return TryGetEntity<Vehicle>(spriteIndex);
 }
 
-void Vehicle::Invalidate()
-{
-    Invalidate2();
-}
-
 namespace
 {
     template<typename T> class TrainIterator;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3603,7 +3603,6 @@ void Vehicle::UpdateCollisionSetup()
         train->sprite_height_positive = 5;
 
         train->MoveTo({ train->x, train->y, train->z });
-        train->Invalidate();
 
         train->SwingSpeed = 0;
     }
@@ -4588,7 +4587,6 @@ void Vehicle::UpdateMotionBoatHire()
         }
 
         MoveTo(unk_F64E20);
-        Invalidate();
     }
 
     // loc_6DAAC9:
@@ -5360,7 +5358,6 @@ void Vehicle::CrashOnLand()
     sprite_height_positive = 5;
 
     MoveTo({ x, y, z });
-    Invalidate();
 
     crash_z = 0;
 }
@@ -5424,7 +5421,6 @@ void Vehicle::CrashOnWater()
     sprite_height_positive = 5;
 
     MoveTo({ x, y, z });
-    Invalidate();
 
     crash_z = -1;
 }
@@ -5508,7 +5504,6 @@ void Vehicle::UpdateCrash()
         }
 
         curVehicle->MoveTo(curPosition);
-        curVehicle->Invalidate();
 
         if (curVehicle->sub_state == 1)
         {
@@ -6370,9 +6365,7 @@ int32_t Vehicle::UpdateMotionDodgems()
 
         if (!DodgemsCarWouldCollideAt(location, &collideSprite))
         {
-            Invalidate();
             MoveTo(location);
-            Invalidate();
         }
     }
 
@@ -6384,8 +6377,6 @@ int32_t Vehicle::UpdateMotionDodgems()
         unk_F64E20.x = x;
         unk_F64E20.y = y;
         unk_F64E20.z = z;
-
-        Invalidate();
 
         while (true)
         {
@@ -6440,7 +6431,6 @@ int32_t Vehicle::UpdateMotionDodgems()
         }
 
         MoveTo(unk_F64E20);
-        Invalidate();
     }
 
     int32_t eax = velocity / 2;
@@ -9144,7 +9134,6 @@ loc_6DCD6B:
 
 loc_6DCDE4:
     MoveTo(unk_F64E20);
-    Invalidate();
 
 loc_6DCE02:
     acceleration /= _vehicleUnkF64E10;
@@ -9575,7 +9564,6 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         }
         // loc_6DBF20
         car->MoveTo(unk_F64E20);
-        car->Invalidate();
 
     loc_6DBF3E:
         car->Sub6DBF3E();

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -318,7 +318,6 @@ struct Vehicle : SpriteBase
     Vehicle* GetHead();
     const Vehicle* GetHead() const;
     Vehicle* GetCar(size_t carIndex) const;
-    void Invalidate();
     void SetState(Vehicle::Status vehicleStatus, uint8_t subState = 0);
     bool IsGhost() const;
     void UpdateSoundParams(std::vector<OpenRCT2::Audio::VehicleSoundParams>& vehicleSoundParamsList) const;

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -104,9 +104,9 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate2();
+                entity->Invalidate();
                 entity->MoveTo({ value, entity->y, entity->z });
-                entity->Invalidate2();
+                entity->Invalidate();
             }
         }
 
@@ -122,9 +122,9 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate2();
+                entity->Invalidate();
                 entity->MoveTo({ entity->x, value, entity->z });
-                entity->Invalidate2();
+                entity->Invalidate();
             }
         }
 
@@ -140,9 +140,9 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate2();
+                entity->Invalidate();
                 entity->MoveTo({ entity->x, entity->y, value });
-                entity->Invalidate2();
+                entity->Invalidate();
             }
         }
 
@@ -152,7 +152,7 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate2();
+                entity->Invalidate();
                 switch (entity->sprite_identifier)
                 {
                     case SpriteIdentifier::Vehicle:

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -104,9 +104,7 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate();
                 entity->MoveTo({ value, entity->y, entity->z });
-                entity->Invalidate();
             }
         }
 
@@ -122,9 +120,7 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate();
                 entity->MoveTo({ entity->x, value, entity->z });
-                entity->Invalidate();
             }
         }
 
@@ -140,9 +136,7 @@ namespace OpenRCT2::Scripting
             auto entity = GetEntity();
             if (entity != nullptr)
             {
-                entity->Invalidate();
                 entity->MoveTo({ entity->x, entity->y, value });
-                entity->Invalidate();
             }
         }
 

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -21,7 +21,7 @@ template<> bool SpriteBase::Is<Balloon>() const
 
 void Balloon::Update()
 {
-    Invalidate2();
+    Invalidate();
     if (popped == 1)
     {
         frame++;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -71,11 +71,6 @@ template<> bool SpriteBase::Is<Duck>() const
     return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::Duck;
 }
 
-void Duck::Invalidate()
-{
-    Invalidate1();
-}
-
 bool Duck::IsFlying()
 {
     return this->state == DuckState::FlyAway || this->state == DuckState::FlyToWater;

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -126,7 +126,6 @@ void Duck::UpdateFlyToWater()
                 destination.z = z;
             }
             MoveTo(destination);
-            Invalidate();
         }
         else
         {
@@ -259,7 +258,6 @@ void Duck::UpdateFlyAway()
         if (map_is_location_valid(destination))
         {
             MoveTo(destination);
-            Invalidate();
         }
         else
         {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -403,7 +403,7 @@ void footpath_remove_litter(const CoordsXYZ& footpathPos)
         int32_t distanceZ = abs(litter->z - footpathPos.z);
         if (distanceZ <= 32)
         {
-            litter->Invalidate0();
+            litter->Invalidate();
             sprite_remove(litter);
         }
     }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -159,7 +159,7 @@ void JumpingFountain::Update()
         return;
     }
 
-    Invalidate0();
+    Invalidate();
     frame++;
 
     switch (static_cast<MiscEntityType>(type))

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -205,7 +205,7 @@ static bool map_animation_invalidate_small_scenery(const CoordsXYZ& loc)
                     peep->ActionFrame = 0;
                     peep->ActionSpriteImageOffset = 0;
                     peep->UpdateCurrentActionSpriteType();
-                    peep->Invalidate1();
+                    peep->Invalidate();
                     break;
                 }
             }

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -99,7 +99,7 @@ void MoneyEffect::Create(money32 value, const CoordsXYZ& loc)
  */
 void MoneyEffect::Update()
 {
-    Invalidate2();
+    Invalidate();
     Wiggle++;
     if (Wiggle >= 22)
     {

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -99,7 +99,6 @@ void MoneyEffect::Create(money32 value, const CoordsXYZ& loc)
  */
 void MoneyEffect::Update()
 {
-    Invalidate();
     Wiggle++;
     if (Wiggle >= 22)
     {

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -60,7 +60,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
  */
 void VehicleCrashParticle::Update()
 {
-    Invalidate0();
+    Invalidate();
     time_to_live--;
     if (time_to_live == 0)
     {
@@ -107,7 +107,7 @@ void VehicleCrashParticle::Update()
         newLoc.z = landZ;
     }
     MoveTo(newLoc);
-    Invalidate0();
+    Invalidate();
 
     frame += 85;
     if (frame >= 3072)
@@ -141,7 +141,7 @@ void crash_splash_create(const CoordsXYZ& splashPos)
  */
 void CrashSplashParticle::Update()
 {
-    Invalidate2();
+    Invalidate();
     frame += 85;
     if (frame >= 7168)
     {

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -107,7 +107,6 @@ void VehicleCrashParticle::Update()
         newLoc.z = landZ;
     }
     MoveTo(newLoc);
-    Invalidate();
 
     frame += 85;
     if (frame >= 3072)

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -730,7 +730,9 @@ static void SpriteSpatialMove(SpriteBase* sprite, const CoordsXY& newLoc)
 }
 
 /**
- * Moves a sprite to a new location.
+ * Moves a sprite to a new location, invalidates the current position if valid
+ * and also the new position.
+ *
  *  rct2: 0x0069E9D3
  *
  * @param x (ax)

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -133,31 +133,47 @@ static void invalidate_sprite_max_zoom(SpriteBase* sprite, int32_t maxZoom)
     }
 }
 
-/**
- * Invalidate the sprite if at closest zoom.
- *  rct2: 0x006EC60B
- */
-void SpriteBase::Invalidate0()
+void SpriteBase::Invalidate()
 {
-    invalidate_sprite_max_zoom(this, 0);
-}
-
-/**
- * Invalidate sprite if at closest zoom or next zoom up from closest.
- *  rct2: 0x006EC53F
- */
-void SpriteBase::Invalidate1()
-{
-    invalidate_sprite_max_zoom(this, 1);
-}
-
-/**
- * Invalidate sprite if not at furthest zoom.
- *  rct2: 0x006EC473
- */
-void SpriteBase::Invalidate2()
-{
-    invalidate_sprite_max_zoom(this, 2);
+    int32_t maxZoom = 0;
+    switch (sprite_identifier)
+    {
+        case SpriteIdentifier::Vehicle:
+            maxZoom = 2;
+            break;
+        case SpriteIdentifier::Peep:
+            maxZoom = 0;
+            break;
+        case SpriteIdentifier::Misc:
+            switch (static_cast<MiscEntityType>(type))
+            {
+                case MiscEntityType::CrashedVehicleParticle:
+                case MiscEntityType::JumpingFountainWater:
+                case MiscEntityType::JumpingFountainSnow:
+                    maxZoom = 0;
+                    break;
+                case MiscEntityType::Duck:
+                    maxZoom = 1;
+                    break;
+                case MiscEntityType::SteamParticle:
+                case MiscEntityType::MoneyEffect:
+                case MiscEntityType::ExplosionCloud:
+                case MiscEntityType::CrashSplash:
+                case MiscEntityType::ExplosionFlare:
+                case MiscEntityType::Balloon:
+                    maxZoom = 2;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case SpriteIdentifier::Litter:
+            maxZoom = 0;
+            break;
+        default:
+            break;
+    }
+    invalidate_sprite_max_zoom(this, maxZoom);
 }
 
 /**
@@ -301,8 +317,8 @@ rct_sprite_checksum sprite_checksum()
                     copy.peep.Name = {};
 
                     // We set this to 0 because as soon the client selects a guest the window will remove the
-                    // invalidation flags causing the sprite checksum to be different than on server, the flag does not affect
-                    // game state.
+                    // invalidation flags causing the sprite checksum to be different than on server, the flag does not
+                    // affect game state.
                     copy.peep.WindowInvalidateFlags = 0;
                 }
 
@@ -498,8 +514,8 @@ static void move_sprite_to_list(SpriteBase* sprite, EntityListId newListIndex)
 
     sprite->next = gSpriteListHead[static_cast<uint8_t>(
         newListIndex)]; // This sprite's next sprite is the old head, since we're the new head
-    gSpriteListHead[static_cast<uint8_t>(newListIndex)] = sprite->sprite_index; // Store this sprite's index as head of its new
-                                                                                // list
+    gSpriteListHead[static_cast<uint8_t>(newListIndex)] = sprite->sprite_index; // Store this sprite's index as head of its
+                                                                                // new list
 
     if (sprite->next != SPRITE_INDEX_NULL)
     {
@@ -527,9 +543,8 @@ static void move_sprite_to_list(SpriteBase* sprite, EntityListId newListIndex)
  */
 void SteamParticle::Update()
 {
-    Invalidate2();
-
     // Move up 1 z every 3 ticks (Starts after 4 ticks)
+    Invalidate();
     time_to_move++;
     if (time_to_move >= 4)
     {
@@ -568,7 +583,7 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
  */
 void ExplosionCloud::Update()
 {
-    Invalidate2();
+    Invalidate();
     frame += 128;
     if (frame >= (36 * 128))
     {
@@ -601,7 +616,7 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
  */
 void ExplosionFlare::Update()
 {
-    Invalidate2();
+    Invalidate();
     frame += 64;
     if (frame >= (124 * 64))
     {
@@ -725,6 +740,12 @@ static void SpriteSpatialMove(SpriteBase* sprite, const CoordsXY& newLoc)
  */
 void SpriteBase::MoveTo(const CoordsXYZ& newLocation)
 {
+    if (x != LOCATION_NULL)
+    {
+        // Invalidate old position.
+        Invalidate();
+    }
+
     auto loc = newLocation;
     if (!map_is_location_valid(loc))
     {
@@ -743,6 +764,7 @@ void SpriteBase::MoveTo(const CoordsXYZ& newLocation)
     else
     {
         sprite_set_coordinates(loc, this);
+        Invalidate(); // Invalidate new position.
     }
 }
 
@@ -833,7 +855,7 @@ void litter_create(const CoordsXYZD& litterPos, int32_t type)
 
         if (newestLitter != nullptr)
         {
-            newestLitter->Invalidate0();
+            newestLitter->Invalidate();
             sprite_remove(newestLitter);
         }
     }
@@ -849,7 +871,6 @@ void litter_create(const CoordsXYZD& litterPos, int32_t type)
     litter->sprite_identifier = SpriteIdentifier::Litter;
     litter->type = type;
     litter->MoveTo(offsetLitterPos);
-    litter->Invalidate0();
     litter->creationTick = gScenarioTicks;
 }
 
@@ -865,7 +886,7 @@ void litter_remove_at(const CoordsXYZ& litterPos)
         {
             if (abs(litter->x - litterPos.x) <= 8 && abs(litter->y - litterPos.y) <= 8)
             {
-                litter->Invalidate0();
+                litter->Invalidate();
                 sprite_remove(litter);
             }
         }
@@ -966,7 +987,7 @@ void sprite_position_tween_all(float alpha)
                   static_cast<int32_t>(std::round(posB.y * alpha + posA.y * inv)),
                   static_cast<int32_t>(std::round(posB.z * alpha + posA.z * inv)) },
                 sprite);
-            sprite->Invalidate2();
+            sprite->Invalidate();
         }
     }
 }
@@ -981,7 +1002,7 @@ void sprite_position_tween_restore()
         auto* sprite = GetEntity(i);
         if (sprite != nullptr && sprite_should_tween(sprite))
         {
-            sprite->Invalidate2();
+            sprite->Invalidate();
 
             auto pos = _spritelocations2[i];
             sprite_set_coordinates(pos, sprite);

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -71,7 +71,6 @@ struct Duck : SpriteGeneric
 
     void Update();
     uint32_t GetFrameImage(int32_t direction) const;
-    void Invalidate();
     bool IsFlying();
     void Remove();
 

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -35,9 +35,7 @@ struct SpriteBase
     uint8_t sprite_direction;
 
     void MoveTo(const CoordsXYZ& newLocation);
-    void Invalidate0();
-    void Invalidate1();
-    void Invalidate2();
+    void Invalidate();
     template<typename T> bool Is() const;
     template<typename T> T* As()
     {


### PR DESCRIPTION
I refactored out the specific invalidation methods ```Invalidate0, Invalidate1, Invalidate2```, I unified the invalidation in a single routine that selects the correct invalidation as some entities are not drawn on a specific zoom level, this just guards useless invalidations for when the object is not visible at a specific zoom level. The other change is to automatically apply invalidation when the sprites move, Peep already had the MoveTo specialized to do exactly that, I moved that into SpriteBase as every sprite that uses MoveTo has to invalidate the old and new position, this allowed also to eliminate a lot of boilerplate code.

I touched some part of the scripting as the CI complained about the missing cases, I updated the documentation accordingly, it had a few types missing while its possible to obtain them I believe.

This PR is based on #13666