### PR TITLE
Powered speed controller

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3655,6 +3655,9 @@ STR_6454    :Can’t rename banner…
 STR_6455    :Can’t rename sign…
 STR_6456    :Giant Screenshot
 STR_6457    :Report a bug on GitHub
+STR_6458    :Speed Controller
+STR_6459    :Control speed
+STR_6460    :Set target speed of powered cars
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2252,9 +2252,33 @@ static void window_ride_construction_invalidate(rct_window* w)
     if (_currentTrackCurve & RideConstructionSpecialPieceSelected)
     {
         stringId = RideConfigurationStringIds[_currentTrackCurve & ~RideConstructionSpecialPieceSelected];
-        if (stringId == STR_RAPIDS && (ride->type == RIDE_TYPE_MONSTER_TRUCKS || ride->type == RIDE_TYPE_CAR_RIDE))
+        if (stringId == STR_RAPIDS)
         {
-            stringId = STR_LOG_BUMPS;
+            switch (RideTypeDescriptors[ride->type].TrackBehaviours.RapidsBehaviour)
+            {
+                case RideRapidsBehaviour::Rapids:
+                    stringId = STR_RAPIDS;
+                    break;
+                case RideRapidsBehaviour::LogBumps:
+                    stringId = STR_LOG_BUMPS;
+                    break;
+            }
+        }
+        else if (stringId == STR_BOOSTER)
+        {
+            switch (RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour)
+            {
+                case RideBoosterBehaviour::Booster:
+                    stringId = STR_BOOSTER;
+                    break;
+                case RideBoosterBehaviour::SpeedController:
+                    stringId = STR_SPEED_CONTROL;
+                    break;
+                default:
+                {
+                    // to make the build systems happy
+                }
+            }
         }
     }
     auto ft = Formatter::Common();
