### PR TITLE
Fix #13958: Queue corruption due to intersecting entrances

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -5298,7 +5298,8 @@ void Guest::UpdateQueuing()
         return;
     }
 
-    if (SubState != 10)
+    // If not in the queue then at front of queue
+    if (RideSubState != PeepRideSubState::InQueue)
     {
         bool is_front = true;
         // Fix #4819: Occasionally the peep->GuestNextInQueue is incorrectly set

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -264,7 +264,8 @@ enum class PeepRideSubState : uint8_t
     LeaveVehicle = 7,
     ApproachExit = 8,
     InExit = 9,
-    // 10, 11 not used
+    InQueue = 10,
+    AtQueueFront = 11,
     ApproachVehicleWaypoints = 12,
     ApproachExitWaypoints = 13,
     ApproachSpiralSlide = 14,


### PR DESCRIPTION
There was a whole host of bugs that this issue has exposed which were caused by intersecting the queue of a ride with an entrance/exit or shop. When this was done the peep would be removed from the queue incorrectly and could end up at the wrong station or a variety of other unexpected behaviour