### PR TITLE
Split free id's into separate vector

### DIFF
--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -286,7 +286,7 @@ static void window_editor_bottom_toolbar_mouseup([[maybe_unused]] rct_window* w,
     if (widgetIndex == WIDX_PREVIOUS_STEP_BUTTON)
     {
         if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-            || (GetEntityListCount(EntityListId::Free) == MAX_SPRITES && !(gParkFlags & PARK_FLAGS_SPRITES_INITIALISED)))
+            || (GetNumFreeEntities() == MAX_SPRITES && !(gParkFlags & PARK_FLAGS_SPRITES_INITIALISED)))
         {
             previous_button_mouseup_events[EnumValue(gS6Info.editor_step)]();
         }
@@ -346,7 +346,7 @@ void window_editor_bottom_toolbar_invalidate(rct_window* w)
         }
         else if (!(gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER))
         {
-            if (GetEntityListCount(EntityListId::Free) != MAX_SPRITES || gParkFlags & PARK_FLAGS_SPRITES_INITIALISED)
+            if (GetNumFreeEntities() != MAX_SPRITES || gParkFlags & PARK_FLAGS_SPRITES_INITIALISED)
             {
                 hide_previous_step_button();
             }
@@ -371,7 +371,7 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         drawPreviousButton = true;
     }
-    else if (GetEntityListCount(EntityListId::Free) != MAX_SPRITES)
+    else if (GetNumFreeEntities() != MAX_SPRITES)
     {
         drawNextButton = true;
     }

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -89,7 +89,7 @@ GameActions::Result::Ptr StaffHireNewAction::QueryExecute(bool execute) const
         return MakeResult(GameActions::Status::InvalidParameters, STR_NONE);
     }
 
-    if (GetEntityListCount(EntityListId::Free) < 400)
+    if (GetNumFreeEntities() < 400)
     {
         return MakeResult(GameActions::Status::NoFreeElements, STR_TOO_MANY_PEOPLE_IN_GAME);
     }

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -1585,7 +1585,7 @@ void Peep::InsertNewThought(PeepThoughtType thoughtType, uint8_t thoughtArgument
  */
 Peep* Peep::Generate(const CoordsXYZ& coords)
 {
-    if (GetEntityListCount(EntityListId::Free) < 400)
+    if (GetNumFreeEntities() < 400)
         return nullptr;
 
     Peep* peep = &create_sprite(SpriteIdentifier::Peep)->peep;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -947,11 +947,6 @@ void S6Exporter::ExportSprites()
         ExportSprite(&_s6.sprites[i], reinterpret_cast<const rct_sprite*>(GetEntity(i)));
     }
 
-    for (int32_t i = 0; i < static_cast<uint8_t>(EntityListId::Count); i++)
-    {
-        //_s6.sprite_lists_head[i] = gSpriteListHead[i];
-        _s6.sprite_lists_count[i] = GetEntityListCount(EntityListId(i));
-    }
     RebuildEntityLinks();
 }
 
@@ -967,6 +962,7 @@ void S6Exporter::RebuildEntityLinks()
         {
             if (entity.unknown.linked_list_type_offset == list)
             {
+                _s6.sprite_lists_count[EnumValue(list) >> 1]++;
                 _s6.sprites[entity.unknown.sprite_index].unknown.previous = previous;
                 if (previous != SPRITE_INDEX_NULL)
                 {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4379,7 +4379,7 @@ static void ride_set_start_finish_points(ride_id_t rideIndex, CoordsXYE* startEl
 static int32_t count_free_misc_sprite_slots()
 {
     int32_t miscSpriteCount = GetEntityListCount(EntityListId::Misc);
-    int32_t remainingSpriteCount = GetEntityListCount(EntityListId::Free);
+    int32_t remainingSpriteCount = GetNumFreeEntities();
     return std::max(0, miscSpriteCount + remainingSpriteCount - 300);
 }
 

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -228,6 +228,7 @@ template<typename T = SpriteBase> T* TryGetEntity(size_t sprite_idx)
 }
 
 uint16_t GetEntityListCount(EntityListId list);
+uint16_t GetNumFreeEntities();
 
 constexpr const uint32_t SPATIAL_INDEX_SIZE = (MAXIMUM_MAP_SIZE_TECHNICAL * MAXIMUM_MAP_SIZE_TECHNICAL) + 1;
 constexpr const uint32_t SPATIAL_INDEX_LOCATION_NULL = SPATIAL_INDEX_SIZE - 1;


### PR DESCRIPTION
This makes it so that free id's will eventually only need to store memory for the uint16_t index (future pr). There is potential future scope to make this fancier so that it doesn't need to store all of the free id's and just stores ranges but for now this will do.

Order is reversed so that back and pop_back can be used to get the next free element and save some memory shuffling.