### PR TITLE
Improve performance of tweening entities between ticks

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -624,7 +624,7 @@ namespace OpenRCT2
                 gFirstTimeSaving = true;
                 game_fix_save_vars();
                 AutoCreateMapAnimations();
-                sprite_position_tween_reset();
+                EntityTweener::Get().Reset();
                 gScreenAge = 0;
                 gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
 
@@ -1003,10 +1003,12 @@ namespace OpenRCT2
         {
             uint32_t currentTick = platform_get_ticks();
 
+            auto& tweener = EntityTweener::Get();
+
             bool draw = !_isWindowMinimised && !gOpenRCT2Headless;
             if (_lastTick == 0)
             {
-                sprite_position_tween_reset();
+                tweener.Reset();
                 _lastTick = currentTick;
             }
 
@@ -1021,7 +1023,7 @@ namespace OpenRCT2
             {
                 // Get the original position of each sprite
                 if (draw)
-                    sprite_position_tween_store_a();
+                    tweener.PreTick();
 
                 Update();
 
@@ -1029,19 +1031,17 @@ namespace OpenRCT2
 
                 // Get the next position of each sprite
                 if (draw)
-                    sprite_position_tween_store_b();
+                    tweener.PostTick();
             }
 
             if (draw)
             {
                 const float alpha = std::min(static_cast<float>(_accumulator) / GAME_UPDATE_TIME_MS, 1.0f);
-                sprite_position_tween_all(alpha);
+                tweener.Tween(alpha);
 
                 _drawingEngine->BeginDraw();
                 _painter->Paint(*_drawingEngine);
                 _drawingEngine->EndDraw();
-
-                sprite_position_tween_restore();
 
                 // Note: It's important to call UpdateWindows after restoring the sprite positions, not in between,
                 // otherwise the window updates to positions of sprites could be reverted.

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -530,7 +530,7 @@ namespace OpenRCT2
 
                 importer->Import();
 
-                sprite_position_tween_reset();
+                EntityTweener::Get().Reset();
 
                 // Load all map global variables.
                 DataSerialiser parkParamsDs(false, data.parkParams);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2718,7 +2718,7 @@ bool NetworkBase::LoadMap(IStream* stream)
         objManager.LoadObjects(loadResult.RequiredObjects.data(), loadResult.RequiredObjects.size());
         importer->Import();
 
-        sprite_position_tween_reset();
+        EntityTweener::Get().Reset();
         AutoCreateMapAnimations();
 
         // Read checksum

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -766,7 +766,7 @@ std::unique_ptr<GameActions::Result> Peep::Place(const TileCoordsXYZ& location, 
         ActionSpriteImageOffset = 0;
         ActionSpriteType = PeepActionSpriteType::None;
         PathCheckOptimisation = 0;
-        sprite_position_tween_reset();
+        EntityTweener::Get().Reset();
 
         if (AssignedPeepType == PeepType::Guest)
         {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1709,7 +1709,7 @@ void load_from_sv6(const char* path)
         s6Importer->Import();
         game_fix_save_vars();
         AutoCreateMapAnimations();
-        sprite_position_tween_reset();
+        EntityTweener::Get().Reset();
         gScreenAge = 0;
         gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
     }
@@ -1749,7 +1749,7 @@ void load_from_sc6(const char* path)
         s6Importer->Import();
         game_fix_save_vars();
         AutoCreateMapAnimations();
-        sprite_position_tween_reset();
+        EntityTweener::Get().Reset();
         return;
     }
     catch (const ObjectLoadException& loadError)

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -939,7 +939,7 @@ void EntityTweener::PopulateEntities(EntityListId id)
     for (auto ent : EntityList(id))
     {
         _ents.push_back(&(*ent));
-        _prePos.push_back({ ent->x, ent->y, ent->z });
+        _prePos.emplace_back(ent->x, ent->y, ent->z);
     }
 }
 
@@ -959,11 +959,11 @@ void EntityTweener::PostTick()
         if (!IsValidEntity(ent))
         {
             // Sprite was removed, add a dummy position to keep the index aligned.
-            _postPos.push_back({});
+            _postPos.emplace_back(0, 0, 0);
         }
         else
         {
-            _postPos.push_back({ ent->x, ent->y, ent->z });
+            _postPos.emplace_back(ent->x, ent->y, ent->z);
         }
     }
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -931,8 +931,8 @@ void EntityTweener::PopulateEntities(EntityListId id)
 {
     for (auto ent : EntityList(id))
     {
-        _ents.push_back(&(*ent));
-        _prePos.emplace_back(ent->x, ent->y, ent->z);
+        Entities.push_back(&(*ent));
+        PrePos.emplace_back(ent->x, ent->y, ent->z);
     }
 }
 
@@ -947,16 +947,16 @@ void EntityTweener::PreTick()
 
 void EntityTweener::PostTick()
 {
-    for (auto* ent : _ents)
+    for (auto* ent : Entities)
     {
         if (ent == nullptr)
         {
             // Sprite was removed, add a dummy position to keep the index aligned.
-            _postPos.emplace_back(0, 0, 0);
+            PostPos.emplace_back(0, 0, 0);
         }
         else
         {
-            _postPos.emplace_back(ent->x, ent->y, ent->z);
+            PostPos.emplace_back(ent->x, ent->y, ent->z);
         }
     }
 }
