### PR TITLE
[Plugin] Add context.setInterval and context.setTimeout

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Feature: [#13583] [Plugin] Add allowed_hosts to plugin section of config.
 - Feature: [#13593] [Plugin] Add ability to read and change the position of ride vehicles.
 - Feature: [#13614] Add terrain surfaces from RollerCoaster Tycoon 1.
+- Feature: [#13675] [Plugin] Add context.setInterval and context.setTimeout.
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
 - Fix: [#13102] Underflow on height chart (Ride measurements).

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -237,6 +237,34 @@ declare global {
         subscribe(hook: "network.leave", callback: (e: NetworkEventArgs) => void): IDisposable;
         subscribe(hook: "ride.ratings.calculate", callback: (e: RideRatingsCalculateArgs) => void): IDisposable;
         subscribe(hook: "action.location", callback: (e: ActionLocationArgs) => void): IDisposable;
+
+        /**
+         * Registers a function to be called every so often in realtime, specified by the given delay.
+         * @param callback The function to call every time the delay has elapsed.
+         * @param delay The number of milliseconds to wait between each call to the given function.
+         */
+        setInterval(callback: Function, delay: number): number;
+
+        /**
+         * Like `setInterval`, except the callback will only execute once after the given delay.
+         * @param callback The function to call after the given delay has elapsed.
+         * @param delay The number of milliseconds to wait for before calling the given function.
+         */
+        setTimeout(callback: Function, delay: number): number;
+
+        /**
+         * Removes the registered interval specified by the numeric handle. The handles
+         * are shared with `setTimeout`.
+         * @param handle 
+         */
+        clearInterval(handle: number): void;
+
+        /**
+         * Removes the registered timeout specified by the numeric handle. The handles
+         * are shared with `setInterval`.
+         * @param handle The numerical handle of the registered timeout to remove.
+         */
+        clearTimeout(handle: number): void;
     }
 
     interface Configuration {

--- a/src/openrct2/scripting/ScContext.hpp
+++ b/src/openrct2/scripting/ScContext.hpp
@@ -324,6 +324,51 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        int32_t SetIntervalOrTimeout(DukValue callback, int32_t delay, bool repeat)
+        {
+            auto& scriptEngine = GetContext()->GetScriptEngine();
+            auto ctx = scriptEngine.GetContext();
+            auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
+
+            int32_t handle = 0;
+            if (callback.is_function())
+            {
+                handle = scriptEngine.AddInterval(plugin, delay, repeat, std::move(callback));
+            }
+            else
+            {
+                duk_error(ctx, DUK_ERR_ERROR, "callback was not a function.");
+            }
+            return handle;
+        }
+
+        void ClearIntervalOrTimeout(int32_t handle)
+        {
+            auto& scriptEngine = GetContext()->GetScriptEngine();
+            auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
+            scriptEngine.RemoveInterval(plugin, handle);
+        }
+
+        int32_t setInterval(DukValue callback, int32_t delay)
+        {
+            return SetIntervalOrTimeout(callback, delay, true);
+        }
+
+        int32_t setTimeout(DukValue callback, int32_t delay)
+        {
+            return SetIntervalOrTimeout(callback, delay, false);
+        }
+
+        void clearInterval(int32_t handle)
+        {
+            ClearIntervalOrTimeout(handle);
+        }
+
+        void clearTimeout(int32_t handle)
+        {
+            ClearIntervalOrTimeout(handle);
+        }
+
     public:
         static void Register(duk_context* ctx)
         {
@@ -338,6 +383,10 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScContext::queryAction, "queryAction");
             dukglue_register_method(ctx, &ScContext::executeAction, "executeAction");
             dukglue_register_method(ctx, &ScContext::registerAction, "registerAction");
+            dukglue_register_method(ctx, &ScContext::setInterval, "setInterval");
+            dukglue_register_method(ctx, &ScContext::setTimeout, "setTimeout");
+            dukglue_register_method(ctx, &ScContext::clearInterval, "clearInterval");
+            dukglue_register_method(ctx, &ScContext::clearTimeout, "clearTimeout");
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -117,6 +117,22 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    using IntervalHandle = int32_t;
+    struct ScriptInterval
+    {
+        std::shared_ptr<Plugin> Owner;
+        IntervalHandle Handle{};
+        uint32_t Delay{};
+        int64_t LastTimestamp{};
+        DukValue Callback;
+        bool Repeat{};
+
+        bool IsValid() const
+        {
+            return Handle != 0;
+        }
+    };
+
     class ScriptEngine
     {
     private:
@@ -132,6 +148,9 @@ namespace OpenRCT2::Scripting
         HookEngine _hookEngine;
         ScriptExecutionInfo _execInfo;
         DukValue _sharedStorage;
+
+        uint32_t _lastIntervalTimestamp{};
+        std::vector<ScriptInterval> _intervals;
 
         std::unique_ptr<FileWatcher> _pluginFileWatcher;
         std::unordered_set<std::string> _changedPluginFiles;
@@ -203,6 +222,9 @@ namespace OpenRCT2::Scripting
 
         void SaveSharedStorage();
 
+        IntervalHandle AddInterval(const std::shared_ptr<Plugin>& plugin, int32_t delay, bool repeat, DukValue&& callback);
+        void RemoveInterval(const std::shared_ptr<Plugin>& plugin, IntervalHandle handle);
+
 #    ifndef DISABLE_NETWORK
         void AddSocket(const std::shared_ptr<ScSocketBase>& socket);
 #    endif
@@ -227,6 +249,10 @@ namespace OpenRCT2::Scripting
 
         void InitSharedStorage();
         void LoadSharedStorage();
+
+        IntervalHandle AllocateHandle();
+        void UpdateIntervals();
+        void RemoveIntervals(const std::shared_ptr<Plugin>& plugin);
 
         void UpdateSockets();
         void RemoveSockets(const std::shared_ptr<Plugin>& plugin);


### PR DESCRIPTION
Behaves mostly like browsers and nodeJS with the exception of not supporting; passing an eval string as the callback, and parameters (just use a closure).