### PR TITLE
Fix #13755. Regression causing entity position corruption

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -951,6 +951,12 @@ namespace OpenRCT2
             {
                 _lastTick = 0;
                 _variableFrame = useVariableFrame;
+
+                // Switching from variable to fixed frame requires reseting
+                // of entity positions back to end of tick positions
+                auto& tweener = EntityTweener::Get();
+                tweener.Restore();
+                tweener.Reset();
             }
 
             if (useVariableFrame)


### PR DESCRIPTION
When switching from variable frame to fixed frame the entity positions could become corrupted. This would cause to end up being stuck inside of tiles that they could not path out of. When switching from normal speed to hyperspeed the rendering switches from variable to fixed frame. Therefore entitys could end up corrupted when enabling hyperspeed. Due to the way the corruption occured a hang or crash could also occur.