### PR TITLE
Fix #7772. Check for vehicles using an object when setting inuse

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
 - Change: [#13857] Change Rotation Control Toggle to track element number 256
 - Fix: [#4605, #11912] Water palettes are not updated properly when selected in Object Selection.
+- Fix: [#7772] Hacked vehicles may incorrectly not mark a vehicle object as in use causing accidental removal when remove_unused_objects is used.
 - Fix: [#9631, #10716] Banners drawing glitches when there are more than 32 on the screen at once.
 - Fix: [#11438] Freeze when shrinking map size.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -200,6 +200,24 @@ void setup_in_use_selection_flags()
         }
     }
 
+    // Apply selected object status for hacked vehicles that may not have an associated ride
+    for (auto vehicle : EntityList<Vehicle>(EntityListId::TrainHead))
+    {
+        ObjectEntryIndex type = vehicle->ride_subtype;
+        if (type != RIDE_ENTRY_INDEX_NULL) // cable lifts use index null. Ignore them
+        {
+            Editor::SetSelectedObject(ObjectType::Ride, type, OBJECT_SELECTION_FLAG_SELECTED);
+        }
+    }
+    for (auto vehicle : EntityList<Vehicle>(EntityListId::Vehicle))
+    {
+        ObjectEntryIndex type = vehicle->ride_subtype;
+        if (type != RIDE_ENTRY_INDEX_NULL) // cable lifts use index null. Ignore them
+        {
+            Editor::SetSelectedObject(ObjectType::Ride, type, OBJECT_SELECTION_FLAG_SELECTED);
+        }
+    }
+
     int32_t numObjects = static_cast<int32_t>(object_repository_get_items_count());
     const ObjectRepositoryItem* items = object_repository_get_items();
     for (int32_t i = 0; i < numObjects; i++)


### PR DESCRIPTION
I think https://github.com/OpenRCT2/OpenRCT2/issues/12069 is also fixed by this. Hard to fully tell. 