### PR TITLE
Check for correct peep state when removing mass

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#11438] Freeze when shrinking map size.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
 - Fix: [#13102] Underflow on height chart (Ride measurements).
+- Fix: [#13234] Incorrect vehicle mass after using Remove All Guests cheat.
 - Fix: [#13236] New ride type appears as new vehicle type in research.
 - Fix: [#13257] Rides that are exactly the minimum objective length are not counted.
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.

--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -644,7 +644,11 @@ void SetCheatAction::RemoveAllGuests() const
                     auto peep = TryGetEntity<Guest>(peepInTrainIndex);
                     if (peep != nullptr)
                     {
-                        vehicle->mass -= peep->Mass;
+                        if ((peep->State == PeepState::OnRide && peep->RideSubState == PeepRideSubState::OnRide)
+                            || (peep->State == PeepState::LeavingRide && peep->RideSubState == PeepRideSubState::LeaveVehicle))
+                        {
+                            vehicle->mass -= peep->Mass;
+                        }
                     }
                     peepInTrainIndex = SPRITE_INDEX_NULL;
                 }

--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -647,7 +647,7 @@ void SetCheatAction::RemoveAllGuests() const
                         if ((peep->State == PeepState::OnRide && peep->RideSubState == PeepRideSubState::OnRide)
                             || (peep->State == PeepState::LeavingRide && peep->RideSubState == PeepRideSubState::LeaveVehicle))
                         {
-                            vehicle->mass -= peep->Mass;
+                            vehicle->ApplyMass(-peep->Mass);
                         }
                     }
                     peepInTrainIndex = SPRITE_INDEX_NULL;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -34,7 +34,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -3836,7 +3836,7 @@ void Guest::UpdateRideEnterVehicle()
                     vehicle->num_peeps++;
                     ride->cur_num_customers++;
 
-                    vehicle->mass += seatedGuest->Mass;
+                    vehicle->ApplyMass(seatedGuest->Mass);
                     seatedGuest->MoveTo({ LOCATION_NULL, 0, 0 });
                     seatedGuest->SetState(PeepState::OnRide);
                     seatedGuest->GuestTimeOnRide = 0;
@@ -3848,7 +3848,7 @@ void Guest::UpdateRideEnterVehicle()
             vehicle->num_peeps++;
             ride->cur_num_customers++;
 
-            vehicle->mass += Mass;
+            vehicle->ApplyMass(Mass);
             vehicle->Invalidate();
 
             MoveTo({ LOCATION_NULL, 0, 0 });
@@ -3897,7 +3897,7 @@ void Guest::UpdateRideLeaveVehicle()
     ActionSpriteImageOffset = 0;
 
     vehicle->num_peeps--;
-    vehicle->mass -= Mass;
+    vehicle->ApplyMass(-Mass);
     vehicle->Invalidate();
 
     if (ride_station >= MAX_STATIONS)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -823,7 +823,6 @@ void Vehicle::ApplyMass(int16_t appliedMass)
     mass = std::clamp<int32_t>(mass + appliedMass, 1, std::numeric_limits<decltype(mass)>::max());
 }
 
-
 void Vehicle::MoveRelativeDistance(int32_t distance)
 {
     remaining_distance += distance;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -818,6 +818,12 @@ uint16_t Vehicle::GetTrackProgress() const
     return vehicle_get_move_info_size(TrackSubposition, track_type);
 }
 
+void Vehicle::ApplyMass(int16_t appliedMass)
+{
+    mass = std::clamp<int32_t>(mass + appliedMass, 1, std::numeric_limits<decltype(mass)>::max());
+}
+
+
 void Vehicle::MoveRelativeDistance(int32_t distance)
 {
     remaining_distance += distance;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -372,6 +372,7 @@ struct Vehicle : SpriteBase
     {
         update_flags |= flag;
     }
+    void ApplyMass(int16_t appliedMass);
 
 private:
     bool SoundCanPlay() const;


### PR DESCRIPTION
This has exposed a bunch of things related to peep references that I want to explore. It looks like vehicles (that aren't ferriswheels) do not clean up after themselves when removing a peep from their vehicle. This should be changed as this will leave potentially invalid references in the vehicle.