### PR TITLE
Fix #12861: Divide-by-0 in UpdateTrackMotionMiniGolf

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9332,7 +9332,8 @@ int32_t Vehicle::UpdateTrackMotionMiniGolf(int32_t* outStation)
         }
         poweredAcceleration -= velocity;
         poweredAcceleration *= powered_acceleration << 1;
-        poweredAcceleration = poweredAcceleration / quarterForce;
+        if (quarterForce != 0)
+            poweredAcceleration /= quarterForce;
 
         if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WATER_RIDE)
         {


### PR DESCRIPTION
This fix had already been applied to UpdateTrackMotionPoweredRideAcceleration(), but not here.