### PR TITLE
Revert "Avoid unnecessary calculations when the passed DPI is the active DPI"

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -1010,12 +1010,6 @@ void OpenGLDrawingContext::HandleTransparency()
 
 void OpenGLDrawingContext::SetDPI(rct_drawpixelinfo* dpi)
 {
-    if (dpi == _dpi)
-    {
-        // Don't need to recalculate anything if identical.
-        return;
-    }
-
     auto screenDPI = _engine->GetDPI();
     auto bytesPerRow = screenDPI->GetBytesPerRow();
     auto bitsOffset = static_cast<size_t>(dpi->bits - screenDPI->bits);


### PR DESCRIPTION
Reverts OpenRCT2/OpenRCT2#13668