@@ -3090,13 +3114,23 @@ static void window_ride_construction_update_widgets(rct_window* w)
     {
         if (brakesSelected)
         {
+            // Brake speed control
             window_ride_construction_widgets[WIDX_BANKING_GROUPBOX].text = STR_RIDE_CONSTRUCTION_BRAKE_SPEED;
             window_ride_construction_widgets[WIDX_BANK_LEFT].tooltip = STR_RIDE_CONSTRUCTION_BRAKE_SPEED_LIMIT_TIP;
             window_ride_construction_widgets[WIDX_BANK_STRAIGHT].tooltip = STR_RIDE_CONSTRUCTION_BRAKE_SPEED_LIMIT_TIP;
             window_ride_construction_widgets[WIDX_BANK_RIGHT].tooltip = STR_RIDE_CONSTRUCTION_BRAKE_SPEED_LIMIT_TIP;
         }
+        else if (RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour == RideBoosterBehaviour::SpeedController)
+        {
+            // Speed controller speed control
+            window_ride_construction_widgets[WIDX_BANKING_GROUPBOX].text = STR_RIDE_CONSTRUCTION_SPEED_CONTROL;
+            window_ride_construction_widgets[WIDX_BANK_LEFT].tooltip = STR_RIDE_CONSTRUCTION_SPEED_CONTROL_TIP;
+            window_ride_construction_widgets[WIDX_BANK_STRAIGHT].tooltip = STR_RIDE_CONSTRUCTION_SPEED_CONTROL_TIP;
+            window_ride_construction_widgets[WIDX_BANK_RIGHT].tooltip = STR_RIDE_CONSTRUCTION_SPEED_CONTROL_TIP;
+        }
         else
         {
+            // Booster speed control
             window_ride_construction_widgets[WIDX_BANKING_GROUPBOX].text = STR_RIDE_CONSTRUCTION_BOOSTER_SPEED;
             window_ride_construction_widgets[WIDX_BANK_LEFT].tooltip = STR_RIDE_CONSTRUCTION_BOOSTER_SPEED_LIMIT_TIP;
             window_ride_construction_widgets[WIDX_BANK_STRAIGHT].tooltip = STR_RIDE_CONSTRUCTION_BOOSTER_SPEED_LIMIT_TIP;
@@ -3328,11 +3362,34 @@ static void window_ride_construction_show_special_track_dropdown(rct_window* w, 
     {
         track_type_t trackPiece = _currentPossibleRideConfigurations[i];
         rct_string_id trackPieceStringId = RideConfigurationStringIds[trackPiece];
-        if (trackPieceStringId == STR_RAPIDS)
+        auto ride = get_ride(_currentRideIndex);
+        if (trackPieceStringId == STR_RAPIDS && ride != nullptr)
         {
-            auto ride = get_ride(_currentRideIndex);
-            if (ride != nullptr && (ride->type == RIDE_TYPE_MONSTER_TRUCKS || ride->type == RIDE_TYPE_CAR_RIDE))
-                trackPieceStringId = STR_LOG_BUMPS;
+            switch (RideTypeDescriptors[ride->type].TrackBehaviours.RapidsBehaviour)
+            {
+                case RideRapidsBehaviour::Rapids:
+                    trackPieceStringId = STR_RAPIDS;
+                    break;
+                case RideRapidsBehaviour::LogBumps:
+                    trackPieceStringId = STR_LOG_BUMPS;
+                    break;
+            }
+        }
+        if (trackPieceStringId == STR_BOOSTER && ride != nullptr)
+        {
+            switch (RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour)
+            {
+                case RideBoosterBehaviour::Booster:
+                    trackPieceStringId = STR_BOOSTER;
+                    break;
+                case RideBoosterBehaviour::SpeedController:
+                    trackPieceStringId = STR_SPEED_CONTROL;
+                    break;
+                default:
+                {
+                    // to make build systems happy
+                }
+            }
         }
         gDropdownItemsFormat[i] = trackPieceStringId;
         if ((trackPiece | RideConstructionSpecialPieceSelected) == _currentTrackCurve)

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2252,33 +2252,16 @@ static void window_ride_construction_invalidate(rct_window* w)
     if (_currentTrackCurve & RideConstructionSpecialPieceSelected)
     {
         stringId = RideConfigurationStringIds[_currentTrackCurve & ~RideConstructionSpecialPieceSelected];
-        if (stringId == STR_RAPIDS)
+        if (stringId == STR_RAPIDS
+            && RideTypeDescriptors[ride->type].TrackBehaviours.RapidsBehaviour == TrackElemTypeAlternateName::LogBumps)
         {
-            switch (RideTypeDescriptors[ride->type].TrackBehaviours.RapidsBehaviour)
-            {
-                case RideRapidsBehaviour::Rapids:
-                    stringId = STR_RAPIDS;
-                    break;
-                case RideRapidsBehaviour::LogBumps:
-                    stringId = STR_LOG_BUMPS;
-                    break;
-            }
+            stringId = STR_LOG_BUMPS;
         }
-        else if (stringId == STR_BOOSTER)
+        else if (
+            stringId == STR_BOOSTER
+            && RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour == TrackElemTypeAlternateName::SpeedController)
         {
-            switch (RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour)
-            {
-                case RideBoosterBehaviour::Booster:
-                    stringId = STR_BOOSTER;
-                    break;
-                case RideBoosterBehaviour::SpeedController:
-                    stringId = STR_SPEED_CONTROL;
-                    break;
-                default:
-                {
-                    // to make the build systems happy
-                }
-            }
+            stringId = STR_SPEED_CONTROL;
         }
     }
     auto ft = Formatter::Common();
@@ -3120,7 +3103,8 @@ static void window_ride_construction_update_widgets(rct_window* w)
             window_ride_construction_widgets[WIDX_BANK_STRAIGHT].tooltip = STR_RIDE_CONSTRUCTION_BRAKE_SPEED_LIMIT_TIP;
             window_ride_construction_widgets[WIDX_BANK_RIGHT].tooltip = STR_RIDE_CONSTRUCTION_BRAKE_SPEED_LIMIT_TIP;
         }
-        else if (RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour == RideBoosterBehaviour::SpeedController)
+        else if (
+            RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour == TrackElemTypeAlternateName::SpeedController)
         {
             // Speed controller speed control
             window_ride_construction_widgets[WIDX_BANKING_GROUPBOX].text = STR_RIDE_CONSTRUCTION_SPEED_CONTROL;
@@ -3363,33 +3347,16 @@ static void window_ride_construction_show_special_track_dropdown(rct_window* w, 
         track_type_t trackPiece = _currentPossibleRideConfigurations[i];
         rct_string_id trackPieceStringId = RideConfigurationStringIds[trackPiece];
         auto ride = get_ride(_currentRideIndex);
-        if (trackPieceStringId == STR_RAPIDS && ride != nullptr)
+        if (trackPieceStringId == STR_RAPIDS && ride != nullptr
+            && RideTypeDescriptors[ride->type].TrackBehaviours.RapidsBehaviour == TrackElemTypeAlternateName::LogBumps)
         {
-            switch (RideTypeDescriptors[ride->type].TrackBehaviours.RapidsBehaviour)
-            {
-                case RideRapidsBehaviour::Rapids:
-                    trackPieceStringId = STR_RAPIDS;
-                    break;
-                case RideRapidsBehaviour::LogBumps:
-                    trackPieceStringId = STR_LOG_BUMPS;
-                    break;
-            }
+            trackPieceStringId = STR_LOG_BUMPS;
         }
-        if (trackPieceStringId == STR_BOOSTER && ride != nullptr)
+        else if (
+            trackPieceStringId == STR_BOOSTER && ride != nullptr
+            && RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour == TrackElemTypeAlternateName::SpeedController)
         {
-            switch (RideTypeDescriptors[ride->type].TrackBehaviours.BoosterBehaviour)
-            {
-                case RideBoosterBehaviour::Booster:
-                    trackPieceStringId = STR_BOOSTER;
-                    break;
-                case RideBoosterBehaviour::SpeedController:
-                    trackPieceStringId = STR_SPEED_CONTROL;
-                    break;
-                default:
-                {
-                    // to make build systems happy
-                }
-            }
+            trackPieceStringId = STR_SPEED_CONTROL;
         }
         gDropdownItemsFormat[i] = trackPieceStringId;
         if ((trackPiece | RideConstructionSpecialPieceSelected) == _currentTrackCurve)

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3911,6 +3911,10 @@ enum
 
     STR_FILE_BUG_ON_GITHUB = 6457,
 
+    STR_SPEED_CONTROL = 6458,
+    STR_RIDE_CONSTRUCTION_SPEED_CONTROL = 6459,
+    STR_RIDE_CONSTRUCTION_SPEED_CONTROL_TIP = 6460,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -75,15 +75,10 @@ enum class RideColourKey : uint8_t
     Toilets
 };
 
-enum class RideBoosterBehaviour : uint8_t
+enum class TrackElemTypeAlternateName : uint16_t
 {
-    Booster,
-    SpeedController
-};
-enum class RideRapidsBehaviour : uint8_t
-{
-
-    Rapids,
+    Default,
+    SpeedController,
     LogBumps
 };
 
@@ -124,8 +119,8 @@ struct RideColourPreview
 
 struct RideTrackBehaviours
 {
-    RideBoosterBehaviour BoosterBehaviour;
-    RideRapidsBehaviour RapidsBehaviour;
+    TrackElemTypeAlternateName BoosterBehaviour; // Booster TrackElemType
+    TrackElemTypeAlternateName RapidsBehaviour;  // Rapids TrackElemType
 };
 
 struct UpkeepCostsDescriptor
@@ -382,7 +377,7 @@ constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { static_cast<uint32_t>(SPR_NONE), static_cast<uint32_t>(SPR_NONE) }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on
 

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -75,6 +75,18 @@ enum class RideColourKey : uint8_t
     Toilets
 };
 
+enum class RideBoosterBehaviour : uint8_t
+{
+    Booster,
+    SpeedController
+};
+enum class RideRapidsBehaviour : uint8_t
+{
+
+    Rapids,
+    LogBumps
+};
+
 struct RideNameConvention
 {
     RideComponentType vehicle;
@@ -108,6 +120,12 @@ struct RideColourPreview
 {
     uint32_t Track;
     uint32_t Supports;
+};
+
+struct RideTrackBehaviours
+{
+    RideBoosterBehaviour BoosterBehaviour;
+    RideRapidsBehaviour RapidsBehaviour;
 };
 
 struct UpkeepCostsDescriptor
@@ -175,6 +193,7 @@ struct RideTypeDescriptor
     track_colour_preset_list ColourPresets;
     RideColourPreview ColourPreview;
     RideColourKey ColourKey;
+    RideTrackBehaviours TrackBehaviours;
 
     bool HasFlag(uint64_t flag) const;
     uint64_t GetAvailableTrackPieces() const;
@@ -362,7 +381,8 @@ constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(BonusValue, 0),
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { static_cast<uint32_t>(SPR_NONE), static_cast<uint32_t>(SPR_NONE) }),
-    SET_FIELD(ColourKey, RideColourKey::Ride)
+    SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on
 

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -345,6 +345,9 @@ extern const uint16_t RideFilmLength[3];
 
 extern const rct_string_id RideModeNames[static_cast<uint8_t>(RideMode::Count)];
 
+constexpr RideTrackBehaviours _defaultTrackBehaviour = { TrackElemTypeAlternateName::Default,
+                                                         TrackElemTypeAlternateName::LogBumps };
+
 // clang-format off
 constexpr const RideTypeDescriptor DummyRTD =
 {
@@ -377,7 +380,7 @@ constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { static_cast<uint32_t>(SPR_NONE), static_cast<uint32_t>(SPR_NONE) }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -8192,6 +8192,13 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, Ride* cur
     {
         update_flags ^= VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE;
     }
+    if (trackType == TrackElemType::Booster && (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED))
+    {
+        // change the powered speed
+        uint8_t targetSpeed = get_booster_speed(curRide->type, (brake_speed << 2));
+        if (speed != targetSpeed)
+            speed = targetSpeed;
+    }
     // Change from original: this used to check if the vehicle allowed doors.
     UpdateSceneryDoorBackwards();
     UpdateLandscapeDoorBackwards();
@@ -8586,6 +8593,18 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* cu
     SetTrackType(trackType);
     SetTrackDirection(direction);
     brake_speed = tileElement->AsTrack()->GetBrakeBoosterSpeed();
+
+    rct_ride_entry_vehicle* vehicleEntry = Entry();
+    if (vehicleEntry != nullptr)
+    {
+        if (trackType == TrackElemType::Booster && (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED))
+        {
+            // change the powered speed
+            uint8_t targetSpeed = get_booster_speed(curRide->type, (brake_speed << 2));
+            if (speed != targetSpeed)
+                speed = targetSpeed;
+        }
+    }
 
     // There are two bytes before the move info list
     uint16_t trackTotalProgress = GetTrackProgress();

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -5352,6 +5352,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_mine_ride(int32_t trackType)
 {
     switch (trackType)
     {
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return mine_ride_track_flat;
         case TrackElemType::EndStation:

--- a/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor AirPoweredVerticalCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor AirPoweredVerticalCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor AirPoweredVerticalCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
+++ b/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor BobsleighCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
+++ b/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor BobsleighCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
+++ b/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor BobsleighCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor ClassicMiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor ClassicMiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor ClassicMiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor CompactInvertedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor CompactInvertedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor CompactInvertedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
@@ -58,5 +58,6 @@ constexpr const RideTypeDescriptor CorkscrewRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
@@ -58,6 +58,6 @@ constexpr const RideTypeDescriptor CorkscrewRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
@@ -58,6 +58,6 @@ constexpr const RideTypeDescriptor CorkscrewRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
@@ -54,6 +54,7 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 
 // Inverted variant
@@ -94,5 +95,6 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
@@ -54,7 +54,7 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 
 // Inverted variant
@@ -95,6 +95,6 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
@@ -54,7 +54,7 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 
 // Inverted variant
@@ -95,6 +95,6 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/GigaCoaster.h
+++ b/src/openrct2/ride/coaster/meta/GigaCoaster.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor GigaCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/GigaCoaster.h
+++ b/src/openrct2/ride/coaster/meta/GigaCoaster.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor GigaCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/GigaCoaster.h
+++ b/src/openrct2/ride/coaster/meta/GigaCoaster.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor GigaCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor HeartlineTwisterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor HeartlineTwisterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor HeartlineTwisterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HybridCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HybridCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor HybridCoasterRTD =
     )),
   SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_SUPPORTS }),
   SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HybridCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HybridCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor HybridCoasterRTD =
     )),
   SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_SUPPORTS }),
   SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HybridCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HybridCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor HybridCoasterRTD =
     )),
   SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_SUPPORTS }),
   SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HyperTwister.h
