### PR TITLE
Eliminate copying of paint_struct, initialize data in-place

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -175,25 +175,22 @@ struct paint_session
         return NextFreePaintStruct >= EndOfPaintStructArray;
     }
 
-    constexpr paint_struct* AllocateNormalPaintEntry(paint_struct&& entry) noexcept
+    constexpr paint_struct* AllocateNormalPaintEntry() noexcept
     {
-        NextFreePaintStruct->basic = entry;
         LastPS = &NextFreePaintStruct->basic;
         NextFreePaintStruct++;
         return LastPS;
     }
 
-    constexpr attached_paint_struct* AllocateAttachedPaintEntry(attached_paint_struct&& entry) noexcept
+    constexpr attached_paint_struct* AllocateAttachedPaintEntry() noexcept
     {
-        NextFreePaintStruct->attached = entry;
         LastAttachedPS = &NextFreePaintStruct->attached;
         NextFreePaintStruct++;
         return LastAttachedPS;
     }
 
-    constexpr paint_string_struct* AllocateStringPaintEntry(paint_string_struct&& entry) noexcept
+    constexpr paint_string_struct* AllocateStringPaintEntry() noexcept
     {
-        NextFreePaintStruct->string = entry;
         if (LastPSString == nullptr)
         {
             PSStringHead = &NextFreePaintStruct->string;


### PR DESCRIPTION
Before:
![sleepy_2021-01-07_10-13-44](https://user-images.githubusercontent.com/5415177/103868889-348de200-50d2-11eb-914e-dee90ae27511.png)

After:
![sleepy_2021-01-07_10-10-03](https://user-images.githubusercontent.com/5415177/103868895-35bf0f00-50d2-11eb-91c5-0fcb933895df.png)

Small performance boost 
