### PR TITLE
[Plugin] Re-add deprecated 'edgesAndCorners' support for footpaths

### DIFF
--- a/src/openrct2/scripting/ScTile.hpp
+++ b/src/openrct2/scripting/ScTile.hpp
@@ -1121,6 +1121,26 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        // Deprecated in favor of seperate 'edges' and 'corners' properties,
+        // left here to maintain compatibility with older plugins.
+        /** @deprecated */
+        uint8_t edgesAndCorners_get() const
+        {
+            auto el = _element->AsPath();
+            return el != nullptr ? el->GetEdgesAndCorners() : 0;
+        }
+        /** @deprecated */
+        void edgesAndCorners_set(uint8_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            auto el = _element->AsPath();
+            if (el != nullptr)
+            {
+                el->SetEdgesAndCorners(value);
+                Invalidate();
+            }
+        }
+
         DukValue edges_get() const
         {
             auto ctx = GetContext()->GetScriptEngine().GetContext();
@@ -1509,6 +1529,8 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScTileElement::parkFences_get, &ScTileElement::parkFences_set, "parkFences");
 
             // Footpath only
+            dukglue_register_property(
+                ctx, &ScTileElement::edgesAndCorners_get, &ScTileElement::edgesAndCorners_set, "edgesAndCorners");
             dukglue_register_property(ctx, &ScTileElement::edges_get, &ScTileElement::edges_set, "edges");
             dukglue_register_property(ctx, &ScTileElement::corners_get, &ScTileElement::corners_set, "corners");
             dukglue_register_property(


### PR DESCRIPTION
Pull request #13536 separated the `edgesAndCorners` property for footpaths into `edges` and `corners`. This is an improvement for the Plugin API, but it broke a few existing plugins in the process.

Some of the plugins affected are my [ProxyPather](http://openrct2plugins.org/plugin/MDEwOlJlcG9zaXRvcnkzMjU4NjIwMDA=/OpenRCT2-ProxyPather) plugin and Oli414's [PathExpander](http://openrct2plugins.org/plugin/MDEwOlJlcG9zaXRvcnkyNjE3MTA1Njg=/PathExpander).

This PR re-adds the property `edgesAndCorners` as a deprecated property. The original C++ methods are re-added, but the `openrct2.d.ts` definition is left out. This means that existing plugins will keep working while new and updated plugins can use `edges` and `corners` separately without knowing that `edgesAndCorners` exists.