### PR TITLE
Fix #13701: Use correct max zoom level for peeps on invalidation

### DIFF
--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -139,10 +139,8 @@ void SpriteBase::Invalidate()
     switch (sprite_identifier)
     {
         case SpriteIdentifier::Vehicle:
-            maxZoom = 2;
-            break;
         case SpriteIdentifier::Peep:
-            maxZoom = 0;
+            maxZoom = 2;
             break;
         case SpriteIdentifier::Misc:
             switch (static_cast<MiscEntityType>(type))


### PR DESCRIPTION
Oversight, my bad.

Closes #13701