### PR TITLE
Fix issues with spinning control toggle

### DIFF
--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -781,7 +781,9 @@ void S6Exporter::ExportRideRatingsCalcData()
     dst.proximity_start_z = src.ProximityStart.z;
     dst.current_ride = src.CurrentRide;
     dst.state = src.State;
-    dst.proximity_track_type = src.ProximityTrackType;
+    dst.proximity_track_type = static_cast<uint8_t>(src.ProximityTrackType);
+    if (src.ProximityTrackType == TrackElemType::RotationControlToggle)
+        dst.proximity_track_type = static_cast<uint8_t>(TrackElemType::RotationControlToggleAlias);
     dst.proximity_base_height = src.ProximityBaseHeight;
     dst.proximity_total = src.ProximityTotal;
     for (size_t i = 0; i < std::size(dst.proximity_scores); i++)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -803,6 +803,9 @@ public:
         dst.CurrentRide = src.current_ride;
         dst.State = src.state;
         dst.ProximityTrackType = src.proximity_track_type;
+        if (src.proximity_track_type == TrackElemType::RotationControlToggleAlias
+            && !RCT2TrackTypeIsBooster(_s6.rides[src.current_ride].type, src.proximity_track_type))
+            dst.ProximityTrackType = TrackElemType::RotationControlToggle;
         dst.ProximityBaseHeight = src.proximity_base_height;
         dst.ProximityTotal = src.proximity_total;
         for (size_t i = 0; i < std::size(src.proximity_scores); i++)

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -203,7 +203,7 @@ static void ride_ratings_update_state_2()
     }
 
     auto loc = gRideRatingsCalcData.Proximity;
-    int32_t trackType = gRideRatingsCalcData.ProximityTrackType;
+    track_type_t trackType = gRideRatingsCalcData.ProximityTrackType;
 
     TileElement* tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
@@ -226,7 +226,7 @@ static void ride_ratings_update_state_2()
                 continue;
         }
 
-        if (trackType == 255
+        if (trackType == TrackElemType::None
             || (tileElement->AsTrack()->GetSequenceIndex() == 0 && trackType == tileElement->AsTrack()->GetTrackType()))
         {
             if (trackType == TrackElemType::EndStation)
@@ -309,7 +309,7 @@ static void ride_ratings_update_state_5()
     }
 
     auto loc = gRideRatingsCalcData.Proximity;
-    int32_t trackType = gRideRatingsCalcData.ProximityTrackType;
+    track_type_t trackType = gRideRatingsCalcData.ProximityTrackType;
 
     TileElement* tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
@@ -332,7 +332,7 @@ static void ride_ratings_update_state_5()
                 continue;
         }
 
-        if (trackType == 255 || trackType == tileElement->AsTrack()->GetTrackType())
+        if (trackType == TrackElemType::None || trackType == tileElement->AsTrack()->GetTrackType())
         {
             ride_ratings_score_close_proximity(tileElement);
 
@@ -390,9 +390,8 @@ static void ride_ratings_begin_proximity_loop()
             }
 
             auto location = ride->stations[i].GetStart();
-
             gRideRatingsCalcData.Proximity = location;
-            gRideRatingsCalcData.ProximityTrackType = 255;
+            gRideRatingsCalcData.ProximityTrackType = TrackElemType::None;
             gRideRatingsCalcData.ProximityStart = location;
             return;
         }

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -14,6 +14,7 @@
 #include "RideTypes.h"
 
 using ride_rating = fixed16_2dp;
+using track_type_t = uint16_t;
 
 // Convenience function for writing ride ratings. The result is a 16 bit signed
 // integer. To create the ride rating 3.65 type RIDE_RATING(3,65)
@@ -44,7 +45,7 @@ struct RideRatingCalculationData
     CoordsXYZ ProximityStart;
     ride_id_t CurrentRide;
     uint8_t State;
-    uint16_t ProximityTrackType;
+    track_type_t ProximityTrackType;
     uint8_t ProximityBaseHeight;
     uint16_t ProximityTotal;
     uint16_t ProximityScores[26];

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -44,7 +44,7 @@ struct RideRatingCalculationData
     CoordsXYZ ProximityStart;
     ride_id_t CurrentRide;
     uint8_t State;
-    uint8_t ProximityTrackType;
+    uint16_t ProximityTrackType;
     uint8_t ProximityBaseHeight;
     uint16_t ProximityTotal;
     uint16_t ProximityScores[26];

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -2939,7 +2939,7 @@ static constexpr const rct_preview_track TrackBlocks255[] = {
 };
 
 static constexpr const rct_preview_track TrackBlocksRotationControlToggle[] = {
-    { 0, 0, 0, 0, 16, { 0b1111, 0b1100 }, 0 },
+    { 0, 0, 0, 0, 0, { 0b1111, 0b1100 }, 0 },
     TRACK_BLOCK_END
 };
 


### PR DESCRIPTION
Everything except the changes to import/export I know to be necessary. I tested with the uin16_t change but without the import/export after I thought I snuck the track element into it, but ratings did not seem to be affected in any way. I added the import/export stuff just to be on the safe side.