### PR TITLE
Fix replays not failing when last tick is the cause

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip")
 set(OBJECTS_SHA1 "151424d24b1d49a167932b58319bedaa6ec368e9")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.25/replays.zip")
-set(REPLAYS_SHA1 "DA3E595E4D0231934F1DCFC3B540097CE2ED1B17")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.27/replays.zip")
+set(REPLAYS_SHA1 "CC0BE0C9B9829062B67E1CFE14E36BEA1182882D")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip</ObjectsUrl>
     <ObjectsSha1>151424d24b1d49a167932b58319bedaa6ec368e9</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.25/replays.zip</ReplaysUrl>
-    <ReplaysSha1>DA3E595E4D0231934F1DCFC3B540097CE2ED1B17</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.27/replays.zip</ReplaysUrl>
+    <ReplaysSha1>CC0BE0C9B9829062B67E1CFE14E36BEA1182882D</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -177,7 +177,11 @@ namespace OpenRCT2
 #ifndef DISABLE_NETWORK
                 // If the network is disabled we will only get a dummy hash which will cause
                 // false positives during replay.
-                CheckState();
+                if (!CheckState())
+                {
+                    StopPlayback();
+                    return;
+                }
 #endif
                 ReplayCommands();
 
@@ -790,12 +794,12 @@ namespace OpenRCT2
         }
 
 #ifndef DISABLE_NETWORK
-        void CheckState()
+        bool CheckState()
         {
             uint32_t checksumIndex = _currentReplay->checksumIndex;
 
             if (checksumIndex >= _currentReplay->checksums.size())
-                return;
+                return true;
 
             const auto& savedChecksum = _currentReplay->checksums[checksumIndex];
             if (_currentReplay->checksums[checksumIndex].first == gCurrentTicks)
@@ -811,6 +815,8 @@ namespace OpenRCT2
                         replayTick, savedChecksum.second.ToString().c_str(), checksum.ToString().c_str());
 
                     _faultyChecksumIndex = checksumIndex;
+
+                    return false;
                 }
                 else
                 {
@@ -821,6 +827,8 @@ namespace OpenRCT2
                 }
                 _currentReplay->checksumIndex++;
             }
+
+            return true;
         }
 #endif // DISABLE_NETWORK
 

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -450,8 +450,9 @@ namespace OpenRCT2
 
         virtual bool IsPlaybackStateMismatching() const override
         {
-            if (_mode != ReplayMode::PLAYING)
+            if (_mode != ReplayMode::NONE)
             {
+                // This state is only valid after the playback.
                 return false;
             }
             return _faultyChecksumIndex != -1;

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -98,8 +98,9 @@ TEST_P(ReplayTests, RunReplay)
     while (replayManager->IsReplaying())
     {
         gs->UpdateLogic();
-        ASSERT_TRUE(replayManager->IsPlaybackStateMismatching() == false);
     }
+    ASSERT_FALSE(replayManager->IsReplaying());
+    ASSERT_FALSE(replayManager->IsPlaybackStateMismatching());
 #endif
 }
 


### PR DESCRIPTION
With the current logic there is an edge case if the last tick has the faulty checksum. After the last tick the _mode is no longer set to Playing and IsPlaybackStateMismatching would always result false.

I changed it to wait for the playback to complete and then test if the state is mismatching. This might cause the CI to fail now with out of date replays.

Later me: Yes the CI did fail as expected, also updating the replay version in this PR to have them all working again.