### PR TITLE
Make entities a singly linked list

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -202,7 +202,6 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(SpriteBase, sprite_identifier);
         COMPARE_FIELD(SpriteBase, next_in_quadrant);
         COMPARE_FIELD(SpriteBase, next);
-        COMPARE_FIELD(SpriteBase, previous);
         COMPARE_FIELD(SpriteBase, linked_list_index);
         COMPARE_FIELD(SpriteBase, sprite_index);
         COMPARE_FIELD(SpriteBase, flags);

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -169,6 +169,16 @@ enum
     RCT12_STATION_STYLE_INVISIBLE, // Added by OpenRCT2
 };
 
+enum class RCT2EntityLinkListOffset : uint8_t
+{
+    Free = 0,
+    TrainHead = 1 * 2,
+    Peep = 2 * 2,
+    Misc = 3 * 2,
+    Litter = 4 * 2,
+    Vehicle = 5 * 2,
+};
+
 #pragma pack(push, 1)
 
 struct RCT12xy8
@@ -677,25 +687,25 @@ assert_struct_size(RCT12EightCarsCorruptElement15, 8);
 
 struct RCT12SpriteBase
 {
-    SpriteIdentifier sprite_identifier; // 0x00
-    uint8_t type;                       // 0x01
-    uint16_t next_in_quadrant;          // 0x02
-    uint16_t next;                      // 0x04
-    uint16_t previous;                  // 0x06
-    uint8_t linked_list_type_offset;    // 0x08
-    uint8_t sprite_height_negative;     // 0x09
-    uint16_t sprite_index;              // 0x0A
-    uint16_t flags;                     // 0x0C
-    int16_t x;                          // 0x0E
-    int16_t y;                          // 0x10
-    int16_t z;                          // 0x12
-    uint8_t sprite_width;               // 0x14
-    uint8_t sprite_height_positive;     // 0x15
-    int16_t sprite_left;                // 0x16
-    int16_t sprite_top;                 // 0x18
-    int16_t sprite_right;               // 0x1A
-    int16_t sprite_bottom;              // 0x1C
-    uint8_t sprite_direction;           // 0x1E
+    SpriteIdentifier sprite_identifier;               // 0x00
+    uint8_t type;                                     // 0x01
+    uint16_t next_in_quadrant;                        // 0x02
+    uint16_t next;                                    // 0x04
+    uint16_t previous;                                // 0x06
+    RCT2EntityLinkListOffset linked_list_type_offset; // 0x08
+    uint8_t sprite_height_negative;                   // 0x09
+    uint16_t sprite_index;                            // 0x0A
+    uint16_t flags;                                   // 0x0C
+    int16_t x;                                        // 0x0E
+    int16_t y;                                        // 0x10
+    int16_t z;                                        // 0x12
+    uint8_t sprite_width;                             // 0x14
+    uint8_t sprite_height_positive;                   // 0x15
+    int16_t sprite_left;                              // 0x16
+    int16_t sprite_top;                               // 0x18
+    int16_t sprite_right;                             // 0x1A
+    int16_t sprite_bottom;                            // 0x1C
+    uint8_t sprite_direction;                         // 0x1E
 };
 assert_struct_size(RCT12SpriteBase, 0x1F);
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -958,6 +958,30 @@ void S6Exporter::ExportSprites()
         _s6.sprite_lists_head[i] = gSpriteListHead[i];
         _s6.sprite_lists_count[i] = gSpriteListCount[i];
     }
+    RebuildEntityLinks();
+}
+
+void S6Exporter::RebuildEntityLinks()
+{
+    // Rebuild next/previous linked list entity indexs
+    for (auto list : { RCT2EntityLinkListOffset::Free, RCT2EntityLinkListOffset::Litter, RCT2EntityLinkListOffset::Misc,
+                       RCT2EntityLinkListOffset::Peep, RCT2EntityLinkListOffset::TrainHead, RCT2EntityLinkListOffset::Vehicle })
+    {
+        uint16_t previous = SPRITE_INDEX_NULL;
+        for (auto& entity : _s6.sprites)
+        {
+            if (entity.unknown.linked_list_type_offset == list)
+            {
+                _s6.sprites[entity.unknown.sprite_index].unknown.previous = previous;
+                if (previous != SPRITE_INDEX_NULL)
+                {
+                    _s6.sprites[previous].unknown.next = entity.unknown.sprite_index;
+                }
+                _s6.sprites[entity.unknown.sprite_index].unknown.next = SPRITE_INDEX_NULL;
+                previous = entity.unknown.sprite_index;
+            }
+        }
+    }
 }
 
 void S6Exporter::ExportSprite(RCT2Sprite* dst, const rct_sprite* src)
