### PR TITLE
Refactor object_entry_get_entry() to return Object

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -540,12 +540,10 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     if (chunk == nullptr)
         return;
 
-    auto entry = object_entry_get_entry(objectEntryType, researchItem->entryIndex);
-
     // Draw preview
     widget = &w->widgets[WIDX_PREVIEW];
 
-    auto* object = object_manager_get_loaded_object(entry);
+    const auto* object = object_entry_get_object(objectEntryType, researchItem->entryIndex);
     if (object != nullptr)
     {
         rct_drawpixelinfo clipDPI;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -353,4 +353,4 @@ const rct_object_entry* object_list_find(rct_object_entry* entry);
 void object_entry_get_name_fixed(utf8* buffer, size_t bufferSize, const rct_object_entry* entry);
 
 void* object_entry_get_chunk(ObjectType objectType, ObjectEntryIndex index);
-const rct_object_entry* object_entry_get_entry(ObjectType objectType, ObjectEntryIndex index);
+const Object* object_entry_get_object(ObjectType objectType, ObjectEntryIndex index);

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -99,7 +99,7 @@ bool find_object_in_entry_group(const rct_object_entry* entry, ObjectType* entry
         auto loadedObj = objectMgr.GetLoadedObject(objectType, i);
         if (loadedObj != nullptr)
         {
-            auto thisEntry = object_entry_get_entry(objectType, i);
+            auto thisEntry = object_entry_get_object(objectType, i)->GetObjectEntry();
             if (object_entry_compare(thisEntry, entry))
             {
                 *entry_type = objectType;
@@ -139,7 +139,7 @@ const rct_object_entry* get_loaded_object_entry(size_t index)
     ObjectEntryIndex entryIndex;
     get_type_entry_index(index, &objectType, &entryIndex);
 
-    return object_entry_get_entry(objectType, entryIndex);
+    return object_entry_get_object(objectType, entryIndex)->GetObjectEntry();
 }
 
 void* get_loaded_object_chunk(size_t index)
@@ -175,14 +175,8 @@ void* object_entry_get_chunk(ObjectType objectType, ObjectEntryIndex index)
     return result;
 }
 
-const rct_object_entry* object_entry_get_entry(ObjectType objectType, ObjectEntryIndex index)
+const Object* object_entry_get_object(ObjectType objectType, ObjectEntryIndex index)
 {
-    const rct_object_entry* result = nullptr;
     auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objectMgr.GetLoadedObject(objectType, index);
-    if (obj != nullptr)
-    {
-        result = obj->GetObjectEntry();
-    }
-    return result;
+    return objectMgr.GetLoadedObject(objectType, index);
 }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -765,15 +765,10 @@ public:
         // This stall was not colourable in RCT2.
         if (dst->type == RIDE_TYPE_FOOD_STALL)
         {
-            auto entry = object_entry_get_entry(ObjectType::Ride, dst->subtype);
-            if (entry != nullptr)
+            auto object = object_entry_get_object(ObjectType::Ride, dst->subtype);
+            if (object != nullptr && object->GetIdentifier() == "rct2.icecr1")
             {
-                char name[DAT_NAME_LENGTH + 1];
-                object_entry_get_name_fixed(name, sizeof(name), entry);
-                if (strncmp(name, "ICECR1  ", DAT_NAME_LENGTH) == 0)
-                {
-                    dst->track_colour[0].main = COLOUR_LIGHT_BLUE;
-                }
+                dst->track_colour[0].main = COLOUR_LIGHT_BLUE;
             }
         }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -233,10 +233,10 @@ std::string_view get_ride_entry_name(ObjectEntryIndex index)
         return {};
     }
 
-    auto objectEntry = object_entry_get_entry(ObjectType::Ride, index);
+    auto objectEntry = object_entry_get_object(ObjectType::Ride, index);
     if (objectEntry != nullptr)
     {
-        return objectEntry->GetName();
+        return objectEntry->GetLegacyIdentifier();
     }
     return {};
 }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -104,11 +104,11 @@ static void track_design_preview_clear_map();
 rct_string_id TrackDesign::CreateTrackDesign(const Ride& ride)
 {
     type = ride.type;
-    auto object = object_entry_get_entry(ObjectType::Ride, ride.subtype);
+    auto object = object_entry_get_object(ObjectType::Ride, ride.subtype);
 
     // Note we are only copying rct_object_entry in size and
     // not the extended as we don't need the chunk size.
-    std::memcpy(&vehicle_object, object, sizeof(rct_object_entry));
+    std::memcpy(&vehicle_object, object->GetObjectEntry(), sizeof(rct_object_entry));
 
     ride_mode = ride.mode;
     colour_scheme = ride.colour_scheme_type & 3;

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -211,7 +211,7 @@ static void track_design_save_push_tile_element_desc(
 static void track_design_save_add_scenery(const CoordsXY& loc, SmallSceneryElement* sceneryElement)
 {
     int32_t entryType = sceneryElement->GetEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::SmallScenery, entryType);
+    auto entry = object_entry_get_object(ObjectType::SmallScenery, entryType);
 
     uint8_t flags = 0;
     flags |= sceneryElement->GetDirection();
@@ -222,7 +222,7 @@ static void track_design_save_add_scenery(const CoordsXY& loc, SmallSceneryEleme
 
     track_design_save_push_tile_element(loc, reinterpret_cast<TileElement*>(sceneryElement));
     track_design_save_push_tile_element_desc(
-        entry, { loc.x, loc.y, sceneryElement->GetBaseZ() }, flags, primaryColour, secondaryColour);
+        entry->GetObjectEntry(), { loc.x, loc.y, sceneryElement->GetBaseZ() }, flags, primaryColour, secondaryColour);
 }
 
 static void track_design_save_add_large_scenery(const CoordsXY& loc, LargeSceneryElement* tileElement)
@@ -237,7 +237,7 @@ static void track_design_save_add_large_scenery(const CoordsXY& loc, LargeScener
     }
 
     int32_t entryType = tileElement->GetEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::LargeScenery, entryType);
