### PR TITLE
Display where a track design is located inside the track selector

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.3.3+ (in development)
 ------------------------------------------------------------------------
+- Feature: [#13967] Track List window now displays the path to the design when debugging tools are on.
 - Feature: [#14071] “Vandals stopped” statistic for security guards.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
+#include <openrct2/config/Config.h>
 #include <openrct2/Context.h>
 #include <openrct2/Editor.h>
 #include <openrct2/OpenRCT2.h>
@@ -500,13 +501,25 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Track preview
     int32_t colour;
     rct_widget* widget = &window_track_list_widgets[WIDX_TRACK_PREVIEW];
-    auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
     colour = ColourMapA[w->colours[0]].darkest;
+    auto screenPos = w->windowPos;
+    utf8* path = _trackDesigns[trackIndex].path;
+    
+    // Show Track file path (in debug mode)
+    if (gConfigGeneral.debugging_tools)
+    {
+        utf8 pathBuffer[MAX_PATH];
+        const utf8* pathPtr = pathBuffer;
+        shorten_path(pathBuffer, sizeof(pathBuffer), path, WW );
+        gfx_fill_rect(dpi, { screenPos + ScreenCoordsXY{ 1, WH }, screenPos + ScreenCoordsXY{ WW + 1, WH + 12 } }, colour);
+        gfx_draw_string_left(dpi, STR_STRING, static_cast<void*>(&pathPtr), w->colours[1], screenPos + ScreenCoordsXY{ 0, WH });
+    }
+
+    screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
     gfx_fill_rect(dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour);
 
     if (_loadedTrackDesignIndex != trackIndex)
-    {
-        utf8* path = _trackDesigns[trackIndex].path;
+    { 
         if (track_list_load_design_for_preview(path))
         {
             _loadedTrackDesignIndex = trackIndex;


### PR DESCRIPTION
Issue: [ #13967 ]

[Code is similar to lines 470-480 in `ScenarioSelect.cpp` ](https://github.com/OpenRCT2/OpenRCT2/blob/e5b412fb5fa8f5b640cbe12a2affc17ddd6f2997/src/openrct2-ui/windows/ScenarioSelect.cpp#L469)

