### PR TITLE
Fix URL in Appstream XML

### DIFF
--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -41,7 +41,7 @@
   <url type="homepage">https://openrct2.io/</url>
   <url type="bugtracker">https://github.com/OpenRCT2/OpenRCT2/issues</url>
   <url type="faq">https://github.com/OpenRCT2/OpenRCT2/wiki/FAQ-&amp;-Common-Issues</url>
-  <url type="help">docs.openrct2.io</url>
+  <url type="help">https://docs.openrct2.io</url>
   <url type="translate">https://github.com/OpenRCT2/Localisation</url>
   <content_rating type="oars-1.0">
     <content_attribute id="violence-cartoon">mild</content_attribute>


### PR DESCRIPTION
Flathub appstream validator requires the URL field to start with the protocol.