### PR TITLE
Refactor code to dynamically add and remove viewports

### DIFF
--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -315,13 +315,9 @@ static void window_banner_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void window_banner_viewport_rotate(rct_window* w)
 {
-    rct_viewport* view = w->viewport;
-    w->viewport = nullptr;
-
-    view->width = 0;
+    w->RemoveViewport();
 
     auto banner = GetBanner(w->number);
-
     auto bannerViewPos = CoordsXYZ{ banner->position.ToCoordsXY().ToTileCentre(), w->frame_no };
 
     // Create viewport

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -106,7 +106,6 @@ extern uint8_t gShowLandRightsRefCount;
 extern uint8_t gShowConstuctionRightsRefCount;
 
 // rct2: 0x014234BC
-extern rct_viewport g_viewport_list[MAX_VIEWPORT_COUNT];
 extern rct_viewport* g_music_tracking_viewport;
 extern ScreenCoordsXY gSavedView;
 extern ZoomLevel gSavedViewZoom;
@@ -120,6 +119,8 @@ std::optional<ScreenCoordsXY> centre_2d_coordinates(const CoordsXYZ& loc, rct_vi
 void viewport_create(
     rct_window* w, const ScreenCoordsXY& screenCoords, int32_t width, int32_t height, int32_t zoom, CoordsXYZ centrePos,
     char flags, uint16_t sprite);
+void viewport_remove(rct_viewport* viewport);
+void viewports_invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t maxZoom = -1);
 void viewport_update_position(rct_window* window);
 void viewport_update_sprite_follow(rct_window* window);
 void viewport_update_smart_sprite_follow(rct_window* window);

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -48,6 +48,6 @@ void rct_window::RemoveViewport()
     if (viewport == nullptr)
         return;
 
-    viewport->width = 0;
+    viewport_remove(viewport);
     viewport = nullptr;
 }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1059,14 +1059,7 @@ void map_invalidate_selection_rect()
     bottom += 32;
     top -= 32 + 2080;
 
-    for (int32_t i = 0; i < MAX_VIEWPORT_COUNT; i++)
-    {
-        rct_viewport* viewport = &g_viewport_list[i];
-        if (viewport->width != 0)
-        {
-            viewport_invalidate(viewport, left, top, right, bottom);
-        }
-    }
+    viewports_invalidate(left, top, right, bottom);
 }
 
 /**
@@ -2028,14 +2021,7 @@ static void map_invalidate_tile_under_zoom(int32_t x, int32_t y, int32_t z0, int
     x2 = screenCoord.x + 32;
     y2 = screenCoord.y + 32 - z0;
 
-    for (int32_t i = 0; i < MAX_VIEWPORT_COUNT; i++)
-    {
-        rct_viewport* viewport = &g_viewport_list[i];
-        if (viewport->width != 0 && (maxZoom == -1 || viewport->zoom <= maxZoom))
-        {
-            viewport_invalidate(viewport, x1, y1, x2, y2);
-        }
-    }
+    viewports_invalidate(x1, y1, x2, y2, maxZoom);
 }
 
 /**
@@ -2096,14 +2082,7 @@ void map_invalidate_region(const CoordsXY& mins, const CoordsXY& maxs)
     bottom += 32;
     top -= 32 + 2080;
 
-    for (int32_t i = 0; i < MAX_VIEWPORT_COUNT; i++)
-    {
-        rct_viewport* viewport = &g_viewport_list[i];
-        if (viewport->width != 0)
-        {
-            viewport_invalidate(viewport, left, top, right, bottom);
-        }
-    }
+    viewports_invalidate(left, top, right, bottom);
 }
 
 int32_t map_get_tile_side(const CoordsXY& mapPos)

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -118,23 +118,11 @@ uint16_t sprite_get_first_in_quadrant(const CoordsXY& spritePos)
     return gSpriteSpatialIndex[GetSpatialIndexOffset(spritePos.x, spritePos.y)];
 }
 
-static void invalidate_sprite_max_zoom(SpriteBase* sprite, int32_t maxZoom)
-{
-    if (sprite->sprite_left == LOCATION_NULL)
-        return;
-
-    for (int32_t i = 0; i < MAX_VIEWPORT_COUNT; i++)
-    {
-        rct_viewport* viewport = &g_viewport_list[i];
-        if (viewport->width != 0 && viewport->zoom <= maxZoom)
-        {
-            viewport_invalidate(viewport, sprite->sprite_left, sprite->sprite_top, sprite->sprite_right, sprite->sprite_bottom);
-        }
-    }
-}
-
 void SpriteBase::Invalidate()
 {
+    if (sprite_left == LOCATION_NULL)
+        return;
+
     int32_t maxZoom = 0;
     switch (sprite_identifier)
     {
@@ -171,7 +159,8 @@ void SpriteBase::Invalidate()
         default:
             break;
     }
-    invalidate_sprite_max_zoom(this, maxZoom);
+
+    viewports_invalidate(sprite_left, sprite_top, sprite_right, sprite_bottom, maxZoom);
 }
 
 /**


### PR DESCRIPTION
Whenever a sprite is invalidated it iterated 64 times over the viewport array regardless if they are used or not, a viewport was considered valid when ```width > 0```. This PR uses std::list and now only iterates the actual amount of active viewports, I used std::list as std::vector can invalidate the pointers when it grows, std::list uses nodes. I also cleaned up some code around the variable and added appropriate functions instead. This PR removes the technical restriction of a maximum of 64 viewports but I left the check in as it would probably kill the framerate, this is now an arbitrary limit.