### PR TITLE
Fix #13629: Refactor RCT1_PEEP_SPRITE_TYPE to use scoped enum

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -404,6 +404,38 @@ namespace RCT1
         }
     };
 
+    enum class PeepSpriteType : uint8_t
+    {
+        Normal = 0,
+        Handyman = 1,
+        Mechanic = 2,
+        Security = 3,
+        EntertainerPanda = 4,
+        EntertainerTiger = 5,
+        EntertainerElephant = 6,
+        EntertainerRoman = 7,
+        EntertainerGorilla = 8,
+        EntertainerSnowman = 9,
+        EntertainerKnight = 10,
+        EntertainerAstronaut = 11,
+
+        Balloon = 16,
+        Candyfloss = 17,
+        Umbrella = 18,
+        Pizza = 19,       // Unsure
+        SecurityAlt = 20, // Unknown
+        Popcorn = 21,
+        ArmsCrossed = 22,
+        HeadDown = 23,
+        Nauseous = 24,
+        VeryNauseous = 25,
+        RequireToilet = 26,
+        Hat = 27,
+        Burger = 28,
+        Tentacle = 29,
+        ToffeeApple = 30
+    };
+
     struct Peep : RCT12SpriteBase
     {
         uint8_t pad_1F[3];
@@ -415,7 +447,7 @@ namespace RCT1
         uint8_t outside_of_park;       // 0x2A
         uint8_t state;                 // 0x2B
         uint8_t sub_state;             // 0x2C
-        uint8_t sprite_type;           // 0x2D
+        PeepSpriteType sprite_type;    // 0x2D
         uint8_t type;                  // 0x2E
         union
         {
@@ -549,38 +581,6 @@ namespace RCT1
         }
     };
     assert_struct_size(Peep, 0x100);
-
-    enum class PeepSpriteType : uint8_t
-    {
-        Normal = 0,
-        Handyman = 1,
-        Mechanic = 2,
-        Security = 3,
-        EntertainerPanda = 4,
-        EntertainerTiger = 5,
-        EntertainerElephant = 6,
-        EntertainerRoman = 7,
-        EntertainerGorilla = 8,
-        EntertainerSnowman = 9,
-        EntertainerKnight = 10,
-        EntertainerAstronaut = 11,
-
-        Balloon = 16,
-        Candyfloss = 17,
-        Umbrella = 18,
-        Pizza = 19,       // Unsure
-        SecurityAlt = 20, // Unknown
-        Popcorn = 21,
-        ArmsCrossed = 22,
-        HeadDown = 23,
-        Nauseous = 24,
-        VeryNauseous = 25,
-        RequireToilet = 26,
-        Hat = 27,
-        Burger = 28,
-        Tentacle = 29,
-        ToffeeApple = 30
-    };
 
     union Entity
     {

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -550,36 +550,36 @@ namespace RCT1
     };
     assert_struct_size(Peep, 0x100);
 
