### PR TITLE
Fix #13871: Crash on banner window invalidation

### DIFF
--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -275,7 +275,7 @@ static void window_banner_invalidate(rct_window* w)
 
     // Scenery item not sure why we use this instead of banner?
     rct_scenery_entry* sceneryEntry = get_banner_entry(banner->type);
-    if (sceneryEntry->banner.flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR)
+    if (sceneryEntry != nullptr && (sceneryEntry->banner.flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR))
     {
         colour_btn->type = WindowWidgetType::ColourBtn;
     }


### PR DESCRIPTION
Not sure how it can be null but in this specific case it is, this prevents the crash at least.

Closes #13871