### PR TITLE
Fix #11912: Update active palette on Object Selection

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Feature: [#13614] Add terrain surfaces from RollerCoaster Tycoon 1.
 - Feature: [#13675] [Plugin] Add context.setInterval and context.setTimeout.
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
+- Fix: [#4605, #11912] Water palettes are not updated properly when selected in Object Selection.
 - Fix: [#9631, #10716] Banners drawing glitches when there are more than 32 on the screen at once.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
 - Fix: [#13102] Underflow on height chart (Ride measurements).

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/audio/audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/object/ObjectList.h>
 #include <openrct2/object/ObjectManager.h>
@@ -1327,6 +1328,11 @@ static void editor_load_selected_objects()
                 }
             }
         }
+    }
+    if (_numSelectedObjectsForType[EnumValue(ObjectType::Water)] == 0)
+    {
+        // Reloads the default cyan water palette if no palette was selected.
+        load_palette();
     }
 }
 


### PR DESCRIPTION
Hey all,

This change fixes issue #11912 where the palette does not reload when selected or when the Object Selection window is closed. For better user experience I chose to make it update instantly when selected, as opposed to only update after the window is closed (which is the case for all other selected objects).

When no palette is selected, it will load the default cyan water palette.

A video of the new fix in action:
https://user-images.githubusercontent.com/20048660/104855359-a35a0f00-590c-11eb-9cff-96bea10fd2b4.mp4

I'd love to hear any feedback on the code and whether this fix suits the project. 😃 