-    enum RCT1_PEEP_SPRITE_TYPE
+    enum class PeepSpriteType : uint8_t
     {
-        RCT1_PEEP_SPRITE_TYPE_NORMAL = 0,
-        RCT1_PEEP_SPRITE_TYPE_HANDYMAN = 1,
-        RCT1_PEEP_SPRITE_TYPE_MECHANIC = 2,
-        RCT1_PEEP_SPRITE_TYPE_SECURITY = 3,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_PANDA = 4,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_TIGER = 5,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_ELEPHANT = 6,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_ROMAN = 7,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_GORILLA = 8,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_SNOWMAN = 9,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_KNIGHT = 10,
-        RCT1_PEEP_SPRITE_TYPE_ENTERTAINER_ASTRONAUT = 11,
+        Normal = 0,
+        Handyman = 1,
+        Mechanic = 2,
+        Security = 3,
+        EntertainerPanda = 4,
+        EntertainerTiger = 5,
+        EntertainerElephant = 6,
+        EntertainerRoman = 7,
+        EntertainerGorilla = 8,
+        EntertainerSnowman = 9,
+        EntertainerKnight = 10,
+        EntertainerAstronaut = 11,
 
-        RCT1_PEEP_SPRITE_TYPE_BALLOON = 16,
-        RCT1_PEEP_SPRITE_TYPE_CANDYFLOSS = 17,
-        RCT1_PEEP_SPRITE_TYPE_UMBRELLA = 18,
-        RCT1_PEEP_SPRITE_TYPE_PIZZA = 19,        // Unsure
-        RCT1_PEEP_SPRITE_TYPE_SECURITY_ALT = 20, // Unknown
-        RCT1_PEEP_SPRITE_TYPE_POPCORN = 21,
-        RCT1_PEEP_SPRITE_TYPE_ARMS_CROSSED = 22,
-        RCT1_PEEP_SPRITE_TYPE_HEAD_DOWN = 23,
-        RCT1_PEEP_SPRITE_TYPE_NAUSEOUS = 24,
-        RCT1_PEEP_SPRITE_TYPE_VERY_NAUSEOUS = 25,
-        RCT1_PEEP_SPRITE_TYPE_REQUIRE_TOILET = 26,
-        RCT1_PEEP_SPRITE_TYPE_HAT = 27,
-        RCT1_PEEP_SPRITE_TYPE_BURGER = 28,
-        RCT1_PEEP_SPRITE_TYPE_TENTACLE = 29,
-        RCT1_PEEP_SPRITE_TYPE_TOFFEE_APPLE = 30
+        Balloon = 16,
+        Candyfloss = 17,
+        Umbrella = 18,
+        Pizza = 19,       // Unsure
+        SecurityAlt = 20, // Unknown
+        Popcorn = 21,
+        ArmsCrossed = 22,
+        HeadDown = 23,
+        Nauseous = 24,
+        VeryNauseous = 25,
+        RequireToilet = 26,
+        Hat = 27,
+        Burger = 28,
+        Tentacle = 29,
+        ToffeeApple = 30
     };
 
     union Entity

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -68,7 +68,7 @@ namespace RCT1
         return map[colour];
     }
 