+++ b/src/openrct2/ride/coaster/meta/HyperTwister.h
@@ -58,5 +58,6 @@ constexpr const RideTypeDescriptor HyperTwisterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HyperTwister.h
+++ b/src/openrct2/ride/coaster/meta/HyperTwister.h
@@ -58,6 +58,6 @@ constexpr const RideTypeDescriptor HyperTwisterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HyperTwister.h
+++ b/src/openrct2/ride/coaster/meta/HyperTwister.h
@@ -58,6 +58,6 @@ constexpr const RideTypeDescriptor HyperTwisterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Hypercoaster.h
+++ b/src/openrct2/ride/coaster/meta/Hypercoaster.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor HypercoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Hypercoaster.h
+++ b/src/openrct2/ride/coaster/meta/Hypercoaster.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor HypercoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Hypercoaster.h
+++ b/src/openrct2/ride/coaster/meta/Hypercoaster.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor HypercoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor InvertedHairpinCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor InvertedHairpinCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor InvertedHairpinCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor InvertedImpulseCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor InvertedImpulseCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor InvertedImpulseCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
@@ -55,5 +55,6 @@ constexpr const RideTypeDescriptor InvertedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
@@ -55,6 +55,6 @@ constexpr const RideTypeDescriptor InvertedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
@@ -55,6 +55,6 @@ constexpr const RideTypeDescriptor InvertedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
@@ -58,5 +58,6 @@ constexpr const RideTypeDescriptor JuniorRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
@@ -58,6 +58,6 @@ constexpr const RideTypeDescriptor JuniorRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
@@ -58,6 +58,6 @@ constexpr const RideTypeDescriptor JuniorRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
@@ -52,6 +52,7 @@ constexpr const RideTypeDescriptor LIMLaunchedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
     
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
@@ -52,7 +52,7 @@ constexpr const RideTypeDescriptor LIMLaunchedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
     
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
@@ -52,7 +52,7 @@ constexpr const RideTypeDescriptor LIMLaunchedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
     
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
@@ -52,6 +52,7 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 
 constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