@@ -987,12 +1011,44 @@ void S6Exporter::ExportSprite(RCT2Sprite* dst, const rct_sprite* src)
     }
 }
 
+constexpr RCT2EntityLinkListOffset GetRCT2LinkListOffset(const SpriteBase* src)
+{
+    RCT2EntityLinkListOffset output = RCT2EntityLinkListOffset::Free;
+    switch (src->sprite_identifier)
+    {
+        case SpriteIdentifier::Vehicle:
+        {
+            auto veh = src->As<Vehicle>();
+            if (veh && veh->IsHead())
+            {
+                output = RCT2EntityLinkListOffset::TrainHead;
+            }
+            else
+            {
+                output = RCT2EntityLinkListOffset::Vehicle;
+            }
+        }
+        break;
+        case SpriteIdentifier::Peep:
+            output = RCT2EntityLinkListOffset::Peep;
+            break;
+        case SpriteIdentifier::Misc:
+            output = RCT2EntityLinkListOffset::Misc;
+            break;
+        case SpriteIdentifier::Litter:
+            output = RCT2EntityLinkListOffset::Litter;
+            break;
+        default:
+            break;
+    }
+}
+
 void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const SpriteBase* src)
 {
     dst->sprite_identifier = src->sprite_identifier;
     dst->next_in_quadrant = src->next_in_quadrant;
     dst->next = src->next;
-    dst->linked_list_type_offset = static_cast<uint8_t>(src->linked_list_index) * 2;
+    dst->linked_list_type_offset = GetRCT2LinkListOffset(src);
     dst->sprite_height_negative = src->sprite_height_negative;
     dst->sprite_index = src->sprite_index;
     dst->flags = src->flags;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -992,7 +992,6 @@ void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const Sprite
     dst->sprite_identifier = src->sprite_identifier;
     dst->next_in_quadrant = src->next_in_quadrant;
     dst->next = src->next;
-    dst->previous = src->previous;
     dst->linked_list_type_offset = static_cast<uint8_t>(src->linked_list_index) * 2;
     dst->sprite_height_negative = src->sprite_height_negative;
     dst->sprite_index = src->sprite_index;

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -78,4 +78,6 @@ private:
 
     std::optional<uint16_t> AllocateUserString(std::string_view value);
     void ExportUserStrings();
+
+    void RebuildEntityLinks();
 };

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1643,7 +1643,6 @@ public:
         dst->sprite_identifier = src->sprite_identifier;
         dst->next_in_quadrant = src->next_in_quadrant;
         dst->next = src->next;
-        dst->previous = src->previous;
         dst->linked_list_index = static_cast<EntityListId>(src->linked_list_type_offset >> 1);
         dst->sprite_height_negative = src->sprite_height_negative;
         dst->sprite_index = src->sprite_index;

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -11,7 +11,6 @@ struct SpriteBase
     SpriteIdentifier sprite_identifier;
     uint16_t next_in_quadrant;
     uint16_t next;
-    uint16_t previous;
     // Valid values are EntityListId::...
     EntityListId linked_list_index;
     // Height from centre of sprite to bottom

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -133,7 +133,6 @@ static void CompareSpriteDataCommon(const SpriteBase& left, const SpriteBase& ri
     COMPARE_FIELD(sprite_identifier);
     COMPARE_FIELD(next_in_quadrant);
     COMPARE_FIELD(next);
-    COMPARE_FIELD(previous);
     COMPARE_FIELD(linked_list_index);
     COMPARE_FIELD(sprite_index);
     COMPARE_FIELD(flags);


### PR DESCRIPTION
I can't see there being much point there being a doubly linked list for entities as the previous is only used when deleting/creating entities which is something that happens infrequently. Might be an idea to profile this one.