### PR TITLE
Fix #13653: Incorrect colours in Inventions List

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3484,7 +3484,7 @@ STR_6226    :Enable early scenario completion
 STR_6227    :Triggers scenario completion when all scenario goals are met before the target date.
 STR_6228    :Scenario Options
 STR_6229    :{WINDOW_COLOUR_2}{STRINGID}: {STRINGID}
-STR_6230    :{STRINGID}:
+STR_6230    :{BLACK}{STRINGID}:
 STR_6231    :{WINDOW_COLOUR_2}{STRINGID}: {MOVE_X}{185}{STRINGID}
 STR_6232    :Frozen
 STR_6233    :Cut-away view

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -615,10 +615,6 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
         if (researchItem.Equals(&_editorInventionsListDraggedItem))
             continue;
 
-        utf8 groupNameBuffer[256], vehicleNameBuffer[256];
-        utf8* groupNamePtr = groupNameBuffer;
-        utf8* vehicleNamePtr = vehicleNameBuffer;
-
         uint8_t colour;
         if (researchItem.IsAlwaysResearched())
         {
@@ -630,41 +626,37 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
         }
         else
         {
-            // TODO: this is actually just a black colour.
-            colour = COLOUR_BRIGHT_GREEN | COLOUR_FLAG_TRANSLUCENT;
+            // TODO: this parameter by itself produces very light text.
+            // It needs a {BLACK} token in the string to work properly.
+            colour = COLOUR_BLACK;
             gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-
-            groupNamePtr = utf8_write_codepoint(groupNamePtr, colour);
-            vehicleNamePtr = utf8_write_codepoint(vehicleNamePtr, colour);
         }
 
-        rct_string_id itemNameId = researchItem.GetName();
+        const rct_string_id itemNameId = researchItem.GetName();
 
         if (researchItem.type == Research::EntryType::Ride
             && !RideTypeDescriptors[researchItem.baseRideType].HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
         {
             const auto rideEntry = get_ride_entry(researchItem.entryIndex);
             const rct_string_id rideTypeName = get_ride_naming(researchItem.baseRideType, rideEntry).Name;
-            format_string(
-                groupNamePtr, std::size(groupNameBuffer), STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME,
-                static_cast<const void*>(&rideTypeName));
-            format_string(vehicleNamePtr, std::size(vehicleNameBuffer), itemNameId, nullptr);
+
+            // Draw group name
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(rideTypeName);
+            DrawTextEllipsised(
+                dpi, { 1, itemY }, columnSplitOffset - 11, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, ft, colour);
+
+            // Draw vehicle name
+            ft = Formatter();
+            ft.Add<rct_string_id>(itemNameId);
+            DrawTextEllipsised(dpi, { columnSplitOffset + 1, itemY }, columnSplitOffset - 11, STR_BLACK_STRING, ft, colour);
         }
         else
         {
-            format_string(groupNamePtr, std::size(groupNameBuffer), itemNameId, nullptr);
-            vehicleNamePtr = nullptr;
-        }
-
-        // Draw group name
-        gfx_clip_string(groupNameBuffer, columnSplitOffset);
-        gfx_draw_string(dpi, groupNameBuffer, colour, { 1, itemY });
-
-        // Draw vehicle name
-        if (vehicleNamePtr)
-        {
-            gfx_clip_string(vehicleNameBuffer, columnSplitOffset - 11);
-            gfx_draw_string(dpi, vehicleNameBuffer, colour, { columnSplitOffset + 1, itemY });
+            // Scenery group, flat ride or shop
+            auto ft = Formatter();
+            ft.Add<rct_string_id>(itemNameId);
+            DrawTextEllipsised(dpi, { 1, itemY }, boxWidth, STR_BLACK_STRING, ft, colour);
         }
     }
 }


### PR DESCRIPTION
This window still wrote colour codepoints to a string, which caused the offset seen in #13653.

I cleaned up the code as well, removing the buffers and deprecated drawing functions in favour of newer ones.