### PR TITLE
Fix entrance or exit stacked on top considered a duplicate

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#13510] [Plugin] list view scroll resets when items is set.
 - Fix: [#13574] Crash when a JSON object does not set `originalId`.
 - Fix: [#13832] Players last action position is invalid on opening/closing a ride in multiplayer.
+- Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "15"
+#define NETWORK_STREAM_VERSION "16"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6710,7 +6710,8 @@ void sub_6CB945(Ride* ride)
         while (locationList != locations.cend())
         {
             const TileCoordsXYZD& locationCoords2 = *locationList++;
-            if (locationCoords.x == locationCoords2.x && locationCoords.y == locationCoords2.y)
+            if (locationCoords.x == locationCoords2.x && locationCoords.y == locationCoords2.y
+                && locationCoords.z == locationCoords2.z)
             {
                 duplicateLocation = true;
                 break;


### PR DESCRIPTION
![2021-01-23_22-33-51](https://user-images.githubusercontent.com/5415177/105613650-7c984e80-5dcc-11eb-9d90-61589a6c3cf6.gif)

It only checked the x and y axis and ignored the height. After the PR this setup works:

![2021-01-23_22-47-20](https://user-images.githubusercontent.com/5415177/105613712-00523b00-5dcd-11eb-84e8-41dc2d52b252.gif)

Edit: I just realized the mechanic was also unable to ever get to the ride when it broke down, this fix helps with that also.