### PR TITLE
Remove next_in_quadrant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip")
 set(OBJECTS_SHA1 "151424d24b1d49a167932b58319bedaa6ec368e9")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.29/replays.zip")
-set(REPLAYS_SHA1 "B64135F28A79758AD9FCB611625ADDB5C89FB40B")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.30/replays.zip")
+set(REPLAYS_SHA1 "FD0949B81A7A267EA3A8F96CB02C460C8C21B923")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip</ObjectsUrl>
     <ObjectsSha1>151424d24b1d49a167932b58319bedaa6ec368e9</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.29/replays.zip</ReplaysUrl>
-    <ReplaysSha1>B64135F28A79758AD9FCB611625ADDB5C89FB40B</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.30/replays.zip</ReplaysUrl>
+    <ReplaysSha1>FD0949B81A7A267EA3A8F96CB02C460C8C21B923</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -200,7 +200,6 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         const SpriteBase& spriteBase, const SpriteBase& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
         COMPARE_FIELD(SpriteBase, sprite_identifier);
-        COMPARE_FIELD(SpriteBase, next_in_quadrant);
         COMPARE_FIELD(SpriteBase, linked_list_index);
         COMPARE_FIELD(SpriteBase, sprite_index);
         COMPARE_FIELD(SpriteBase, flags);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -981,6 +981,27 @@ void S6Exporter::RebuildEntityLinks()
             }
         }
     }
+
+    // Rebuild next_in_quadrant linked list entity indexs
+    for (auto x = 0; x < 255; ++x)
+    {
+        for (auto y = 0; y < 255; ++y)
+        {
+            uint16_t previous = SPRITE_INDEX_NULL;
+            for (auto* entity : EntityTileList(TileCoordsXY{ x, y }.ToCoordsXY()))
+            {
+                if (previous != SPRITE_INDEX_NULL)
+                {
+                    _s6.sprites[previous].unknown.next_in_quadrant = entity->sprite_index;
+                }
+                previous = entity->sprite_index;
+            }
+            if (previous != SPRITE_INDEX_NULL)
+            {
+                _s6.sprites[previous].unknown.next_in_quadrant = SPRITE_INDEX_NULL;
+            }
+        }
+    }
 }
 
 void S6Exporter::ExportSprite(RCT2Sprite* dst, const rct_sprite* src)
