### PR TITLE
Cleanup variables usage and initialize them

### DIFF
--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -111,17 +111,17 @@ namespace OpenRCT2::Audio
             SDL_RWops* rw = SDL_RWFromFile(path, "rb");
             if (rw != nullptr)
             {
-                uint32_t numSounds;
+                uint32_t numSounds{};
                 SDL_RWread(rw, &numSounds, sizeof(numSounds), 1);
                 if (index < numSounds)
                 {
                     SDL_RWseek(rw, index * 4, RW_SEEK_CUR);
 
-                    uint32_t pcmOffset;
+                    uint32_t pcmOffset{};
                     SDL_RWread(rw, &pcmOffset, sizeof(pcmOffset), 1);
                     SDL_RWseek(rw, pcmOffset, RW_SEEK_SET);
 
-                    uint32_t pcmSize;
+                    uint32_t pcmSize{};
                     SDL_RWread(rw, &pcmSize, sizeof(pcmSize), 1);
                     _length = pcmSize;
 

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -188,20 +188,17 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_about_openrct2_common_paint(w, dpi);
 
-    int32_t width;
-    rct_size16 logoSize;
-
     int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
 
     ScreenCoordsXY aboutCoords(
         w->windowPos.x + (w->width / 2), w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight);
-    width = w->width - 20;
+    int32_t width = w->width - 20;
 
     aboutCoords.y += gfx_draw_string_centred_wrapped(
                          dpi, nullptr, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION, w->colours[2])
         + lineHeight;
 
-    logoSize = gfx_get_sprite_size(SPR_G2_LOGO);
+    rct_size16 logoSize = gfx_get_sprite_size(SPR_G2_LOGO);
     gfx_draw_sprite(dpi, SPR_G2_LOGO, aboutCoords - ScreenCoordsXY{ logoSize.width / 2, 0 }, 0);
     aboutCoords.y += logoSize.height + lineHeight * 2;
 
@@ -267,11 +264,9 @@ static void window_about_rct2_mouseup(rct_window* w, rct_widgetindex widgetIndex
  */
 static void window_about_rct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t yPage;
-
     window_about_openrct2_common_paint(w, dpi);
 
-    yPage = w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + 5;
+    int32_t yPage = w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + 5;
 
     auto screenCoords = ScreenCoordsXY{ w->windowPos.x + 200, yPage + 5 };
 

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1276,7 +1276,6 @@ void window_move_position(rct_window* w, const ScreenCoordsXY& deltaCoords)
 
 void window_resize(rct_window* w, int32_t dw, int32_t dh)
 {
-    int32_t i;
     if (dw == 0 && dh == 0)
         return;
 
@@ -1291,7 +1290,7 @@ void window_resize(rct_window* w, int32_t dw, int32_t dh)
     window_event_invalidate_call(w);
 
     // Update scroll widgets
-    for (i = 0; i < 3; i++)
+    for (int32_t i = 0; i < 3; i++)
     {
         w->scrolls[i].h_right = WINDOW_SCROLL_UNDEFINED;
         w->scrolls[i].v_bottom = WINDOW_SCROLL_UNDEFINED;

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -123,14 +123,12 @@ void finance_pay_wages()
  **/
 void finance_pay_research()
 {
-    uint8_t level;
-
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
 
-    level = gResearchFundingLevel;
+    const uint8_t level = gResearchFundingLevel;
     finance_payment(research_cost_table[level] / 4, ExpenditureType::Research);
 }
 
@@ -140,18 +138,16 @@ void finance_pay_research()
  */
 void finance_pay_interest()
 {
-    // This variable uses the 64-bit type as the computation below can involve multiplying very large numbers
-    // that will overflow money32 if the loan is greater than (1 << 31) / (5 * current_interest_rate)
-    money64 current_loan = gBankLoan;
-    uint8_t current_interest_rate = gBankLoanInterestRate;
-    money32 interest_to_pay;
-
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
     {
         return;
     }
 
-    interest_to_pay = (current_loan * 5 * current_interest_rate) >> 14;
+    // This variable uses the 64-bit type as the computation below can involve multiplying very large numbers
+    // that will overflow money32 if the loan is greater than (1 << 31) / (5 * current_interest_rate)
+    const money64 current_loan = gBankLoan;
+    const uint8_t current_interest_rate = gBankLoanInterestRate;
+    const money32 interest_to_pay = (current_loan * 5 * current_interest_rate) >> 14;
 
     finance_payment(interest_to_pay, ExpenditureType::Interest);
 }

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -54,7 +54,7 @@ public:
     money32 Price{};
     TERRAIN_SURFACE_FLAGS Flags{};
 
-    uint32_t NumImagesLoaded;
+    uint32_t NumImagesLoaded{};
 
     explicit TerrainSurfaceObject(const rct_object_entry& entry)
         : Object(entry)

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -990,7 +990,6 @@ static void ride_ratings_apply_adjustments(Ride* ride, RatingTuple* ratings)
     if (RideTypeDescriptors[ride->type].Flags & RIDE_TYPE_FLAG_HAS_AIR_TIME)
     {
         int32_t excitementModifier;
-        int32_t nauseaModifier;
         if (rideEntry->flags & RIDE_ENTRY_FLAG_LIMIT_AIRTIME_BONUS)
         {
             // Limit airtime bonus for heartline twister coaster (see issues #2031 and #2064)
@@ -1000,7 +999,7 @@ static void ride_ratings_apply_adjustments(Ride* ride, RatingTuple* ratings)
         {
             excitementModifier = ride->total_air_time / 8;
         }
-        nauseaModifier = ride->total_air_time / 16;
+        int32_t nauseaModifier = ride->total_air_time / 16;
 
         ride_ratings_add(ratings, excitementModifier, 0, nauseaModifier);
     }
@@ -1013,7 +1012,7 @@ static void ride_ratings_apply_adjustments(Ride* ride, RatingTuple* ratings)
  */
 static void ride_ratings_apply_intensity_penalty(RatingTuple* ratings)
 {
-    static const ride_rating intensityBounds[] = { 1000, 1100, 1200, 1320, 1450 };
+    static constexpr ride_rating intensityBounds[] = { 1000, 1100, 1200, 1320, 1450 };
     ride_rating excitement = ratings->Excitement;
     for (auto intensityBound : intensityBounds)
     {
@@ -2999,8 +2998,6 @@ void ride_ratings_calculate_reverse_freefall_coaster(Ride* ride)
 
 void ride_ratings_calculate_lift(Ride* ride)
 {
-    int32_t totalLength;
-
     if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
         return;
 
@@ -3010,7 +3007,7 @@ void ride_ratings_calculate_lift(Ride* ride)
     RatingTuple ratings;
     ride_ratings_set(&ratings, RIDE_RATING(1, 11), RIDE_RATING(0, 35), RIDE_RATING(0, 30));
 
-    totalLength = ride_get_total_length(ride) >> 16;
+    int32_t totalLength = ride_get_total_length(ride) >> 16;
     ride_ratings_add(&ratings, (totalLength * 45875) >> 16, 0, (totalLength * 26214) >> 16);
 
     ride_ratings_apply_proximity(&ratings, 11183);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2088,7 +2088,8 @@ void Vehicle::UpdateMovingToEndOfStation()
     if (curRide == nullptr)
         return;
 
-    int32_t curFlags, station;
+    int32_t curFlags = 0;
+    int32_t station = 0;
 
     switch (curRide->mode)
     {
@@ -2836,10 +2837,9 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
      */
 
     int32_t direction = tileElement->GetDirectionWithOffset(1);
-    int32_t spaceBetween;
     int32_t maxCheckDistance = RIDE_ADJACENCY_CHECK_DISTANCE;
+    int32_t spaceBetween = maxCheckDistance;
 
-    spaceBetween = maxCheckDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[SYNCHRONISED_VEHICLE_COUNT - 1])
     {
         location += CoordsXYZ{ CoordsDirectionDelta[direction], 0 };
@@ -3891,6 +3891,8 @@ void Vehicle::UpdateArriving()
         return;
 
     uint8_t unkF64E35 = 1;
+    uint32_t curFlags = 0;
+
     switch (curRide->mode)
     {
         case RideMode::Swing:
@@ -4013,7 +4015,6 @@ void Vehicle::UpdateArriving()
         }
     }
 
-    uint32_t curFlags;
 loc_6D8E36:
     curFlags = UpdateTrackMotion(nullptr);
     if (curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_COLLISION && unkF64E35 == 0)
@@ -7128,7 +7129,7 @@ void Vehicle::UpdateSpinningCar()
     int32_t spinningInertia = vehicleEntry->spinning_inertia;
     int32_t trackType = GetTrackType();
     int32_t dword_F64E08 = _vehicleVelocityF64E08;
-    int32_t spinSpeed;
+    int32_t spinSpeed{};
     // An L spin adds to the spin speed, R does the opposite
     // The number indicates how much right shift of the velocity will become spin
     // The bigger the number the less change in spin.
@@ -7251,8 +7252,9 @@ static void steam_particle_create(const CoordsXYZ& coords)
  */
 void Vehicle::UpdateAdditionalAnimation()
 {
-    uint8_t al, ah;
-    uint32_t eax;
+    uint8_t al{};
+    uint8_t ah{};
+    uint32_t eax{};
 
     uint32_t* curVar_C8 = reinterpret_cast<uint32_t*>(&var_C8);
     auto vehicleEntry = Entry();
@@ -8374,7 +8376,7 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* cu
         return false;
 
     bool nextTileBackwards = true;
-    int32_t direction;
+    int32_t direction = 0;
     // loc_6DBB08:;
     auto trackPos = CoordsXYZ{ TrackLocation.x, TrackLocation.y, 0 };
 
@@ -8438,7 +8440,7 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* cu
         // loc_6DBB4F:;
         CoordsXYE input;
         CoordsXYE output;
-        int32_t outputZ;
+        int32_t outputZ{};
 
         input.x = trackPos.x;
         input.y = trackPos.y;
@@ -8680,6 +8682,7 @@ void Vehicle::UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* ri
     uint16_t otherVehicleIndex = SPRITE_INDEX_NULL;
     TileElement* tileElement = nullptr;
     CoordsXYZ trackPos;
+    int32_t direction{};
 
     _vehicleUnkF64E10 = 1;
     acceleration = dword_9A2970[vehicle_sprite_type];
@@ -8794,10 +8797,10 @@ loc_6DC476:
     }
 
     tileElement = map_get_track_element_at_of_type_seq(TrackLocation, GetTrackType(), 0);
-    int32_t direction;
     {
         CoordsXYE output;
-        int32_t outZ, outDirection;
+        int32_t outZ{};
+        int32_t outDirection{};
         CoordsXYE input = { TrackLocation, tileElement };
         if (!track_block_get_next(&input, &output, &outZ, &outDirection))
         {
@@ -9748,8 +9751,8 @@ void Vehicle::UpdateCrossings() const
         backVehicle = this;
     }
 
-    track_begin_end output;
-    int32_t direction;
+    track_begin_end output{};
+    int32_t direction{};
 
     CoordsXYE xyElement = { frontVehicle->TrackLocation,
                             map_get_track_element_at_of_type_seq(

--- a/src/openrct2/util/SawyerCoding.cpp
+++ b/src/openrct2/util/SawyerCoding.cpp
@@ -27,9 +27,8 @@ bool gUseRLE = true;
 
 uint32_t sawyercoding_calculate_checksum(const uint8_t* buffer, size_t length)
 {
-    size_t i;
     uint32_t checksum = 0;
-    for (i = 0; i < length; i++)
+    for (size_t i = 0; i < length; i++)
         checksum += buffer[i];
 
     return checksum;
@@ -125,14 +124,11 @@ size_t sawyercoding_decode_sc4(const uint8_t* src, uint8_t* dst, size_t length, 
 
 size_t sawyercoding_encode_sv4(const uint8_t* src, uint8_t* dst, size_t length)
 {
-    size_t encodedLength;
-    uint32_t checksum;
-
     // Encode
-    encodedLength = encode_chunk_rle(src, dst, length);
+    size_t encodedLength = encode_chunk_rle(src, dst, length);
 
     // Append checksum
-    checksum = sawyercoding_calculate_checksum(dst, encodedLength);
+    uint32_t checksum = sawyercoding_calculate_checksum(dst, encodedLength);
     *(reinterpret_cast<uint32_t*>(&dst[encodedLength])) = checksum;
 
     return encodedLength + 4;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -644,10 +644,7 @@ static void neighbour_list_sort(rct_neighbour_list* neighbourList)
 
 static TileElement* footpath_get_element(const CoordsXYRangedZ& footpathPos, int32_t direction)
 {
-    TileElement* tileElement;
-    int32_t slope;
-
-    tileElement = map_get_first_element_at(footpathPos);
+    TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
         return nullptr;
     do
@@ -659,7 +656,7 @@ static TileElement* footpath_get_element(const CoordsXYRangedZ& footpathPos, int
         {
             if (tileElement->AsPath()->IsSloped())
             {
-                slope = tileElement->AsPath()->GetSlopeDirection();
+                auto slope = tileElement->AsPath()->GetSlopeDirection();
                 if (slope != direction)
                     break;
             }
@@ -670,7 +667,7 @@ static TileElement* footpath_get_element(const CoordsXYRangedZ& footpathPos, int
             if (!tileElement->AsPath()->IsSloped())
                 break;
 
-            slope = direction_reverse(tileElement->AsPath()->GetSlopeDirection());
+            auto slope = direction_reverse(tileElement->AsPath()->GetSlopeDirection());
             if (slope != direction)
                 break;
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -56,7 +56,7 @@ struct CoordsXYE : public CoordsXY
         , element(_e)
     {
     }
-    TileElement* element;
+    TileElement* element = nullptr;
 };
 
 enum

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -339,10 +339,8 @@ void Park::Update(const Date& date)
 
 int32_t Park::CalculateParkSize() const
 {
-    int32_t tiles;
+    int32_t tiles = 0;
     tile_element_iterator it;
-
-    tiles = 0;
     tile_element_iterator_begin(&it);
     do
     {


### PR DESCRIPTION
I've been looking into some issues and one of them had this strange value used as a pointer so I went digging and found that when the operating mode is changed the code in UpdateMovingToEndOfStation could potentially use an uninitialized variable for the station index. While I was doing that I looked at what other variables are potentially uninitialized and fixed up a bunch of them, we all know thats never good. Also did some improvements here and there code readability wise.