### PR TITLE
Fix replay snapshots comparing states with different ticks

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -533,7 +533,8 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     virtual GameStateCompareData_t Compare(const GameStateSnapshot_t& base, const GameStateSnapshot_t& cmp) const override final
     {
         GameStateCompareData_t res;
-        res.tick = base.tick;
+        res.tickLeft = base.tick;
+        res.tickRight = cmp.tick;
         res.srand0Left = base.srand0;
         res.srand0Right = cmp.srand0;
 
@@ -643,7 +644,13 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         std::string outputBuffer;
         char tempBuffer[1024] = {};
 
-        snprintf(tempBuffer, sizeof(tempBuffer), "tick: %08X\n", cmpData.tick);
+        if (cmpData.tickLeft != cmpData.tickRight)
+        {
+            outputBuffer += "WARNING: Comparing two snapshots with different ticks, this will very likely result in false "
+                            "positives\n";
+        }
+
+        snprintf(tempBuffer, sizeof(tempBuffer), "tick left = %08X, tick right = %08X\n", cmpData.tickLeft, cmpData.tickRight);
         outputBuffer += tempBuffer;
 
         snprintf(

--- a/src/openrct2/GameStateSnapshots.h
+++ b/src/openrct2/GameStateSnapshots.h
@@ -48,7 +48,8 @@ struct GameStateSpriteChange_t
 
 struct GameStateCompareData_t
 {
-    uint32_t tick;
+    uint32_t tickLeft;
+    uint32_t tickRight;
     uint32_t srand0Left;
     uint32_t srand0Right;
     std::vector<GameStateSpriteChange_t> spriteChanges;

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -98,6 +98,8 @@ TEST_P(ReplayTests, RunReplay)
     while (replayManager->IsReplaying())
     {
         gs->UpdateLogic();
+        if (replayManager->IsPlaybackStateMismatching())
+            break;
     }
     ASSERT_FALSE(replayManager->IsReplaying());
     ASSERT_FALSE(replayManager->IsPlaybackStateMismatching());


### PR DESCRIPTION
I added a check that it would stop the replay the moment it detected a desync but apparently the snapshot data relies to be the last tick of the replay so it has to continue all the way. I instead placed the early break logic in the Tests and added a warning to when the snapshot tick isn't matching.

The snapshot system never checked the ticks as this system has different assumptions than the replay manager.