@@ -90,5 +91,6 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
@@ -52,7 +52,7 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 
 constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
@@ -91,6 +91,6 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
@@ -52,7 +52,7 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 
 constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
@@ -91,6 +91,6 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor LoopingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor LoopingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor LoopingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineRide.h
+++ b/src/openrct2/ride/coaster/meta/MineRide.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor MineRideRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_ROLLERCOASTER),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_FLAT_ROLL_BANKING) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE) | (1ULL << TRACK_HELIX_SMALL) | (1ULL << TRACK_ON_RIDE_PHOTO)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_mine_ride),
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor MineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineRide.h
+++ b/src/openrct2/ride/coaster/meta/MineRide.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor MineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineRide.h
+++ b/src/openrct2/ride/coaster/meta/MineRide.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor MineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor MineTrainCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor MineTrainCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor MineTrainCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor MiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor MiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor MiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor MiniSuspendedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor MiniSuspendedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor MiniSuspendedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
@@ -53,6 +53,7 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 
 constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
@@ -91,5 +92,6 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
@@ -53,7 +53,7 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 
 constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
@@ -92,6 +92,6 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
@@ -53,7 +53,7 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 
 constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
@@ -92,6 +92,6 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor ReverseFreefallCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor ReverseFreefallCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor ReverseFreefallCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor ReverserRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor ReverserRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor ReverserRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SideFrictionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SideFrictionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SideFrictionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor SingleRailRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor SingleRailRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
@@ -50,6 +50,6 @@ constexpr const RideTypeDescriptor SingleRailRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor SpinningWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor SpinningWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor SpinningWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor SpiralRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor SpiralRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor SpiralRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
@@ -55,5 +55,6 @@ constexpr const RideTypeDescriptor StandUpRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
@@ -55,6 +55,6 @@ constexpr const RideTypeDescriptor StandUpRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
@@ -55,6 +55,6 @@ constexpr const RideTypeDescriptor StandUpRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SteelWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SteelWildMouse.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor SteelWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SteelWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SteelWildMouse.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor SteelWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SteelWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SteelWildMouse.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor SteelWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Steeplechase.h
+++ b/src/openrct2/ride/coaster/meta/Steeplechase.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor SteeplechaseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_TRACK, SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Steeplechase.h
+++ b/src/openrct2/ride/coaster/meta/Steeplechase.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor SteeplechaseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_TRACK, SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Steeplechase.h
+++ b/src/openrct2/ride/coaster/meta/Steeplechase.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor SteeplechaseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_TRACK, SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor SuspendedSwingingCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor SuspendedSwingingCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor SuspendedSwingingCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
@@ -62,5 +62,6 @@ constexpr const RideTypeDescriptor TwisterRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
@@ -62,6 +62,6 @@ constexpr const RideTypeDescriptor TwisterRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
@@ -62,6 +62,6 @@ constexpr const RideTypeDescriptor TwisterRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
+++ b/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor VerticalDropCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
+++ b/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor VerticalDropCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
+++ b/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor VerticalDropCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VirginiaReel.h
+++ b/src/openrct2/ride/coaster/meta/VirginiaReel.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor VirginiaReelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_TRACK, SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VirginiaReel.h
+++ b/src/openrct2/ride/coaster/meta/VirginiaReel.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor VirginiaReelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_TRACK, SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VirginiaReel.h
+++ b/src/openrct2/ride/coaster/meta/VirginiaReel.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor VirginiaReelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_TRACK, SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WaterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WaterCoaster.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor WaterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WaterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WaterCoaster.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor WaterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::Default, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WaterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WaterCoaster.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor WaterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor WoodenRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor WoodenRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor WoodenRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor WoodenWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor WoodenWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor WoodenWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -707,6 +707,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_car_ride(int32_t trackType)
 {
     switch (trackType)
     {
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return paint_car_ride_track_flat;
 

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -527,6 +527,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_ghost_train(int32_t trackType)
 {
     switch (trackType)
     {
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return paint_ghost_train_track_flat;
 

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -308,6 +308,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_mini_helicopters(int32_t trackType
     switch (trackType)
     {
         case TrackElemType::Flat:
+        case TrackElemType::Booster:
             return paint_mini_helicopters_track_flat;
 
         case TrackElemType::EndStation:

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -636,6 +636,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_monorail_cycles(int32_t trackType)
     switch (trackType)
     {
         case TrackElemType::Flat:
+        case TrackElemType::Booster:
             return paint_monorail_cycles_track_flat;
 
         case TrackElemType::EndStation:

--- a/src/openrct2/ride/gentle/meta/CarRide.h
+++ b/src/openrct2/ride/gentle/meta/CarRide.h
@@ -21,7 +21,7 @@ constexpr const RideTypeDescriptor CarRideRTD =
     SET_FIELD(Category, RIDE_CATEGORY_GENTLE),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE)
                                   | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_SPINNING_TUNNEL)),
-    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_RAPIDS)),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_RAPIDS) | (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_car_ride),
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor CarRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CarRide.h
+++ b/src/openrct2/ride/gentle/meta/CarRide.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor CarRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CarRide.h
+++ b/src/openrct2/ride/gentle/meta/CarRide.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor CarRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CrookedHouse.h
+++ b/src/openrct2/ride/gentle/meta/CrookedHouse.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor CrookedHouseRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CrookedHouse.h
+++ b/src/openrct2/ride/gentle/meta/CrookedHouse.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor CrookedHouseRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CrookedHouse.h
+++ b/src/openrct2/ride/gentle/meta/CrookedHouse.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor CrookedHouseRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Dodgems.h
+++ b/src/openrct2/ride/gentle/meta/Dodgems.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor DodgemsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DODGEMS_TRACK, SPR_RIDE_DESIGN_PREVIEW_DODGEMS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Dodgems.h
+++ b/src/openrct2/ride/gentle/meta/Dodgems.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor DodgemsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DODGEMS_TRACK, SPR_RIDE_DESIGN_PREVIEW_DODGEMS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Dodgems.h
+++ b/src/openrct2/ride/gentle/meta/Dodgems.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor DodgemsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DODGEMS_TRACK, SPR_RIDE_DESIGN_PREVIEW_DODGEMS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FerrisWheel.h
+++ b/src/openrct2/ride/gentle/meta/FerrisWheel.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor FerrisWheelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FERRIS_WHEEL_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FerrisWheel.h
+++ b/src/openrct2/ride/gentle/meta/FerrisWheel.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor FerrisWheelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FERRIS_WHEEL_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FerrisWheel.h
+++ b/src/openrct2/ride/gentle/meta/FerrisWheel.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor FerrisWheelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FERRIS_WHEEL_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FlyingSaucers.h
+++ b/src/openrct2/ride/gentle/meta/FlyingSaucers.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor FlyingSaucersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_SAUCERS_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FlyingSaucers.h
+++ b/src/openrct2/ride/gentle/meta/FlyingSaucers.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor FlyingSaucersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_SAUCERS_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FlyingSaucers.h
+++ b/src/openrct2/ride/gentle/meta/FlyingSaucers.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor FlyingSaucersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_SAUCERS_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/GhostTrain.h
+++ b/src/openrct2/ride/gentle/meta/GhostTrain.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_GENTLE),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_BRAKES) | (1ULL << TRACK_SPINNING_TUNNEL)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_ghost_train),
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_TRACK, SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/GhostTrain.h
+++ b/src/openrct2/ride/gentle/meta/GhostTrain.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_TRACK, SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/GhostTrain.h
+++ b/src/openrct2/ride/gentle/meta/GhostTrain.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_TRACK, SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/HauntedHouse.h
+++ b/src/openrct2/ride/gentle/meta/HauntedHouse.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor HauntedHouseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/HauntedHouse.h
+++ b/src/openrct2/ride/gentle/meta/HauntedHouse.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor HauntedHouseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/HauntedHouse.h
+++ b/src/openrct2/ride/gentle/meta/HauntedHouse.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor HauntedHouseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor MazeRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor MazeRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor MazeRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MerryGoRound.h
+++ b/src/openrct2/ride/gentle/meta/MerryGoRound.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor MerryGoRoundRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MerryGoRound.h
+++ b/src/openrct2/ride/gentle/meta/MerryGoRound.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor MerryGoRoundRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MerryGoRound.h
+++ b/src/openrct2/ride/gentle/meta/MerryGoRound.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor MerryGoRoundRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -51,6 +51,6 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_GENTLE),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_mini_helicopters),
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonorailCycles.h
+++ b/src/openrct2/ride/gentle/meta/MonorailCycles.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonorailCycles.h
+++ b/src/openrct2/ride/gentle/meta/MonorailCycles.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonorailCycles.h
+++ b/src/openrct2/ride/gentle/meta/MonorailCycles.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_GENTLE),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_monorail_cycles),
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonsterTrucks.h
+++ b/src/openrct2/ride/gentle/meta/MonsterTrucks.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor MonsterTrucksRTD =
     SET_FIELD(Category, RIDE_CATEGORY_GENTLE),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE)
                                   | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_RAPIDS)),
