### PR TITLE
Fix OpenRCT2#13693: superfluous case in Upward Launch

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3270,17 +3270,8 @@ void Vehicle::UpdateDeparting()
         case RideMode::PoweredLaunchBlockSectioned:
         case RideMode::LimPoweredLaunch:
         case RideMode::UpwardLaunch:
-            if (curRide->type == RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER)
-            {
-                if ((curRide->launch_speed << 16) > velocity)
-                {
-                    acceleration = curRide->launch_speed << 13;
-                }
-                break;
-            }
-
             if ((curRide->launch_speed << 16) > velocity)
-                acceleration = curRide->launch_speed << 12;
+                acceleration = curRide->launch_speed << 13;
             break;
         case RideMode::DownwardLaunch:
             if (var_CE >= 1)


### PR DESCRIPTION
The updward launch mode contained a case for the Air Powered Vertical Coaster that doesn't make any sense because this coaster doesn't have this mode by default. The bitshift value used there was correct, however. This was possibly the result of a faulty regex or merge.