+    auto entry = object_entry_get_object(ObjectType::LargeScenery, entryType);
     sceneryTiles = get_large_scenery_entry(entryType)->large_scenery.tiles;
 
     int32_t z = tileElement->base_height;
@@ -269,7 +269,8 @@ static void track_design_save_add_large_scenery(const CoordsXY& loc, LargeScener
                 uint8_t primaryColour = largeElement->GetPrimaryColour();
                 uint8_t secondaryColour = largeElement->GetSecondaryColour();
 
-                track_design_save_push_tile_element_desc(entry, tileLoc, flags, primaryColour, secondaryColour);
+                track_design_save_push_tile_element_desc(
+                    entry->GetObjectEntry(), tileLoc, flags, primaryColour, secondaryColour);
             }
             track_design_save_push_tile_element({ tileLoc.x, tileLoc.y }, reinterpret_cast<TileElement*>(largeElement));
         }
@@ -279,7 +280,7 @@ static void track_design_save_add_large_scenery(const CoordsXY& loc, LargeScener
 static void track_design_save_add_wall(const CoordsXY& loc, WallElement* wallElement)
 {
     int32_t entryType = wallElement->GetEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::Walls, entryType);
+    auto entry = object_entry_get_object(ObjectType::Walls, entryType);
 
     uint8_t flags = 0;
     flags |= wallElement->GetDirection();
@@ -290,13 +291,13 @@ static void track_design_save_add_wall(const CoordsXY& loc, WallElement* wallEle
 
     track_design_save_push_tile_element(loc, reinterpret_cast<TileElement*>(wallElement));
     track_design_save_push_tile_element_desc(
-        entry, { loc.x, loc.y, wallElement->GetBaseZ() }, flags, primaryColour, secondaryColour);
+        entry->GetObjectEntry(), { loc.x, loc.y, wallElement->GetBaseZ() }, flags, primaryColour, secondaryColour);
 }
 
 static void track_design_save_add_footpath(const CoordsXY& loc, PathElement* pathElement)
 {
     int32_t entryType = pathElement->GetSurfaceEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::Paths, entryType);
+    auto entry = object_entry_get_object(ObjectType::Paths, entryType);
 
     uint8_t flags = 0;
     flags |= pathElement->GetEdges();
