### PR TITLE
Fix #13916: use correct constant for maximum station locations

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6966,7 +6966,7 @@ void sub_6CB945(Ride* ride)
         }
     }
 
-    FixedVector<TileCoordsXYZD, MAX_STATIONS> locations;
+    FixedVector<TileCoordsXYZD, MAX_STATION_LOCATIONS> locations;
     for (StationIndex stationId = 0; stationId < MAX_STATIONS; ++stationId)
     {
         auto entrance = ride_get_entrance_location(ride, stationId);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -46,6 +46,7 @@ struct Staff;
 #define RIDE_TYPE_NULL 255
 #define RIDE_ADJACENCY_CHECK_DISTANCE 5
 
+constexpr uint16_t const MAX_STATION_LOCATIONS = MAX_STATIONS * 2; // Entrance and exit per station
 constexpr uint16_t const MAX_INVERSIONS = RCT12_MAX_INVERSIONS;
 constexpr uint16_t const MAX_GOLF_HOLES = RCT12_MAX_GOLF_HOLES;
 constexpr uint16_t const MAX_HELICES = RCT12_MAX_HELICES;


### PR DESCRIPTION
This makes more sense.

Closes #13916