### PR TITLE
Add ccache action to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Build OpenRCT2
         run: |
           sudo su
@@ -100,6 +102,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Build OpenRCT2
         run: |
           sudo su
@@ -149,6 +153,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Get pre-reqs
         shell: bash
         run: . scripts/setenv && get-discord-rpc
@@ -184,6 +190,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Get pre-reqs
         shell: bash
         run: . scripts/setenv && get-discord-rpc
@@ -224,6 +232,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Get pre-reqs
         shell: bash
         run: . scripts/setenv -q && get-discord-rpc
@@ -282,6 +292,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Build OpenRCT2
         shell: bash
         run: . scripts/setenv && build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DDISABLE_NETWORK=ON -DDISABLE_HTTP=ON -DDISABLE_OPENGL=ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
         uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: windows-mingw
       - name: Build OpenRCT2
         run: |
           sudo su
@@ -104,6 +106,8 @@ jobs:
         uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: windows-mingw-nt51
       - name: Build OpenRCT2
         run: |
           sudo su
@@ -155,6 +159,8 @@ jobs:
         uses: actions/checkout@v1
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-portable
       - name: Get pre-reqs
         shell: bash
         run: . scripts/setenv && get-discord-rpc
@@ -192,6 +198,8 @@ jobs:
         uses: actions/checkout@v1
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-portable-32
       - name: Get pre-reqs
         shell: bash
         run: . scripts/setenv && get-discord-rpc
@@ -234,6 +242,8 @@ jobs:
         uses: actions/checkout@v1
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-appimage
       - name: Get pre-reqs
         shell: bash
         run: . scripts/setenv -q && get-discord-rpc
@@ -294,6 +304,8 @@ jobs:
         uses: actions/checkout@v1
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-clang
       - name: Build OpenRCT2
         shell: bash
         run: . scripts/setenv && build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DDISABLE_NETWORK=ON -DDISABLE_HTTP=ON -DDISABLE_OPENGL=ON
@@ -308,6 +320,8 @@ jobs:
         uses: actions/checkout@v1
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: android
       - name: Build OpenRCT2
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         run: . scripts/setenv -q && get-discord-rpc
       - name: Build OpenRCT2
         shell: bash
-        run: . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=Release -DAPPIMAGE=ON -DOPENRCT2_USE_CCACHE=off
+        run: . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=Release -DAPPIMAGE=ON -DOPENRCT2_USE_CCACHE=on
       - name: Build AppImage
         shell: bash
         run: . scripts/setenv -q && build-appimage
@@ -306,6 +306,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
       - name: Build OpenRCT2
         shell: bash
         run: |

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -146,6 +146,19 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++1z ${COMMON_COMPILE_OPTIONS} -Wnon-virtual-dtor")
 get_filename_component(ORCT2_ROOT "${CMAKE_SOURCE_DIR}/../../../../../" REALPATH)
 
+list(APPEND CMAKE_MODULE_PATH "${ORCT2_ROOT}/cmake")
+
+find_package(CCache)
+
+if (CCache_FOUND)
+    option(OPENRCT2_USE_CCACHE "Use CCache to improve recompilation speed (optional)" ON)
+    if (OPENRCT2_USE_CCACHE)
+        # Use e.g. "ccache clang++" instead of "clang++"
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCache_EXECUTABLE}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "${CCache_EXECUTABLE}")
+    endif (OPENRCT2_USE_CCACHE)
+endif (CCache_FOUND)
+
 file(GLOB_RECURSE LIBOPENRCT2_SOURCES
     "${ORCT2_ROOT}/src/openrct2/*.cpp"
     "${ORCT2_ROOT}/src/openrct2/*.h"


### PR DESCRIPTION
We already have ccache discovery in our CMake setup, so it should work out of the box.

I'm not sure which of the builds will use it properly, as there are some that are being ran in docker container. To verify this, the action is said to report ccache stats at the end.