### PR TITLE
Fix #14012: 'Finish 5 coasters' goal listed incorrectly in selector

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -44,6 +44,7 @@
 - Fix: [#13832] Players last action position is invalid on opening/closing a ride in multiplayer.
 - Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Fix: [#13961] Animation for Guests sliding down Spiral Slide is missing on close zoom levels.
+- Fix: [#14012] 'Finish 5 roller coasters' goal is listed incorrectly in scenario selector.
 - Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -514,7 +514,10 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ft.Add<int16_t>(scenario->objective_arg_3);
         ft.Add<int16_t>(date_get_total_months(MONTH_OCTOBER, scenario->objective_arg_1));
-        ft.Add<int32_t>(scenario->objective_arg_2);
+        if (scenario->objective_type == OBJECTIVE_FINISH_5_ROLLERCOASTERS)
+            ft.Add<uint16_t>(scenario->objective_arg_2);
+        else
+            ft.Add<money32>(scenario->objective_arg_2);
     }
     screenPos.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, 170, STR_OBJECTIVE, COLOUR_BLACK) + 5;
 


### PR DESCRIPTION
I really hope to see the back of this bug now.