@@ -307,7 +308,7 @@ static void track_design_save_add_footpath(const CoordsXY& loc, PathElement* pat
         flags |= 1 << 7;
 
     track_design_save_push_tile_element(loc, reinterpret_cast<TileElement*>(pathElement));
-    track_design_save_push_tile_element_desc(entry, { loc.x, loc.y, pathElement->GetBaseZ() }, flags, 0, 0);
+    track_design_save_push_tile_element_desc(entry->GetObjectEntry(), { loc.x, loc.y, pathElement->GetBaseZ() }, flags, 0, 0);
 }
 
 /**
@@ -399,14 +400,14 @@ static void track_design_save_pop_tile_element_desc(const rct_object_entry* entr
 static void track_design_save_remove_scenery(const CoordsXY& loc, SmallSceneryElement* sceneryElement)
 {
     int32_t entryType = sceneryElement->GetEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::SmallScenery, entryType);
+    auto entry = object_entry_get_object(ObjectType::SmallScenery, entryType);
 
     uint8_t flags = 0;
     flags |= sceneryElement->GetDirection();
     flags |= sceneryElement->GetSceneryQuadrant() << 2;
 
     track_design_save_pop_tile_element(loc, reinterpret_cast<TileElement*>(sceneryElement));
-    track_design_save_pop_tile_element_desc(entry, { loc.x, loc.y, sceneryElement->GetBaseZ() }, flags);
+    track_design_save_pop_tile_element_desc(entry->GetObjectEntry(), { loc.x, loc.y, sceneryElement->GetBaseZ() }, flags);
 }
 
 static void track_design_save_remove_large_scenery(const CoordsXY& loc, LargeSceneryElement* tileElement)
@@ -421,7 +422,7 @@ static void track_design_save_remove_large_scenery(const CoordsXY& loc, LargeSce
     }
 
     int32_t entryType = tileElement->GetEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::LargeScenery, entryType);
+    auto entry = object_entry_get_object(ObjectType::LargeScenery, entryType);
     sceneryTiles = get_large_scenery_entry(entryType)->large_scenery.tiles;
 
     int32_t z = tileElement->base_height;
@@ -450,7 +451,7 @@ static void track_design_save_remove_large_scenery(const CoordsXY& loc, LargeSce
             if (sequence == 0)
             {
                 uint8_t flags = largeElement->GetDirection();
-                track_design_save_pop_tile_element_desc(entry, tileLoc, flags);
+                track_design_save_pop_tile_element_desc(entry->GetObjectEntry(), tileLoc, flags);
             }
             track_design_save_pop_tile_element({ tileLoc.x, tileLoc.y }, reinterpret_cast<TileElement*>(largeElement));
         }
@@ -460,20 +461,20 @@ static void track_design_save_remove_large_scenery(const CoordsXY& loc, LargeSce
 static void track_design_save_remove_wall(const CoordsXY& loc, WallElement* wallElement)
 {
     int32_t entryType = wallElement->GetEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::Walls, entryType);
+    auto entry = object_entry_get_object(ObjectType::Walls, entryType);
 
     uint8_t flags = 0;
     flags |= wallElement->GetDirection();
     flags |= wallElement->GetTertiaryColour() << 2;
 
     track_design_save_pop_tile_element(loc, reinterpret_cast<TileElement*>(wallElement));
-    track_design_save_pop_tile_element_desc(entry, { loc.x, loc.y, wallElement->GetBaseZ() }, flags);
+    track_design_save_pop_tile_element_desc(entry->GetObjectEntry(), { loc.x, loc.y, wallElement->GetBaseZ() }, flags);
 }
 
 static void track_design_save_remove_footpath(const CoordsXY& loc, PathElement* pathElement)
 {
     int32_t entryType = pathElement->GetSurfaceEntryIndex();
-    auto entry = object_entry_get_entry(ObjectType::Paths, entryType);
+    auto entry = object_entry_get_object(ObjectType::Paths, entryType);
 
     uint8_t flags = 0;
     flags |= pathElement->GetEdges();
@@ -484,7 +485,7 @@ static void track_design_save_remove_footpath(const CoordsXY& loc, PathElement* 
         flags |= (1 << 7);
 
     track_design_save_pop_tile_element(loc, reinterpret_cast<TileElement*>(pathElement));
-    track_design_save_pop_tile_element_desc(entry, { loc.x, loc.y, pathElement->GetBaseZ() }, flags);
+    track_design_save_pop_tile_element_desc(entry->GetObjectEntry(), { loc.x, loc.y, pathElement->GetBaseZ() }, flags);
 }
 
 /**

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -46,36 +46,36 @@ static struct
 
 static constexpr const char* GrassTrees[] = {
     // Dark
-    "TCF     ", // Caucasian Fir Tree
-    "TRF     ", // Red Fir Tree
-    "TRF2    ", // Red Fir Tree
-    "TSP     ", // Scots Pine Tree
-    "TMZP    ", // Montezuma Pine Tree
-    "TAP     ", // Aleppo Pine Tree
-    "TCRP    ", // Corsican Pine Tree
-    "TBP     ", // Black Poplar Tree
+    "rct2.tcf",  // Caucasian Fir Tree
+    "rct2.trf",  // Red Fir Tree
+    "rct2.trf2", // Red Fir Tree
+    "rct2.tsp",  // Scots Pine Tree
+    "rct2.tmzp", // Montezuma Pine Tree
+    "rct2.tap",  // Aleppo Pine Tree
+    "rct2.tcrp", // Corsican Pine Tree
+    "rct2.tbp",  // Black Poplar Tree
 
     // Light
-    "TCL     ", // Cedar of Lebanon Tree
-    "TEL     ", // European Larch Tree
+    "rct2.tcl", // Cedar of Lebanon Tree
+    "rct2.tel", // European Larch Tree
 };
 
 static constexpr const char* DesertTrees[] = {
-    "TMP     ", // Monkey-Puzzle Tree
-    "THL     ", // Honey Locust Tree
-    "TH1     ", // Canary Palm Tree
-    "TH2     ", // Palm Tree
-    "TPM     ", // Palm Tree
-    "TROPT1  ", // Tree
-    "TBC     ", // Cactus
-    "TSC     ", // Cactus
+    "rct2.tmp",    // Monkey-Puzzle Tree
+    "rct2.thl",    // Honey Locust Tree
+    "rct2.th1",    // Canary Palm Tree
+    "rct2.th2",    // Palm Tree
+    "rct2.tpm",    // Palm Tree
+    "rct2.tropt1", // Tree
+    "rct2.tbc",    // Cactus
+    "rct2.tsc",    // Cactus
 };
 
 static constexpr const char* SnowTrees[] = {
-    "TCFS    ", // Snow-covered Caucasian Fir Tree
-    "TNSS    ", // Snow-covered Norway Spruce Tree
-    "TRF3    ", // Snow-covered Red Fir Tree
-    "TRFS    ", // Snow-covered Red Fir Tree
+    "rct2.tcfs", // Snow-covered Caucasian Fir Tree
+    "rct2.tnss", // Snow-covered Norway Spruce Tree
+    "rct2.trf3", // Snow-covered Red Fir Tree
+    "rct2.trfs", // Snow-covered Red Fir Tree
 };
 
 #pragma endregion
@@ -263,7 +263,7 @@ static void mapgen_place_trees()
     for (int32_t i = 0; i < object_entry_group_counts[EnumValue(ObjectType::SmallScenery)]; i++)
     {
         auto sceneryEntry = get_small_scenery_entry(i);
-        auto entry = object_entry_get_entry(ObjectType::SmallScenery, i);
+        auto entry = object_entry_get_object(ObjectType::SmallScenery, i);
 
         if (sceneryEntry == nullptr)
             continue;
@@ -271,7 +271,7 @@ static void mapgen_place_trees()
         uint32_t j;
         for (j = 0; j < std::size(GrassTrees); j++)
         {
-            if (strncmp(GrassTrees[j], entry->name, 8) == 0)
+            if (GrassTrees[j] == entry->GetIdentifier())
                 break;
         }
         if (j != std::size(GrassTrees))
@@ -282,7 +282,7 @@ static void mapgen_place_trees()
 
         for (j = 0; j < std::size(DesertTrees); j++)
         {
-            if (strncmp(DesertTrees[j], entry->name, 8) == 0)
+            if (DesertTrees[j] == entry->GetIdentifier())
                 break;
         }
         if (j != std::size(DesertTrees))
@@ -293,7 +293,7 @@ static void mapgen_place_trees()
 
         for (j = 0; j < std::size(SnowTrees); j++)
         {
-            if (strncmp(SnowTrees[j], entry->name, 8) == 0)
+            if (SnowTrees[j] == entry->GetIdentifier())
                 break;
         }
         if (j != std::size(SnowTrees))


### PR DESCRIPTION
Part of the refactor to remove hard dependencies on rct_object_entry and use `Object` where appropriate.