-    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_SPINNING_TUNNEL)),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_SPINNING_TUNNEL) | (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_car_ride),
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor MonsterTrucksRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonsterTrucks.h
+++ b/src/openrct2/ride/gentle/meta/MonsterTrucks.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor MonsterTrucksRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonsterTrucks.h
+++ b/src/openrct2/ride/gentle/meta/MonsterTrucks.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor MonsterTrucksRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/ObservationTower.h
+++ b/src/openrct2/ride/gentle/meta/ObservationTower.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor ObservationTowerRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_TRACK, SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/ObservationTower.h
+++ b/src/openrct2/ride/gentle/meta/ObservationTower.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor ObservationTowerRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_TRACK, SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/ObservationTower.h
+++ b/src/openrct2/ride/gentle/meta/ObservationTower.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor ObservationTowerRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_TRACK, SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpaceRings.h
+++ b/src/openrct2/ride/gentle/meta/SpaceRings.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor SpaceRingsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpaceRings.h
+++ b/src/openrct2/ride/gentle/meta/SpaceRings.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor SpaceRingsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpaceRings.h
+++ b/src/openrct2/ride/gentle/meta/SpaceRings.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor SpaceRingsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_SLIDE_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_SLIDE_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_SLIDE_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -46,5 +46,6 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::CashMachine),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -46,6 +46,6 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::CashMachine),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -46,6 +46,6 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::CashMachine),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Drink),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Drink),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Drink),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::FirstAid),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::FirstAid),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::FirstAid),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Food),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Food),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Food),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::InfoKiosk),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::InfoKiosk),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::InfoKiosk),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Shop),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Shop),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Shop),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Toilets),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Toilets),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -47,6 +47,6 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Toilets),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/3DCinema.h
+++ b/src/openrct2/ride/thrill/meta/3DCinema.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor CinemaRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/3DCinema.h
+++ b/src/openrct2/ride/thrill/meta/3DCinema.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor CinemaRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/3DCinema.h
+++ b/src/openrct2/ride/thrill/meta/3DCinema.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor CinemaRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Enterprise.h
+++ b/src/openrct2/ride/thrill/meta/Enterprise.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor EnterpriseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Enterprise.h
+++ b/src/openrct2/ride/thrill/meta/Enterprise.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor EnterpriseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Enterprise.h
+++ b/src/openrct2/ride/thrill/meta/Enterprise.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor EnterpriseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/GoKarts.h
+++ b/src/openrct2/ride/thrill/meta/GoKarts.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor GoKartsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/GoKarts.h
+++ b/src/openrct2/ride/thrill/meta/GoKarts.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor GoKartsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/GoKarts.h
+++ b/src/openrct2/ride/thrill/meta/GoKarts.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor GoKartsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, {TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
+++ b/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor LaunchedFreefallRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
+++ b/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor LaunchedFreefallRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
+++ b/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor LaunchedFreefallRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MagicCarpet.h
+++ b/src/openrct2/ride/thrill/meta/MagicCarpet.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor MagicCarpetRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_TRACK, SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MagicCarpet.h
+++ b/src/openrct2/ride/thrill/meta/MagicCarpet.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor MagicCarpetRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_TRACK, SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MagicCarpet.h
+++ b/src/openrct2/ride/thrill/meta/MagicCarpet.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor MagicCarpetRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_TRACK, SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MotionSimulator.h
+++ b/src/openrct2/ride/thrill/meta/MotionSimulator.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor MotionSimulatorRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MotionSimulator.h
+++ b/src/openrct2/ride/thrill/meta/MotionSimulator.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor MotionSimulatorRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MotionSimulator.h
+++ b/src/openrct2/ride/thrill/meta/MotionSimulator.h
@@ -49,6 +49,6 @@ constexpr const RideTypeDescriptor MotionSimulatorRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/RotoDrop.h
+++ b/src/openrct2/ride/thrill/meta/RotoDrop.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor RotoDropRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_TRACK, SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/RotoDrop.h
+++ b/src/openrct2/ride/thrill/meta/RotoDrop.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor RotoDropRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_TRACK, SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/RotoDrop.h
+++ b/src/openrct2/ride/thrill/meta/RotoDrop.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor RotoDropRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_TRACK, SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SwingingInverterShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SwingingInverterShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SwingingInverterShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingShip.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SwingingShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingShip.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SwingingShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/TopSpin.h
+++ b/src/openrct2/ride/thrill/meta/TopSpin.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor TopSpinRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TOP_SPIN_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/TopSpin.h
+++ b/src/openrct2/ride/thrill/meta/TopSpin.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor TopSpinRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TOP_SPIN_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/TopSpin.h
+++ b/src/openrct2/ride/thrill/meta/TopSpin.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor TopSpinRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TOP_SPIN_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -48,5 +48,6 @@ constexpr const RideTypeDescriptor TwistRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -48,6 +48,6 @@ constexpr const RideTypeDescriptor TwistRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -48,6 +48,6 @@ constexpr const RideTypeDescriptor TwistRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -2157,6 +2157,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_miniature_railway(int32_t trackTyp
 {
     switch (trackType)
     {
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return paint_miniature_railway_track_flat;
 

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -1332,6 +1332,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_monorail(int32_t trackType)
 {
     switch (trackType)
     {
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return paint_monorail_track_flat;
 

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -1882,6 +1882,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_suspended_monorail(int32_t trackTy
 {
     switch (trackType)
     {
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return suspended_monorail_track_flat;
         case TrackElemType::EndStation:

--- a/src/openrct2/ride/transport/meta/Chairlift.h
+++ b/src/openrct2/ride/transport/meta/Chairlift.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor ChairliftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_TRACK, SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Chairlift.h
+++ b/src/openrct2/ride/transport/meta/Chairlift.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor ChairliftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_TRACK, SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Chairlift.h
+++ b/src/openrct2/ride/transport/meta/Chairlift.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor ChairliftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_TRACK, SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Lift.h
+++ b/src/openrct2/ride/transport/meta/Lift.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor LiftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIFT_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Lift.h
+++ b/src/openrct2/ride/transport/meta/Lift.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor LiftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIFT_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Lift.h
+++ b/src/openrct2/ride/transport/meta/Lift.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor LiftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIFT_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, _defaultTrackBehaviour)
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/MiniatureRailway.h
+++ b/src/openrct2/ride/transport/meta/MiniatureRailway.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_TRANSPORT),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_miniature_railway),
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/MiniatureRailway.h
+++ b/src/openrct2/ride/transport/meta/MiniatureRailway.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/MiniatureRailway.h
+++ b/src/openrct2/ride/transport/meta/MiniatureRailway.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Monorail.h
+++ b/src/openrct2/ride/transport/meta/Monorail.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor MonorailRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_TRANSPORT),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_monorail),
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor MonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Monorail.h
+++ b/src/openrct2/ride/transport/meta/Monorail.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor MonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Monorail.h
+++ b/src/openrct2/ride/transport/meta/Monorail.h
@@ -57,6 +57,6 @@ constexpr const RideTypeDescriptor MonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/SuspendedMonorail.h
+++ b/src/openrct2/ride/transport/meta/SuspendedMonorail.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor SuspendedMonorailRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_TRANSPORT),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_CURVE)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_suspended_monorail),
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor SuspendedMonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/SuspendedMonorail.h
+++ b/src/openrct2/ride/transport/meta/SuspendedMonorail.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor SuspendedMonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::LogBumps})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/SuspendedMonorail.h
+++ b/src/openrct2/ride/transport/meta/SuspendedMonorail.h
@@ -56,6 +56,6 @@ constexpr const RideTypeDescriptor SuspendedMonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::LogBumps})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::LogBumps })
 };
 // clang-format on

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -842,6 +842,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_river_rapids(int32_t trackType)
     switch (trackType)
     {
         case TrackElemType::Flat:
+        case TrackElemType::Booster:
             return paint_river_rapids_track_flat;
 
         case TrackElemType::EndStation:

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -1211,6 +1211,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_splash_boats(int32_t trackType)
 
         // Originally taken from River Rafts
         case TrackElemType::Flat:
+        case TrackElemType::Booster:
             return paint_splash_boats_track_flat;
         case TrackElemType::EndStation:
         case TrackElemType::BeginStation:

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -223,6 +223,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_submarine_ride(int32_t trackType)
         case TrackElemType::EndStation:
             return submarine_ride_paint_track_station;
 
+        case TrackElemType::Booster:
         case TrackElemType::Flat:
             return submarine_ride_paint_track_flat;
 

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/DinghySlide.h
+++ b/src/openrct2/ride/water/meta/DinghySlide.h
@@ -64,5 +64,6 @@ constexpr const RideTypeDescriptor DinghySlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/DinghySlide.h
+++ b/src/openrct2/ride/water/meta/DinghySlide.h
@@ -64,6 +64,6 @@ constexpr const RideTypeDescriptor DinghySlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::Default, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/DinghySlide.h
+++ b/src/openrct2/ride/water/meta/DinghySlide.h
@@ -64,6 +64,6 @@ constexpr const RideTypeDescriptor DinghySlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::Booster,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::Default,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/LogFlume.h
+++ b/src/openrct2/ride/water/meta/LogFlume.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/LogFlume.h
+++ b/src/openrct2/ride/water/meta/LogFlume.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_WATER),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE_SMALL) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_LOG_FLUME_REVERSER)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_log_flume),
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/LogFlume.h
+++ b/src/openrct2/ride/water/meta/LogFlume.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, {TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRafts.h
+++ b/src/openrct2/ride/water/meta/RiverRafts.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor RiverRaftsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRafts.h
+++ b/src/openrct2/ride/water/meta/RiverRafts.h
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor RiverRaftsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRafts.h
+++ b/src/openrct2/ride/water/meta/RiverRafts.h
@@ -21,7 +21,7 @@ constexpr const RideTypeDescriptor RiverRaftsRTD =
     SET_FIELD(Category, RIDE_CATEGORY_WATER),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_S_BEND) | (1ULL << TRACK_CURVE)),
     SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_SLOPE) | (1ULL << TRACK_SLOPE_STEEP) | (1ULL << TRACK_ON_RIDE_PHOTO)),
