### PR TITLE
Add nullptr check in get_loaded_object_entry

### DIFF
--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -138,8 +138,13 @@ const rct_object_entry* get_loaded_object_entry(size_t index)
     ObjectType objectType;
     ObjectEntryIndex entryIndex;
     get_type_entry_index(index, &objectType, &entryIndex);
+    auto obj = object_entry_get_object(objectType, entryIndex);
+    if (obj == nullptr)
+    {
+        return nullptr;
+    }
 
-    return object_entry_get_object(objectType, entryIndex)->GetObjectEntry();
+    return obj->GetObjectEntry();
 }
 
 void* get_loaded_object_chunk(size_t index)

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -168,7 +168,7 @@ void S6Exporter::Export()
         const rct_object_entry* entry = get_loaded_object_entry(i);
         void* entryData = get_loaded_object_chunk(i);
         // RCT2 uses (void *)-1 to mark NULL. Make sure it's written in a vanilla-compatible way.
-        if (entryData == nullptr || entryData == reinterpret_cast<void*>(-1))
+        if (entry == nullptr || entryData == nullptr || entryData == reinterpret_cast<void*>(-1))
         {
             std::memset(&_s6.objects[i], 0xFF, sizeof(rct_object_entry));
         }


### PR DESCRIPTION
I can easily hit that with following steps:
1. Launch new scenario `Crazy Castle` (the very first one)
2. Try saving the game (or have autosave trigger)

```
#4  0x00007ffff6977fd3 in get_loaded_object_entry (index=98)
    at ../src/openrct2/object/ObjectList.cpp:142
#5  0x00007ffff6a1ea26 in S6Exporter::Export (this=0x5555590f36c0)
    at ../src/openrct2/rct2/S6Exporter.cpp:168
#6  0x00007ffff6a24ea4 in scenario_save (
    path=0x7fffffffd680 "/home/mijn/.config/OpenRCT2/save/autosave/autosave_2021-01-23_21-57-29.sv6", flags=-2147483648) at ../src/openrct2/rct2/S6Exporter.cpp:1778
#7  0x00007ffff67534c6 in game_autosave () at ../src/openrct2/Game.cpp:765
#8  0x00007ffff6dca1ac in scenario_autosave_check () at ../src/openrct2/scenario/Scenario.cpp:283
#9  0x00007ffff6757eef in OpenRCT2::GameState::Update (this=0x555555f78160)
    at ../src/openrct2/GameState.cpp:216
#10 0x00007ffff6738743 in OpenRCT2::Context::Update (this=0x555555d3f2b0)
    at ../src/openrct2/Context.cpp:1084
#11 0x00007ffff67382e9 in OpenRCT2::Context::RunFixedFrame (this=0x555555d3f2b0)
    at ../src/openrct2/Context.cpp:995
#12 0x00007ffff67381de in OpenRCT2::Context::RunFrame (this=0x555555d3f2b0)
    at ../src/openrct2/Context.cpp:968
#13 0x00007ffff6738127 in OpenRCT2::Context::RunGameLoop (this=0x555555d3f2b0)
    at ../src/openrct2/Context.cpp:933
#14 0x00007ffff6737ecc in OpenRCT2::Context::Launch (this=0x555555d3f2b0)
    at ../src/openrct2/Context.cpp:905
#15 0x00007ffff67354af in OpenRCT2::Context::RunOpenRCT2 (this=0x555555d3f2b0, argc=1, 
    argv=0x7fffffffdc98) at ../src/openrct2/Context.cpp:263
#16 0x00005555556395de in main (argc=1, argv=0x7fffffffdc98) at ../src/openrct2-ui/Ui.cpp:62
```