### PR TITLE
Use specific type for peep list access

### DIFF
--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -656,13 +656,10 @@ void SetCheatAction::RemoveAllGuests() const
     }
 
     // Do not use the FOR_ALL_PEEPS macro for this as next sprite index
-    // will be fetched on a deleted peep.
-    for (auto peep : EntityList<Peep>(EntityListId::Peep))
+    // will be fetched on a deleted guest.
+    for (auto guest : EntityList<Guest>(EntityListId::Peep))
     {
-        if (peep->AssignedPeepType == PeepType::Guest)
-        {
-            peep->Remove();
-        }
+        guest->Remove();
     }
 
     window_invalidate_by_class(WC_RIDE);

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -263,21 +263,15 @@ static bool award_is_deserved_best_staff(int32_t activeAwardTypes)
     if (activeAwardTypes & EnumToFlag(ParkAward::MostUntidy))
         return false;
 
-    auto peepCount = 0;
     auto staffCount = 0;
     auto staffTypeFlags = 0;
-    for (auto peep : EntityList<Peep>(EntityListId::Peep))
+    for (auto staff : EntityList<Staff>(EntityListId::Peep))
     {
-        if (peep->AssignedPeepType == PeepType::Staff)
-        {
-            staffCount++;
-            staffTypeFlags |= (1 << static_cast<uint8_t>(peep->AssignedStaffType));
-        }
-        else
-        {
-            peepCount++;
-        }
+        staffCount++;
+        staffTypeFlags |= (1 << static_cast<uint8_t>(staff->AssignedStaffType));
     }
+    auto guests = EntityList<Guest>(EntityListId::Peep);
+    auto peepCount = std::distance(guests.begin(), guests.end());
 
     return ((staffTypeFlags & 0xF) && staffCount >= 20 && staffCount >= peepCount / 32);
 }

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -263,17 +263,12 @@ static bool award_is_deserved_best_staff(int32_t activeAwardTypes)
     if (activeAwardTypes & EnumToFlag(ParkAward::MostUntidy))
         return false;
 
-    auto staffCount = 0;
-    auto staffTypeFlags = 0;
-    for (auto staff : EntityList<Staff>(EntityListId::Peep))
-    {
-        staffCount++;
-        staffTypeFlags |= (1 << static_cast<uint8_t>(staff->AssignedStaffType));
-    }
+    auto staff = EntityList<Staff>(EntityListId::Peep);
+    auto staffCount = std::distance(staff.begin(), staff.end());
     auto guests = EntityList<Guest>(EntityListId::Peep);
     auto peepCount = std::distance(guests.begin(), guests.end());
 
-    return ((staffTypeFlags & 0xF) && staffCount >= 20 && staffCount >= peepCount / 32);
+    return ((staffCount != 0) && staffCount >= 20 && staffCount >= peepCount / 32);
 }
 
 /** At least 7 shops, 4 unique, one shop per 128 guests and no more than 12 hungry guests. */

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -377,7 +377,7 @@ void peep_update_all()
 
     int32_t i = 0;
     // Warning this loop can delete peeps
-    for (auto peep : EntityList<Peep>(EntityListId::Peep))
+    for (auto peep : EntityList<Guest>(EntityListId::Peep))
     {
         if (static_cast<uint32_t>(i & 0x7F) != (gCurrentTicks & 0x7F))
         {
@@ -386,9 +386,29 @@ void peep_update_all()
         else
         {
             peep_128_tick_update(peep, i);
+            // 128 tick can delete so double check its not deleted
             if (peep->sprite_identifier == SpriteIdentifier::Peep)
             {
                 peep->Update();
+            }
+        }
+
+        i++;
+    }
+
+    for (auto staff : EntityList<Staff>(EntityListId::Peep))
+    {
+        if (static_cast<uint32_t>(i & 0x7F) != (gCurrentTicks & 0x7F))
+        {
+            staff->Update();
+        }
+        else
+        {
+            peep_128_tick_update(staff, i);
+            // 128 tick can delete so double check its not deleted
+            if (staff->sprite_identifier == SpriteIdentifier::Peep)
+            {
+                staff->Update();
             }
         }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1120,8 +1120,8 @@ void ride_remove_peeps(Ride* ride)
         }
     }
 
-    // Place all the peeps at exit
-    for (auto peep : EntityList<Peep>(EntityListId::Peep))
+    // Place all the guests at exit
+    for (auto peep : EntityList<Guest>(EntityListId::Peep))
     {
         if (peep->State == PeepState::QueuingFront || peep->State == PeepState::EnteringRide
             || peep->State == PeepState::LeavingRide || peep->State == PeepState::OnRide)
@@ -1155,7 +1155,34 @@ void ride_remove_peeps(Ride* ride)
             peep->WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_STATS;
         }
     }
+    // Place all the staff at exit
+    for (auto peep : EntityList<Staff>(EntityListId::Peep))
+    {
+        if (peep->State == PeepState::Fixing || peep->State == PeepState::Inspecting)
+        {
+            if (peep->CurrentRide != ride->id)
+                continue;
 
+            if (exitPosition.direction == INVALID_DIRECTION)
+            {
+                CoordsXYZ newLoc = { peep->NextLoc.ToTileCentre(), peep->NextLoc.z };
+                if (peep->GetNextIsSloped())
+                    newLoc.z += COORDS_Z_STEP;
+                newLoc.z++;
+                peep->MoveTo(newLoc);
+            }
+            else
+            {
+                peep->MoveTo(exitPosition);
+                peep->sprite_direction = exitPosition.direction;
+            }
+
+            peep->State = PeepState::Falling;
+            peep->SwitchToSpecialSprite(0);
+
+            peep->WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_STATS;
+        }
+    }
     ride->num_riders = 0;
     ride->slide_in_use = 0;
     ride->window_invalidate_flags |= RIDE_INVALIDATE_RIDE_MAIN;


### PR DESCRIPTION
As mentioned on discord. The vast majority of accesses to these lists specifies the type so might as well split up the lists on type reducing type checking eventually. 

Wip. Will break replays. Need to test the mechanic changes.