### PR TITLE
Avoid some allocations by using a fixed size vector

### DIFF
--- a/src/openrct2/core/FixedVector.h
+++ b/src/openrct2/core/FixedVector.h
@@ -1,0 +1,176 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "Guard.hpp"
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+template<typename T, size_t MAX> class FixedVector
+{
+public:
+    using container = std::array<T, MAX>;
+    using iterator = typename container::iterator;
+    using const_iterator = typename container::const_iterator;
+    using reverse_iterator = typename container::reverse_iterator;
+    using const_reverse_iterator = typename container::const_reverse_iterator;
+    using value_type = typename container::value_type;
+    using reference_type = value_type&;
+    using const_reference_type = const value_type&;
+
+    iterator begin()
+    {
+        if (_count == 0)
+            return _data.end();
+
+        return _data.begin();
+    }
+
+    iterator end()
+    {
+        if (_count == 0)
+            return _data.end();
+        return begin() + _count;
+    }
+
+    const_iterator cbegin() const
+    {
+        if (_count == 0)
+            return _data.cend();
+
+        return _data.cbegin();
+    }
+
+    const_iterator cend() const
+    {
+        if (_count == 0)
+            return _data.cend();
+        return cbegin() + _count;
+    }
+
+    reverse_iterator rbegin()
+    {
+        if (_count == 0)
+            return _data.rend();
+        return _data.rbegin() + (MAX - _count);
+    }
+
+    reverse_iterator rend()
+    {
+        return _data.rend();
+    }
+
+    const_reverse_iterator rbegin() const
+    {
+        return _data.rbegin() + (MAX - _count);
+    }
+
+    const_reverse_iterator rend() const
+    {
+        return _data.rend();
+    }
+
+    reference_type back()
+    {
+        return _data[_count - 1];
+    }
+
+    const_reference_type back() const
+    {
+        return _data[_count - 1];
+    }
+
+    void push_back(const T& val)
+    {
+        Guard::Assert(_count < MAX);
+        _data[_count++] = val;
+    }
+
+    void push_back(T&& val)
+    {
+        Guard::Assert(_count < MAX);
+        _data[_count++] = std::move(val);
+    }
+
+    iterator insert(iterator pos, const T& val)
+    {
+        // Make sure the end iterator is correct.
+        auto itCurEnd = end();
+        push_back(val);
+
+        // Shift all elements to the right
+        auto offset = pos - begin();
+        std::rotate(_data.begin(), pos, itCurEnd);
+
+        return _data.begin() + offset;
+    }
+
+    iterator insert(iterator pos, T&& val)
+    {
+        // Make sure the end iterator is correct.
+        auto itCurEnd = end();
+        emplace_back(std::move(val));
+
+        // Shift all elements to the right
+        auto offset = pos - begin();
+        std::rotate(_data.begin() + offset, itCurEnd, end());
+
+        return _data.begin() + offset;
+    }
+
+    template<typename... Args> reference_type emplace_back(Args&&... args)
+    {
+        Guard::Assert(_count < MAX);
+        reference_type res = _data[_count++];
+        ::new (&res) T(std::forward<Args&&>(args)...);
+        return res;
+    }
+
+    reference_type operator[](const size_t n)
+    {
+        return _data[n];
+    }
+
+    const_reference_type operator[](const size_t n) const
+    {
+        return _data[n];
+    }
+
+    void pop_back()
+    {
+        _count--;
+    }
+
+    void clear()
+    {
+        _count = 0;
+    }
+
+    size_t size() const
+    {
+        return _count;
+    }
+
+    size_t capacity() const
+    {
+        return _data.size();
+    }
+
+    bool empty() const
+    {
+        return _count == 0;
+    }
+
+private:
+    size_t _count = 0;
+    container _data;
+};

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="core\Path.hpp" />
     <ClInclude Include="core\Random.hpp" />
     <ClInclude Include="core\RTL.h" />
+    <ClInclude Include="core\FixedVector.h" />
     <ClInclude Include="core\String.hpp" />
     <ClInclude Include="core\StringBuilder.h" />
     <ClInclude Include="core\StringReader.h" />

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -24,6 +24,7 @@
 #include "../audio/audio.h"
 #include "../common.h"
 #include "../config/Config.h"
+#include "../core/FixedVector.h"
 #include "../core/Guard.hpp"
 #include "../interface/Window.h"
 #include "../localisation/Date.h"
@@ -6938,7 +6939,7 @@ void sub_6CB945(Ride* ride)
         }
     }
 
-    std::vector<TileCoordsXYZD> locations;
+    FixedVector<TileCoordsXYZD, MAX_STATIONS> locations;
     for (StationIndex stationId = 0; stationId < MAX_STATIONS; ++stationId)
     {
         auto entrance = ride_get_entrance_location(ride, stationId);
@@ -6959,7 +6960,7 @@ void sub_6CB945(Ride* ride)
     auto locationListIter = locations.cbegin();
     for (const TileCoordsXYZD& locationCoords : locations)
     {
-        auto locationList = ++locationListIter;
+        auto locationList = std::next(locationListIter);
 
         bool duplicateLocation = false;
         while (locationList != locations.cend())


### PR DESCRIPTION
Also makes the code a bit easier to read. There are more places where we can use this, just one thing to note that its not just a pure flat array, it still keeps track of the count so this can not be replaced with raw array or std::array when the structure fields must remain POD.