-    ::PeepSpriteType GetPeepSpriteType(PeepSpriteType rct1SpriteType)
+    ::PeepSpriteType GetPeepSpriteType(::RCT1::PeepSpriteType rct1SpriteType)
     {
         static constexpr const ::PeepSpriteType map[] =
         {

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -68,52 +68,52 @@ namespace RCT1
         return map[colour];
     }
 
-    PeepSpriteType GetPeepSpriteType(uint8_t rct1SpriteType)
+    ::PeepSpriteType GetPeepSpriteType(PeepSpriteType rct1SpriteType)
     {
-        static constexpr const PeepSpriteType map[] =
+        static constexpr const ::PeepSpriteType map[] =
         {
-            PeepSpriteType::Normal, // 0x00
-            PeepSpriteType::Handyman, // 0x01
-            PeepSpriteType::Mechanic, // 0x02
-            PeepSpriteType::Security, // 0x03
-            PeepSpriteType::EntertainerPanda, // 0x04
-            PeepSpriteType::EntertainerTiger, // 0x05
-            PeepSpriteType::EntertainerElephant, // 0x06
-            PeepSpriteType::EntertainerRoman, // 0x07
-            PeepSpriteType::EntertainerGorilla, // 0x08
-            PeepSpriteType::EntertainerSnowman, // 0x09
-            PeepSpriteType::EntertainerKnight, // 0x0A
-            PeepSpriteType::EntertainerAstronaut, // 0x0B
-            PeepSpriteType::IceCream, // 0x0C
-            PeepSpriteType::Chips, // 0x0D
-            PeepSpriteType::Burger, // 0x0E
-            PeepSpriteType::Drink, // 0x0F
-            PeepSpriteType::Balloon, // 0x10
-            PeepSpriteType::Candyfloss, // 0x11
-            PeepSpriteType::Umbrella, // 0x12
-            PeepSpriteType::Pizza, // 0x13
-            PeepSpriteType::SecurityAlt, // 0x14
-            PeepSpriteType::Popcorn, // 0x15
-            PeepSpriteType::ArmsCrossed, // 0x16
-            PeepSpriteType::HeadDown, // 0x17
-            PeepSpriteType::Nauseous, // 0x18
-            PeepSpriteType::VeryNauseous, // 0x19
-            PeepSpriteType::RequireToilet, // 0x1A
-            PeepSpriteType::Hat, // 0x1B
-            PeepSpriteType::HotDog, // 0x1C
-            PeepSpriteType::Tentacle, // 0x1D
-            PeepSpriteType::ToffeeApple, // 0x1E
-            PeepSpriteType::Doughnut, // 0x1F
-            PeepSpriteType::Coffee, // 0x20
-            PeepSpriteType::Chicken, // 0x21
-            PeepSpriteType::Lemonade, // 0x22
+            ::PeepSpriteType::Normal, // 0x00
+            ::PeepSpriteType::Handyman, // 0x01
+            ::PeepSpriteType::Mechanic, // 0x02
+            ::PeepSpriteType::Security, // 0x03
+            ::PeepSpriteType::EntertainerPanda, // 0x04
+            ::PeepSpriteType::EntertainerTiger, // 0x05
+            ::PeepSpriteType::EntertainerElephant, // 0x06
+            ::PeepSpriteType::EntertainerRoman, // 0x07
+            ::PeepSpriteType::EntertainerGorilla, // 0x08
+            ::PeepSpriteType::EntertainerSnowman, // 0x09
+            ::PeepSpriteType::EntertainerKnight, // 0x0A
+            ::PeepSpriteType::EntertainerAstronaut, // 0x0B
+            ::PeepSpriteType::IceCream, // 0x0C
+            ::PeepSpriteType::Chips, // 0x0D
+            ::PeepSpriteType::Burger, // 0x0E
+            ::PeepSpriteType::Drink, // 0x0F
+            ::PeepSpriteType::Balloon, // 0x10
+            ::PeepSpriteType::Candyfloss, // 0x11
+            ::PeepSpriteType::Umbrella, // 0x12
+            ::PeepSpriteType::Pizza, // 0x13
+            ::PeepSpriteType::SecurityAlt, // 0x14
+            ::PeepSpriteType::Popcorn, // 0x15
+            ::PeepSpriteType::ArmsCrossed, // 0x16
+            ::PeepSpriteType::HeadDown, // 0x17
+            ::PeepSpriteType::Nauseous, // 0x18
+            ::PeepSpriteType::VeryNauseous, // 0x19
+            ::PeepSpriteType::RequireToilet, // 0x1A
+            ::PeepSpriteType::Hat, // 0x1B
+            ::PeepSpriteType::HotDog, // 0x1C
+            ::PeepSpriteType::Tentacle, // 0x1D
+            ::PeepSpriteType::ToffeeApple, // 0x1E
+            ::PeepSpriteType::Doughnut, // 0x1F
+            ::PeepSpriteType::Coffee, // 0x20
+            ::PeepSpriteType::Chicken, // 0x21
+            ::PeepSpriteType::Lemonade, // 0x22
         };
-        if (rct1SpriteType >= std::size(map))
+        if (EnumValue(rct1SpriteType) >= std::size(map))
         {
-            log_warning("Unsupported RCT1 peep sprite type: %d.", rct1SpriteType);
-            return PeepSpriteType::Normal;
+            log_warning("Unsupported RCT1 peep sprite type: %d.", EnumValue(rct1SpriteType));
+            return ::PeepSpriteType::Normal;
         }
-        return map[rct1SpriteType];
+        return map[EnumValue(rct1SpriteType)];
     }
 
     std::string_view GetTerrainSurfaceObject(uint8_t terrainSurface)

--- a/src/openrct2/rct1/Tables.h
+++ b/src/openrct2/rct1/Tables.h
@@ -22,6 +22,7 @@ namespace RCT1
     };
 
     enum class RideType : uint8_t;
+    enum class PeepSpriteType : uint8_t;
 
     colour_t GetColour(colour_t colour);
     ::PeepSpriteType GetPeepSpriteType(PeepSpriteType rct1SpriteType);

--- a/src/openrct2/rct1/Tables.h
+++ b/src/openrct2/rct1/Tables.h
@@ -24,7 +24,7 @@ namespace RCT1
     enum class RideType : uint8_t;
 
     colour_t GetColour(colour_t colour);
-    PeepSpriteType GetPeepSpriteType(uint8_t rct1SpriteType);
+    ::PeepSpriteType GetPeepSpriteType(PeepSpriteType rct1SpriteType);
 
     uint8_t GetRideType(RideType rideType, uint8_t vehicleType);
     VehicleColourSchemeCopyDescriptor GetColourSchemeCopyDescriptor(uint8_t vehicleType);


### PR DESCRIPTION
This PR is an implementation for #13629

The intent of the modified code is a little confusing though. RCT1::PeepSpriteType is coupled to the index of the array (map) in RCT1::GetPeepSpriteType. I think it would be a good idea to better communicate the intent explicitly when mapping the RCT1 to OpenRCT2.