### PR TITLE
update ChecksumIndex when checksum mismatch

### DIFF
--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -816,6 +816,7 @@ namespace OpenRCT2
 
                     _faultyChecksumIndex = checksumIndex;
 
+                    _currentReplay->checksumIndex++;
                     return false;
                 }
                 else


### PR DESCRIPTION
This appears to solve the issues outlined in the comments section of https://github.com/OpenRCT2/OpenRCT2/pull/13838

When cherry-picking a7a0441 onto this commit, the desync is only 3kb compared to the 8000kb desync without this commit.