### PR TITLE
Fix #13832: Game action position is invalid on opening/closing a ride

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -34,6 +34,7 @@
 - Fix: [#13489] Mechanics continue heading to inspect broken down rides.
 - Fix: [#13510] [Plugin] list view scroll resets when items is set.
 - Fix: [#13574] Crash when a JSON object does not set `originalId`.
+- Fix: [#13832] Players last action position is invalid on opening/closing a ride in multiplayer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.
 - Improved: [#13587] Allow up to 128 ride objects to be selected in track designer.

--- a/src/openrct2/actions/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/RideSetStatusAction.cpp
@@ -135,7 +135,7 @@ GameActions::Result::Ptr RideSetStatusAction::Execute() const
     if (!ride->overall_view.isNull())
     {
         auto location = ride->overall_view.ToTileCentre();
-        res->Position = { location, tile_element_height(res->Position) };
+        res->Position = { location, tile_element_height(location) };
     }
 
     switch (_status)


### PR DESCRIPTION
Wrong variable has been used.

Closes #13832