@@ -969,22 +969,22 @@ void EntityTweener::RemoveEntity(SpriteBase* entity)
         return;
     }
 
-    auto it = std::find(_ents.begin(), _ents.end(), entity);
-    if (it != _ents.end())
+    auto it = std::find(Entities.begin(), Entities.end(), entity);
+    if (it != Entities.end())
         *it = nullptr;
 }
 
 void EntityTweener::Tween(float alpha)
 {
     const float inv = (1.0f - alpha);
-    for (size_t i = 0; i < _ents.size(); ++i)
+    for (size_t i = 0; i < Entities.size(); ++i)
     {
-        auto* ent = _ents[i];
+        auto* ent = Entities[i];
         if (ent == nullptr)
             continue;
 
-        auto& posA = _prePos[i];
-        auto& posB = _postPos[i];
+        auto& posA = PrePos[i];
+        auto& posB = PostPos[i];
 
         if (posA == posB)
             continue;
@@ -1000,22 +1000,22 @@ void EntityTweener::Tween(float alpha)
 
 void EntityTweener::Restore()
 {
-    for (size_t i = 0; i < _ents.size(); ++i)
+    for (size_t i = 0; i < Entities.size(); ++i)
     {
-        auto* ent = _ents[i];
+        auto* ent = Entities[i];
         if (ent == nullptr)
             continue;
 
-        sprite_set_coordinates(_postPos[i], ent);
+        sprite_set_coordinates(PostPos[i], ent);
         ent->Invalidate();
     }
 }
 
 void EntityTweener::Reset()
 {
-    _ents.clear();
-    _prePos.clear();
-    _postPos.clear();
+    Entities.clear();
+    PrePos.clear();
+    PostPos.clear();
 }
 
 static EntityTweener tweener;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -375,9 +375,9 @@ public:
 
 class EntityTweener
 {
-    std::vector<SpriteBase*> _ents;
-    std::vector<CoordsXYZ> _prePos;
-    std::vector<CoordsXYZ> _postPos;
+    std::vector<SpriteBase*> Entities;
+    std::vector<CoordsXYZ> PrePos;
+    std::vector<CoordsXYZ> PostPos;
 
 private:
     void PopulateEntities(EntityListId id);

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -387,6 +387,7 @@ public:
 
     void PreTick();
     void PostTick();
+    void RemoveEntity(SpriteBase* entity);
     void Tween(float alpha);
     void Restore();
     void Reset();

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -246,11 +246,6 @@ uint16_t remove_floating_sprites();
 void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos);
 void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos);
 uint16_t sprite_get_first_in_quadrant(const CoordsXY& spritePos);
-void sprite_position_tween_store_a();
-void sprite_position_tween_store_b();
-void sprite_position_tween_all(float nudge);
-void sprite_position_tween_restore();
-void sprite_position_tween_reset();
 
 ///////////////////////////////////////////////////////////////
 // Balloon
@@ -376,6 +371,25 @@ public:
     {
         return EntityListIterator(SPRITE_INDEX_NULL);
     }
+};
+
+class EntityTweener
+{
+    std::vector<SpriteBase*> _ents;
+    std::vector<CoordsXYZ> _prePos;
+    std::vector<CoordsXYZ> _postPos;
+
+private:
+    void PopulateEntities(EntityListId id);
+
+public:
+    static EntityTweener& Get();
+
+    void PreTick();
+    void PostTick();
+    void Tween(float alpha);
+    void Restore();
+    void Reset();
 };
 
 #endif

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -54,7 +54,7 @@ static std::unique_ptr<IContext> localStartGame(const std::string& parkPath)
     scenery_set_default_placement_configuration();
     load_palette();
     map_reorganise_elements();
-    sprite_position_tween_reset();
+    EntityTweener::Get().Reset();
     AutoCreateMapAnimations();
     fix_invalid_vehicle_sprite_sizes();
 

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -68,7 +68,7 @@ static void GameInit(bool retainSpatialIndices)
     scenery_set_default_placement_configuration();
     load_palette();
     map_reorganise_elements();
-    sprite_position_tween_reset();
+    EntityTweener::Get().Reset();
     AutoCreateMapAnimations();
     fix_invalid_vehicle_sprite_sizes();
 


### PR DESCRIPTION
```
Renderer: Software, 720p, bpb.sv6
	develop: 125~ FPS
	PR: 160~ FPS
	
Renderer: Software (HW), 720p, bpb.sv6
	develop: 125~ FPS
	PR: 160~ FPS
	
Renderer: OpenGL, 720p, bpb.sv6
	develop: 385~ FPS
	PR: 465~ FPS
```
I think the numbers speak for themselves. Given that we only tween peeps and vehicles we can use the linked list in which each object is stored accordingly rather than messing around with every sprite slot there is.