### PR TITLE
Move window update out of variable frame updates

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -338,11 +338,6 @@ public:
         window_draw_all(&_bitsDPI, 0, 0, _width, _height);
     }
 
-    void UpdateWindows() override
-    {
-        window_update_all();
-    }
-
     void PaintWeather() override
     {
         _drawingContext->SetDPI(&_bitsDPI);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -987,6 +987,10 @@ namespace OpenRCT2
             while (_accumulator >= GAME_UPDATE_TIME_MS)
             {
                 Update();
+
+                // Always run this at a fixed rate, Update can cause multiple ticks if the game is speed up.
+                window_update_all();
+
                 _accumulator -= GAME_UPDATE_TIME_MS;
             }
 
@@ -995,7 +999,6 @@ namespace OpenRCT2
                 _drawingEngine->BeginDraw();
                 _painter->Paint(*_drawingEngine);
                 _drawingEngine->EndDraw();
-                _drawingEngine->UpdateWindows();
             }
         }
 
@@ -1027,6 +1030,9 @@ namespace OpenRCT2
 
                 Update();
 
+                // Always run this at a fixed rate, Update can cause multiple ticks if the game is speed up.
+                window_update_all();
+
                 _accumulator -= GAME_UPDATE_TIME_MS;
 
                 // Get the next position of each sprite
@@ -1042,12 +1048,6 @@ namespace OpenRCT2
                 _drawingEngine->BeginDraw();
                 _painter->Paint(*_drawingEngine);
                 _drawingEngine->EndDraw();
-
-                // Note: It's important to call UpdateWindows after restoring the sprite positions, not in between,
-                // otherwise the window updates to positions of sprites could be reverted.
-                // This can be observed when changing ride settings using the mouse wheel that removes all
-                // vehicles and peeps from the ride: it can freeze the game.
-                _drawingEngine->UpdateWindows();
             }
         }
 

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -62,7 +62,6 @@ namespace OpenRCT2::Drawing
         virtual void BeginDraw() abstract;
         virtual void EndDraw() abstract;
         virtual void PaintWindows() abstract;
-        virtual void UpdateWindows() abstract;
         virtual void PaintWeather() abstract;
         virtual void CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy) abstract;
         virtual std::string Screenshot() abstract;

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -220,11 +220,6 @@ void X8DrawingEngine::PaintWindows()
     DrawAllDirtyBlocks();
 }
 
-void X8DrawingEngine::UpdateWindows()
-{
-    window_update_all();
-}
-
 void X8DrawingEngine::PaintWeather()
 {
     DrawWeather(&_bitsDPI, &_weatherDrawer);

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -106,7 +106,6 @@ namespace OpenRCT2
             void BeginDraw() override;
             void EndDraw() override;
             void PaintWindows() override;
-            void UpdateWindows() override;
             void PaintWeather() override;
             void CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy) override;
             std::string Screenshot() override;


### PR DESCRIPTION
1. The drawing engine shouldn't do windows update calls.
2. The vanilla logic is to always update the windows at 40hz, this did it every frame but is locked to the real time ticks variable so the updates are not doing anything between updates.

