### PR TITLE
Reset peep index to null

### DIFF
--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -644,10 +644,15 @@ void SetCheatAction::RemoveAllGuests() const
                     auto peep = TryGetEntity<Guest>(peepInTrainIndex);
                     if (peep != nullptr)
                     {
-                        if ((peep->State == PeepState::OnRide && peep->RideSubState == PeepRideSubState::OnRide)
-                            || (peep->State == PeepState::LeavingRide && peep->RideSubState == PeepRideSubState::LeaveVehicle))
+                        // Due to mistake in vanilla saves may have peep indexs that are invalid
+                        if (peep->CurrentRide == vehicle->ride)
                         {
-                            vehicle->ApplyMass(-peep->Mass);
+                            if ((peep->State == PeepState::OnRide && peep->RideSubState == PeepRideSubState::OnRide)
+                                || (peep->State == PeepState::LeavingRide
+                                    && peep->RideSubState == PeepRideSubState::LeaveVehicle))
+                            {
+                                vehicle->ApplyMass(-peep->Mass);
+                            }
                         }
                     }
                     peepInTrainIndex = SPRITE_INDEX_NULL;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -3898,6 +3898,7 @@ void Guest::UpdateRideLeaveVehicle()
 
     vehicle->num_peeps--;
     vehicle->ApplyMass(-Mass);
+    vehicle->peep[CurrentSeat] = SPRITE_INDEX_NULL;
     vehicle->Invalidate();
 
     if (ride_station >= MAX_STATIONS)


### PR DESCRIPTION
Fixes #13989 and applies even more checks to the remove all guests cheat.
Will break replays.