### PR TITLE
Fix Window IDX enum names

### DIFF
--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -25,7 +25,7 @@ static constexpr const int32_t WH = 94;
 static constexpr const int32_t WW = 98;
 
 // clang-format off
-enum WINDOW_WATER_WIDGET_IDX {
+enum WINDOW_LAND_RIGHTS_WIDGET_IDX {
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -54,7 +54,7 @@ static constexpr const notification_def NewsItemOptionDefinitions[] = {
     { NOTIFICATION_CATEGORY_GUEST,  STR_NOTIFICATION_GUEST_DIED,                        offsetof(NotificationConfiguration, guest_died)                         },
 };
 
-enum WINDOW_NEWS_WIDGET_IDX {
+enum WINDOW_NEWS_OPTIONS_WIDGET_IDX {
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -15,7 +15,7 @@
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/world/Scenery.h>
 
-enum WINDOW_CLEAR_SCENERY_WIDGET_IDX
+enum WINDOW_SCENERY_SCATTER_WIDGET_IDX
 {
     WIDX_BACKGROUND,
     WIDX_TITLE,

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -65,7 +65,7 @@ static rct_window_event_list window_themes_events([](auto& events)
     events.scroll_paint = &window_themes_scrollpaint;
 });
 
-enum WINDOW_STAFF_LIST_WIDGET_IDX {
+enum WINDOW_THEMES_WIDGET_IDX {
     WIDX_THEMES_BACKGROUND,
     WIDX_THEMES_TITLE,
     WIDX_THEMES_CLOSE,

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -49,7 +49,7 @@ static TITLE_COMMAND_ORDER _window_title_command_editor_orders[] = {
 
 #define NUM_COMMANDS std::size(_window_title_command_editor_orders)
 
-enum WINDOW_WATER_WIDGET_IDX {
+enum WINDOW_TITLE_COMMAND_EDITOR_WIDGET_IDX {
     WIDX_BACKGROUND,
     WIDX_TITLE,
     WIDX_CLOSE,


### PR DESCRIPTION
I was trying to build OpenRCT2 on my Linux (Lubuntu) device (which I recently setup), and the compiler was throwing errors related to [ODR](https://en.cppreference.com/w/cpp/language/definition). I realized that some of the enum names were duplicated across files. This looks like a mistake made from a copy-and-paste. Fixing the enum names fixed the build for me.