### PR TITLE
Refactor/string view

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -211,7 +211,7 @@ public:
         return window_error_open(title, message, args);
     }
 
-    rct_window* ShowError(const std::string_view& title, const std::string_view& message) override
+    rct_window* ShowError(std::string_view title, std::string_view message) override
     {
         return window_error_open(title, message);
     }

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -56,7 +56,7 @@ namespace OpenRCT2::Ui::Windows
         std::vector<std::string> Cells;
 
         ListViewItem() = default;
-        explicit ListViewItem(const std::string_view& text)
+        explicit ListViewItem(std::string_view text)
         {
             Cells.emplace_back(text);
         }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -1088,7 +1088,7 @@ namespace OpenRCT2::Ui::Windows
         return {};
     }
 
-    void UpdateWindowTitle(rct_window* w, const std::string_view& value)
+    void UpdateWindowTitle(rct_window* w, std::string_view value)
     {
         if (w->custom_info != nullptr)
         {
@@ -1097,7 +1097,7 @@ namespace OpenRCT2::Ui::Windows
         }
     }
 
-    void UpdateWidgetText(rct_window* w, rct_widgetindex widgetIndex, const std::string_view& value)
+    void UpdateWidgetText(rct_window* w, rct_widgetindex widgetIndex, std::string_view value)
     {
         if (w->custom_info != nullptr)
         {
@@ -1242,7 +1242,7 @@ namespace OpenRCT2::Ui::Windows
         return -1;
     }
 
-    rct_window* FindCustomWindowByClassification(const std::string_view& classification)
+    rct_window* FindCustomWindowByClassification(std::string_view classification)
     {
         for (auto w : g_window_list)
         {
@@ -1258,7 +1258,7 @@ namespace OpenRCT2::Ui::Windows
         return nullptr;
     }
 
-    std::optional<rct_widgetindex> FindWidgetIndexByName(rct_window* w, const std::string_view& name)
+    std::optional<rct_widgetindex> FindWidgetIndexByName(rct_window* w, std::string_view name)
     {
         if (w->custom_info != nullptr)
         {
@@ -1292,7 +1292,7 @@ namespace OpenRCT2::Ui::Windows
         return {};
     }
 
-    void SetWidgetName(rct_window* w, rct_widgetindex widgetIndex, const std::string_view& name)
+    void SetWidgetName(rct_window* w, rct_widgetindex widgetIndex, std::string_view name)
     {
         if (w->custom_info != nullptr)
         {

--- a/src/openrct2-ui/scripting/CustomWindow.h
+++ b/src/openrct2-ui/scripting/CustomWindow.h
@@ -21,18 +21,18 @@ namespace OpenRCT2::Ui::Windows
     class CustomListView;
 
     std::string GetWindowTitle(rct_window* w);
-    void UpdateWindowTitle(rct_window* w, const std::string_view& value);
-    void UpdateWidgetText(rct_window* w, rct_widgetindex widget, const std::string_view& string_view);
+    void UpdateWindowTitle(rct_window* w, std::string_view value);
+    void UpdateWidgetText(rct_window* w, rct_widgetindex widget, std::string_view string_view);
     void UpdateWidgetItems(rct_window* w, rct_widgetindex widgetIndex, const std::vector<std::string>& items);
     void UpdateWidgetColour(rct_window* w, rct_widgetindex widgetIndex, colour_t colour);
     void UpdateWidgetSelectedIndex(rct_window* w, rct_widgetindex widgetIndex, int32_t selectedIndex);
     std::vector<std::string> GetWidgetItems(rct_window* w, rct_widgetindex widgetIndex);
     colour_t GetWidgetColour(rct_window* w, rct_widgetindex widgetIndex);
     int32_t GetWidgetSelectedIndex(rct_window* w, rct_widgetindex widgetIndex);
-    rct_window* FindCustomWindowByClassification(const std::string_view& classification);
-    std::optional<rct_widgetindex> FindWidgetIndexByName(rct_window* w, const std::string_view& name);
+    rct_window* FindCustomWindowByClassification(std::string_view classification);
+    std::optional<rct_widgetindex> FindWidgetIndexByName(rct_window* w, std::string_view name);
     std::string GetWidgetName(rct_window* w, rct_widgetindex widgetIndex);
-    void SetWidgetName(rct_window* w, rct_widgetindex widgetIndex, const std::string_view& name);
+    void SetWidgetName(rct_window* w, rct_widgetindex widgetIndex, std::string_view name);
     CustomListView* GetCustomListView(rct_window* w, rct_widgetindex widgetIndex);
 } // namespace OpenRCT2::Ui::Windows
 

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -198,7 +198,7 @@ namespace OpenRCT2::Scripting
                 auto callback = desc["callback"];
                 window_text_input_open(
                     title, description, initialValue, std::max(0, maxLength),
-                    [this, plugin, callback](const std::string_view& value) {
+                    [this, plugin, callback](std::string_view value) {
                         auto dukValue = ToDuk(_scriptEngine.GetContext(), value);
                         _scriptEngine.ExecutePluginCall(plugin, callback, { dukValue }, false);
                     },

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -54,7 +54,7 @@ rct_window* window_error_open(rct_string_id title, rct_string_id message, const 
     return window_error_open(titlez, messagez);
 }
 
-rct_window* window_error_open(const std::string_view& title, const std::string_view& message)
+rct_window* window_error_open(std::string_view title, std::string_view message)
 {
     int32_t numLines, fontHeight, width, height, maxY;
     rct_window* w;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -73,7 +73,7 @@ static int32_t _maxInputLength;
 
 static std::string _title;
 static std::string _description;
-static std::function<void(const std::string_view&)> _callback;
+static std::function<void(std::string_view)> _callback;
 static std::function<void()> _cancelCallback;
 
 void window_text_input_open(
@@ -157,8 +157,8 @@ void window_text_input_raw_open(
 }
 
 void window_text_input_open(
-    const std::string_view& title, const std::string_view& description, const std::string_view& initialValue, size_t maxLength,
-    std::function<void(const std::string_view&)> callback, std::function<void()> cancelCallback)
+    std::string_view title, std::string_view description, std::string_view initialValue, size_t maxLength,
+    std::function<void(std::string_view)> callback, std::function<void()> cancelCallback)
 {
     _title = title;
     _description = description;

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -108,7 +108,7 @@ void window_title_command_editor_open(struct TitleSequence* sequence, int32_t co
 rct_window* window_scenarioselect_open(scenarioselect_callback callback, bool titleEditor);
 
 rct_window* window_error_open(rct_string_id title, rct_string_id message, const class Formatter& formatter);
-rct_window* window_error_open(const std::string_view& title, const std::string_view& message);
+rct_window* window_error_open(std::string_view title, std::string_view message);
 struct TrackDesign;
 rct_window* window_loadsave_open(int32_t type, const char* defaultName, loadsave_callback callback, TrackDesign* t6Exporter);
 rct_window* window_track_place_open(const struct track_design_file_ref* tdFileRef);
@@ -161,8 +161,8 @@ void window_text_input_raw_open(
     const_utf8string existing_text, int32_t maxLength);
 
 void window_text_input_open(
-    const std::string_view& title, const std::string_view& description, const std::string_view& initialValue, size_t maxLength,
-    std::function<void(const std::string_view&)> okCallback, std::function<void()> cancelCallback);
+    std::string_view title, std::string_view description, std::string_view initialValue, size_t maxLength,
+    std::function<void(std::string_view)> okCallback, std::function<void()> cancelCallback);
 
 rct_window* window_object_load_error_open(utf8* path, size_t numMissingObjects, const rct_object_entry* missingObjects);
 

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -158,15 +158,15 @@ class GameActionParameterVisitor
 public:
     virtual ~GameActionParameterVisitor() = default;
 
-    virtual void Visit(const std::string_view& name, bool& param)
+    virtual void Visit(std::string_view name, bool& param)
     {
     }
 
-    virtual void Visit(const std::string_view& name, int32_t& param)
+    virtual void Visit(std::string_view name, int32_t& param)
     {
     }
 
-    virtual void Visit(const std::string_view& name, std::string& param)
+    virtual void Visit(std::string_view name, std::string& param)
     {
     }
 
@@ -191,7 +191,7 @@ public:
         Visit("direction", param.direction);
     }
 
-    template<typename T> void Visit(const std::string_view& name, T& param)
+    template<typename T> void Visit(std::string_view name, T& param)
     {
         static_assert(std::is_arithmetic_v<T> || std::is_enum_v<T>, "Not an arithmetic type");
         auto value = static_cast<int32_t>(param);
@@ -199,7 +199,7 @@ public:
         param = static_cast<T>(value);
     }
 
-    template<typename T, size_t _TypeID> void Visit(const std::string_view& name, NetworkObjectId_t<T, _TypeID>& param)
+    template<typename T, size_t _TypeID> void Visit(std::string_view name, NetworkObjectId_t<T, _TypeID>& param)
     {
         Visit(name, param.id);
     }

--- a/src/openrct2/core/Crypt.CNG.cpp
+++ b/src/openrct2/core/Crypt.CNG.cpp
@@ -29,7 +29,7 @@ constexpr bool NT_SUCCESS(NTSTATUS status) {return status >= 0;}
 
 using namespace Crypt;
 
-static void CngThrowOnBadStatus(const std::string_view& name, NTSTATUS status)
+static void CngThrowOnBadStatus(std::string_view name, NTSTATUS status)
 {
     if (!NT_SUCCESS(status))
     {
@@ -409,7 +409,7 @@ public:
         _hAlg = {};
     }
 
-    void SetPrivate(const std::string_view& pem) override
+    void SetPrivate(std::string_view pem) override
     {
         auto der = ReadPEM(pem, SZ_PRIVATE_BEGIN_TOKEN, SZ_PRIVATE_END_TOKEN);
         DerReader derReader(der);
@@ -427,7 +427,7 @@ public:
         ImportKey(params);
     }
 
-    void SetPublic(const std::string_view& pem) override
+    void SetPublic(std::string_view pem) override
     {
         auto der = ReadPEM(pem, SZ_PUBLIC_BEGIN_TOKEN, SZ_PUBLIC_END_TOKEN);
         DerReader derReader(der);
@@ -531,8 +531,7 @@ private:
         return RsaKeyParams::FromBlob(blob);
     }
 
-    static std::vector<uint8_t> ReadPEM(
-        const std::string_view& pem, const std::string_view& beginToken, const std::string_view& endToken)
+    static std::vector<uint8_t> ReadPEM(std::string_view pem, std::string_view beginToken, std::string_view endToken)
     {
         auto beginPos = pem.find(beginToken);
         auto endPos = pem.find(endToken);
@@ -586,7 +585,7 @@ private:
         return result;
     }
 
-    static std::vector<uint8_t> DecodeBase64(const std::string_view& input)
+    static std::vector<uint8_t> DecodeBase64(std::string_view input)
     {
         DWORD cbBinary{};
         if (!CryptStringToBinaryA(

--- a/src/openrct2/core/Crypt.OpenSSL.cpp
+++ b/src/openrct2/core/Crypt.OpenSSL.cpp
@@ -19,7 +19,7 @@
 
 using namespace Crypt;
 
-static void OpenSSLThrowOnBadStatus(const std::string_view& name, int status)
+static void OpenSSLThrowOnBadStatus(std::string_view name, int status)
 {
     if (status != 1)
     {
@@ -156,12 +156,12 @@ public:
         }
     }
 
-    void SetPrivate(const std::string_view& pem) override
+    void SetPrivate(std::string_view pem) override
     {
         SetKey(pem, true);
     }
 
-    void SetPublic(const std::string_view& pem) override
+    void SetPublic(std::string_view pem) override
     {
         SetKey(pem, false);
     }
@@ -179,7 +179,7 @@ public:
 private:
     EVP_PKEY* _evpKey{};
 
-    void SetKey(const std::string_view& pem, bool isPrivate)
+    void SetKey(std::string_view pem, bool isPrivate)
     {
         // Read PEM data via BIO buffer
         // HACK first parameter is not const on MINGW for some reason

--- a/src/openrct2/core/Crypt.h
+++ b/src/openrct2/core/Crypt.h
@@ -32,8 +32,8 @@ namespace Crypt
     public:
         virtual ~RsaKey() = default;
         virtual void Generate() = 0;
-        virtual void SetPrivate(const std::string_view& pem) = 0;
-        virtual void SetPublic(const std::string_view& pem) = 0;
+        virtual void SetPrivate(std::string_view pem) = 0;
+        virtual void SetPublic(std::string_view pem) = 0;
         virtual std::string GetPrivate() = 0;
         virtual std::string GetPublic() = 0;
     };

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -43,21 +43,20 @@ namespace File
         return platform_file_move(srcPath.c_str(), dstPath.c_str());
     }
 
-    std::vector<uint8_t> ReadAllBytes(const std::string_view& path)
+    std::vector<uint8_t> ReadAllBytes(std::string_view path)
     {
-        std::vector<uint8_t> result;
-
 #if defined(_WIN32) && !defined(__MINGW32__)
-        auto pathW = String::ToWideChar(std::string(path));
+        auto pathW = String::ToWideChar(path);
         std::ifstream fs(pathW, std::ios::in | std::ios::binary);
 #else
         std::ifstream fs(std::string(path), std::ios::in | std::ios::binary);
 #endif
         if (!fs.is_open())
         {
-            throw IOException("Unable to open " + std::string(path.data()));
+            throw IOException("Unable to open " + std::string(path));
         }
 
+        std::vector<uint8_t> result;
         fs.seekg(0, std::ios::end);
         auto fsize = static_cast<size_t>(fs.tellg());
         if (fsize > SIZE_MAX)
@@ -76,7 +75,7 @@ namespace File
         return result;
     }
 
-    std::string ReadAllText(const std::string_view& path)
+    std::string ReadAllText(std::string_view path)
     {
         auto bytes = ReadAllBytes(path);
         // TODO skip BOM
@@ -85,13 +84,7 @@ namespace File
         return result;
     }
 
-    void WriteAllBytes(const std::string& path, const void* buffer, size_t length)
-    {
-        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
-        fs.Write(buffer, length);
-    }
-
-    std::vector<std::string> ReadAllLines(const std::string& path)
+    std::vector<std::string> ReadAllLines(std::string_view path)
     {
         std::vector<std::string> lines;
         auto data = ReadAllBytes(path);
@@ -120,11 +113,17 @@ namespace File
         return lines;
     }
 
+    void WriteAllBytes(const std::string& path, const void* buffer, size_t length)
+    {
+        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
+        fs.Write(buffer, length);
+    }
+
     uint64_t GetLastModified(const std::string& path)
     {
         uint64_t lastModified = 0;
 #ifdef _WIN32
-        auto pathW = String::ToWideChar(path.c_str());
+        auto pathW = String::ToWideChar(path);
         auto hFile = CreateFileW(pathW.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
         if (hFile != INVALID_HANDLE_VALUE)
         {

--- a/src/openrct2/core/File.h
+++ b/src/openrct2/core/File.h
@@ -21,9 +21,9 @@ namespace File
     bool Copy(const std::string& srcPath, const std::string& dstPath, bool overwrite);
     bool Delete(const std::string& path);
     bool Move(const std::string& srcPath, const std::string& dstPath);
-    std::vector<uint8_t> ReadAllBytes(const std::string_view& path);
-    std::string ReadAllText(const std::string_view& path);
+    std::vector<uint8_t> ReadAllBytes(std::string_view path);
+    std::string ReadAllText(std::string_view path);
+    std::vector<std::string> ReadAllLines(std::string_view path);
     void WriteAllBytes(const std::string& path, const void* buffer, size_t length);
-    std::vector<std::string> ReadAllLines(const std::string& path);
     uint64_t GetLastModified(const std::string& path);
 } // namespace File

--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -251,7 +251,7 @@ namespace Imaging
         }
     }
 
-    IMAGE_FORMAT GetImageFormatFromPath(const std::string_view& path)
+    IMAGE_FORMAT GetImageFormatFromPath(std::string_view path)
     {
         if (String::EndsWith(path, ".png", true))
         {
@@ -304,7 +304,7 @@ namespace Imaging
         }
     }
 
-    Image ReadFromFile(const std::string_view& path, IMAGE_FORMAT format)
+    Image ReadFromFile(std::string_view path, IMAGE_FORMAT format)
     {
         switch (format)
         {
@@ -316,7 +316,7 @@ namespace Imaging
                 auto pathW = String::ToWideChar(path);
                 std::ifstream fs(pathW, std::ios::binary);
 #else
-                std::ifstream fs(path.data(), std::ios::binary);
+                std::ifstream fs(std::string(path), std::ios::binary);
 #endif
                 return ReadFromStream(fs, format);
             }
@@ -329,7 +329,7 @@ namespace Imaging
         return ReadFromStream(istream, format);
     }
 
-    void WriteToFile(const std::string_view& path, const Image& image, IMAGE_FORMAT format)
+    void WriteToFile(std::string_view path, const Image& image, IMAGE_FORMAT format)
     {
         switch (format)
         {
@@ -342,7 +342,7 @@ namespace Imaging
                 auto pathW = String::ToWideChar(path);
                 std::ofstream fs(pathW, std::ios::binary);
 #else
-                std::ofstream fs(path.data(), std::ios::binary);
+                std::ofstream fs(std::string(path), std::ios::binary);
 #endif
                 WritePng(fs, image);
                 break;

--- a/src/openrct2/core/Imaging.h
+++ b/src/openrct2/core/Imaging.h
@@ -46,10 +46,10 @@ using ImageReaderFunc = std::function<Image(std::istream&, IMAGE_FORMAT)>;
 
 namespace Imaging
 {
-    IMAGE_FORMAT GetImageFormatFromPath(const std::string_view& path);
-    Image ReadFromFile(const std::string_view& path, IMAGE_FORMAT format = IMAGE_FORMAT::AUTOMATIC);
+    IMAGE_FORMAT GetImageFormatFromPath(std::string_view path);
+    Image ReadFromFile(std::string_view path, IMAGE_FORMAT format = IMAGE_FORMAT::AUTOMATIC);
     Image ReadFromBuffer(const std::vector<uint8_t>& buffer, IMAGE_FORMAT format = IMAGE_FORMAT::AUTOMATIC);
-    void WriteToFile(const std::string_view& path, const Image& image, IMAGE_FORMAT format = IMAGE_FORMAT::AUTOMATIC);
+    void WriteToFile(std::string_view path, const Image& image, IMAGE_FORMAT format = IMAGE_FORMAT::AUTOMATIC);
 
     void SetReader(IMAGE_FORMAT format, ImageReaderFunc impl);
 } // namespace Imaging

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -65,7 +65,7 @@ namespace String
         return returnValue;
     }
 
-    std::string ToUtf8(const std::wstring_view& src)
+    std::string ToUtf8(std::wstring_view src)
     {
 #ifdef _WIN32
         int srcLen = static_cast<int>(src.size());
@@ -93,7 +93,7 @@ namespace String
 #endif
     }
 
-    std::wstring ToWideChar(const std::string_view& src)
+    std::wstring ToWideChar(std::string_view src)
     {
 #ifdef _WIN32
         int srcLen = static_cast<int>(src.size());
@@ -171,7 +171,7 @@ namespace String
         }
     }
 
-    bool Equals(const std::string_view a, const std::string_view b, bool ignoreCase)
+    bool Equals(std::string_view a, std::string_view b, bool ignoreCase)
     {
         if (ignoreCase)
         {
@@ -250,12 +250,12 @@ namespace String
         return StartsWith(str.c_str(), match.c_str(), ignoreCase);
     }
 
-    bool EndsWith(const std::string_view& str, const std::string_view& match, bool ignoreCase)
+    bool EndsWith(std::string_view str, std::string_view match, bool ignoreCase)
     {
         if (str.size() >= match.size())
         {
             auto view = str.substr(str.size() - match.size());
-            return Equals(view.data(), match.data(), ignoreCase);
+            return Equals(view, match, ignoreCase);
         }
         return false;
     }
@@ -460,7 +460,7 @@ namespace String
         return DiscardUse(ptr, String::Duplicate(replacement));
     }
 
-    std::vector<std::string> Split(const std::string& s, const std::string& delimiter)
+    std::vector<std::string> Split(std::string_view s, std::string_view delimiter)
     {
         if (delimiter.empty())
         {
@@ -475,16 +475,14 @@ namespace String
             do
             {
                 nextIndex = s.find(delimiter, index);
-                std::string value;
                 if (nextIndex == std::string::npos)
                 {
-                    value = s.substr(index);
+                    results.emplace_back(s.substr(index));
                 }
                 else
                 {
-                    value = s.substr(index, nextIndex - index);
+                    results.emplace_back(s.substr(index, nextIndex - index));
                 }
-                results.push_back(value);
                 index = nextIndex + delimiter.size();
             } while (nextIndex != SIZE_MAX);
         }
@@ -711,7 +709,7 @@ namespace String
     }
 #endif
 
-    std::string Convert(const std::string_view& src, int32_t srcCodePage, int32_t dstCodePage)
+    std::string Convert(std::string_view src, int32_t srcCodePage, int32_t dstCodePage)
     {
 #ifdef _WIN32
         // Convert from source code page to UTF-16
@@ -751,7 +749,7 @@ namespace String
 #endif
     }
 
-    std::string ToUpper(const std::string_view& src)
+    std::string ToUpper(std::string_view src)
     {
 #ifdef _WIN32
 #    if _WIN32_WINNT >= 0x0600

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -36,8 +36,8 @@ namespace String
     std::string ToStd(const utf8* str);
     std::string StdFormat_VA(const utf8* format, va_list args);
     std::string StdFormat(const utf8* format, ...);
-    std::string ToUtf8(const std::wstring_view& src);
-    std::wstring ToWideChar(const std::string_view& src);
+    std::string ToUtf8(std::wstring_view src);
+    std::wstring ToWideChar(std::string_view src);
 
     /**
      * Creates a string_view from a char pointer with a length up to either the
@@ -48,12 +48,12 @@ namespace String
     bool IsNullOrEmpty(const utf8* str);
     int32_t Compare(const std::string& a, const std::string& b, bool ignoreCase = false);
     int32_t Compare(const utf8* a, const utf8* b, bool ignoreCase = false);
-    bool Equals(const std::string_view a, const std::string_view b, bool ignoreCase = false);
+    bool Equals(std::string_view a, std::string_view b, bool ignoreCase = false);
     bool Equals(const std::string& a, const std::string& b, bool ignoreCase = false);
     bool Equals(const utf8* a, const utf8* b, bool ignoreCase = false);
     bool StartsWith(const utf8* str, const utf8* match, bool ignoreCase = false);
     bool StartsWith(const std::string& str, const std::string& match, bool ignoreCase = false);
-    bool EndsWith(const std::string_view& str, const std::string_view& match, bool ignoreCase = false);
+    bool EndsWith(std::string_view str, std::string_view match, bool ignoreCase = false);
     size_t IndexOf(const utf8* str, utf8 match, size_t startIndex = 0);
     ptrdiff_t LastIndexOf(const utf8* str, utf8 match);
 
@@ -91,7 +91,7 @@ namespace String
      * Splits the given string by a delimiter and returns the values as a new string array.
      * @returns the number of values.
      */
-    std::vector<std::string> Split(const std::string& s, const std::string& delimiter);
+    std::vector<std::string> Split(std::string_view s, std::string_view delimiter);
 
     utf8* SkipBOM(utf8* buffer);
     const utf8* SkipBOM(const utf8* buffer);
@@ -112,12 +112,12 @@ namespace String
     /**
      * Converts a multi-byte string from one code page to another.
      */
-    std::string Convert(const std::string_view& src, int32_t srcCodePage, int32_t dstCodePage);
+    std::string Convert(std::string_view src, int32_t srcCodePage, int32_t dstCodePage);
 
     /**
      * Returns an uppercased version of a UTF-8 string.
      */
-    std::string ToUpper(const std::string_view& src);
+    std::string ToUpper(std::string_view src);
 } // namespace String
 
 class CodepointView

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -31,7 +31,7 @@ public:
         }
 
         int32_t error;
-        _zip = zip_open(std::string(path).data(), zipOpenMode, &error);
+        _zip = zip_open(std::string(path).c_str(), zipOpenMode, &error);
         if (_zip == nullptr)
         {
             throw IOException("Unable to open zip file.");

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -22,7 +22,7 @@ private:
     std::vector<std::vector<uint8_t>> _writeBuffers;
 
 public:
-    ZipArchive(const std::string_view& path, ZIP_ACCESS access)
+    ZipArchive(std::string_view path, ZIP_ACCESS access)
     {
         auto zipOpenMode = ZIP_RDONLY;
         if (access == ZIP_ACCESS::WRITE)
@@ -31,7 +31,7 @@ public:
         }
 
         int32_t error;
-        _zip = zip_open(path.data(), zipOpenMode, &error);
+        _zip = zip_open(std::string(path).data(), zipOpenMode, &error);
         if (_zip == nullptr)
         {
             throw IOException("Unable to open zip file.");
@@ -74,7 +74,7 @@ public:
         }
     }
 
-    std::vector<uint8_t> GetFileData(const std::string_view& path) const override
+    std::vector<uint8_t> GetFileData(std::string_view path) const override
     {
         std::vector<uint8_t> result;
         auto index = GetIndexFromPath(path);
@@ -97,7 +97,7 @@ public:
         return result;
     }
 
-    void SetFileData(const std::string_view& path, std::vector<uint8_t>&& data) override
+    void SetFileData(std::string_view path, std::vector<uint8_t>&& data) override
     {
         // Push buffer to an internal list as libzip requires access to it until the zip
         // handle is closed.
@@ -116,13 +116,13 @@ public:
         }
     }
 
-    void DeleteFile(const std::string_view& path) override
+    void DeleteFile(std::string_view path) override
     {
         auto index = GetIndexFromPath(path);
         zip_delete(_zip, index);
     }
 
-    void RenameFile(const std::string_view& path, const std::string_view& newPath) override
+    void RenameFile(std::string_view path, std::string_view newPath) override
     {
         auto index = GetIndexFromPath(path);
         zip_file_rename(_zip, index, newPath.data(), ZIP_FL_ENC_GUESS);
@@ -132,7 +132,7 @@ private:
     /**
      * Normalises both the given path and the stored paths and finds the first match.
      */
-    zip_int64_t GetIndexFromPath(const std::string_view& path) const
+    zip_int64_t GetIndexFromPath(std::string_view path) const
     {
         auto normalisedPath = NormalisePath(path);
         if (!normalisedPath.empty())
@@ -150,13 +150,12 @@ private:
         return -1;
     }
 
-    static std::string NormalisePath(const std::string_view& path)
+    static std::string NormalisePath(std::string_view path)
     {
-        std::string result;
+        std::string result(path);
         if (!path.empty())
         {
             // Convert back slashes to forward slashes
-            result = std::string(path);
             for (auto ch = result.data(); *ch != '\0'; ch++)
             {
                 if (*ch == '\\')
@@ -171,12 +170,12 @@ private:
 
 namespace Zip
 {
-    std::unique_ptr<IZipArchive> Open(const std::string_view& path, ZIP_ACCESS access)
+    std::unique_ptr<IZipArchive> Open(std::string_view path, ZIP_ACCESS access)
     {
         return std::make_unique<ZipArchive>(path, access);
     }
 
-    std::unique_ptr<IZipArchive> TryOpen(const std::string_view& path, ZIP_ACCESS access)
+    std::unique_ptr<IZipArchive> TryOpen(std::string_view path, ZIP_ACCESS access)
     {
         std::unique_ptr<IZipArchive> result;
         try

--- a/src/openrct2/core/Zip.h
+++ b/src/openrct2/core/Zip.h
@@ -27,17 +27,17 @@ struct IZipArchive
     virtual size_t GetNumFiles() const abstract;
     virtual std::string GetFileName(size_t index) const abstract;
     virtual uint64_t GetFileSize(size_t index) const abstract;
-    virtual std::vector<uint8_t> GetFileData(const std::string_view& path) const abstract;
+    virtual std::vector<uint8_t> GetFileData(std::string_view path) const abstract;
 
     /**
      * Creates or overwrites a file within the zip archive to the given data buffer.
      * @param path The path of the file within the zip.
      * @param data The data to write.
      */
-    virtual void SetFileData(const std::string_view& path, std::vector<uint8_t>&& data) abstract;
+    virtual void SetFileData(std::string_view path, std::vector<uint8_t>&& data) abstract;
 
-    virtual void DeleteFile(const std::string_view& path) abstract;
-    virtual void RenameFile(const std::string_view& path, const std::string_view& newPath) abstract;
+    virtual void DeleteFile(std::string_view path) abstract;
+    virtual void RenameFile(std::string_view path, std::string_view newPath) abstract;
 };
 
 enum class ZIP_ACCESS
@@ -48,6 +48,6 @@ enum class ZIP_ACCESS
 
 namespace Zip
 {
-    std::unique_ptr<IZipArchive> Open(const std::string_view& path, ZIP_ACCESS zipAccess);
-    std::unique_ptr<IZipArchive> TryOpen(const std::string_view& path, ZIP_ACCESS zipAccess);
+    std::unique_ptr<IZipArchive> Open(std::string_view path, ZIP_ACCESS zipAccess);
+    std::unique_ptr<IZipArchive> TryOpen(std::string_view path, ZIP_ACCESS zipAccess);
 } // namespace Zip

--- a/src/openrct2/core/ZipAndroid.cpp
+++ b/src/openrct2/core/ZipAndroid.cpp
@@ -22,7 +22,7 @@ private:
     jobject _zip;
 
 public:
-    ZipArchive(const std::string_view& path, ZIP_ACCESS access)
+    ZipArchive(std::string_view path, ZIP_ACCESS access)
     {
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
@@ -94,7 +94,7 @@ public:
         return (size_t)env->CallLongMethod(_zip, fileSizeMethod, (jint)index);
     }
 
-    std::vector<uint8_t> GetFileData(const std::string_view& path) const override
+    std::vector<uint8_t> GetFileData(std::string_view path) const override
     {
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
@@ -113,17 +113,17 @@ public:
         return std::vector<uint8_t>(dataPtr, dataPtr + dataSize);
     }
 
-    void SetFileData(const std::string_view& path, std::vector<uint8_t>&& data) override
+    void SetFileData(std::string_view path, std::vector<uint8_t>&& data) override
     {
         STUB();
     }
 
-    void DeleteFile(const std::string_view&) override
+    void DeleteFile(std::string_view) override
     {
         STUB();
     }
 
-    void RenameFile(const std::string_view&, const std::string_view&) override
+    void RenameFile(std::string_view, std::string_view) override
     {
         STUB();
     }
@@ -131,12 +131,12 @@ public:
 
 namespace Zip
 {
-    std::unique_ptr<IZipArchive> Open(const std::string_view& path, ZIP_ACCESS access)
+    std::unique_ptr<IZipArchive> Open(std::string_view path, ZIP_ACCESS access)
     {
         return std::make_unique<ZipArchive>(path, access);
     }
 
-    std::unique_ptr<IZipArchive> TryOpen(const std::string_view& path, ZIP_ACCESS access)
+    std::unique_ptr<IZipArchive> TryOpen(std::string_view path, ZIP_ACCESS access)
     {
         std::unique_ptr<IZipArchive> result;
         try

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -522,7 +522,7 @@ static void ttf_draw_character_sprite(rct_drawpixelinfo* dpi, int32_t codepoint,
     info->x += characterWidth;
 }
 
-static void ttf_draw_string_raw_sprite(rct_drawpixelinfo* dpi, const std::string_view text, text_draw_info* info)
+static void ttf_draw_string_raw_sprite(rct_drawpixelinfo* dpi, std::string_view text, text_draw_info* info)
 {
     CodepointView codepoints(text);
     for (auto codepoint : codepoints)
@@ -778,7 +778,7 @@ static bool ShouldUseSpriteForCodepoint(char32_t codepoint)
     }
 }
 
-static void ttf_process_string_literal(rct_drawpixelinfo* dpi, const std::string_view text, text_draw_info* info)
+static void ttf_process_string_literal(rct_drawpixelinfo* dpi, std::string_view text, text_draw_info* info)
 {
 #ifndef NO_TTF
     bool isTTF = info->flags & TEXT_DRAW_FLAG_TTF;

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -181,10 +181,10 @@ static void ttf_close_font(TTF_Font* font)
     TTF_CloseFont(font);
 }
 
-static uint32_t ttf_surface_cache_hash(TTF_Font* font, const std::string_view text)
+static uint32_t ttf_surface_cache_hash(TTF_Font* font, std::string_view text)
 {
     uint32_t hash = static_cast<uint32_t>(((reinterpret_cast<uintptr_t>(font) * 23) ^ 0xAAAAAAAA) & 0xFFFFFFFF);
-    for (auto& c : text)
+    for (auto c : text)
     {
         hash = ror32(hash, 3) ^ (c * 13);
     }

--- a/src/openrct2/interface/Colour.cpp
+++ b/src/openrct2/interface/Colour.cpp
@@ -60,7 +60,7 @@ void colours_init_maps()
 
 namespace Colour
 {
-    colour_t FromString(const std::string_view& s, colour_t defaultValue)
+    colour_t FromString(std::string_view s, colour_t defaultValue)
     {
         static const std::unordered_map<std::string_view, colour_t> LookupTable{
             { "black", COLOUR_BLACK },

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -211,7 +211,7 @@ void colours_init_maps();
 
 namespace Colour
 {
-    colour_t FromString(const std::string_view& s, colour_t defaultValue = COLOUR_BLACK);
+    colour_t FromString(std::string_view s, colour_t defaultValue = COLOUR_BLACK);
 }
 
 #ifndef NO_TTF

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -42,7 +42,7 @@ using namespace OpenRCT2::Drawing;
 
 uint8_t gScreenshotCountdown = 0;
 
-static bool WriteDpiToFile(const std::string_view& path, const rct_drawpixelinfo* dpi, const GamePalette& palette)
+static bool WriteDpiToFile(std::string_view path, const rct_drawpixelinfo* dpi, const GamePalette& palette)
 {
     auto const pixels8 = dpi->bits;
     auto const pixelsLen = (dpi->width + dpi->pitch) * dpi->height;

--- a/src/openrct2/localisation/Convert.cpp
+++ b/src/openrct2/localisation/Convert.cpp
@@ -19,7 +19,7 @@
  * Decodes an RCT2 string to a wide char string still in the original code page.
  * An RCT2 string is a multi-byte string where every two-byte code point is preceeded with a byte value of 255.
  */
-static std::wstring DecodeToWideChar(const std::string_view& src)
+static std::wstring DecodeToWideChar(std::string_view src)
 {
     std::wstring decoded;
     decoded.reserve(src.size());
@@ -62,7 +62,7 @@ static std::wstring DecodeToWideChar(const std::string_view& src)
     return decoded;
 }
 
-static std::string DecodeToMultiByte(const std::string_view& src)
+static std::string DecodeToMultiByte(std::string_view src)
 {
     auto wide = DecodeToWideChar(src);
     std::string result;
@@ -85,7 +85,7 @@ static std::string DecodeToMultiByte(const std::string_view& src)
 /**
  * Encodes a UTF-8 string as an RCT2 string.
  */
-static std::string Encode(const std::string_view& src)
+static std::string Encode(const std::string& src)
 {
     std::string dst;
     const utf8* ch = src.data();
@@ -129,7 +129,7 @@ static int32_t GetCodePageForRCT2Language(RCT2LanguageId languageId)
     }
 }
 
-template<typename TConvertFunc> static std::string DecodeConvertWithTable(const std::string_view& src, TConvertFunc func)
+template<typename TConvertFunc> static std::string DecodeConvertWithTable(std::string_view src, TConvertFunc func)
 {
     auto decoded = DecodeToWideChar(src);
     std::wstring u16;
@@ -141,7 +141,7 @@ template<typename TConvertFunc> static std::string DecodeConvertWithTable(const 
     return String::ToUtf8(u16);
 }
 
-std::string rct2_to_utf8(const std::string_view& src, RCT2LanguageId languageId)
+std::string rct2_to_utf8(std::string_view src, RCT2LanguageId languageId)
 {
     auto codePage = GetCodePageForRCT2Language(languageId);
     if (codePage == CODE_PAGE::CP_1252)
@@ -156,10 +156,10 @@ std::string rct2_to_utf8(const std::string_view& src, RCT2LanguageId languageId)
     }
 }
 
-std::string utf8_to_rct2(const std::string_view& src)
+std::string utf8_to_rct2(std::string_view src)
 {
     // NOTE: This is only used for SC6 / SV6 files which don't store the language identifier
     //       because of this, we can only store in RCT2's CP_1252 format. We can preserve some
     //       unicode characters, but only those between 256 and 65535.
-    return Encode(src);
+    return Encode(std::string(src));
 }

--- a/src/openrct2/localisation/Language.h
+++ b/src/openrct2/localisation/Language.h
@@ -101,8 +101,8 @@ bool utf8_is_codepoint_start(const utf8* text);
 int32_t utf8_get_codepoint_length(char32_t codepoint);
 int32_t utf8_length(const utf8* text);
 
-std::string rct2_to_utf8(const std::string_view& src, RCT2LanguageId languageId);
-std::string utf8_to_rct2(const std::string_view& src);
+std::string rct2_to_utf8(std::string_view src, RCT2LanguageId languageId);
+std::string utf8_to_rct2(std::string_view src);
 bool language_get_localised_scenario_strings(const utf8* scenarioFilename, rct_string_id* outStringIds);
 void language_free_object_string(rct_string_id stringId);
 rct_string_id language_allocate_object_string(const std::string& target);

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -191,7 +191,7 @@ public:
         }
     }
 
-    rct_string_id GetObjectOverrideStringId(const std::string_view& legacyIdentifier, uint8_t index) override
+    rct_string_id GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) override
     {
         Guard::Assert(index < ObjectOverrideMaxStringCount);
 

--- a/src/openrct2/localisation/LanguagePack.h
+++ b/src/openrct2/localisation/LanguagePack.h
@@ -24,7 +24,7 @@ struct ILanguagePack
     virtual void RemoveString(rct_string_id stringId) abstract;
     virtual void SetString(rct_string_id stringId, const std::string& str) abstract;
     virtual const utf8* GetString(rct_string_id stringId) const abstract;
-    virtual rct_string_id GetObjectOverrideStringId(const std::string_view& legacyIdentifier, uint8_t index) abstract;
+    virtual rct_string_id GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) abstract;
     virtual rct_string_id GetScenarioOverrideStringId(const utf8* scenarioFilename, uint8_t index) abstract;
 };
 

--- a/src/openrct2/localisation/LocalisationService.cpp
+++ b/src/openrct2/localisation/LocalisationService.cpp
@@ -119,7 +119,7 @@ std::tuple<rct_string_id, rct_string_id, rct_string_id> LocalisationService::Get
     return std::make_tuple(result0, result1, result2);
 }
 
-rct_string_id LocalisationService::GetObjectOverrideStringId(const std::string_view& legacyIdentifier, uint8_t index) const
+rct_string_id LocalisationService::GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) const
 {
     if (_languageCurrent == nullptr)
     {

--- a/src/openrct2/localisation/LocalisationService.h
+++ b/src/openrct2/localisation/LocalisationService.h
@@ -57,7 +57,7 @@ namespace OpenRCT2::Localisation
         const char* GetString(rct_string_id id) const;
         std::tuple<rct_string_id, rct_string_id, rct_string_id> GetLocalisedScenarioStrings(
             const std::string& scenarioFilename) const;
-        rct_string_id GetObjectOverrideStringId(const std::string_view& legacyIdentifier, uint8_t index) const;
+        rct_string_id GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) const;
         std::string GetLanguagePath(uint32_t languageId) const;
 
         void OpenLanguage(int32_t id);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1730,7 +1730,7 @@ void NetworkBase::ProcessPending()
 }
 
 static bool ProcessPlayerAuthenticatePluginHooks(
-    const NetworkConnection& connection, const std::string_view& name, const std::string_view& publicKeyHash)
+    const NetworkConnection& connection, std::string_view name, std::string_view publicKeyHash)
 {
 #    ifdef ENABLE_SCRIPTING
     using namespace OpenRCT2::Scripting;

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -130,7 +130,7 @@ std::string Object::GetName(int32_t language) const
     return GetString(language, ObjectStringID::NAME);
 }
 
-void rct_object_entry::SetName(const std::string_view& value)
+void rct_object_entry::SetName(std::string_view value)
 {
     std::memset(name, ' ', sizeof(name));
     std::memcpy(name, value.data(), std::min(sizeof(name), value.size()));

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -101,7 +101,7 @@ struct rct_object_entry
         return std::string_view(name, std::size(name));
     }
 
-    void SetName(const std::string_view& value);
+    void SetName(std::string_view value);
 
     ObjectType GetType() const
     {
@@ -207,7 +207,7 @@ struct IReadObjectContext
     virtual std::string_view GetObjectIdentifier() abstract;
     virtual IObjectRepository& GetObjectRepository() abstract;
     virtual bool ShouldLoadImages() abstract;
-    virtual std::vector<uint8_t> GetData(const std::string_view& path) abstract;
+    virtual std::vector<uint8_t> GetData(std::string_view path) abstract;
 
     virtual void LogWarning(ObjectError code, const utf8* text) abstract;
     virtual void LogError(ObjectError code, const utf8* text) abstract;
@@ -265,7 +265,7 @@ public:
     {
         return _identifier;
     }
-    void SetIdentifier(const std::string_view& identifier)
+    void SetIdentifier(std::string_view identifier)
     {
         _identifier = identifier;
     }

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -59,7 +59,7 @@ public:
 
     std::vector<uint8_t> GetData(std::string_view path) const override
     {
-        auto absolutePath = Path::Combine(_basePath, std::string(path).data());
+        auto absolutePath = Path::Combine(_basePath, std::string(path).c_str());
         return File::ReadAllBytes(absolutePath);
     }
 };

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -43,7 +43,7 @@
 struct IFileDataRetriever
 {
     virtual ~IFileDataRetriever() = default;
-    virtual std::vector<uint8_t> GetData(const std::string_view& path) const abstract;
+    virtual std::vector<uint8_t> GetData(std::string_view path) const abstract;
 };
 
 class FileSystemDataRetriever : public IFileDataRetriever
@@ -52,14 +52,14 @@ private:
     std::string _basePath;
 
 public:
-    FileSystemDataRetriever(const std::string_view& basePath)
+    FileSystemDataRetriever(std::string_view basePath)
         : _basePath(basePath)
     {
     }
 
-    std::vector<uint8_t> GetData(const std::string_view& path) const override
+    std::vector<uint8_t> GetData(std::string_view path) const override
     {
-        auto absolutePath = Path::Combine(_basePath, path.data());
+        auto absolutePath = Path::Combine(_basePath, std::string(path).data());
         return File::ReadAllBytes(absolutePath);
     }
 };
@@ -75,7 +75,7 @@ public:
     {
     }
 
-    std::vector<uint8_t> GetData(const std::string_view& path) const override
+    std::vector<uint8_t> GetData(std::string_view path) const override
     {
         return _zipArchive.GetFileData(path);
     }
@@ -128,7 +128,7 @@ public:
         return _loadImages;
     }
 
-    std::vector<uint8_t> GetData(const std::string_view& path) override
+    std::vector<uint8_t> GetData(std::string_view path) override
     {
         if (_fileDataRetriever != nullptr)
         {
@@ -351,7 +351,7 @@ namespace ObjectFactory
         return ObjectType::None;
     }
 
-    std::unique_ptr<Object> CreateObjectFromZipFile(IObjectRepository& objectRepository, const std::string_view& path)
+    std::unique_ptr<Object> CreateObjectFromZipFile(IObjectRepository& objectRepository, std::string_view path)
     {
         try
         {
@@ -372,7 +372,7 @@ namespace ObjectFactory
         }
         catch (const std::exception& e)
         {
-            Console::Error::WriteLine("Unable to open or read '%s': %s", path.data(), e.what());
+            Console::Error::WriteLine("Unable to open or read '%s': %s", std::string(path).c_str(), e.what());
         }
         return nullptr;
     }

--- a/src/openrct2/object/ObjectFactory.h
+++ b/src/openrct2/object/ObjectFactory.h
@@ -23,7 +23,7 @@ namespace ObjectFactory
     std::unique_ptr<Object> CreateObjectFromLegacyFile(IObjectRepository& objectRepository, const utf8* path);
     std::unique_ptr<Object> CreateObjectFromLegacyData(
         IObjectRepository& objectRepository, const rct_object_entry* entry, const void* data, size_t dataSize);
-    std::unique_ptr<Object> CreateObjectFromZipFile(IObjectRepository& objectRepository, const std::string_view& path);
+    std::unique_ptr<Object> CreateObjectFromZipFile(IObjectRepository& objectRepository, std::string_view path);
     std::unique_ptr<Object> CreateObject(const rct_object_entry& entry);
 
     std::unique_ptr<Object> CreateObjectFromJsonFile(IObjectRepository& objectRepository, const std::string& path);

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -206,7 +206,7 @@ public:
         return _items.data();
     }
 
-    const ObjectRepositoryItem* FindObjectLegacy(const std::string_view& legacyIdentifier) const override
+    const ObjectRepositoryItem* FindObjectLegacy(std::string_view legacyIdentifier) const override
     {
         rct_object_entry entry = {};
         entry.SetName(legacyIdentifier);
@@ -310,7 +310,7 @@ public:
         }
     }
 
-    void AddObjectFromFile(const std::string_view& objectName, const void* data, size_t dataSize) override
+    void AddObjectFromFile(std::string_view objectName, const void* data, size_t dataSize) override
     {
         log_verbose("Adding object: [%s]", std::string(objectName).c_str());
         auto path = GetPathForNewObject(objectName);
@@ -448,7 +448,7 @@ private:
     }
 
     static void SaveObject(
-        const std::string_view& path, const rct_object_entry* entry, const void* data, size_t dataSize, bool fixChecksum = true)
+        std::string_view path, const rct_object_entry* entry, const void* data, size_t dataSize, bool fixChecksum = true)
     {
         if (fixChecksum)
         {
@@ -554,7 +554,7 @@ private:
         return salt;
     }
 
-    std::string GetPathForNewObject(const std::string_view& name)
+    std::string GetPathForNewObject(std::string_view name)
     {
         // Get object directory and create it if it doesn't exist
         auto userObjPath = _env->GetDirectoryPath(DIRBASE::USER, DIRID::OBJECT);
@@ -573,7 +573,7 @@ private:
         return fullPath;
     }
 
-    std::string GetFileNameForNewObject(const std::string_view& name)
+    std::string GetFileNameForNewObject(std::string_view name)
     {
         // Trim name
         char normalisedName[9] = { 0 };

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -72,7 +72,7 @@ struct IObjectRepository
     virtual void Construct(int32_t language) abstract;
     virtual size_t GetNumObjects() const abstract;
     virtual const ObjectRepositoryItem* GetObjects() const abstract;
-    virtual const ObjectRepositoryItem* FindObjectLegacy(const std::string_view& legacyIdentifier) const abstract;
+    virtual const ObjectRepositoryItem* FindObjectLegacy(std::string_view legacyIdentifier) const abstract;
     virtual const ObjectRepositoryItem* FindObject(std::string_view identifier) const abstract;
     virtual const ObjectRepositoryItem* FindObject(const rct_object_entry* objectEntry) const abstract;
     virtual const ObjectRepositoryItem* FindObject(const ObjectEntryDescriptor& oed) const abstract;
@@ -82,7 +82,7 @@ struct IObjectRepository
     virtual void UnregisterLoadedObject(const ObjectRepositoryItem* ori, Object* object) abstract;
 
     virtual void AddObject(const rct_object_entry* objectEntry, const void* data, size_t dataSize) abstract;
-    virtual void AddObjectFromFile(const std::string_view& objectName, const void* data, size_t dataSize) abstract;
+    virtual void AddObjectFromFile(std::string_view objectName, const void* data, size_t dataSize) abstract;
 
     virtual void ExportPackedObject(OpenRCT2::IStream* stream) abstract;
     virtual void WritePackedObjects(OpenRCT2::IStream* stream, std::vector<const ObjectRepositoryItem*>& objects) abstract;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1952,7 +1952,7 @@ std::string Peep::GetName() const
     return format_string(STR_STRINGID, ft.Data());
 }
 
-bool Peep::SetName(const std::string_view& value)
+bool Peep::SetName(std::string_view value)
 {
     if (value.empty())
     {

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -752,7 +752,7 @@ public: // Peep
     void FormatActionTo(Formatter&) const;
     void FormatNameTo(Formatter&) const;
     std::string GetName() const;
-    bool SetName(const std::string_view& value);
+    bool SetName(std::string_view value);
 
     // Reset the peep's stored goal, which means they will forget any stored pathfinding history
     // on the next peep_pathfind_choose_direction call.

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -383,7 +383,7 @@ namespace Platform
         return _dllModule;
     }
 
-    static std::wstring get_progIdName(const std::string_view& extension)
+    static std::wstring get_progIdName(std::string_view extension)
     {
         auto progIdName = std::string(OPENRCT2_NAME) + std::string(extension);
         auto progIdNameW = String::ToWideChar(progIdName);
@@ -392,8 +392,8 @@ namespace Platform
 #    endif
 
     bool SetUpFileAssociation(
-        const std::string extension, const std::string fileTypeText, const std::string commandText,
-        const std::string commandArgs, const uint32_t iconIndex)
+        std::string_view extension, std::string_view fileTypeText, std::string_view commandText, std::string_view commandArgs,
+        const uint32_t iconIndex)
     {
 #    if _WIN32_WINNT >= 0x0600
         wchar_t exePathW[MAX_PATH];

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -52,8 +52,8 @@ namespace Platform
     bool IsOSVersionAtLeast(uint32_t major, uint32_t minor, uint32_t build);
     void SetUpFileAssociations();
     bool SetUpFileAssociation(
-        const std::string extension, const std::string fileTypeText, const std::string commandText,
-        const std::string commandArgs, const uint32_t iconIndex);
+        std::string_view extension, std::string_view fileTypeText, std::string_view commandText, std::string_view commandArgs,
+        const uint32_t iconIndex);
     void RemoveFileAssociations();
 #endif
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1619,7 +1619,7 @@ void S6Exporter::ExportTileElement(RCT12TileElement* dst, TileElement* src)
     }
 }
 
-std::optional<uint16_t> S6Exporter::AllocateUserString(const std::string_view& value)
+std::optional<uint16_t> S6Exporter::AllocateUserString(std::string_view value)
 {
     auto nextId = _userStrings.size();
     if (nextId < RCT12_MAX_USER_STRINGS)
@@ -1630,7 +1630,7 @@ std::optional<uint16_t> S6Exporter::AllocateUserString(const std::string_view& v
     return std::nullopt;
 }
 
-static std::string GetTruncatedRCT2String(const std::string_view& src)
+static std::string GetTruncatedRCT2String(std::string_view src)
 {
     auto rct2encoded = utf8_to_rct2(src);
     if (rct2encoded.size() > RCT12_USER_STRING_MAX_LENGTH - 1)

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -76,6 +76,6 @@ private:
     void ExportTileElements();
     void ExportTileElement(RCT12TileElement* dst, TileElement* src);
 
-    std::optional<uint16_t> AllocateUserString(const std::string_view& value);
+    std::optional<uint16_t> AllocateUserString(std::string_view value);
     void ExportUserStrings();
 };

--- a/src/openrct2/rct2/SeaDecrypt.cpp
+++ b/src/openrct2/rct2/SeaDecrypt.cpp
@@ -25,7 +25,7 @@ struct EncryptionKey
     uint32_t Seed1{};
 };
 
-static EncryptionKey GetEncryptionKey(const std::string_view& fileName)
+static EncryptionKey GetEncryptionKey(std::string_view fileName)
 {
     auto fileNameLen = static_cast<int32_t>(fileName.size());
     uint32_t s0 = 0;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5544,7 +5544,7 @@ static bool ride_with_colour_config_exists(uint8_t ride_type, const TrackColour*
     return false;
 }
 
-bool Ride::NameExists(const std::string_view& name, ride_id_t excludeRideId)
+bool Ride::NameExists(std::string_view name, ride_id_t excludeRideId)
 {
     char buffer[256]{};
     for (auto& ride : GetRideManager())
@@ -5554,7 +5554,7 @@ bool Ride::NameExists(const std::string_view& name, ride_id_t excludeRideId)
             Formatter ft;
             ride.FormatNameTo(ft);
             format_string(buffer, 256, STR_STRINGID, ft.Data());
-            if (std::string_view(buffer) == name && ride_has_any_track_elements(&ride))
+            if (name == buffer && ride_has_any_track_elements(&ride))
             {
                 return true;
             }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -439,7 +439,7 @@ public:
     void FormatStatusTo(Formatter&) const;
 
     static void UpdateAll();
-    static bool NameExists(const std::string_view& name, ride_id_t excludeRideId = RIDE_ID_NULL);
+    static bool NameExists(std::string_view name, ride_id_t excludeRideId = RIDE_ID_NULL);
 
     std::unique_ptr<TrackDesign> SaveToTrackDesign() const;
 

--- a/src/openrct2/scripting/Duktape.hpp
+++ b/src/openrct2/scripting/Duktape.hpp
@@ -29,7 +29,7 @@ namespace OpenRCT2::Scripting
 
     template<typename T> T AsOrDefault(const DukValue& value, const T& defaultValue = {}) = delete;
 
-    inline std::string AsOrDefault(const DukValue& value, const std::string_view& defaultValue)
+    inline std::string AsOrDefault(const DukValue& value, std::string_view defaultValue)
     {
         return value.type() == DukValue::STRING ? value.as_string() : std::string(defaultValue);
     }
@@ -101,7 +101,7 @@ namespace OpenRCT2::Scripting
             duk_put_prop_string(_ctx, _idx, name);
         }
 
-        void Set(const char* name, const std::string_view& value)
+        void Set(const char* name, std::string_view value)
         {
             EnsureObjectPushed();
             duk_push_lstring(_ctx, value.data(), value.size());
@@ -214,7 +214,7 @@ namespace OpenRCT2::Scripting
             return it->second;
         }
 
-        T operator[](const std::string_view& k) const
+        T operator[](std::string_view k) const
         {
             auto it = _s2n.find(k);
             if (it == _s2n.end())
@@ -231,7 +231,7 @@ namespace OpenRCT2::Scripting
         return 1;
     }
 
-    inline std::optional<DukValue> DuktapeTryParseJson(duk_context* ctx, const std::string_view& json)
+    inline std::optional<DukValue> DuktapeTryParseJson(duk_context* ctx, std::string_view json)
     {
         duk_push_lstring(ctx, json.data(), json.size());
         if (duk_safe_call(ctx, duk_json_decode_wrapper, nullptr, 1, 1) == DUK_EXEC_SUCCESS)

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -158,7 +158,7 @@ PluginType Plugin::ParsePluginType(std::string_view type)
 void Plugin::CheckForLicence(const DukValue& dukLicence, std::string_view pluginName)
 {
     if (dukLicence.type() != DukValue::Type::STRING || dukLicence.as_string().empty())
-        log_error("Plugin %s does not specify a licence", std::string(pluginName).data());
+        log_error("Plugin %s does not specify a licence", std::string(pluginName).c_str());
 }
 
 #endif

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -28,7 +28,7 @@ Plugin::Plugin(duk_context* context, const std::string& path)
 {
 }
 
-void Plugin::SetCode(const std::string_view& code)
+void Plugin::SetCode(std::string_view code)
 {
     _code = code;
 }
@@ -146,7 +146,7 @@ PluginMetadata Plugin::GetMetadata(const DukValue& dukMetadata)
     return metadata;
 }
 
-PluginType Plugin::ParsePluginType(const std::string_view& type)
+PluginType Plugin::ParsePluginType(std::string_view type)
 {
     if (type == "local")
         return PluginType::Local;
@@ -155,10 +155,10 @@ PluginType Plugin::ParsePluginType(const std::string_view& type)
     throw std::invalid_argument("Unknown plugin type.");
 }
 
-void Plugin::CheckForLicence(const DukValue& dukLicence, const std::string_view& pluginName)
+void Plugin::CheckForLicence(const DukValue& dukLicence, std::string_view pluginName)
 {
     if (dukLicence.type() != DukValue::Type::STRING || dukLicence.as_string().empty())
-        log_error("Plugin %s does not specify a licence", pluginName.data());
+        log_error("Plugin %s does not specify a licence", std::string(pluginName).data());
 }
 
 #endif

--- a/src/openrct2/scripting/Plugin.h
+++ b/src/openrct2/scripting/Plugin.h
@@ -85,7 +85,7 @@ namespace OpenRCT2::Scripting
         Plugin(const Plugin&) = delete;
         Plugin(Plugin&&) = delete;
 
-        void SetCode(const std::string_view& code);
+        void SetCode(std::string_view code);
         void Load();
         void Start();
         void Stop();
@@ -94,8 +94,8 @@ namespace OpenRCT2::Scripting
         void LoadCodeFromFile();
 
         static PluginMetadata GetMetadata(const DukValue& dukMetadata);
-        static PluginType ParsePluginType(const std::string_view& type);
-        static void CheckForLicence(const DukValue& dukLicence, const std::string_view& pluginName);
+        static PluginType ParsePluginType(std::string_view type);
+        static void CheckForLicence(const DukValue& dukLicence, std::string_view pluginName);
     };
 } // namespace OpenRCT2::Scripting
 

--- a/src/openrct2/scripting/ScConfiguration.hpp
+++ b/src/openrct2/scripting/ScConfiguration.hpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::Scripting
         }
 
     private:
-        std::pair<std::string_view, std::string_view> GetNextNamespace(const std::string_view& input) const
+        std::pair<std::string_view, std::string_view> GetNextNamespace(std::string_view input) const
         {
             auto pos = input.find('.');
             if (pos == std::string_view::npos)
@@ -60,14 +60,14 @@ namespace OpenRCT2::Scripting
             }
         }
 
-        std::pair<std::string_view, std::string_view> GetNamespaceAndKey(const std::string_view& input) const
+        std::pair<std::string_view, std::string_view> GetNamespaceAndKey(std::string_view input) const
         {
             auto pos = input.find_last_of('.');
             return pos == std::string_view::npos ? std::make_pair(std::string_view(), input)
                                                  : std::make_pair(input.substr(0, pos), input.substr(pos + 1));
         }
 
-        std::optional<DukValue> GetNamespaceObject(const std::string_view& ns) const
+        std::optional<DukValue> GetNamespaceObject(std::string_view ns) const
         {
             auto store = _backingObject;
             auto k = ns;
@@ -82,7 +82,7 @@ namespace OpenRCT2::Scripting
             return store.type() == DukValue::OBJECT ? std::make_optional(store) : std::nullopt;
         }
 
-        DukValue GetOrCreateNamespaceObject(duk_context* ctx, const std::string_view& ns) const
+        DukValue GetOrCreateNamespaceObject(duk_context* ctx, std::string_view ns) const
         {
             auto store = _backingObject;
             if (!ns.empty())
@@ -112,7 +112,7 @@ namespace OpenRCT2::Scripting
             return store;
         }
 
-        bool IsValidNamespace(const std::string_view& ns) const
+        bool IsValidNamespace(std::string_view ns) const
         {
             if (ns.empty() || ns[0] == '.' || ns[ns.size() - 1] == '.')
             {
@@ -128,7 +128,7 @@ namespace OpenRCT2::Scripting
             return true;
         }
 
-        bool IsValidKey(const std::string_view& key) const
+        bool IsValidKey(std::string_view key) const
         {
             return !key.empty() && key.find('.') == std::string_view::npos;
         }

--- a/src/openrct2/scripting/ScObject.hpp
+++ b/src/openrct2/scripting/ScObject.hpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScObject::name_get, nullptr, "name");
         }
 
-        static std::optional<ObjectType> StringToObjectType(const std::string_view& type)
+        static std::optional<ObjectType> StringToObjectType(std::string_view type)
         {
             for (uint8_t i = 0; i < EnumValue(ObjectType::Count); i++)
             {

--- a/src/openrct2/scripting/ScSocket.hpp
+++ b/src/openrct2/scripting/ScSocket.hpp
@@ -484,7 +484,7 @@ namespace OpenRCT2::Scripting
             return this;
         }
 
-        uint32_t GetEventType(const std::string_view& name)
+        uint32_t GetEventType(std::string_view name)
         {
             if (name == "connection")
                 return EVENT_CONNECTION;

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -716,13 +716,13 @@ DukValue ScriptEngine::ExecutePluginCall(
     return DukValue();
 }
 
-void ScriptEngine::LogPluginInfo(const std::shared_ptr<Plugin>& plugin, const std::string_view& message)
+void ScriptEngine::LogPluginInfo(const std::shared_ptr<Plugin>& plugin, std::string_view message)
 {
     const auto& pluginName = plugin->GetMetadata().Name;
     _console.WriteLine("[" + pluginName + "] " + std::string(message));
 }
 
-void ScriptEngine::AddNetworkPlugin(const std::string_view& code)
+void ScriptEngine::AddNetworkPlugin(std::string_view code)
 {
     auto plugin = std::make_shared<Plugin>(_context, std::string());
     plugin->SetCode(code);
@@ -730,7 +730,7 @@ void ScriptEngine::AddNetworkPlugin(const std::string_view& code)
 }
 
 std::unique_ptr<GameActions::Result> ScriptEngine::QueryOrExecuteCustomGameAction(
-    const std::string_view& id, const std::string_view& args, bool isExecute)
+    std::string_view id, std::string_view args, bool isExecute)
 {
     std::string actionz = std::string(id);
     auto kvp = _customActions.find(actionz);
@@ -818,7 +818,7 @@ std::string_view ScriptEngine::ExpenditureTypeToString(ExpenditureType expenditu
     return {};
 }
 
-ExpenditureType ScriptEngine::StringToExpenditureType(const std::string_view& expenditureType)
+ExpenditureType ScriptEngine::StringToExpenditureType(std::string_view expenditureType)
 {
     auto it = std::find(std::begin(ExpenditureTypes), std::end(ExpenditureTypes), expenditureType);
     if (it != std::end(ExpenditureTypes))
@@ -873,7 +873,7 @@ DukValue ScriptEngine::GameActionResultToDuk(const GameAction& action, const std
 }
 
 bool ScriptEngine::RegisterCustomAction(
-    const std::shared_ptr<Plugin>& plugin, const std::string_view& action, const DukValue& query, const DukValue& execute)
+    const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute)
 {
     std::string actionz = std::string(action);
     if (_customActions.find(actionz) != _customActions.end())
@@ -912,21 +912,21 @@ private:
 
 public:
     DukToGameActionParameterVisitor(DukValue&& dukValue)
-        : _dukValue(dukValue)
+        : _dukValue(std::move(dukValue))
     {
     }
 
-    void Visit(const std::string_view& name, bool& param) override
+    void Visit(std::string_view name, bool& param) override
     {
         param = _dukValue[name].as_bool();
     }
 
-    void Visit(const std::string_view& name, int32_t& param) override
+    void Visit(std::string_view name, int32_t& param) override
     {
         param = _dukValue[name].as_int();
     }
 
-    void Visit(const std::string_view& name, std::string& param) override
+    void Visit(std::string_view name, std::string& param) override
     {
         param = _dukValue[name].as_string();
     }
@@ -943,19 +943,19 @@ public:
     {
     }
 
-    void Visit(const std::string_view& name, bool& param) override
+    void Visit(std::string_view name, bool& param) override
     {
         std::string szName(name);
         _dukObject.Set(szName.c_str(), param);
     }
 
-    void Visit(const std::string_view& name, int32_t& param) override
+    void Visit(std::string_view name, int32_t& param) override
     {
         std::string szName(name);
         _dukObject.Set(szName.c_str(), param);
     }
 
-    void Visit(const std::string_view& name, std::string& param) override
+    void Visit(std::string_view name, std::string& param) override
     {
         std::string szName(name);
         _dukObject.Set(szName.c_str(), param);

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -203,20 +203,19 @@ namespace OpenRCT2::Scripting
             const std::shared_ptr<Plugin>& plugin, const DukValue& func, const std::vector<DukValue>& args,
             bool isGameStateMutable);
 
-        void LogPluginInfo(const std::shared_ptr<Plugin>& plugin, const std::string_view& message);
+        void LogPluginInfo(const std::shared_ptr<Plugin>& plugin, std::string_view message);
 
         void SubscribeToPluginStoppedEvent(std::function<void(std::shared_ptr<Plugin>)> callback)
         {
             _pluginStoppedSubscriptions.push_back(callback);
         }
 
-        void AddNetworkPlugin(const std::string_view& code);
+        void AddNetworkPlugin(std::string_view code);
 
         std::unique_ptr<GameActions::Result> QueryOrExecuteCustomGameAction(
-            const std::string_view& id, const std::string_view& args, bool isExecute);
+            std::string_view id, std::string_view args, bool isExecute);
         bool RegisterCustomAction(
-            const std::shared_ptr<Plugin>& plugin, const std::string_view& action, const DukValue& query,
-            const DukValue& execute);
+            const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, std::unique_ptr<GameActions::Result>& result, bool isExecute);
         std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args);
 
@@ -245,7 +244,7 @@ namespace OpenRCT2::Scripting
         std::unique_ptr<GameActions::Result> DukToGameActionResult(const DukValue& d);
         DukValue GameActionResultToDuk(const GameAction& action, const std::unique_ptr<GameActions::Result>& result);
         static std::string_view ExpenditureTypeToString(ExpenditureType expenditureType);
-        static ExpenditureType StringToExpenditureType(const std::string_view& expenditureType);
+        static ExpenditureType StringToExpenditureType(std::string_view expenditureType);
 
         void InitSharedStorage();
         void LoadSharedStorage();

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -30,7 +30,7 @@ namespace OpenRCT2::Ui
         {
             return nullptr;
         }
-        rct_window* ShowError(const std::string_view& /*title*/, const std::string_view& /*message*/) override
+        rct_window* ShowError(std::string_view /*title*/, std::string_view /*message*/) override
         {
             return nullptr;
         }

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -32,7 +32,7 @@ namespace OpenRCT2::Ui
         virtual rct_window* OpenIntent(Intent* intent) abstract;
         virtual void BroadcastIntent(const Intent& intent) abstract;
         virtual rct_window* ShowError(rct_string_id title, rct_string_id message, const Formatter& formatter) abstract;
-        virtual rct_window* ShowError(const std::string_view& title, const std::string_view& message) abstract;
+        virtual rct_window* ShowError(std::string_view title, std::string_view message) abstract;
         virtual void ForceClose(rct_windowclass windowClass) abstract;
         virtual void UpdateMapTooltip() abstract;
         virtual void HandleInput() abstract;

--- a/test/tests/ImageImporterTests.cpp
+++ b/test/tests/ImageImporterTests.cpp
@@ -21,7 +21,7 @@ class ImageImporterTests : public testing::Test
 public:
     static std::string GetImagePath(const std::string& name)
     {
-        return Path::Combine(TestData::GetBasePath(), "images", name.data());
+        return Path::Combine(TestData::GetBasePath(), "images", name.c_str());
     }
 
     static uint32_t GetHash(void* buffer, size_t bufferLength)

--- a/test/tests/ImageImporterTests.cpp
+++ b/test/tests/ImageImporterTests.cpp
@@ -19,7 +19,7 @@ using namespace OpenRCT2::Drawing;
 class ImageImporterTests : public testing::Test
 {
 public:
-    static std::string GetImagePath(const std::string_view& name)
+    static std::string GetImagePath(const std::string& name)
     {
         return Path::Combine(TestData::GetBasePath(), "images", name.data());
     }

--- a/test/tests/helpers/StringHelpers.hpp
+++ b/test/tests/helpers/StringHelpers.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <string_view>
 
-inline std::string StringFromHex(const std::string_view& input)
+inline std::string StringFromHex(std::string_view input)
 {
     assert((input.size() & 1) == 0);
 
@@ -25,7 +25,7 @@ inline std::string StringFromHex(const std::string_view& input)
     return result;
 }
 
-inline std::string NormaliseLineEndings(const std::string_view& input)
+inline std::string NormaliseLineEndings(std::string_view input)
 {
     std::string result;
     result.reserve(input.size());


### PR DESCRIPTION
Refactored string_view usages through codebase

- Modified `const std::string_view&` to `std::string_view`
- Modified a number of potentially problematic usages of string_view such as printing out to exception messages