@@ -1047,6 +1068,7 @@ void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const Sprite
 {
     dst->sprite_identifier = src->sprite_identifier;
     dst->linked_list_type_offset = GetRCT2LinkListOffset(src);
+    dst->next_in_quadrant = SPRITE_INDEX_NULL;
     dst->sprite_height_negative = src->sprite_height_negative;
     dst->sprite_index = src->sprite_index;
     dst->flags = src->flags;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1046,7 +1046,6 @@ constexpr RCT12EntityLinkListOffset GetRCT2LinkListOffset(const SpriteBase* src)
 void S6Exporter::ExportSpriteCommonProperties(RCT12SpriteBase* dst, const SpriteBase* src)
 {
     dst->sprite_identifier = src->sprite_identifier;
-    dst->next_in_quadrant = src->next_in_quadrant;
     dst->linked_list_type_offset = GetRCT2LinkListOffset(src);
     dst->sprite_height_negative = src->sprite_height_negative;
     dst->sprite_index = src->sprite_index;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1656,7 +1656,6 @@ public:
     void ImportSpriteCommonProperties(SpriteBase* dst, const RCT12SpriteBase* src)
     {
         dst->sprite_identifier = src->sprite_identifier;
-        dst->next_in_quadrant = src->next_in_quadrant;
         dst->linked_list_index = static_cast<EntityListId>(EnumValue(src->linked_list_type_offset) >> 1);
         dst->sprite_height_negative = src->sprite_height_negative;
         dst->sprite_index = src->sprite_index;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -397,15 +397,19 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
  */
 void footpath_remove_litter(const CoordsXYZ& footpathPos)
 {
-    auto quad = EntityTileList<Litter>(footpathPos);
-    for (auto litter : quad)
+    std::vector<Litter*> removals;
+    for (auto litter : EntityTileList<Litter>(footpathPos))
     {
         int32_t distanceZ = abs(litter->z - footpathPos.z);
         if (distanceZ <= 32)
         {
-            litter->Invalidate();
-            sprite_remove(litter);
+            removals.push_back(litter);
         }
+    }
+    for (auto* litter : removals)
+    {
+        litter->Invalidate();
+        sprite_remove(litter);
     }
 }
 

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -31,8 +31,7 @@ static std::array<std::list<uint16_t>, EnumValue(EntityListId::Count)> gEntityLi
 
 static bool _spriteFlashingList[MAX_SPRITES];
 
-uint16_t gSpriteSpatialIndex[SPATIAL_INDEX_SIZE];
-std::array<std::vector<uint16_t>, SPATIAL_INDEX_SIZE> gSpriteSpatialIndex2;
+std::array<std::vector<uint16_t>, SPATIAL_INDEX_SIZE> gSpriteSpatialIndex;
 
 const rct_string_id litterNames[12] = { STR_LITTER_VOMIT,
                                         STR_LITTER_VOMIT,
@@ -120,7 +119,7 @@ SpriteBase* get_sprite(size_t spriteIndex)
 
 const std::vector<uint16_t>& GetEntityTileList(const CoordsXY& spritePos)
 {
-    return gSpriteSpatialIndex2[GetSpatialIndexOffset(spritePos.x, spritePos.y)];
+    return gSpriteSpatialIndex[GetSpatialIndexOffset(spritePos.x, spritePos.y)];
 }
 
 void SpriteBase::Invalidate()
@@ -254,7 +253,7 @@ static void SpriteSpatialInsert(SpriteBase* sprite, const CoordsXY& newLoc);
  */
 void reset_sprite_spatial_index()
 {
-    for (auto& vec : gSpriteSpatialIndex2)
+    for (auto& vec : gSpriteSpatialIndex)
     {
         vec.clear();
     }
@@ -281,7 +280,7 @@ static size_t GetSpatialIndexOffset(int32_t x, int32_t y)
         index = (flooredX << 3) | tileY;
     }
 
-    if (index >= sizeof(gSpriteSpatialIndex2))
+    if (index >= sizeof(gSpriteSpatialIndex))
     {
         return SPATIAL_INDEX_LOCATION_NULL;
     }
@@ -591,7 +590,7 @@ void sprite_misc_update_all()
 static void SpriteSpatialInsert(SpriteBase* sprite, const CoordsXY& newLoc)
 {
     size_t newIndex = GetSpatialIndexOffset(newLoc.x, newLoc.y);
-    auto& spatialVector = gSpriteSpatialIndex2[newIndex];
+    auto& spatialVector = gSpriteSpatialIndex[newIndex];
     auto index = std::lower_bound(std::begin(spatialVector), std::end(spatialVector), sprite->sprite_index);
     spatialVector.insert(index, sprite->sprite_index);
 }
@@ -599,7 +598,7 @@ static void SpriteSpatialInsert(SpriteBase* sprite, const CoordsXY& newLoc)
 static void SpriteSpatialRemove(SpriteBase* sprite)
 {
     size_t currentIndex = GetSpatialIndexOffset(sprite->x, sprite->y);
-    auto& spatialVector = gSpriteSpatialIndex2[currentIndex];
+    auto& spatialVector = gSpriteSpatialIndex[currentIndex];
     auto index = std::lower_bound(std::begin(spatialVector), std::end(spatialVector), sprite->sprite_index);
     if (index != std::end(spatialVector) && *index == sprite->sprite_index)
     {

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -322,15 +322,6 @@ rct_sprite_checksum sprite_checksum()
                 copy.misc.sprite_left = copy.misc.sprite_right = copy.misc.sprite_top = copy.misc.sprite_bottom = 0;
                 copy.misc.sprite_width = copy.misc.sprite_height_negative = copy.misc.sprite_height_positive = 0;
 
-                // Next in quadrant might be a misc sprite, set first non-misc sprite in quadrant.
-                while (auto* nextSprite = GetEntity(copy.misc.next_in_quadrant))
-                {
-                    if (nextSprite->sprite_identifier == SpriteIdentifier::Misc)
-                        copy.misc.next_in_quadrant = nextSprite->next_in_quadrant;
-                    else
-                        break;
-                }
-
                 if (copy.misc.Is<Peep>())
                 {
                     // Name is pointer and will not be the same across clients
@@ -369,14 +360,12 @@ static void sprite_reset(SpriteBase* sprite)
 {
     // Need to retain how the sprite is linked in lists
     auto llto = sprite->linked_list_index;
-    uint16_t next_in_quadrant = sprite->next_in_quadrant;
     uint16_t sprite_index = sprite->sprite_index;
     _spriteFlashingList[sprite_index] = false;
 
     std::memset(sprite, 0, sizeof(rct_sprite));
 
     sprite->linked_list_index = llto;
-    sprite->next_in_quadrant = next_in_quadrant;
     sprite->sprite_index = sprite_index;
     sprite->sprite_identifier = SpriteIdentifier::Null;
 }
@@ -392,13 +381,6 @@ void sprite_clear_all_unused()
         sprite_reset(sprite);
         sprite->linked_list_index = EntityListId::Free;
 
-        // sprite->next_in_quadrant will only end up as zero owing to corruption
-        // most likely due to previous builds not preserving it when resetting sprites
-        // We reset it to SPRITE_INDEX_NULL to prevent cycles in the sprite lists
-        if (sprite->next_in_quadrant == 0)
-        {
-            sprite->next_in_quadrant = SPRITE_INDEX_NULL;
-        }
         _spriteFlashingList[sprite->sprite_index] = false;
     }
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -795,16 +795,21 @@ void litter_create(const CoordsXYZD& litterPos, LitterType type)
  */
 void litter_remove_at(const CoordsXYZ& litterPos)
 {
+    std::vector<Litter*> removals;
     for (auto litter : EntityTileList<Litter>(litterPos))
     {
         if (abs(litter->z - litterPos.z) <= 16)
         {
             if (abs(litter->x - litterPos.x) <= 8 && abs(litter->y - litterPos.y) <= 8)
             {
-                litter->Invalidate();
-                sprite_remove(litter);
+                removals.push_back(litter);
             }
         }
+    }
+    for (auto* litter : removals)
+    {
+        litter->Invalidate();
+        sprite_remove(litter);
     }
 }
 

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -231,7 +231,6 @@ uint16_t GetEntityListCount(EntityListId list);
 
 constexpr const uint32_t SPATIAL_INDEX_SIZE = (MAXIMUM_MAP_SIZE_TECHNICAL * MAXIMUM_MAP_SIZE_TECHNICAL) + 1;
 constexpr const uint32_t SPATIAL_INDEX_LOCATION_NULL = SPATIAL_INDEX_SIZE - 1;
-extern uint16_t gSpriteSpatialIndex[SPATIAL_INDEX_SIZE];
 
 extern const rct_string_id litterNames[12];
 
@@ -336,14 +335,14 @@ public:
 template<typename T> class EntityTileIterator
 {
 private:
-    const std::vector<uint16_t>& vec;
     std::vector<uint16_t>::const_iterator iter;
+    std::vector<uint16_t>::const_iterator end;
     T* Entity = nullptr;
 
 public:
-    EntityTileIterator(const std::vector<uint16_t>& _vec, std::vector<uint16_t>::const_iterator _iter)
-        : vec(_vec)
-        , iter(_iter)
+    EntityTileIterator( std::vector<uint16_t>::const_iterator _iter, std::vector<uint16_t>::const_iterator _end)
+        : iter(_iter)
+        , end(_end)
     {
         ++(*this);
     }
@@ -351,7 +350,7 @@ public:
     {
         Entity = nullptr;
 
-        while (iter != std::end(vec) && Entity == nullptr)
+        while (iter != end && Entity == nullptr)
         {
             Entity = GetEntity<T>(*iter++);
         }
@@ -397,11 +396,11 @@ public:
 
     EntityTileIterator<T> begin()
     {
-        return EntityTileIterator<T>(vec, std::begin(vec));
+        return EntityTileIterator<T>(std::begin(vec), std::end(vec));
     }
     EntityTileIterator<T> end()
     {
-        return EntityTileIterator<T>(vec, std::end(vec));
+        return EntityTileIterator<T>(std::end(vec), std::end(vec));
     }
 };
 

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -249,7 +249,7 @@ void litter_remove_at(const CoordsXYZ& litterPos);
 uint16_t remove_floating_sprites();
 void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos);
 void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos);
-uint16_t sprite_get_first_in_quadrant(const CoordsXY& spritePos);
+const std::vector<uint16_t>& GetEntityTileList(const CoordsXY& spritePos);
 
 ///////////////////////////////////////////////////////////////
 // Balloon
@@ -333,25 +333,75 @@ public:
     using iterator_category = std::forward_iterator_tag;
 };
 
+template<typename T> class EntityTileIterator
+{
+private:
+    const std::vector<uint16_t>& vec;
+    std::vector<uint16_t>::const_iterator iter;
+    T* Entity = nullptr;
+
+public:
+    EntityTileIterator(const std::vector<uint16_t>& _vec, std::vector<uint16_t>::const_iterator _iter)
+        : vec(_vec)
+        , iter(_iter)
+    {
+        ++(*this);
+    }
+    EntityTileIterator& operator++()
+    {
+        Entity = nullptr;
+
+        while (iter != std::end(vec) && Entity == nullptr)
+        {
+            Entity = GetEntity<T>(*iter++);
+        }
+        return *this;
+    }
+
+    EntityTileIterator operator++(int)
+    {
+        EntityTileIterator retval = *this;
+        ++(*this);
+        return *iter;
+    }
+    bool operator==(EntityTileIterator other) const
+    {
+        return Entity == other.Entity;
+    }
+    bool operator!=(EntityTileIterator other) const
+    {
+        return !(*this == other);
+    }
+    T* operator*()
+    {
+        return Entity;
+    }
+    // iterator traits
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = const T*;
+    using reference = const T&;
+    using iterator_category = std::forward_iterator_tag;
+};
+
 template<typename T = SpriteBase> class EntityTileList
 {
 private:
-    uint16_t FirstEntity = SPRITE_INDEX_NULL;
-    using EntityTileIterator = EntityIterator<T, &SpriteBase::next_in_quadrant>;
+    const std::vector<uint16_t>& vec;
 
 public:
     EntityTileList(const CoordsXY& loc)
-        : FirstEntity(sprite_get_first_in_quadrant(loc))
+        : vec(GetEntityTileList(loc))
     {
     }
 
-    EntityTileIterator begin()
+    EntityTileIterator<T> begin()
     {
-        return EntityTileIterator(FirstEntity);
+        return EntityTileIterator<T>(vec, std::begin(vec));
     }
-    EntityTileIterator end()
+    EntityTileIterator<T> end()
     {
-        return EntityTileIterator(SPRITE_INDEX_NULL);
+        return EntityTileIterator<T>(vec, std::end(vec));
     }
 };
 

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -340,7 +340,7 @@ private:
     T* Entity = nullptr;
 
 public:
-    EntityTileIterator( std::vector<uint16_t>::const_iterator _iter, std::vector<uint16_t>::const_iterator _end)
+    EntityTileIterator(std::vector<uint16_t>::const_iterator _iter, std::vector<uint16_t>::const_iterator _end)
         : iter(_iter)
         , end(_end)
     {

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -9,7 +9,6 @@ enum class SpriteIdentifier : uint8_t;
 struct SpriteBase
 {
     SpriteIdentifier sprite_identifier;
-    uint16_t next_in_quadrant;
     // Valid values are EntityListId::...
     EntityListId linked_list_index;
     // Height from centre of sprite to bottom

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -131,7 +131,6 @@ static void AdvanceGameTicks(uint32_t ticks, std::unique_ptr<IContext>& context)
 static void CompareSpriteDataCommon(const SpriteBase& left, const SpriteBase& right)
 {
     COMPARE_FIELD(sprite_identifier);
-    COMPARE_FIELD(next_in_quadrant);
     COMPARE_FIELD(linked_list_index);
     COMPARE_FIELD(sprite_index);
     COMPARE_FIELD(flags);


### PR DESCRIPTION
Another field that doesn't need to be located in the Entity base. We rebuild the spatial index on load so this field was never read from the SV6/4 file.