### PR TITLE
Remove type from SpriteBase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip")
 set(OBJECTS_SHA1 "151424d24b1d49a167932b58319bedaa6ec368e9")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.23/replays.zip")
-set(REPLAYS_SHA1 "AC67B93731B6246A31D9A8B01A6CA12AE98AE0D1")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.24/replays.zip")
+set(REPLAYS_SHA1 "58AD8B2D2A804D2FEE787597A2A4DEADBF4D2A65")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip</ObjectsUrl>
     <ObjectsSha1>151424d24b1d49a167932b58319bedaa6ec368e9</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.23/replays.zip</ReplaysUrl>
-    <ReplaysSha1>AC67B93731B6246A31D9A8B01A6CA12AE98AE0D1</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.24/replays.zip</ReplaysUrl>
+    <ReplaysSha1>58AD8B2D2A804D2FEE787597A2A4DEADBF4D2A65</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -195,7 +195,7 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                 case SpriteIdentifier::Misc:
                     if (game_is_not_paused())
                     {
-                        switch (entity->As<SpriteGeneric>()->misc_type)
+                        switch (entity->As<SpriteGeneric>()->SubType)
                         {
                             case MiscEntityType::Balloon:
                             {

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -195,7 +195,7 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                 case SpriteIdentifier::Misc:
                     if (game_is_not_paused())
                     {
-                        switch (static_cast<MiscEntityType>(reinterpret_cast<SpriteGeneric*>(entity)->misc_type))
+                        switch (entity->As<SpriteGeneric>()->misc_type)
                         {
                             case MiscEntityType::Balloon:
                             {

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -195,7 +195,7 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                 case SpriteIdentifier::Misc:
                     if (game_is_not_paused())
                     {
-                        switch (static_cast<MiscEntityType>(entity->type))
+                        switch (static_cast<MiscEntityType>(reinterpret_cast<SpriteGeneric*>(entity)->misc_type))
                         {
                             case MiscEntityType::Balloon:
                             {

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -195,7 +195,7 @@ bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords)
                 case SpriteIdentifier::Misc:
                     if (game_is_not_paused())
                     {
-                        switch (entity->As<SpriteGeneric>()->SubType)
+                        switch (entity->As<MiscEntity>()->SubType)
                         {
                             case MiscEntityType::Balloon:
                             {

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -657,10 +657,10 @@ static void window_title_command_editor_tool_down(
         }
         else if (litter != nullptr)
         {
-            if (litter->l_type < std::size(litterNames))
+            if (litter->SubType < std::size(litterNames))
             {
                 validSprite = true;
-                format_string(_command.SpriteName, USER_STRING_MAX_LENGTH, litterNames[litter->l_type], nullptr);
+                format_string(_command.SpriteName, USER_STRING_MAX_LENGTH, litterNames[litter->SubType], nullptr);
             }
         }
         else if (balloon != nullptr)

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -657,10 +657,10 @@ static void window_title_command_editor_tool_down(
         }
         else if (litter != nullptr)
         {
-            if (litter->type < std::size(litterNames))
+            if (litter->l_type < std::size(litterNames))
             {
                 validSprite = true;
-                format_string(_command.SpriteName, USER_STRING_MAX_LENGTH, litterNames[litter->type], nullptr);
+                format_string(_command.SpriteName, USER_STRING_MAX_LENGTH, litterNames[litter->l_type], nullptr);
             }
         }
         else if (balloon != nullptr)

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -91,8 +91,8 @@ struct GameStateSnapshot_t
                     break;
                 case SpriteIdentifier::Misc:
                 {
-                    ds << sprite.generic.misc_type;
-                    switch (sprite.generic.misc_type)
+                    ds << sprite.generic.SubType;
+                    switch (sprite.generic.SubType)
                     {
                         case MiscEntityType::MoneyEffect:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(MoneyEffect)]>(sprite.money_effect);
@@ -493,7 +493,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
                     CompareSpriteDataGeneric(spriteBase.generic, spriteCmp.generic, changeData);
-                    switch (spriteBase.generic.misc_type)
+                    switch (spriteBase.generic.SubType)
                     {
                         case MiscEntityType::SteamParticle:
                             CompareSpriteDataSteamParticle(spriteBase.steam_particle, spriteCmp.steam_particle, changeData);
@@ -550,7 +550,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             const rct_sprite& spriteCmp = spritesCmp[i];
 
             changeData.spriteIdentifier = spriteBase.generic.sprite_identifier;
-            changeData.miscIdentifier = spriteBase.generic.misc_type;
+            changeData.miscIdentifier = spriteBase.generic.SubType;
 
             if (spriteBase.generic.sprite_identifier == SpriteIdentifier::Null
                 && spriteCmp.generic.sprite_identifier != SpriteIdentifier::Null)

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -92,7 +92,7 @@ struct GameStateSnapshot_t
                 case SpriteIdentifier::Misc:
                 {
                     ds << sprite.generic.misc_type;
-                    switch (static_cast<MiscEntityType>(sprite.generic.misc_type))
+                    switch (sprite.generic.misc_type)
                     {
                         case MiscEntityType::MoneyEffect:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(MoneyEffect)]>(sprite.money_effect);
@@ -493,7 +493,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
                     CompareSpriteDataGeneric(spriteBase.generic, spriteCmp.generic, changeData);
-                    switch (static_cast<MiscEntityType>(spriteBase.generic.misc_type))
+                    switch (spriteBase.generic.misc_type)
                     {
                         case MiscEntityType::SteamParticle:
                             CompareSpriteDataSteamParticle(spriteBase.steam_particle, spriteCmp.steam_particle, changeData);
@@ -654,8 +654,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             if (change.changeType == GameStateSpriteChange_t::EQUAL)
                 continue;
 
-            const char* typeName = GetSpriteIdentifierName(
-                change.spriteIdentifier, static_cast<MiscEntityType>(change.miscIdentifier));
+            const char* typeName = GetSpriteIdentifierName(change.spriteIdentifier, change.miscIdentifier);
 
             if (change.changeType == GameStateSpriteChange_t::ADDED)
             {

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -91,8 +91,8 @@ struct GameStateSnapshot_t
                     break;
                 case SpriteIdentifier::Misc:
                 {
-                    ds << sprite.generic.type;
-                    switch (static_cast<MiscEntityType>(sprite.generic.type))
+                    ds << sprite.generic.misc_type;
+                    switch (static_cast<MiscEntityType>(sprite.generic.misc_type))
                     {
                         case MiscEntityType::MoneyEffect:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(MoneyEffect)]>(sprite.money_effect);
@@ -200,7 +200,6 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         const SpriteBase& spriteBase, const SpriteBase& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
         COMPARE_FIELD(SpriteBase, sprite_identifier);
-        COMPARE_FIELD(SpriteBase, type);
         COMPARE_FIELD(SpriteBase, next_in_quadrant);
         COMPARE_FIELD(SpriteBase, next);
         COMPARE_FIELD(SpriteBase, previous);
@@ -494,7 +493,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
                     CompareSpriteDataGeneric(spriteBase.generic, spriteCmp.generic, changeData);
-                    switch (static_cast<MiscEntityType>(spriteBase.generic.type))
+                    switch (static_cast<MiscEntityType>(spriteBase.generic.misc_type))
                     {
                         case MiscEntityType::SteamParticle:
                             CompareSpriteDataSteamParticle(spriteBase.steam_particle, spriteCmp.steam_particle, changeData);
@@ -551,7 +550,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             const rct_sprite& spriteCmp = spritesCmp[i];
 
             changeData.spriteIdentifier = spriteBase.generic.sprite_identifier;
-            changeData.miscIdentifier = spriteBase.generic.type;
+            changeData.miscIdentifier = spriteBase.generic.misc_type;
 
             if (spriteBase.generic.sprite_identifier == SpriteIdentifier::Null
                 && spriteCmp.generic.sprite_identifier != SpriteIdentifier::Null)

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -49,7 +49,7 @@ struct GameStateSnapshot_t
             for (size_t i = 0; i < numSprites; i++)
             {
                 auto entity = getEntity(i);
-                if (entity == nullptr || entity->generic.sprite_identifier == SpriteIdentifier::Null)
+                if (entity == nullptr || entity->misc.sprite_identifier == SpriteIdentifier::Null)
                     continue;
                 indexTable.push_back(static_cast<uint32_t>(i));
             }
@@ -76,9 +76,9 @@ struct GameStateSnapshot_t
             }
             auto& sprite = *entity;
 
-            ds << sprite.generic.sprite_identifier;
+            ds << sprite.misc.sprite_identifier;
 
-            switch (sprite.generic.sprite_identifier)
+            switch (sprite.misc.sprite_identifier)
             {
                 case SpriteIdentifier::Vehicle:
                     ds << reinterpret_cast<uint8_t(&)[sizeof(Vehicle)]>(sprite.vehicle);
@@ -91,8 +91,8 @@ struct GameStateSnapshot_t
                     break;
                 case SpriteIdentifier::Misc:
                 {
-                    ds << sprite.generic.SubType;
-                    switch (sprite.generic.SubType)
+                    ds << sprite.misc.SubType;
+                    switch (sprite.misc.SubType)
                     {
                         case MiscEntityType::MoneyEffect:
                             ds << reinterpret_cast<uint8_t(&)[sizeof(MoneyEffect)]>(sprite.money_effect);
@@ -176,7 +176,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         for (auto& sprite : spriteList)
         {
             // By default they don't exist.
-            sprite.generic.sprite_identifier = SpriteIdentifier::Null;
+            sprite.misc.sprite_identifier = SpriteIdentifier::Null;
         }
 
         snapshot.SerialiseSprites([&spriteList](const size_t index) { return &spriteList[index]; }, MAX_SPRITES, false);
@@ -471,15 +471,16 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     void CompareSpriteDataGeneric(
         const MiscEntity& spriteBase, const MiscEntity& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
+        COMPARE_FIELD(MiscEntity, SubType);
         COMPARE_FIELD(MiscEntity, frame);
     }
 
     void CompareSpriteData(const rct_sprite& spriteBase, const rct_sprite& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
-        CompareSpriteDataCommon(spriteBase.generic, spriteCmp.generic, changeData);
-        if (spriteBase.generic.sprite_identifier == spriteCmp.generic.sprite_identifier)
+        CompareSpriteDataCommon(spriteBase.misc, spriteCmp.misc, changeData);
+        if (spriteBase.misc.sprite_identifier == spriteCmp.misc.sprite_identifier)
         {
-            switch (spriteBase.generic.sprite_identifier)
+            switch (spriteBase.misc.sprite_identifier)
             {
                 case SpriteIdentifier::Peep:
                     CompareSpriteDataPeep(spriteBase.peep, spriteCmp.peep, changeData);
@@ -492,8 +493,8 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                     break;
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
-                    CompareSpriteDataGeneric(spriteBase.generic, spriteCmp.generic, changeData);
-                    switch (spriteBase.generic.SubType)
+                    CompareSpriteDataGeneric(spriteBase.misc, spriteCmp.misc, changeData);
+                    switch (spriteBase.misc.SubType)
                     {
                         case MiscEntityType::SteamParticle:
                             CompareSpriteDataSteamParticle(spriteBase.steam_particle, spriteCmp.steam_particle, changeData);
@@ -549,27 +550,27 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             const rct_sprite& spriteBase = spritesBase[i];
             const rct_sprite& spriteCmp = spritesCmp[i];
 
-            changeData.spriteIdentifier = spriteBase.generic.sprite_identifier;
-            changeData.miscIdentifier = spriteBase.generic.SubType;
+            changeData.spriteIdentifier = spriteBase.misc.sprite_identifier;
+            changeData.miscIdentifier = spriteBase.misc.SubType;
 
-            if (spriteBase.generic.sprite_identifier == SpriteIdentifier::Null
-                && spriteCmp.generic.sprite_identifier != SpriteIdentifier::Null)
+            if (spriteBase.misc.sprite_identifier == SpriteIdentifier::Null
+                && spriteCmp.misc.sprite_identifier != SpriteIdentifier::Null)
             {
                 // Sprite was added.
                 changeData.changeType = GameStateSpriteChange_t::ADDED;
-                changeData.spriteIdentifier = spriteCmp.generic.sprite_identifier;
+                changeData.spriteIdentifier = spriteCmp.misc.sprite_identifier;
             }
             else if (
-                spriteBase.generic.sprite_identifier != SpriteIdentifier::Null
-                && spriteCmp.generic.sprite_identifier == SpriteIdentifier::Null)
+                spriteBase.misc.sprite_identifier != SpriteIdentifier::Null
+                && spriteCmp.misc.sprite_identifier == SpriteIdentifier::Null)
             {
                 // Sprite was removed.
                 changeData.changeType = GameStateSpriteChange_t::REMOVED;
-                changeData.spriteIdentifier = spriteBase.generic.sprite_identifier;
+                changeData.spriteIdentifier = spriteBase.misc.sprite_identifier;
             }
             else if (
-                spriteBase.generic.sprite_identifier == SpriteIdentifier::Null
-                && spriteCmp.generic.sprite_identifier == SpriteIdentifier::Null)
+                spriteBase.misc.sprite_identifier == SpriteIdentifier::Null
+                && spriteCmp.misc.sprite_identifier == SpriteIdentifier::Null)
             {
                 // Do nothing.
                 changeData.changeType = GameStateSpriteChange_t::EQUAL;

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -468,7 +468,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(JumpingFountain, Iteration);
     }
 
-    void CompareSpriteDataGeneric(
+    void CompareSpriteDataMisc(
         const MiscEntity& spriteBase, const MiscEntity& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
         COMPARE_FIELD(MiscEntity, SubType);
@@ -493,7 +493,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                     break;
                 case SpriteIdentifier::Misc:
                     // This is not expected to happen, as misc sprites do not constitute sprite checksum
-                    CompareSpriteDataGeneric(spriteBase.misc, spriteCmp.misc, changeData);
+                    CompareSpriteDataMisc(spriteBase.misc, spriteCmp.misc, changeData);
                     switch (spriteBase.misc.SubType)
                     {
                         case MiscEntityType::SteamParticle:
@@ -551,6 +551,9 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             const rct_sprite& spriteCmp = spritesCmp[i];
 
             changeData.spriteIdentifier = spriteBase.misc.sprite_identifier;
+            // This will be nonsense information for all types apart from MiscEntities.
+            // This is not an issue though as only MiscEntities will use this field in GetSpriteIdentifierName
+            // TODO: Don't do this.
             changeData.miscIdentifier = spriteBase.misc.SubType;
 
             if (spriteBase.misc.sprite_identifier == SpriteIdentifier::Null

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -469,9 +469,9 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     }
 
     void CompareSpriteDataGeneric(
-        const SpriteGeneric& spriteBase, const SpriteGeneric& spriteCmp, GameStateSpriteChange_t& changeData) const
+        const MiscEntity& spriteBase, const MiscEntity& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
-        COMPARE_FIELD(SpriteGeneric, frame);
+        COMPARE_FIELD(MiscEntity, frame);
     }
 
     void CompareSpriteData(const rct_sprite& spriteBase, const rct_sprite& spriteCmp, GameStateSpriteChange_t& changeData) const
@@ -508,7 +508,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
                         case MiscEntityType::ExplosionCloud:
                         case MiscEntityType::CrashSplash:
                         case MiscEntityType::ExplosionFlare:
-                            // SpriteGeneric
+                            // MiscEntity
                             break;
                         case MiscEntityType::JumpingFountainWater:
                         case MiscEntityType::JumpingFountainSnow:

--- a/src/openrct2/GameStateSnapshots.h
+++ b/src/openrct2/GameStateSnapshots.h
@@ -40,7 +40,7 @@ struct GameStateSpriteChange_t
 
     uint8_t changeType;
     SpriteIdentifier spriteIdentifier;
-    uint8_t miscIdentifier;
+    MiscEntityType miscIdentifier;
     uint32_t spriteIndex;
 
     std::vector<Diff_t> diffs;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/paint/sprite/Paint.Litter.cpp
+++ b/src/openrct2/paint/sprite/Paint.Litter.cpp
@@ -77,9 +77,9 @@ void litter_paint(paint_session* session, const Litter* litter, int32_t imageDir
     imageDirection >>= 3;
     // Some litter types have only 1 direction so remove
     // anything that isn't required.
-    imageDirection &= litter_sprites[litter->l_type].direction_mask;
+    imageDirection &= litter_sprites[litter->SubType].direction_mask;
 
-    uint32_t image_id = imageDirection + litter_sprites[litter->l_type].base_id;
+    uint32_t image_id = imageDirection + litter_sprites[litter->SubType].base_id;
 
     // In the following call to PaintAddImageAsParent, we add 4 (instead of 2) to the
     //  bound_box_offset_z to make sure litter is drawn on top of railways

--- a/src/openrct2/paint/sprite/Paint.Litter.cpp
+++ b/src/openrct2/paint/sprite/Paint.Litter.cpp
@@ -77,9 +77,9 @@ void litter_paint(paint_session* session, const Litter* litter, int32_t imageDir
     imageDirection >>= 3;
     // Some litter types have only 1 direction so remove
     // anything that isn't required.
-    imageDirection &= litter_sprites[litter->type].direction_mask;
+    imageDirection &= litter_sprites[litter->l_type].direction_mask;
 
-    uint32_t image_id = imageDirection + litter_sprites[litter->type].base_id;
+    uint32_t image_id = imageDirection + litter_sprites[litter->l_type].base_id;
 
     // In the following call to PaintAddImageAsParent, we add 4 (instead of 2) to the
     //  bound_box_offset_z to make sure litter is drawn on top of railways

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -33,7 +33,7 @@ void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t image
 {
     rct_drawpixelinfo* dpi = &session->DPI;
 
-    switch (misc->misc_type)
+    switch (misc->SubType)
     {
         case MiscEntityType::SteamParticle: // 0
         {
@@ -134,7 +134,7 @@ void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t image
                 isAntiClockwise = !isAntiClockwise;
             }
 
-            uint32_t baseImageId = (jumpingFountain->misc_type == MiscEntityType::JumpingFountainSnow) ? 23037 : 22973;
+            uint32_t baseImageId = (jumpingFountain->SubType == MiscEntityType::JumpingFountainSnow) ? 23037 : 22973;
             uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;
             constexpr std::array<CoordsXY, 2> antiClockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, -3 },
                                                                              CoordsXY{ 0, -3 } };

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -33,7 +33,7 @@ void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t image
 {
     rct_drawpixelinfo* dpi = &session->DPI;
 
-    switch (static_cast<MiscEntityType>(misc->misc_type))
+    switch (misc->misc_type)
     {
         case MiscEntityType::SteamParticle: // 0
         {
@@ -134,9 +134,7 @@ void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t image
                 isAntiClockwise = !isAntiClockwise;
             }
 
-            uint32_t baseImageId = (static_cast<MiscEntityType>(jumpingFountain->misc_type) == MiscEntityType::JumpingFountainSnow)
-                ? 23037
-                : 22973;
+            uint32_t baseImageId = (jumpingFountain->misc_type == MiscEntityType::JumpingFountainSnow) ? 23037 : 22973;
             uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;
             constexpr std::array<CoordsXY, 2> antiClockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, -3 },
                                                                              CoordsXY{ 0, -3 } };

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -29,7 +29,7 @@ const uint32_t vehicle_particle_base_sprites[] = {
 /**
  * rct2: 0x00672AC9
  */
-void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t imageDirection)
+void misc_paint(paint_session* session, const MiscEntity* misc, int32_t imageDirection)
 {
     rct_drawpixelinfo* dpi = &session->DPI;
 

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -29,11 +29,11 @@ const uint32_t vehicle_particle_base_sprites[] = {
 /**
  * rct2: 0x00672AC9
  */
-void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDirection)
+void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t imageDirection)
 {
     rct_drawpixelinfo* dpi = &session->DPI;
 
-    switch (static_cast<MiscEntityType>(misc->type))
+    switch (static_cast<MiscEntityType>(misc->misc_type))
     {
         case MiscEntityType::SteamParticle: // 0
         {
@@ -134,7 +134,7 @@ void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDir
                 isAntiClockwise = !isAntiClockwise;
             }
 
-            uint32_t baseImageId = (static_cast<MiscEntityType>(jumpingFountain->type) == MiscEntityType::JumpingFountainSnow)
+            uint32_t baseImageId = (static_cast<MiscEntityType>(jumpingFountain->misc_type) == MiscEntityType::JumpingFountainSnow)
                 ? 23037
                 : 22973;
             uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -115,7 +115,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
                 break;
             case SpriteIdentifier::Misc:
                 // TODO: Update misc_paint to take a specific sprite type
-                misc_paint(session, spr->As<SpriteGeneric>(), image_direction);
+                misc_paint(session, spr->As<MiscEntity>(), image_direction);
                 break;
             case SpriteIdentifier::Litter:
                 litter_paint(session, spr->As<Litter>(), image_direction);

--- a/src/openrct2/paint/sprite/Paint.Sprite.cpp
+++ b/src/openrct2/paint/sprite/Paint.Sprite.cpp
@@ -115,7 +115,7 @@ void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t
                 break;
             case SpriteIdentifier::Misc:
                 // TODO: Update misc_paint to take a specific sprite type
-                misc_paint(session, spr, image_direction);
+                misc_paint(session, spr->As<SpriteGeneric>(), image_direction);
                 break;
             case SpriteIdentifier::Litter:
                 litter_paint(session, spr->As<Litter>(), image_direction);

--- a/src/openrct2/paint/sprite/Paint.Sprite.h
+++ b/src/openrct2/paint/sprite/Paint.Sprite.h
@@ -17,7 +17,7 @@ struct paint_session;
 
 void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t y);
 
-void misc_paint(paint_session* session, const SpriteBase* misc, int32_t imageDirection);
+void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t imageDirection);
 void litter_paint(paint_session* session, const Litter* litter, int32_t imageDirection);
 void peep_paint(paint_session* session, const Peep* peep, int32_t imageDirection);
 

--- a/src/openrct2/paint/sprite/Paint.Sprite.h
+++ b/src/openrct2/paint/sprite/Paint.Sprite.h
@@ -17,7 +17,7 @@ struct paint_session;
 
 void sprite_paint_setup(paint_session* session, const uint16_t x, const uint16_t y);
 
-void misc_paint(paint_session* session, const SpriteGeneric* misc, int32_t imageDirection);
+void misc_paint(paint_session* session, const MiscEntity* misc, int32_t imageDirection);
 void litter_paint(paint_session* session, const Litter* litter, int32_t imageDirection);
 void peep_paint(paint_session* session, const Peep* peep, int32_t imageDirection);
 

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5076,13 +5076,13 @@ void Guest::UpdateWalking()
         {
             if ((0xFFFF & scenario_rand()) <= 4096)
             {
-                static constexpr const uint8_t litter_types[] = {
+                static constexpr const LitterType litter_types[] = {
                     LITTER_TYPE_EMPTY_CAN,
                     LITTER_TYPE_RUBBISH,
                     LITTER_TYPE_EMPTY_BURGER_BOX,
                     LITTER_TYPE_EMPTY_CUP,
                 };
-                int32_t litterType = litter_types[scenario_rand() & 0x3];
+                auto litterType = litter_types[scenario_rand() & 0x3];
                 int32_t litterX = x + (scenario_rand() & 0x7) - 3;
                 int32_t litterY = y + (scenario_rand() & 0x7) - 3;
                 Direction litterDirection = (scenario_rand() & 0x3);
@@ -5097,13 +5097,13 @@ void Guest::UpdateWalking()
             && ((0xFFFF & scenario_rand()) <= 4096))
         {
             int32_t container = bitscanforward(GetEmptyContainerFlags());
-            int32_t litterType = 0;
+            LitterType litterType = LITTER_TYPE_SICK;
 
             if (container != -1)
             {
                 auto item = static_cast<ShopItem>(container);
                 RemoveItem(item);
-                litterType = GetShopItemDescriptor(item).LitterType;
+                litterType = LitterType(GetShopItemDescriptor(item).LitterType);
             }
 
             WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
@@ -5672,7 +5672,8 @@ void Guest::UpdateUsingBin()
                     UpdateSpriteType();
                     continue;
                 }
-                uint8_t litterType = GetShopItemDescriptor(item).LitterType;
+
+                LitterType litterType = LitterType(GetShopItemDescriptor(item).LitterType);
 
                 int32_t litterX = x + (scenario_rand() & 7) - 3;
                 int32_t litterY = y + (scenario_rand() & 7) - 3;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2640,7 +2640,7 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
                 continue;
 
             litter_count++;
-            if (litter->type != LITTER_TYPE_SICK && litter->type != LITTER_TYPE_SICK_ALT)
+            if (litter->l_type != LITTER_TYPE_SICK && litter->l_type != LITTER_TYPE_SICK_ALT)
                 continue;
 
             litter_count--;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -2640,7 +2640,7 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
                 continue;
 
             litter_count++;
-            if (litter->l_type != LITTER_TYPE_SICK && litter->l_type != LITTER_TYPE_SICK_ALT)
+            if (litter->SubType != LITTER_TYPE_SICK && litter->SubType != LITTER_TYPE_SICK_ALT)
                 continue;
 
             litter_count--;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1170,7 +1170,7 @@ private:
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(ride->subtype);
 
         dst->vehicle_type = vehicleEntryIndex;
-        dst->v_type = Vehicle::Type(src->type);
+        dst->SubType = Vehicle::Type(src->type);
         dst->var_44 = src->var_44;
         dst->remaining_distance = src->remaining_distance;
 
@@ -1651,7 +1651,7 @@ private:
 
                 Litter* litter = reinterpret_cast<Litter*>(create_sprite(SpriteIdentifier::Litter));
                 litter->sprite_identifier = srcLitter->sprite_identifier;
-                litter->l_type = LitterType(srcLitter->type);
+                litter->SubType = LitterType(srcLitter->type);
 
                 litter->x = srcLitter->x;
                 litter->y = srcLitter->y;
@@ -1680,7 +1680,7 @@ private:
                     break;
                 }
                 dst->sprite_identifier = src->sprite_identifier;
-                dst->misc_type = MiscEntityType(src->type);
+                dst->SubType = MiscEntityType(src->type);
                 dst->flags = src->flags;
                 dst->sprite_direction = src->sprite_direction;
                 dst->sprite_width = src->sprite_width;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1680,7 +1680,7 @@ private:
                     break;
                 }
                 dst->sprite_identifier = src->sprite_identifier;
-                dst->misc_type = src->type;
+                dst->misc_type = MiscEntityType(src->type);
                 dst->flags = src->flags;
                 dst->sprite_direction = src->sprite_direction;
                 dst->sprite_width = src->sprite_width;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1673,7 +1673,7 @@ private:
             if (sprite.unknown.sprite_identifier == SpriteIdentifier::Misc)
             {
                 rct1_unk_sprite* src = &sprite.unknown;
-                SpriteGeneric* dst = reinterpret_cast<SpriteGeneric*>(create_sprite(SpriteIdentifier::Misc));
+                MiscEntity* dst = reinterpret_cast<MiscEntity*>(create_sprite(SpriteIdentifier::Misc));
                 if (dst == nullptr)
                 {
                     log_warning("SV4 has too many misc entities. No more misc entities will be imported!");

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1651,7 +1651,7 @@ private:
 
                 Litter* litter = reinterpret_cast<Litter*>(create_sprite(SpriteIdentifier::Litter));
                 litter->sprite_identifier = srcLitter->sprite_identifier;
-                litter->l_type = srcLitter->type;
+                litter->l_type = LitterType(srcLitter->type);
 
                 litter->x = srcLitter->x;
                 litter->y = srcLitter->y;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1170,7 +1170,7 @@ private:
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(ride->subtype);
 
         dst->vehicle_type = vehicleEntryIndex;
-        dst->type = src->type;
+        dst->v_type = Vehicle::Type(src->type);
         dst->var_44 = src->var_44;
         dst->remaining_distance = src->remaining_distance;
 
@@ -1651,7 +1651,7 @@ private:
 
                 Litter* litter = reinterpret_cast<Litter*>(create_sprite(SpriteIdentifier::Litter));
                 litter->sprite_identifier = srcLitter->sprite_identifier;
-                litter->type = srcLitter->type;
+                litter->l_type = srcLitter->type;
 
                 litter->x = srcLitter->x;
                 litter->y = srcLitter->y;
@@ -1680,7 +1680,7 @@ private:
                     break;
                 }
                 dst->sprite_identifier = src->sprite_identifier;
-                dst->type = src->type;
+                dst->misc_type = src->type;
                 dst->flags = src->flags;
                 dst->sprite_direction = src->sprite_direction;
                 dst->sprite_width = src->sprite_width;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1014,7 +1014,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src)
     const auto* ride = src->GetRide();
 
     ExportSpriteCommonProperties(dst, static_cast<const SpriteBase*>(src));
-    dst->type = static_cast<uint8_t>(src->v_type);
+    dst->type = static_cast<uint8_t>(src->SubType);
     dst->vehicle_sprite_type = src->vehicle_sprite_type;
     dst->bank_rotation = src->bank_rotation;
     dst->remaining_distance = src->remaining_distance;
@@ -1251,8 +1251,8 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteGeneric* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
-    cdst->type = static_cast<uint8_t>(csrc->misc_type);
-    switch (csrc->misc_type)
+    cdst->type = static_cast<uint8_t>(csrc->SubType);
+    switch (csrc->SubType)
     {
         case MiscEntityType::SteamParticle:
         {
@@ -1344,7 +1344,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteGeneric* cs
 void S6Exporter::ExportSpriteLitter(RCT12SpriteLitter* dst, const Litter* src)
 {
     ExportSpriteCommonProperties(dst, src);
-    dst->type = static_cast<uint8_t>(src->l_type);
+    dst->type = static_cast<uint8_t>(src->SubType);
     dst->creationTick = src->creationTick;
 }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1251,8 +1251,8 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteGeneric* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
-    cdst->type = csrc->misc_type;
-    switch (static_cast<MiscEntityType>(csrc->misc_type))
+    cdst->type = static_cast<uint8_t>(csrc->misc_type);
+    switch (csrc->misc_type)
     {
         case MiscEntityType::SteamParticle:
         {

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -990,7 +990,6 @@ void S6Exporter::ExportSprite(RCT2Sprite* dst, const rct_sprite* src)
 void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const SpriteBase* src)
 {
     dst->sprite_identifier = src->sprite_identifier;
-    dst->type = src->type;
     dst->next_in_quadrant = src->next_in_quadrant;
     dst->next = src->next;
     dst->previous = src->previous;
@@ -1015,6 +1014,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src)
     const auto* ride = src->GetRide();
 
     ExportSpriteCommonProperties(dst, static_cast<const SpriteBase*>(src));
+    dst->type = static_cast<uint8_t>(src->v_type);
     dst->vehicle_sprite_type = src->vehicle_sprite_type;
     dst->bank_rotation = src->bank_rotation;
     dst->remaining_distance = src->remaining_distance;
@@ -1099,7 +1099,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src)
 void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 {
     ExportSpriteCommonProperties(dst, static_cast<const SpriteBase*>(src));
-
+    
     auto generateName = true;
     if (src->Name != nullptr)
     {
@@ -1248,10 +1248,11 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->item_standard_flags = static_cast<uint32_t>(src->GetItemFlags());
 }
 
-void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
+void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteGeneric* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
-    switch (static_cast<MiscEntityType>(cdst->type))
+    cdst->type = csrc->misc_type;
+    switch (static_cast<MiscEntityType>(csrc->misc_type))
     {
         case MiscEntityType::SteamParticle:
         {
@@ -1343,6 +1344,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteBase* csrc)
 void S6Exporter::ExportSpriteLitter(RCT12SpriteLitter* dst, const Litter* src)
 {
     ExportSpriteCommonProperties(dst, src);
+    dst->type = static_cast<uint8_t>(src->l_type);
     dst->creationTick = src->creationTick;
 }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1014,7 +1014,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src)
     const auto* ride = src->GetRide();
 
     ExportSpriteCommonProperties(dst, static_cast<const SpriteBase*>(src));
-    dst->type = static_cast<uint8_t>(src->SubType);
+    dst->type = EnumValue(src->SubType);
     dst->vehicle_sprite_type = src->vehicle_sprite_type;
     dst->bank_rotation = src->bank_rotation;
     dst->remaining_distance = src->remaining_distance;
@@ -1251,7 +1251,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const MiscEntity* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
-    cdst->type = static_cast<uint8_t>(csrc->SubType);
+    cdst->type = EnumValue(csrc->SubType);
     switch (csrc->SubType)
     {
         case MiscEntityType::SteamParticle:
@@ -1344,7 +1344,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const MiscEntity* csrc)
 void S6Exporter::ExportSpriteLitter(RCT12SpriteLitter* dst, const Litter* src)
 {
     ExportSpriteCommonProperties(dst, src);
-    dst->type = static_cast<uint8_t>(src->SubType);
+    dst->type = EnumValue(src->SubType);
     dst->creationTick = src->creationTick;
 }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1248,7 +1248,7 @@ void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
     dst->item_standard_flags = static_cast<uint32_t>(src->GetItemFlags());
 }
 
-void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteGeneric* csrc)
+void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const MiscEntity* csrc)
 {
     ExportSpriteCommonProperties(cdst, csrc);
     cdst->type = static_cast<uint8_t>(csrc->SubType);
@@ -1296,7 +1296,7 @@ void S6Exporter::ExportSpriteMisc(RCT12SpriteBase* cdst, const SpriteGeneric* cs
         case MiscEntityType::ExplosionFlare:
         case MiscEntityType::CrashSplash:
         {
-            auto src = static_cast<const SpriteGeneric*>(csrc);
+            auto src = static_cast<const MiscEntity*>(csrc);
             auto dst = static_cast<RCT12SpriteParticle*>(cdst);
             dst->frame = src->frame;
             break;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -963,10 +963,10 @@ void S6Exporter::ExportSprites()
 void S6Exporter::ExportSprite(RCT2Sprite* dst, const rct_sprite* src)
 {
     std::memset(dst, 0, sizeof(rct_sprite));
-    switch (src->generic.sprite_identifier)
+    switch (src->misc.sprite_identifier)
     {
         case SpriteIdentifier::Null:
-            ExportSpriteCommonProperties(&dst->unknown, &src->generic);
+            ExportSpriteCommonProperties(&dst->unknown, &src->misc);
             break;
         case SpriteIdentifier::Vehicle:
             ExportSpriteVehicle(&dst->vehicle, &src->vehicle);
@@ -975,14 +975,14 @@ void S6Exporter::ExportSprite(RCT2Sprite* dst, const rct_sprite* src)
             ExportSpritePeep(&dst->peep, &src->peep);
             break;
         case SpriteIdentifier::Misc:
-            ExportSpriteMisc(&dst->unknown, &src->generic);
+            ExportSpriteMisc(&dst->unknown, &src->misc);
             break;
         case SpriteIdentifier::Litter:
             ExportSpriteLitter(&dst->litter, &src->litter);
             break;
         default:
-            ExportSpriteCommonProperties(&dst->unknown, &src->generic);
-            log_warning("Sprite identifier %d can not be exported.", src->generic.sprite_identifier);
+            ExportSpriteCommonProperties(&dst->unknown, &src->misc);
+            log_warning("Sprite identifier %d can not be exported.", src->misc.sprite_identifier);
             break;
     }
 }
@@ -1099,7 +1099,7 @@ void S6Exporter::ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src)
 void S6Exporter::ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src)
 {
     ExportSpriteCommonProperties(dst, static_cast<const SpriteBase*>(src));
-    
+
     auto generateName = true;
     if (src->Name != nullptr)
     {

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -51,7 +51,7 @@ public:
     void ExportSpriteCommonProperties(RCT12SpriteBase* dst, const SpriteBase* src);
     void ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src);
     void ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src);
-    void ExportSpriteMisc(RCT12SpriteBase* dst, const SpriteBase* src);
+    void ExportSpriteMisc(RCT12SpriteBase* dst, const SpriteGeneric* src);
     void ExportSpriteLitter(RCT12SpriteLitter* dst, const Litter* src);
 
 private:

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -51,7 +51,7 @@ public:
     void ExportSpriteCommonProperties(RCT12SpriteBase* dst, const SpriteBase* src);
     void ExportSpriteVehicle(RCT2SpriteVehicle* dst, const Vehicle* src);
     void ExportSpritePeep(RCT2SpritePeep* dst, const Peep* src);
-    void ExportSpriteMisc(RCT12SpriteBase* dst, const SpriteGeneric* src);
+    void ExportSpriteMisc(RCT12SpriteBase* dst, const MiscEntity* src);
     void ExportSpriteLitter(RCT12SpriteLitter* dst, const Litter* src);
 
 private:

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1335,6 +1335,7 @@ public:
         const auto& ride = _s6.rides[src->ride];
 
         ImportSpriteCommonProperties(static_cast<SpriteBase*>(dst), src);
+        dst->v_type = Vehicle::Type(src->type);
         dst->vehicle_sprite_type = src->vehicle_sprite_type;
         dst->bank_rotation = src->bank_rotation;
         dst->remaining_distance = src->remaining_distance;
@@ -1530,10 +1531,11 @@ public:
         dst->FavouriteRideRating = src->favourite_ride_rating;
     }
 
-    void ImportSpriteMisc(SpriteBase* cdst, const RCT12SpriteBase* csrc)
+    void ImportSpriteMisc(SpriteGeneric* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        switch (static_cast<MiscEntityType>(cdst->type))
+        cdst->misc_type = csrc->type;
+        switch (static_cast<MiscEntityType>(cdst->misc_type))
         {
             case MiscEntityType::SteamParticle:
             {
@@ -1616,7 +1618,7 @@ public:
                 break;
             }
             default:
-                log_warning("Misc. sprite type %d can not be imported.", cdst->type);
+                log_warning("Misc. sprite type %d can not be imported.", cdst->misc_type);
                 break;
         }
     }
@@ -1624,13 +1626,13 @@ public:
     void ImportSpriteLitter(Litter* dst, const RCT12SpriteLitter* src)
     {
         ImportSpriteCommonProperties(dst, src);
+        dst->l_type = src->type;
         dst->creationTick = src->creationTick;
     }
 
     void ImportSpriteCommonProperties(SpriteBase* dst, const RCT12SpriteBase* src)
     {
         dst->sprite_identifier = src->sprite_identifier;
-        dst->type = src->type;
         dst->next_in_quadrant = src->next_in_quadrant;
         dst->next = src->next;
         dst->previous = src->previous;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1335,7 +1335,7 @@ public:
         const auto& ride = _s6.rides[src->ride];
 
         ImportSpriteCommonProperties(static_cast<SpriteBase*>(dst), src);
-        dst->v_type = Vehicle::Type(src->type);
+        dst->SubType = Vehicle::Type(src->type);
         dst->vehicle_sprite_type = src->vehicle_sprite_type;
         dst->bank_rotation = src->bank_rotation;
         dst->remaining_distance = src->remaining_distance;
@@ -1534,8 +1534,8 @@ public:
     void ImportSpriteMisc(SpriteGeneric* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        cdst->misc_type = MiscEntityType(csrc->type);
-        switch (cdst->misc_type)
+        cdst->SubType = MiscEntityType(csrc->type);
+        switch (cdst->SubType)
         {
             case MiscEntityType::SteamParticle:
             {
@@ -1618,7 +1618,7 @@ public:
                 break;
             }
             default:
-                log_warning("Misc. sprite type %d can not be imported.", cdst->misc_type);
+                log_warning("Misc. sprite type %d can not be imported.", cdst->SubType);
                 break;
         }
     }
@@ -1626,7 +1626,7 @@ public:
     void ImportSpriteLitter(Litter* dst, const RCT12SpriteLitter* src)
     {
         ImportSpriteCommonProperties(dst, src);
-        dst->l_type = LitterType(src->type);
+        dst->SubType = LitterType(src->type);
         dst->creationTick = src->creationTick;
     }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1318,7 +1318,7 @@ public:
                 ImportSpritePeep(&dst->peep, &src->peep);
                 break;
             case SpriteIdentifier::Misc:
-                ImportSpriteMisc(&dst->generic, &src->unknown);
+                ImportSpriteMisc(&dst->misc, &src->unknown);
                 break;
             case SpriteIdentifier::Litter:
                 ImportSpriteLitter(&dst->litter, &src->litter);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1531,7 +1531,7 @@ public:
         dst->FavouriteRideRating = src->favourite_ride_rating;
     }
 
-    void ImportSpriteMisc(SpriteGeneric* cdst, const RCT12SpriteBase* csrc)
+    void ImportSpriteMisc(MiscEntity* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
         cdst->SubType = MiscEntityType(csrc->type);
@@ -1580,7 +1580,7 @@ public:
             case MiscEntityType::CrashSplash:
             {
                 auto src = static_cast<const RCT12SpriteParticle*>(csrc);
-                auto dst = static_cast<SpriteGeneric*>(cdst);
+                auto dst = static_cast<MiscEntity*>(cdst);
                 dst->frame = src->frame;
                 break;
             }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1626,7 +1626,7 @@ public:
     void ImportSpriteLitter(Litter* dst, const RCT12SpriteLitter* src)
     {
         ImportSpriteCommonProperties(dst, src);
-        dst->l_type = src->type;
+        dst->l_type = LitterType(src->type);
         dst->creationTick = src->creationTick;
     }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1534,8 +1534,8 @@ public:
     void ImportSpriteMisc(SpriteGeneric* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        cdst->misc_type = csrc->type;
-        switch (static_cast<MiscEntityType>(cdst->misc_type))
+        cdst->misc_type = MiscEntityType(csrc->type);
+        switch (cdst->misc_type)
         {
             case MiscEntityType::SteamParticle:
             {

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -32,7 +32,7 @@ Vehicle* cable_lift_segment_create(
     {
         ride.cable_lift = current->sprite_index;
     }
-    current->type = static_cast<uint8_t>(head ? Vehicle::Type::Head : Vehicle::Type::Tail);
+    current->v_type = head ? Vehicle::Type::Head : Vehicle::Type::Tail;
     current->var_44 = var_44;
     current->remaining_distance = remaining_distance;
     current->sprite_width = 10;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -32,7 +32,7 @@ Vehicle* cable_lift_segment_create(
     {
         ride.cable_lift = current->sprite_index;
     }
-    current->v_type = head ? Vehicle::Type::Head : Vehicle::Type::Tail;
+    current->SubType = head ? Vehicle::Type::Head : Vehicle::Type::Tail;
     current->var_44 = var_44;
     current->remaining_distance = remaining_distance;
     current->sprite_width = 10;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4403,7 +4403,7 @@ static Vehicle* vehicle_create_car(
     vehicle->ride_subtype = ride->subtype;
 
     vehicle->vehicle_type = vehicleEntryIndex;
-    vehicle->type = static_cast<uint8_t>(carIndex == 0 ? Vehicle::Type::Head : Vehicle::Type::Tail);
+    vehicle->v_type = carIndex == 0 ? Vehicle::Type::Head : Vehicle::Type::Tail;
     vehicle->var_44 = ror32(vehicleEntry->spacing, 10) & 0xFFFF;
     auto edx = vehicleEntry->spacing >> 1;
     *remainingDistance -= edx;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4403,7 +4403,7 @@ static Vehicle* vehicle_create_car(
     vehicle->ride_subtype = ride->subtype;
 
     vehicle->vehicle_type = vehicleEntryIndex;
-    vehicle->v_type = carIndex == 0 ? Vehicle::Type::Head : Vehicle::Type::Tail;
+    vehicle->SubType = carIndex == 0 ? Vehicle::Type::Head : Vehicle::Type::Tail;
     vehicle->var_44 = ror32(vehicleEntry->spacing, 10) & 0xFFFF;
     auto edx = vehicleEntry->spacing >> 1;
     *remainingDistance -= edx;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7239,7 +7239,7 @@ static void steam_particle_create(const CoordsXYZ& coords)
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
         steam->sprite_identifier = SpriteIdentifier::Misc;
-        steam->misc_type = EnumValue(MiscEntityType::SteamParticle);
+        steam->misc_type = MiscEntityType::SteamParticle;
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7239,7 +7239,7 @@ static void steam_particle_create(const CoordsXYZ& coords)
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
         steam->sprite_identifier = SpriteIdentifier::Misc;
-        steam->type = EnumValue(MiscEntityType::SteamParticle);
+        steam->misc_type = EnumValue(MiscEntityType::SteamParticle);
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7239,7 +7239,7 @@ static void steam_particle_create(const CoordsXYZ& coords)
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
         steam->sprite_identifier = SpriteIdentifier::Misc;
-        steam->misc_type = MiscEntityType::SteamParticle;
+        steam->SubType = MiscEntityType::SteamParticle;
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -198,7 +198,7 @@ struct Vehicle : SpriteBase
         StoppedByBlockBrakes
     };
 
-    Type v_type;
+    Type SubType;
     uint8_t vehicle_sprite_type;
     uint8_t bank_rotation;
     int32_t remaining_distance;
@@ -313,7 +313,7 @@ struct Vehicle : SpriteBase
 
     constexpr bool IsHead() const
     {
-        return v_type == Vehicle::Type::Head;
+        return SubType == Vehicle::Type::Head;
     }
     void Update();
     Vehicle* GetHead();

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -198,6 +198,7 @@ struct Vehicle : SpriteBase
         StoppedByBlockBrakes
     };
 
+    Type v_type;
     uint8_t vehicle_sprite_type;
     uint8_t bank_rotation;
     int32_t remaining_distance;
@@ -312,7 +313,7 @@ struct Vehicle : SpriteBase
 
     constexpr bool IsHead() const
     {
-        return type == static_cast<uint8_t>(Vehicle::Type::Head);
+        return v_type == Vehicle::Type::Head;
     }
     void Update();
     Vehicle* GetHead();

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,7 +57,7 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (entity->As<SpriteGeneric>()->SubType)
+                        switch (entity->As<MiscEntity>()->SubType)
                         {
                             case MiscEntityType::SteamParticle:
                                 return "steam_particle";

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,7 +57,7 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (static_cast<MiscEntityType>(entity->As<SpriteGeneric>()->misc_type))
+                        switch (entity->As<SpriteGeneric>()->misc_type)
                         {
                             case MiscEntityType::SteamParticle:
                                 return "steam_particle";

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,7 +57,13 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (entity->As<MiscEntity>()->SubType)
+                    {
+                        auto misc = entity->As<MiscEntity>();
+                        if (misc == nullptr)
+                        {
+                            return "unknown";
+                        }
+                        switch (misc->SubType)
                         {
                             case MiscEntityType::SteamParticle:
                                 return "steam_particle";
@@ -82,7 +88,8 @@ namespace OpenRCT2::Scripting
                             default:
                                 break;
                         }
-                        break;
+                    }
+                    break;
                     case SpriteIdentifier::Litter:
                         return "litter";
                     case SpriteIdentifier::Null:

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,7 +57,7 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (static_cast<MiscEntityType>(entity->type))
+                        switch (static_cast<MiscEntityType>(entity->As<SpriteGeneric>()->misc_type))
                         {
                             case MiscEntityType::SteamParticle:
                                 return "steam_particle";

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -57,7 +57,7 @@ namespace OpenRCT2::Scripting
                     case SpriteIdentifier::Peep:
                         return "peep";
                     case SpriteIdentifier::Misc:
-                        switch (entity->As<SpriteGeneric>()->misc_type)
+                        switch (entity->As<SpriteGeneric>()->SubType)
                         {
                             case MiscEntityType::SteamParticle:
                                 return "steam_particle";

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -131,7 +131,7 @@ namespace OpenRCT2::Scripting
             for (auto sprite : EntityList(targetList))
             {
                 // Only the misc list checks the type property
-                if (targetList != EntityListId::Misc || sprite->type == targetType)
+                if (targetList != EntityListId::Misc || sprite->As<SpriteGeneric>()->misc_type == targetType)
                 {
                     if (targetList == EntityListId::Peep)
                     {

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -131,7 +131,7 @@ namespace OpenRCT2::Scripting
             for (auto sprite : EntityList(targetList))
             {
                 // Only the misc list checks the type property
-                if (targetList != EntityListId::Misc || sprite->As<SpriteGeneric>()->SubType == targetType)
+                if (targetList != EntityListId::Misc || sprite->As<MiscEntity>()->SubType == targetType)
                 {
                     if (targetList == EntityListId::Peep)
                     {

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -130,26 +130,26 @@ namespace OpenRCT2::Scripting
             std::vector<DukValue> result;
             for (auto sprite : EntityList(targetList))
             {
-                // Only the misc list checks the type property
-                if (targetList != EntityListId::Misc || sprite->As<MiscEntity>()->SubType == targetType)
+                if (targetList == EntityListId::Peep)
                 {
-                    if (targetList == EntityListId::Peep)
-                    {
-                        if (sprite->Is<Staff>())
-                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
-                        else
-                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
-                    }
-                    else if (targetList == EntityListId::TrainHead)
-                    {
-                        for (auto carId = sprite->sprite_index; carId != SPRITE_INDEX_NULL;)
-                        {
-                            auto car = GetEntity<Vehicle>(carId);
-                            result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(carId)));
-                            carId = car->next_vehicle_on_train;
-                        }
-                    }
+                    if (sprite->Is<Staff>())
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
                     else
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
+                }
+                else if (targetList == EntityListId::TrainHead)
+                {
+                    for (auto carId = sprite->sprite_index; carId != SPRITE_INDEX_NULL;)
+                    {
+                        auto car = GetEntity<Vehicle>(carId);
+                        result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(carId)));
+                        carId = car->next_vehicle_on_train;
+                    }
+                }
+                else if (targetList == EntityListId::Misc)
+                {
+                    auto* misc = sprite->As<MiscEntity>();
+                    if (misc && misc->SubType == targetType)
                     {
                         result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
                     }

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -99,11 +99,11 @@ namespace OpenRCT2::Scripting
         std::vector<DukValue> getAllEntities(const std::string& type) const
         {
             EntityListId targetList{};
-            uint8_t targetType{};
+            MiscEntityType targetType{};
             if (type == "balloon")
             {
                 targetList = EntityListId::Misc;
-                targetType = EnumValue(MiscEntityType::Balloon);
+                targetType = MiscEntityType::Balloon;
             }
             if (type == "car")
             {
@@ -116,7 +116,7 @@ namespace OpenRCT2::Scripting
             else if (type == "duck")
             {
                 targetList = EntityListId::Misc;
-                targetType = EnumValue(MiscEntityType::Duck);
+                targetType = MiscEntityType::Duck;
             }
             else if (type == "peep")
             {

--- a/src/openrct2/scripting/ScMap.hpp
+++ b/src/openrct2/scripting/ScMap.hpp
@@ -131,7 +131,7 @@ namespace OpenRCT2::Scripting
             for (auto sprite : EntityList(targetList))
             {
                 // Only the misc list checks the type property
-                if (targetList != EntityListId::Misc || sprite->As<SpriteGeneric>()->misc_type == targetType)
+                if (targetList != EntityListId::Misc || sprite->As<SpriteGeneric>()->SubType == targetType)
                 {
                     if (targetList == EntityListId::Peep)
                     {

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -85,9 +85,9 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     rct_sprite* sprite = create_sprite(SpriteIdentifier::Misc);
     if (sprite == nullptr)
         return;
-    sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.SubType = MiscEntityType::Balloon;
-    auto balloon = sprite->generic.As<Balloon>();
+    sprite->misc.sprite_identifier = SpriteIdentifier::Misc;
+    sprite->misc.SubType = MiscEntityType::Balloon;
+    auto balloon = sprite->misc.As<Balloon>();
     if (balloon == nullptr)
         return; // can never happen
 

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -16,7 +16,8 @@
 
 template<> bool SpriteBase::Is<Balloon>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::Balloon;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::Balloon;
 }
 
 void Balloon::Update()
@@ -85,7 +86,7 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (sprite == nullptr)
         return;
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.type = EnumValue(MiscEntityType::Balloon);
+    sprite->generic.misc_type = EnumValue(MiscEntityType::Balloon);
     auto balloon = sprite->generic.As<Balloon>();
     if (balloon == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -16,7 +16,7 @@
 
 template<> bool SpriteBase::Is<Balloon>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::Balloon;
 }
 

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -17,7 +17,7 @@
 template<> bool SpriteBase::Is<Balloon>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::Balloon;
+    return misc && misc->SubType == MiscEntityType::Balloon;
 }
 
 void Balloon::Update()
@@ -86,7 +86,7 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (sprite == nullptr)
         return;
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.misc_type = MiscEntityType::Balloon;
+    sprite->generic.SubType = MiscEntityType::Balloon;
     auto balloon = sprite->generic.As<Balloon>();
     if (balloon == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -17,7 +17,7 @@
 template<> bool SpriteBase::Is<Balloon>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::Balloon;
+    return misc && misc->misc_type == MiscEntityType::Balloon;
 }
 
 void Balloon::Update()
@@ -86,7 +86,7 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (sprite == nullptr)
         return;
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.misc_type = EnumValue(MiscEntityType::Balloon);
+    sprite->generic.misc_type = MiscEntityType::Balloon;
     auto balloon = sprite->generic.As<Balloon>();
     if (balloon == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -68,7 +68,7 @@ static constexpr const uint8_t * DuckAnimations[] =
 
 template<> bool SpriteBase::Is<Duck>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::Duck;
 }
 

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -68,7 +68,8 @@ static constexpr const uint8_t * DuckAnimations[] =
 
 template<> bool SpriteBase::Is<Duck>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::Duck;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::Duck;
 }
 
 bool Duck::IsFlying()
@@ -291,7 +292,7 @@ void create_duck(const CoordsXY& pos)
     targetPos.y += offsetXY;
 
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.type = EnumValue(MiscEntityType::Duck);
+    sprite->generic.misc_type = EnumValue(MiscEntityType::Duck);
     auto duck = sprite->generic.As<Duck>();
     if (duck == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -69,7 +69,7 @@ static constexpr const uint8_t * DuckAnimations[] =
 template<> bool SpriteBase::Is<Duck>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::Duck;
+    return misc && misc->misc_type == MiscEntityType::Duck;
 }
 
 bool Duck::IsFlying()
@@ -292,7 +292,7 @@ void create_duck(const CoordsXY& pos)
     targetPos.y += offsetXY;
 
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.misc_type = EnumValue(MiscEntityType::Duck);
+    sprite->generic.misc_type = MiscEntityType::Duck;
     auto duck = sprite->generic.As<Duck>();
     if (duck == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -69,7 +69,7 @@ static constexpr const uint8_t * DuckAnimations[] =
 template<> bool SpriteBase::Is<Duck>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::Duck;
+    return misc && misc->SubType == MiscEntityType::Duck;
 }
 
 bool Duck::IsFlying()
@@ -292,7 +292,7 @@ void create_duck(const CoordsXY& pos)
     targetPos.y += offsetXY;
 
     sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.misc_type = MiscEntityType::Duck;
+    sprite->generic.SubType = MiscEntityType::Duck;
     auto duck = sprite->generic.As<Duck>();
     if (duck == nullptr)
         return; // can never happen

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -291,9 +291,9 @@ void create_duck(const CoordsXY& pos)
     targetPos.x += offsetXY;
     targetPos.y += offsetXY;
 
-    sprite->generic.sprite_identifier = SpriteIdentifier::Misc;
-    sprite->generic.SubType = MiscEntityType::Duck;
-    auto duck = sprite->generic.As<Duck>();
+    sprite->misc.sprite_identifier = SpriteIdentifier::Misc;
+    sprite->misc.SubType = MiscEntityType::Duck;
+    auto duck = sprite->misc.As<Duck>();
     if (duck == nullptr)
         return; // can never happen
     duck->sprite_width = 9;

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -74,7 +74,7 @@ template<> bool SpriteBase::Is<JumpingFountain>() const
 {
     auto* misc = As<SpriteGeneric>();
     return misc
-        && (misc->misc_type == MiscEntityType::JumpingFountainSnow || misc->misc_type == MiscEntityType::JumpingFountainWater);
+        && (misc->SubType == MiscEntityType::JumpingFountainSnow || misc->SubType == MiscEntityType::JumpingFountainWater);
 }
 
 void JumpingFountain::StartAnimation(const int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement)
@@ -140,7 +140,7 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->sprite_identifier = SpriteIdentifier::Misc;
         jumpingFountain->MoveTo(newLoc);
-        jumpingFountain->misc_type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? MiscEntityType::JumpingFountainSnow
+        jumpingFountain->SubType = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? MiscEntityType::JumpingFountainSnow
                                                                            : MiscEntityType::JumpingFountainWater;
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
@@ -162,7 +162,7 @@ void JumpingFountain::Update()
     Invalidate();
     frame++;
 
-    switch (misc_type)
+    switch (SubType)
     {
         case MiscEntityType::JumpingFountainWater:
             if (frame == 11 && (FountainFlags & FOUNTAIN_FLAG::FAST))
@@ -192,7 +192,7 @@ void JumpingFountain::Update()
 
 int32_t JumpingFountain::GetType() const
 {
-    const int32_t fountainType = misc_type == MiscEntityType::JumpingFountainSnow ? JUMPING_FOUNTAIN_TYPE_SNOW
+    const int32_t fountainType = SubType == MiscEntityType::JumpingFountainSnow ? JUMPING_FOUNTAIN_TYPE_SNOW
                                                                                   : JUMPING_FOUNTAIN_TYPE_WATER;
     return fountainType;
 }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -74,8 +74,7 @@ template<> bool SpriteBase::Is<JumpingFountain>() const
 {
     auto* misc = As<SpriteGeneric>();
     return misc
-        && (static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::JumpingFountainSnow
-            || static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::JumpingFountainWater);
+        && (misc->misc_type == MiscEntityType::JumpingFountainSnow || misc->misc_type == MiscEntityType::JumpingFountainWater);
 }
 
 void JumpingFountain::StartAnimation(const int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement)
@@ -141,8 +140,8 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->sprite_identifier = SpriteIdentifier::Misc;
         jumpingFountain->MoveTo(newLoc);
-        jumpingFountain->misc_type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? EnumValue(MiscEntityType::JumpingFountainSnow)
-                                                                      : EnumValue(MiscEntityType::JumpingFountainWater);
+        jumpingFountain->misc_type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? MiscEntityType::JumpingFountainSnow
+                                                                           : MiscEntityType::JumpingFountainWater;
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
     }
@@ -163,7 +162,7 @@ void JumpingFountain::Update()
     Invalidate();
     frame++;
 
-    switch (static_cast<MiscEntityType>(misc_type))
+    switch (misc_type)
     {
         case MiscEntityType::JumpingFountainWater:
             if (frame == 11 && (FountainFlags & FOUNTAIN_FLAG::FAST))
@@ -193,9 +192,8 @@ void JumpingFountain::Update()
 
 int32_t JumpingFountain::GetType() const
 {
-    const int32_t fountainType = static_cast<MiscEntityType>(misc_type) == MiscEntityType::JumpingFountainSnow
-        ? JUMPING_FOUNTAIN_TYPE_SNOW
-        : JUMPING_FOUNTAIN_TYPE_WATER;
+    const int32_t fountainType = misc_type == MiscEntityType::JumpingFountainSnow ? JUMPING_FOUNTAIN_TYPE_SNOW
+                                                                                  : JUMPING_FOUNTAIN_TYPE_WATER;
     return fountainType;
 }
 

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -72,7 +72,7 @@ const uint8_t _fountainPatternFlags[] = {
 
 template<> bool SpriteBase::Is<JumpingFountain>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc
         && (misc->SubType == MiscEntityType::JumpingFountainSnow || misc->SubType == MiscEntityType::JumpingFountainWater);
 }

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -141,7 +141,7 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_identifier = SpriteIdentifier::Misc;
         jumpingFountain->MoveTo(newLoc);
         jumpingFountain->SubType = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? MiscEntityType::JumpingFountainSnow
-                                                                           : MiscEntityType::JumpingFountainWater;
+                                                                         : MiscEntityType::JumpingFountainWater;
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
     }
@@ -193,7 +193,7 @@ void JumpingFountain::Update()
 int32_t JumpingFountain::GetType() const
 {
     const int32_t fountainType = SubType == MiscEntityType::JumpingFountainSnow ? JUMPING_FOUNTAIN_TYPE_SNOW
-                                                                                  : JUMPING_FOUNTAIN_TYPE_WATER;
+                                                                                : JUMPING_FOUNTAIN_TYPE_WATER;
     return fountainType;
 }
 

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -72,9 +72,10 @@ const uint8_t _fountainPatternFlags[] = {
 
 template<> bool SpriteBase::Is<JumpingFountain>() const
 {
-    const auto miscType = static_cast<MiscEntityType>(type);
-    return sprite_identifier == SpriteIdentifier::Misc
-        && (miscType == MiscEntityType::JumpingFountainSnow || miscType == MiscEntityType::JumpingFountainWater);
+    auto* misc = As<SpriteGeneric>();
+    return misc
+        && (static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::JumpingFountainSnow
+            || static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::JumpingFountainWater);
 }
 
 void JumpingFountain::StartAnimation(const int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement)
@@ -140,7 +141,7 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->sprite_identifier = SpriteIdentifier::Misc;
         jumpingFountain->MoveTo(newLoc);
-        jumpingFountain->type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? EnumValue(MiscEntityType::JumpingFountainSnow)
+        jumpingFountain->misc_type = newType == JUMPING_FOUNTAIN_TYPE_SNOW ? EnumValue(MiscEntityType::JumpingFountainSnow)
                                                                       : EnumValue(MiscEntityType::JumpingFountainWater);
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
@@ -162,7 +163,7 @@ void JumpingFountain::Update()
     Invalidate();
     frame++;
 
-    switch (static_cast<MiscEntityType>(type))
+    switch (static_cast<MiscEntityType>(misc_type))
     {
         case MiscEntityType::JumpingFountainWater:
             if (frame == 11 && (FountainFlags & FOUNTAIN_FLAG::FAST))
@@ -192,7 +193,7 @@ void JumpingFountain::Update()
 
 int32_t JumpingFountain::GetType() const
 {
-    const int32_t fountainType = static_cast<MiscEntityType>(type) == MiscEntityType::JumpingFountainSnow
+    const int32_t fountainType = static_cast<MiscEntityType>(misc_type) == MiscEntityType::JumpingFountainSnow
         ? JUMPING_FOUNTAIN_TYPE_SNOW
         : JUMPING_FOUNTAIN_TYPE_WATER;
     return fountainType;

--- a/src/openrct2/world/Fountain.h
+++ b/src/openrct2/world/Fountain.h
@@ -13,7 +13,7 @@
 #include "Map.h"
 #include "SpriteBase.h"
 
-struct JumpingFountain : SpriteGeneric
+struct JumpingFountain : MiscEntity
 {
     uint8_t NumTicksAlive;
     uint8_t FountainFlags;

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -21,7 +21,7 @@ static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }
 template<> bool SpriteBase::Is<MoneyEffect>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::MoneyEffect;
+    return misc && misc->misc_type == MiscEntityType::MoneyEffect;
 }
 
 /**
@@ -44,7 +44,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SpriteIdentifier::Misc;
     moneyEffect->MoveTo(effectPos);
-    moneyEffect->misc_type = EnumValue(MiscEntityType::MoneyEffect);
+    moneyEffect->misc_type = MiscEntityType::MoneyEffect;
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;
 

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -21,7 +21,7 @@ static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }
 template<> bool SpriteBase::Is<MoneyEffect>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::MoneyEffect;
+    return misc && misc->SubType == MiscEntityType::MoneyEffect;
 }
 
 /**
@@ -44,7 +44,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SpriteIdentifier::Misc;
     moneyEffect->MoveTo(effectPos);
-    moneyEffect->misc_type = MiscEntityType::MoneyEffect;
+    moneyEffect->SubType = MiscEntityType::MoneyEffect;
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;
 

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -20,7 +20,7 @@ static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }
 
 template<> bool SpriteBase::Is<MoneyEffect>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::MoneyEffect;
 }
 

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -20,7 +20,8 @@ static constexpr const CoordsXY _moneyEffectMoveOffset[] = { { 1, -1 }, { 1, 1 }
 
 template<> bool SpriteBase::Is<MoneyEffect>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::MoneyEffect;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::MoneyEffect;
 }
 
 /**
@@ -43,7 +44,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->sprite_identifier = SpriteIdentifier::Misc;
     moneyEffect->MoveTo(effectPos);
-    moneyEffect->type = EnumValue(MiscEntityType::MoneyEffect);
+    moneyEffect->misc_type = EnumValue(MiscEntityType::MoneyEffect);
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;
 

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -17,13 +17,13 @@
 template<> bool SpriteBase::Is<VehicleCrashParticle>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::CrashedVehicleParticle;
+    return misc && misc->SubType == MiscEntityType::CrashedVehicleParticle;
 }
 
 template<> bool SpriteBase::Is<CrashSplashParticle>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::CrashSplash;
+    return misc && misc->SubType == MiscEntityType::CrashSplash;
 }
 /**
  *
@@ -41,7 +41,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(vehiclePos);
-        sprite->misc_type = MiscEntityType::CrashedVehicleParticle;
+        sprite->SubType = MiscEntityType::CrashedVehicleParticle;
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -130,7 +130,7 @@ void crash_splash_create(const CoordsXYZ& splashPos)
         sprite->sprite_height_positive = 16;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
-        sprite->misc_type = MiscEntityType::CrashSplash;
+        sprite->SubType = MiscEntityType::CrashSplash;
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -16,13 +16,13 @@
 
 template<> bool SpriteBase::Is<VehicleCrashParticle>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::CrashedVehicleParticle;
 }
 
 template<> bool SpriteBase::Is<CrashSplashParticle>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::CrashSplash;
 }
 /**
@@ -122,7 +122,7 @@ void VehicleCrashParticle::Update()
  */
 void crash_splash_create(const CoordsXYZ& splashPos)
 {
-    SpriteGeneric* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
+    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
     if (sprite != nullptr)
     {
         sprite->sprite_width = 33;

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -17,13 +17,13 @@
 template<> bool SpriteBase::Is<VehicleCrashParticle>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::CrashedVehicleParticle;
+    return misc && misc->misc_type == MiscEntityType::CrashedVehicleParticle;
 }
 
 template<> bool SpriteBase::Is<CrashSplashParticle>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::CrashSplash;
+    return misc && misc->misc_type == MiscEntityType::CrashSplash;
 }
 /**
  *
@@ -41,7 +41,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(vehiclePos);
-        sprite->misc_type = EnumValue(MiscEntityType::CrashedVehicleParticle);
+        sprite->misc_type = MiscEntityType::CrashedVehicleParticle;
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -130,7 +130,7 @@ void crash_splash_create(const CoordsXYZ& splashPos)
         sprite->sprite_height_positive = 16;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
-        sprite->misc_type = EnumValue(MiscEntityType::CrashSplash);
+        sprite->misc_type = MiscEntityType::CrashSplash;
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -16,13 +16,14 @@
 
 template<> bool SpriteBase::Is<VehicleCrashParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc
-        && static_cast<MiscEntityType>(type) == MiscEntityType::CrashedVehicleParticle;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::CrashedVehicleParticle;
 }
 
 template<> bool SpriteBase::Is<CrashSplashParticle>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::CrashSplash;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::CrashSplash;
 }
 /**
  *
@@ -40,7 +41,7 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(vehiclePos);
-        sprite->type = EnumValue(MiscEntityType::CrashedVehicleParticle);
+        sprite->misc_type = EnumValue(MiscEntityType::CrashedVehicleParticle);
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -129,7 +130,7 @@ void crash_splash_create(const CoordsXYZ& splashPos)
         sprite->sprite_height_positive = 16;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
-        sprite->type = EnumValue(MiscEntityType::CrashSplash);
+        sprite->misc_type = EnumValue(MiscEntityType::CrashSplash);
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -122,7 +122,7 @@ void VehicleCrashParticle::Update()
  */
 void crash_splash_create(const CoordsXYZ& splashPos)
 {
-    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
+    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->misc;
     if (sprite != nullptr)
     {
         sprite->sprite_width = 33;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -60,19 +60,27 @@ template<> bool SpriteBase::Is<Litter>() const
     return sprite_identifier == SpriteIdentifier::Litter;
 }
 
-template<> bool SpriteBase::Is<SteamParticle>() const
+template<> bool SpriteBase::Is<SpriteGeneric>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::SteamParticle;
+    return sprite_identifier == SpriteIdentifier::Misc;
+}
+
+template<> bool SpriteBase::Is<SteamParticle>() const
+    {
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::SteamParticle;
 }
 
 template<> bool SpriteBase::Is<ExplosionFlare>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::ExplosionFlare;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::ExplosionFlare;
 }
 
 template<> bool SpriteBase::Is<ExplosionCloud>() const
 {
-    return sprite_identifier == SpriteIdentifier::Misc && static_cast<MiscEntityType>(type) == MiscEntityType::ExplosionCloud;
+    auto* misc = As<SpriteGeneric>();
+    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::ExplosionCloud;
 }
 
 uint16_t GetEntityListCount(EntityListId list)
@@ -128,7 +136,7 @@ void SpriteBase::Invalidate()
             maxZoom = 2;
             break;
         case SpriteIdentifier::Misc:
-            switch (static_cast<MiscEntityType>(type))
+            switch (static_cast<MiscEntityType>(reinterpret_cast<SpriteGeneric*>(this)->misc_type))
             {
                 case MiscEntityType::CrashedVehicleParticle:
                 case MiscEntityType::JumpingFountainWater:
@@ -556,7 +564,7 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
         sprite->sprite_height_positive = 34;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
-        sprite->type = EnumValue(MiscEntityType::ExplosionCloud);
+        sprite->misc_type = EnumValue(MiscEntityType::ExplosionCloud);
         sprite->frame = 0;
     }
 }
@@ -589,7 +597,7 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
-        sprite->type = EnumValue(MiscEntityType::ExplosionFlare);
+        sprite->misc_type = EnumValue(MiscEntityType::ExplosionFlare);
         sprite->frame = 0;
     }
 }
@@ -612,9 +620,9 @@ void ExplosionFlare::Update()
  *
  *  rct2: 0x006731CD
  */
-static void sprite_misc_update(SpriteBase* sprite)
+static void sprite_misc_update(SpriteGeneric* sprite)
 {
-    switch (static_cast<MiscEntityType>(sprite->type))
+    switch (static_cast<MiscEntityType>(sprite->misc_type))
     {
         case MiscEntityType::SteamParticle:
             sprite->As<SteamParticle>()->Update();
@@ -655,7 +663,7 @@ static void sprite_misc_update(SpriteBase* sprite)
  */
 void sprite_misc_update_all()
 {
-    for (auto entity : EntityList(EntityListId::Misc))
+    for (auto entity : EntityList<SpriteGeneric>(EntityListId::Misc))
     {
         sprite_misc_update(entity);
     }
@@ -857,7 +865,7 @@ void litter_create(const CoordsXYZD& litterPos, int32_t type)
     litter->sprite_height_negative = 6;
     litter->sprite_height_positive = 3;
     litter->sprite_identifier = SpriteIdentifier::Litter;
-    litter->type = type;
+    litter->l_type = type;
     litter->MoveTo(offsetLitterPos);
     litter->creationTick = gScenarioTicks;
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -68,19 +68,19 @@ template<> bool SpriteBase::Is<SpriteGeneric>() const
 template<> bool SpriteBase::Is<SteamParticle>() const
     {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::SteamParticle;
+    return misc && misc->SubType == MiscEntityType::SteamParticle;
 }
 
 template<> bool SpriteBase::Is<ExplosionFlare>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::ExplosionFlare;
+    return misc && misc->SubType == MiscEntityType::ExplosionFlare;
 }
 
 template<> bool SpriteBase::Is<ExplosionCloud>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && misc->misc_type == MiscEntityType::ExplosionCloud;
+    return misc && misc->SubType == MiscEntityType::ExplosionCloud;
 }
 
 uint16_t GetEntityListCount(EntityListId list)
@@ -136,7 +136,7 @@ void SpriteBase::Invalidate()
             maxZoom = 2;
             break;
         case SpriteIdentifier::Misc:
-            switch (this->As<SpriteGeneric>()->misc_type)
+            switch (this->As<SpriteGeneric>()->SubType)
             {
                 case MiscEntityType::CrashedVehicleParticle:
                 case MiscEntityType::JumpingFountainWater:
@@ -564,7 +564,7 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
         sprite->sprite_height_positive = 34;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
-        sprite->misc_type = MiscEntityType::ExplosionCloud;
+        sprite->SubType = MiscEntityType::ExplosionCloud;
         sprite->frame = 0;
     }
 }
@@ -597,7 +597,7 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
-        sprite->misc_type = MiscEntityType::ExplosionFlare;
+        sprite->SubType = MiscEntityType::ExplosionFlare;
         sprite->frame = 0;
     }
 }
@@ -622,7 +622,7 @@ void ExplosionFlare::Update()
  */
 static void sprite_misc_update(SpriteGeneric* sprite)
 {
-    switch (sprite->misc_type)
+    switch (sprite->SubType)
     {
         case MiscEntityType::SteamParticle:
             sprite->As<SteamParticle>()->Update();
@@ -865,7 +865,7 @@ void litter_create(const CoordsXYZD& litterPos, LitterType type)
     litter->sprite_height_negative = 6;
     litter->sprite_height_positive = 3;
     litter->sprite_identifier = SpriteIdentifier::Litter;
-    litter->l_type = type;
+    litter->SubType = type;
     litter->MoveTo(offsetLitterPos);
     litter->creationTick = gScenarioTicks;
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -136,7 +136,13 @@ void SpriteBase::Invalidate()
             maxZoom = 2;
             break;
         case SpriteIdentifier::Misc:
-            switch (this->As<MiscEntity>()->SubType)
+        {
+            auto* misc = As<MiscEntity>();
+            if (misc == nullptr)
+            {
+                return;
+            }
+            switch (misc->SubType)
             {
                 case MiscEntityType::CrashedVehicleParticle:
                 case MiscEntityType::JumpingFountainWater:
@@ -157,7 +163,8 @@ void SpriteBase::Invalidate()
                 default:
                     break;
             }
-            break;
+        }
+        break;
         case SpriteIdentifier::Litter:
             maxZoom = 0;
             break;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -68,19 +68,19 @@ template<> bool SpriteBase::Is<SpriteGeneric>() const
 template<> bool SpriteBase::Is<SteamParticle>() const
     {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::SteamParticle;
+    return misc && misc->misc_type == MiscEntityType::SteamParticle;
 }
 
 template<> bool SpriteBase::Is<ExplosionFlare>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::ExplosionFlare;
+    return misc && misc->misc_type == MiscEntityType::ExplosionFlare;
 }
 
 template<> bool SpriteBase::Is<ExplosionCloud>() const
 {
     auto* misc = As<SpriteGeneric>();
-    return misc && static_cast<MiscEntityType>(misc->misc_type) == MiscEntityType::ExplosionCloud;
+    return misc && misc->misc_type == MiscEntityType::ExplosionCloud;
 }
 
 uint16_t GetEntityListCount(EntityListId list)
@@ -136,7 +136,7 @@ void SpriteBase::Invalidate()
             maxZoom = 2;
             break;
         case SpriteIdentifier::Misc:
-            switch (static_cast<MiscEntityType>(reinterpret_cast<SpriteGeneric*>(this)->misc_type))
+            switch (this->As<SpriteGeneric>()->misc_type)
             {
                 case MiscEntityType::CrashedVehicleParticle:
                 case MiscEntityType::JumpingFountainWater:
@@ -564,7 +564,7 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
         sprite->sprite_height_positive = 34;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
-        sprite->misc_type = EnumValue(MiscEntityType::ExplosionCloud);
+        sprite->misc_type = MiscEntityType::ExplosionCloud;
         sprite->frame = 0;
     }
 }
@@ -597,7 +597,7 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
         sprite->sprite_height_positive = 8;
         sprite->sprite_identifier = SpriteIdentifier::Misc;
         sprite->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
-        sprite->misc_type = EnumValue(MiscEntityType::ExplosionFlare);
+        sprite->misc_type = MiscEntityType::ExplosionFlare;
         sprite->frame = 0;
     }
 }
@@ -622,7 +622,7 @@ void ExplosionFlare::Update()
  */
 static void sprite_misc_update(SpriteGeneric* sprite)
 {
-    switch (static_cast<MiscEntityType>(sprite->misc_type))
+    switch (sprite->misc_type)
     {
         case MiscEntityType::SteamParticle:
             sprite->As<SteamParticle>()->Update();

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -60,26 +60,26 @@ template<> bool SpriteBase::Is<Litter>() const
     return sprite_identifier == SpriteIdentifier::Litter;
 }
 
-template<> bool SpriteBase::Is<SpriteGeneric>() const
+template<> bool SpriteBase::Is<MiscEntity>() const
 {
     return sprite_identifier == SpriteIdentifier::Misc;
 }
 
 template<> bool SpriteBase::Is<SteamParticle>() const
     {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::SteamParticle;
 }
 
 template<> bool SpriteBase::Is<ExplosionFlare>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::ExplosionFlare;
 }
 
 template<> bool SpriteBase::Is<ExplosionCloud>() const
 {
-    auto* misc = As<SpriteGeneric>();
+    auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::ExplosionCloud;
 }
 
@@ -136,7 +136,7 @@ void SpriteBase::Invalidate()
             maxZoom = 2;
             break;
         case SpriteIdentifier::Misc:
-            switch (this->As<SpriteGeneric>()->SubType)
+            switch (this->As<MiscEntity>()->SubType)
             {
                 case MiscEntityType::CrashedVehicleParticle:
                 case MiscEntityType::JumpingFountainWater:
@@ -556,7 +556,7 @@ void SteamParticle::Update()
  */
 void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
 {
-    SpriteGeneric* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
+    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
     if (sprite != nullptr)
     {
         sprite->sprite_width = 44;
@@ -589,7 +589,7 @@ void ExplosionCloud::Update()
  */
 void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
 {
-    SpriteGeneric* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
+    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
     if (sprite != nullptr)
     {
         sprite->sprite_width = 25;
@@ -620,7 +620,7 @@ void ExplosionFlare::Update()
  *
  *  rct2: 0x006731CD
  */
-static void sprite_misc_update(SpriteGeneric* sprite)
+static void sprite_misc_update(MiscEntity* sprite)
 {
     switch (sprite->SubType)
     {
@@ -663,7 +663,7 @@ static void sprite_misc_update(SpriteGeneric* sprite)
  */
 void sprite_misc_update_all()
 {
-    for (auto entity : EntityList<SpriteGeneric>(EntityListId::Misc))
+    for (auto entity : EntityList<MiscEntity>(EntityListId::Misc))
     {
         sprite_misc_update(entity);
     }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -66,7 +66,7 @@ template<> bool SpriteBase::Is<MiscEntity>() const
 }
 
 template<> bool SpriteBase::Is<SteamParticle>() const
-    {
+{
     auto* misc = As<MiscEntity>();
     return misc && misc->SubType == MiscEntityType::SteamParticle;
 }
@@ -105,7 +105,7 @@ std::string rct_sprite_checksum::ToString() const
 
 SpriteBase* try_get_sprite(size_t spriteIndex)
 {
-    return spriteIndex >= MAX_SPRITES ? nullptr : &_spriteList[spriteIndex].generic;
+    return spriteIndex >= MAX_SPRITES ? nullptr : &_spriteList[spriteIndex].misc;
 }
 
 SpriteBase* get_sprite(size_t spriteIndex)
@@ -291,19 +291,19 @@ rct_sprite_checksum sprite_checksum()
                 auto copy = *reinterpret_cast<rct_sprite*>(sprite);
 
                 // Only required for rendering/invalidation, has no meaning to the game state.
-                copy.generic.sprite_left = copy.generic.sprite_right = copy.generic.sprite_top = copy.generic.sprite_bottom = 0;
-                copy.generic.sprite_width = copy.generic.sprite_height_negative = copy.generic.sprite_height_positive = 0;
+                copy.misc.sprite_left = copy.misc.sprite_right = copy.misc.sprite_top = copy.misc.sprite_bottom = 0;
+                copy.misc.sprite_width = copy.misc.sprite_height_negative = copy.misc.sprite_height_positive = 0;
 
                 // Next in quadrant might be a misc sprite, set first non-misc sprite in quadrant.
-                while (auto* nextSprite = GetEntity(copy.generic.next_in_quadrant))
+                while (auto* nextSprite = GetEntity(copy.misc.next_in_quadrant))
                 {
                     if (nextSprite->sprite_identifier == SpriteIdentifier::Misc)
-                        copy.generic.next_in_quadrant = nextSprite->next_in_quadrant;
+                        copy.misc.next_in_quadrant = nextSprite->next_in_quadrant;
                     else
                         break;
                 }
 
-                if (copy.generic.Is<Peep>())
+                if (copy.misc.Is<Peep>())
                 {
                     // Name is pointer and will not be the same across clients
                     copy.peep.Name = {};
@@ -556,7 +556,7 @@ void SteamParticle::Update()
  */
 void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
 {
-    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
+    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->misc;
     if (sprite != nullptr)
     {
         sprite->sprite_width = 44;
@@ -589,7 +589,7 @@ void ExplosionCloud::Update()
  */
 void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
 {
-    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->generic;
+    MiscEntity* sprite = &create_sprite(SpriteIdentifier::Misc)->misc;
     if (sprite != nullptr)
     {
         sprite->sprite_width = 25;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -824,7 +824,7 @@ static bool litter_can_be_at(const CoordsXYZ& mapPos)
  *
  *  rct2: 0x0067375D
  */
-void litter_create(const CoordsXYZD& litterPos, int32_t type)
+void litter_create(const CoordsXYZD& litterPos, LitterType type)
 {
     if (gCheatsDisableLittering)
         return;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -39,9 +39,11 @@ enum class EntityListId : uint8_t
     Count,
 };
 
+enum LitterType : uint8_t;
+
 struct Litter : SpriteBase
 {
-    uint8_t l_type;
+    LitterType l_type;
     uint32_t creationTick;
 };
 
@@ -193,7 +195,7 @@ enum
     SPRITE_FLAGS_PEEP_FLASHING = 1 << 9, // Deprecated: Use sprite_set_flashing/sprite_get_flashing instead.
 };
 
-enum
+enum LitterType : uint8_t
 {
     LITTER_TYPE_SICK,
     LITTER_TYPE_SICK_ALT,
@@ -241,7 +243,7 @@ void sprite_clear_all_unused();
 void sprite_misc_update_all();
 void sprite_set_coordinates(const CoordsXYZ& spritePos, SpriteBase* sprite);
 void sprite_remove(SpriteBase* sprite);
-void litter_create(const CoordsXYZD& litterPos, int32_t type);
+void litter_create(const CoordsXYZD& litterPos, LitterType type);
 void litter_remove_at(const CoordsXYZ& litterPos);
 uint16_t remove_floating_sprites();
 void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos);

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -145,7 +145,7 @@ struct SteamParticle : MiscEntity
 union rct_sprite
 {
     uint8_t pad_00[0x200];
-    MiscEntity generic;
+    MiscEntity misc;
     Peep peep;
     Litter litter;
     Vehicle vehicle;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -41,6 +41,7 @@ enum class EntityListId : uint8_t
 
 struct Litter : SpriteBase
 {
+    uint8_t l_type;
     uint32_t creationTick;
 };
 
@@ -82,7 +83,7 @@ private:
     void UpdateFlyAway();
 };
 
-struct MoneyEffect : SpriteBase
+struct MoneyEffect : SpriteGeneric
 {
     uint16_t MoveDelay;
     uint8_t NumMovements;

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -43,7 +43,7 @@ enum LitterType : uint8_t;
 
 struct Litter : SpriteBase
 {
-    LitterType l_type;
+    LitterType SubType;
     uint32_t creationTick;
 };
 

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -47,7 +47,7 @@ struct Litter : SpriteBase
     uint32_t creationTick;
 };
 
-struct Balloon : SpriteGeneric
+struct Balloon : MiscEntity
 {
     uint16_t popped;
     uint8_t time_to_move;
@@ -58,7 +58,7 @@ struct Balloon : SpriteGeneric
     void Press();
 };
 
-struct Duck : SpriteGeneric
+struct Duck : MiscEntity
 {
     enum class DuckState : uint8_t
     {
@@ -85,7 +85,7 @@ private:
     void UpdateFlyAway();
 };
 
-struct MoneyEffect : SpriteGeneric
+struct MoneyEffect : MiscEntity
 {
     uint16_t MoveDelay;
     uint8_t NumMovements;
@@ -100,7 +100,7 @@ struct MoneyEffect : SpriteGeneric
     std::pair<rct_string_id, money32> GetStringId() const;
 };
 
-struct VehicleCrashParticle : SpriteGeneric
+struct VehicleCrashParticle : MiscEntity
 {
     uint16_t time_to_live;
     uint8_t colour[2];
@@ -115,22 +115,22 @@ struct VehicleCrashParticle : SpriteGeneric
     void Update();
 };
 
-struct ExplosionFlare : SpriteGeneric
+struct ExplosionFlare : MiscEntity
 {
     void Update();
 };
 
-struct ExplosionCloud : SpriteGeneric
+struct ExplosionCloud : MiscEntity
 {
     void Update();
 };
 
-struct CrashSplashParticle : SpriteGeneric
+struct CrashSplashParticle : MiscEntity
 {
     void Update();
 };
 
-struct SteamParticle : SpriteGeneric
+struct SteamParticle : MiscEntity
 {
     uint16_t time_to_move;
 
@@ -145,7 +145,7 @@ struct SteamParticle : SpriteGeneric
 union rct_sprite
 {
     uint8_t pad_00[0x200];
-    SpriteGeneric generic;
+    MiscEntity generic;
     Peep peep;
     Litter litter;
     Vehicle vehicle;

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -49,6 +49,6 @@ struct SpriteBase
 enum class MiscEntityType : uint8_t;
 struct SpriteGeneric : SpriteBase
 {
-    MiscEntityType misc_type;
+    MiscEntityType SubType;
     uint16_t frame;
 };

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -47,7 +47,7 @@ struct SpriteBase
 };
 
 enum class MiscEntityType : uint8_t;
-struct SpriteGeneric : SpriteBase
+struct MiscEntity : SpriteBase
 {
     MiscEntityType SubType;
     uint16_t frame;

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -46,8 +46,9 @@ struct SpriteBase
     }
 };
 
+enum class MiscEntityType : uint8_t;
 struct SpriteGeneric : SpriteBase
 {
-    uint8_t misc_type;
+    MiscEntityType misc_type;
     uint16_t frame;
 };

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -9,7 +9,6 @@ enum class SpriteIdentifier : uint8_t;
 struct SpriteBase
 {
     SpriteIdentifier sprite_identifier;
-    uint8_t type;
     uint16_t next_in_quadrant;
     uint16_t next;
     uint16_t previous;
@@ -49,5 +48,6 @@ struct SpriteBase
 
 struct SpriteGeneric : SpriteBase
 {
+    uint8_t misc_type;
     uint16_t frame;
 };

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -421,7 +421,7 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
                 break;
             case SpriteIdentifier::Misc:
                 COMPARE_FIELD(generic.misc_type);
-                switch (static_cast<MiscEntityType>(left.generic.misc_type))
+                switch (left.generic.misc_type)
                 {
                     case MiscEntityType::SteamParticle:
                         CompareSpriteDataSteamParticle(left.steam_particle, right.steam_particle);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -270,7 +270,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
 
 static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)
 {
-    COMPARE_FIELD(v_type);
+    COMPARE_FIELD(SubType);
     COMPARE_FIELD(vehicle_sprite_type);
     COMPARE_FIELD(bank_rotation);
     COMPARE_FIELD(remaining_distance);
@@ -345,7 +345,7 @@ static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)
 
 static void CompareSpriteDataLitter(const Litter& left, const Litter& right)
 {
-    COMPARE_FIELD(l_type);
+    COMPARE_FIELD(SubType);
     COMPARE_FIELD(creationTick);
 }
 
@@ -420,8 +420,8 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
                 CompareSpriteDataLitter(left.litter, right.litter);
                 break;
             case SpriteIdentifier::Misc:
-                COMPARE_FIELD(generic.misc_type);
-                switch (left.generic.misc_type)
+                COMPARE_FIELD(generic.SubType);
+                switch (left.generic.SubType)
                 {
                     case MiscEntityType::SteamParticle:
                         CompareSpriteDataSteamParticle(left.steam_particle, right.steam_particle);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -131,7 +131,6 @@ static void AdvanceGameTicks(uint32_t ticks, std::unique_ptr<IContext>& context)
 static void CompareSpriteDataCommon(const SpriteBase& left, const SpriteBase& right)
 {
     COMPARE_FIELD(sprite_identifier);
-    COMPARE_FIELD(type);
     COMPARE_FIELD(next_in_quadrant);
     COMPARE_FIELD(next);
     COMPARE_FIELD(previous);
@@ -271,6 +270,7 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
 
 static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)
 {
+    COMPARE_FIELD(v_type);
     COMPARE_FIELD(vehicle_sprite_type);
     COMPARE_FIELD(bank_rotation);
     COMPARE_FIELD(remaining_distance);
@@ -345,6 +345,7 @@ static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)
 
 static void CompareSpriteDataLitter(const Litter& left, const Litter& right)
 {
+    COMPARE_FIELD(l_type);
     COMPARE_FIELD(creationTick);
 }
 
@@ -419,7 +420,8 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
                 CompareSpriteDataLitter(left.litter, right.litter);
                 break;
             case SpriteIdentifier::Misc:
-                switch (static_cast<MiscEntityType>(left.generic.type))
+                COMPARE_FIELD(generic.misc_type);
+                switch (static_cast<MiscEntityType>(left.generic.misc_type))
                 {
                     case MiscEntityType::SteamParticle:
                         CompareSpriteDataSteamParticle(left.steam_particle, right.steam_particle);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -110,7 +110,7 @@ static std::unique_ptr<GameState_t> GetGameState(std::unique_ptr<IContext>& cont
     {
         rct_sprite* sprite = reinterpret_cast<rct_sprite*>(GetEntity(spriteIdx));
         if (sprite == nullptr)
-            res->sprites[spriteIdx].generic.sprite_identifier = SpriteIdentifier::Null;
+            res->sprites[spriteIdx].misc.sprite_identifier = SpriteIdentifier::Null;
         else
             res->sprites[spriteIdx] = *sprite;
     }
@@ -405,10 +405,10 @@ static void CompareSpriteDataDuck(const Duck& left, const Duck& right)
 
 static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
 {
-    CompareSpriteDataCommon(left.generic, right.generic);
-    if (left.generic.sprite_identifier == right.generic.sprite_identifier)
+    CompareSpriteDataCommon(left.misc, right.misc);
+    if (left.misc.sprite_identifier == right.misc.sprite_identifier)
     {
-        switch (left.generic.sprite_identifier)
+        switch (left.misc.sprite_identifier)
         {
             case SpriteIdentifier::Peep:
                 CompareSpriteDataPeep(left.peep, right.peep);
@@ -420,8 +420,8 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
                 CompareSpriteDataLitter(left.litter, right.litter);
                 break;
             case SpriteIdentifier::Misc:
-                COMPARE_FIELD(generic.SubType);
-                switch (left.generic.SubType)
+                COMPARE_FIELD(misc.SubType);
+                switch (left.misc.SubType)
                 {
                     case MiscEntityType::SteamParticle:
                         CompareSpriteDataSteamParticle(left.steam_particle, right.steam_particle);
@@ -466,8 +466,8 @@ static void CompareStates(
 
     for (size_t spriteIdx = 0; spriteIdx < MAX_SPRITES; ++spriteIdx)
     {
-        if (importedState->sprites[spriteIdx].generic.sprite_identifier == SpriteIdentifier::Null
-            && exportedState->sprites[spriteIdx].generic.sprite_identifier == SpriteIdentifier::Null)
+        if (importedState->sprites[spriteIdx].misc.sprite_identifier == SpriteIdentifier::Null
+            && exportedState->sprites[spriteIdx].misc.sprite_identifier == SpriteIdentifier::Null)
         {
             continue;
         }


### PR DESCRIPTION
`type` is specific to the entity `sprite_identifier` and should therefore be part of the sub structure. This PR removes `type` from `SpriteBase` and puts it into `Vehicle`, `Litter`, `SpriteGeneric` (`MiscEntity`). In the process renames it to `SubType` and uses the correct specific type. Also renamed `SpriteGeneric` to `MiscEntity`. MoneyEffects had to be modified to now derive from `MiscEntity` no issues expected from this though.