### PR TITLE
Revert #13668

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -1010,12 +1010,6 @@ void OpenGLDrawingContext::HandleTransparency()
 
 void OpenGLDrawingContext::SetDPI(rct_drawpixelinfo* dpi)
 {
-    if (dpi == _dpi)
-    {
-        // Don't need to recalculate anything if identical.
-        return;
-    }
-
     auto screenDPI = _engine->GetDPI();
     auto bytesPerRow = screenDPI->GetBytesPerRow();
     auto bitsOffset = static_cast<size_t>(dpi->bits - screenDPI->bits);


### PR DESCRIPTION
Small oversight, when the DPI sits on the stack the pointer can be identical while the data changed, so the check would cause false positives.

Closes #13670