### PR TITLE
Allow the main game loop to scale the delta time

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -118,7 +118,8 @@ namespace OpenRCT2
         bool _initialised = false;
         bool _isWindowMinimised = false;
         uint32_t _lastTick = 0;
-        uint32_t _accumulator = 0;
+        float _accumulator = 0.0f;
+        float _timeScale = 1.0f;
         uint32_t _lastUpdateTime = 0;
         bool _variableFrame = false;
 
@@ -978,9 +979,9 @@ namespace OpenRCT2
                 _lastTick = currentTick;
             }
 
-            uint32_t elapsed = currentTick - _lastTick;
+            float elapsed = (currentTick - _lastTick) * _timeScale;
             _lastTick = currentTick;
-            _accumulator = std::min(_accumulator + elapsed, static_cast<uint32_t>(GAME_UPDATE_MAX_THRESHOLD));
+            _accumulator = std::min(_accumulator + elapsed, static_cast<float>(GAME_UPDATE_MAX_THRESHOLD));
 
             _uiContext->ProcessMessages();
 
@@ -1021,10 +1022,10 @@ namespace OpenRCT2
                 _lastTick = currentTick;
             }
 
-            uint32_t elapsed = currentTick - _lastTick;
+            float elapsed = (currentTick - _lastTick) * _timeScale;
 
             _lastTick = currentTick;
-            _accumulator = std::min(_accumulator + elapsed, static_cast<uint32_t>(GAME_UPDATE_MAX_THRESHOLD));
+            _accumulator = std::min(_accumulator + elapsed, static_cast<float>(GAME_UPDATE_MAX_THRESHOLD));
 
             _uiContext->ProcessMessages();
 
@@ -1048,7 +1049,7 @@ namespace OpenRCT2
 
             if (draw)
             {
-                const float alpha = std::min(static_cast<float>(_accumulator) / GAME_UPDATE_TIME_MS, 1.0f);
+                const float alpha = std::min(_accumulator / static_cast<float>(GAME_UPDATE_TIME_MS), 1.0f);
                 tweener.Tween(alpha);
 
                 _drawingEngine->BeginDraw();
@@ -1220,6 +1221,16 @@ namespace OpenRCT2
         {
             return &_newVersionInfo;
         }
+
+        void SetTimeScale(float newScale) override
+        {
+            _timeScale = std::clamp(newScale, GAME_MIN_TIME_SCALE, GAME_MAX_TIME_SCALE);
+        }
+
+        float GetTimeScale() const override
+        {
+            return _timeScale;
+        }
     };
 
     Context* Context::Instance = nullptr;
@@ -1240,6 +1251,7 @@ namespace OpenRCT2
     {
         return Context::Instance;
     }
+
 } // namespace OpenRCT2
 
 void context_init()

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -150,6 +150,9 @@ namespace OpenRCT2
          * This is deprecated, use IPlatformEnvironment.
          */
         virtual std::string GetPathLegacy(int32_t pathId) abstract;
+
+        virtual void SetTimeScale(float newScale) abstract;
+        virtual float GetTimeScale() const abstract;
     };
 
     std::unique_ptr<IContext> CreateContext();
@@ -170,6 +173,9 @@ enum
     // The maximum threshold to advance.
     GAME_UPDATE_MAX_THRESHOLD = GAME_UPDATE_TIME_MS * GAME_MAX_UPDATES,
 };
+
+constexpr float GAME_MIN_TIME_SCALE = 0.1f;
+constexpr float GAME_MAX_TIME_SCALE = 5.0f;
 
 /**
  * Legacy get_file_path IDs.

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -693,6 +693,10 @@ static int32_t cc_get(InteractiveConsole& console, const arguments_t& argv)
         {
             console.WriteFormatLine("current_rotation %d", get_current_rotation());
         }
+        else if (argv[0] == "host_timescale")
+        {
+            console.WriteFormatLine("host_timescale %.02f", OpenRCT2::GetContext()->GetTimeScale());
+        }
 #ifndef NO_TTF
         else if (argv[0] == "enable_hinting")
         {
@@ -1010,6 +1014,14 @@ static int32_t cc_set(InteractiveConsole& console, const arguments_t& argv)
                 window_rotate_camera(mainWindow, newRotation - currentRotation);
             }
             console.Execute("get current_rotation");
+        }
+        else if (argv[0] == "host_timescale" && invalidArguments(&invalidArgs, double_valid[0]))
+        {
+            float newScale = static_cast<float>(double_val[0]);
+
+            OpenRCT2::GetContext()->SetTimeScale(newScale);
+
+            console.Execute("get host_timescale");
         }
 #ifndef NO_TTF
         else if (argv[0] == "enable_hinting" && invalidArguments(&invalidArgs, int_valid[0]))


### PR DESCRIPTION
Which results in this:

https://www.youtube.com/watch?v=dNNmagd1nOs

The final goal is to get rid of the inner loop that drives the game speed and have input/windows update at fixed time, I already have scrolling fixed locally but I want to do smaller changes over time. 