-    SET_FIELD(CoveredTrackPieces, 0),
+    SET_FIELD(CoveredTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_splash_boats),
     SET_FIELD(Flags, RIDE_TYPE_FLAGS_TRACK_HAS_3_COLOURS | RIDE_TYPE_FLAG_HAS_LEAVE_WHEN_ANOTHER_VEHICLE_ARRIVES_AT_STATION |
@@ -53,6 +53,6 @@ constexpr const RideTypeDescriptor RiverRaftsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRapids.h
+++ b/src/openrct2/ride/water/meta/RiverRapids.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRapids.h
+++ b/src/openrct2/ride/water/meta/RiverRapids.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRapids.h
+++ b/src/openrct2/ride/water/meta/RiverRapids.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_WATER),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_SLOPE) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_ON_RIDE_PHOTO) | (1ULL << TRACK_RAPIDS) | (1ULL << TRACK_WATERFALL) | (1ULL << TRACK_WHIRLPOOL)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_river_rapids),
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SplashBoats.h
+++ b/src/openrct2/ride/water/meta/SplashBoats.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor SplashBoatsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SplashBoats.h
+++ b/src/openrct2/ride/water/meta/SplashBoats.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor SplashBoatsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SplashBoats.h
+++ b/src/openrct2/ride/water/meta/SplashBoats.h
@@ -54,6 +54,6 @@ constexpr const RideTypeDescriptor SplashBoatsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::Default })
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -20,7 +20,7 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_WATER),
     SET_FIELD(EnabledTrackPieces, (1ULL << TRACK_STRAIGHT) | (1ULL << TRACK_STATION_END) | (1ULL << TRACK_CURVE_VERY_SMALL) | (1ULL << TRACK_CURVE_SMALL)),
-    SET_FIELD(ExtraTrackPieces, 0),
+    SET_FIELD(ExtraTrackPieces, (1ULL << TRACK_BOOSTER)),
     SET_FIELD(CoveredTrackPieces, 0),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, get_track_paint_function_submarine_ride),
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{RideBoosterBehaviour::SpeedController,RideRapidsBehaviour::Rapids})
+    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -52,6 +52,6 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
-    SET_FIELD(TrackBehaviours,{TrackElemTypeAlternateName::SpeedController,TrackElemTypeAlternateName::Default})
+    SET_FIELD(TrackBehaviours, { TrackElemTypeAlternateName::SpeedController, TrackElemTypeAlternateName::Default })
 };
 // clang-format on


### PR DESCRIPTION
This modifies booster behavior to affect powered vehicle target speed when passing onto the piece. Boosters take on a new name when built as part of certain powered rides. The pieces inherit the graphics of the flat piece and are all hidden behind the 'all drawable track pieces' cheat.

https://user-images.githubusercontent.com/3454156/104439231-bdc76d80-5545-11eb-848f-2b2200f25be1.mp4

