### PR TITLE
[Plugin] Add optional filter to custom tools

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,7 +20,8 @@
 - Feature: [#13675] [Plugin] Add context.setInterval and context.setTimeout.
 - Feature: [#13927] [Plugin] Add isVisible and text box widget.
 - Feature: [#13969] [Plugin] Add APIs for editing title sequences.
-- Feature: [#14002] [Plugin] Feature: Use allowed_hosts when checking the binding IP for listening
+- Feature: [#14002] [Plugin] Use allowed_hosts when checking the binding IP for listening.
+- Feature: [#14059] [Plugin] Add optional filter to custom tools.
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
 - Change: [#13857] Change Rotation Control Toggle to track element number 256
 - Fix: [#4605, #11912] Water palettes are not updated properly when selected in Object Selection.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1904,6 +1904,12 @@ declare global {
         id: string;
         cursor?: CursorType;
 
+        /**
+         * What types of object in the game can be selected with the tool.
+         * E.g. only specify terrain if you only want a tile selection.
+         */
+        filter?: ToolFilter[];
+
         onStart?: () => void;
         onDown?: (e: ToolEventArgs) => void;
         onMove?: (e: ToolEventArgs) => void;
@@ -1939,6 +1945,20 @@ declare global {
         "walk_down" |
         "water_down" |
         "zzz";
+
+    type ToolFilter =
+        "terrain" |
+        "entity" |
+        "ride" |
+        "water" |
+        "scenery" |
+        "footpath" |
+        "footpath_item" |
+        "park_entrance" |
+        "wall" |
+        "large_scenery" |
+        "label" |
+        "banner";
 
     /**
      * Represents the type of a widget, e.g. button or label.

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -65,7 +65,7 @@ InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoord
 
     info = get_map_coordinates_from_pos(
         screenCoords,
-        VIEWPORT_INTERACTION_MASK_ENTITY & VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_PARK_ENTRANCE);
+        EnumsToFlags(ViewportInteractionItem::Entity, ViewportInteractionItem::Ride, ViewportInteractionItem::ParkEntrance));
     auto tileElement = info.SpriteType != ViewportInteractionItem::Entity ? info.Element : nullptr;
     // Only valid when info.SpriteType == ViewportInteractionItem::Entity, but can't assign nullptr without compiler
     // complaining
@@ -261,7 +261,8 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) && gS6Info.editor_step != EditorStep::RollercoasterDesigner)
         return info;
 
-    info = get_map_coordinates_from_pos(screenCoords, ~(VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER));
+    auto flags = static_cast<int32_t>(~EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
+    info = get_map_coordinates_from_pos(screenCoords, flags);
     auto tileElement = info.Element;
 
     switch (info.SpriteType)
@@ -761,7 +762,7 @@ CoordsXY ViewportInteractionGetTileStartAtCursor(const ScreenCoordsXY& screenCoo
     }
     auto viewport = window->viewport;
     auto info = get_map_coordinates_from_pos_window(
-        window, screenCoords, VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER);
+        window, screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
     auto initialPos = info.Loc;
 
     if (info.SpriteType == ViewportInteractionItem::None)

--- a/src/openrct2-ui/scripting/CustomMenu.h
+++ b/src/openrct2-ui/scripting/CustomMenu.h
@@ -49,6 +49,7 @@ namespace OpenRCT2::Scripting
         std::shared_ptr<Plugin> Owner;
         std::string Id;
         CursorID Cursor = CursorID::Undefined;
+        uint32_t Filter{};
         bool MouseDown{};
 
         // Event handlers

--- a/src/openrct2-ui/scripting/ScViewport.hpp
+++ b/src/openrct2-ui/scripting/ScViewport.hpp
@@ -272,6 +272,7 @@ namespace OpenRCT2::Scripting
                     viewport->flags &= ~WF_SCROLLING_TO_LOCATION;
                     w->savedViewPos.x = viewport->viewPos.x;
                     w->savedViewPos.y = viewport->viewPos.y;
+                    viewport->Invalidate();
                 }
             }
         }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -710,7 +710,7 @@ static void window_footpath_set_provisional_path_at_point(const ScreenCoordsXY& 
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
     auto info = get_map_coordinates_from_pos(
-        screenCoords, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN);
+        screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath));
 
     if (info.SpriteType == ViewportInteractionItem::None || info.Element == nullptr)
     {
@@ -834,7 +834,7 @@ static void window_footpath_place_path_at_point(const ScreenCoordsXY& screenCoor
     footpath_provisional_update();
 
     const auto info = get_map_coordinates_from_pos(
-        screenCoords, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN);
+        screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath));
 
     if (info.SpriteType == ViewportInteractionItem::None)
     {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1145,7 +1145,7 @@ void window_guest_overview_tool_update(rct_window* w, rct_widgetindex widgetInde
 
     gPickupPeepImage = UINT32_MAX;
 
-    auto info = get_map_coordinates_from_pos(screenCoords, VIEWPORT_INTERACTION_MASK_NONE);
+    auto info = get_map_coordinates_from_pos(screenCoords, ViewportInteractionItemAll);
     if (info.SpriteType == ViewportInteractionItem::None)
         return;
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4211,7 +4211,7 @@ static int32_t window_ride_has_track_colour(Ride* ride, int32_t trackColour)
 static void window_ride_set_track_colour_scheme(rct_window* w, const ScreenCoordsXY& screenPos)
 {
     auto newColourScheme = static_cast<uint8_t>(w->ride_colour);
-    auto info = get_map_coordinates_from_pos(screenPos, VIEWPORT_INTERACTION_MASK_RIDE);
+    auto info = get_map_coordinates_from_pos(screenPos, EnumsToFlags(ViewportInteractionItem::Ride));
 
     if (info.SpriteType != ViewportInteractionItem::Ride)
         return;
@@ -5455,7 +5455,10 @@ static void window_ride_measurements_tooldown(rct_window* w, rct_widgetindex wid
     _lastSceneryY = screenCoords.y;
     _collectTrackDesignScenery = true; // Default to true in case user does not select anything valid
 
-    auto info = get_map_coordinates_from_pos(screenCoords, 0xFCCF);
+    auto flags = EnumsToFlags(
+        ViewportInteractionItem::Scenery, ViewportInteractionItem::Footpath, ViewportInteractionItem::Wall,
+        ViewportInteractionItem::LargeScenery);
+    auto info = get_map_coordinates_from_pos(screenCoords, flags);
     switch (info.SpriteType)
     {
         case ViewportInteractionItem::Scenery:
@@ -5477,7 +5480,10 @@ static void window_ride_measurements_tooldrag(rct_window* w, rct_widgetindex wid
     _lastSceneryX = screenCoords.x;
     _lastSceneryY = screenCoords.y;
 
-    auto info = get_map_coordinates_from_pos(screenCoords, 0xFCCF);
+    auto flags = EnumsToFlags(
+        ViewportInteractionItem::Scenery, ViewportInteractionItem::Footpath, ViewportInteractionItem::Wall,
+        ViewportInteractionItem::LargeScenery);
+    auto info = get_map_coordinates_from_pos(screenCoords, flags);
     switch (info.SpriteType)
     {
         case ViewportInteractionItem::Scenery:

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1170,7 +1170,7 @@ void window_staff_overview_tool_update(rct_window* w, rct_widgetindex widgetInde
 
     gPickupPeepImage = UINT32_MAX;
 
-    auto info = get_map_coordinates_from_pos(screenCoords, VIEWPORT_INTERACTION_MASK_NONE);
+    auto info = get_map_coordinates_from_pos(screenCoords, ViewportInteractionItemAll);
     if (info.SpriteType == ViewportInteractionItem::None)
         return;
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -406,10 +406,11 @@ static struct {
 };
 
 // clang-format on
-static constexpr int32_t ViewportInteractionFlags = VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_ENTITY
-    & VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_SCENERY & VIEWPORT_INTERACTION_MASK_FOOTPATH
-    & VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM & VIEWPORT_INTERACTION_MASK_PARK_ENTRANCE & VIEWPORT_INTERACTION_MASK_WALL
-    & VIEWPORT_INTERACTION_MASK_LARGE_SCENERY & VIEWPORT_INTERACTION_MASK_BANNER;
+static constexpr int32_t ViewportInteractionFlags = EnumsToFlags(
+    ViewportInteractionItem::Terrain, ViewportInteractionItem::Entity, ViewportInteractionItem::Ride,
+    ViewportInteractionItem::Scenery, ViewportInteractionItem::Footpath, ViewportInteractionItem::FootpathItem,
+    ViewportInteractionItem::ParkEntrance, ViewportInteractionItem::Wall, ViewportInteractionItem::LargeScenery,
+    ViewportInteractionItem::Banner);
 
 static int16_t windowTileInspectorHighlightedIndex = -1;
 static bool windowTileInspectorTileSelected = false;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -172,7 +172,7 @@ static TileCoordsXY get_location()
     if (w != nullptr)
     {
         auto info = get_map_coordinates_from_pos_window(
-            w, { w->viewport->view_width / 2, w->viewport->view_height / 2 }, VIEWPORT_INTERACTION_MASK_TERRAIN);
+            w, { w->viewport->view_width / 2, w->viewport->view_height / 2 }, EnumsToFlags(ViewportInteractionItem::Terrain));
         auto mapCoord = info.Loc;
         mapCoord.x -= 16;
         mapCoord.y -= 16;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -994,12 +994,10 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void repaint_scenery_tool_down(const ScreenCoordsXY& windowPos, rct_widgetindex widgetIndex)
 {
-    auto flags = VIEWPORT_INTERACTION_MASK_SCENERY & VIEWPORT_INTERACTION_MASK_WALL & VIEWPORT_INTERACTION_MASK_LARGE_SCENERY
-        & VIEWPORT_INTERACTION_MASK_BANNER;
-    // This is -2 as banner is 12 but flags are offset different
-
+    auto flags = EnumsToFlags(
+        ViewportInteractionItem::Scenery, ViewportInteractionItem::Wall, ViewportInteractionItem::LargeScenery,
+        ViewportInteractionItem::Banner);
     auto info = get_map_coordinates_from_pos(windowPos, flags);
-
     switch (info.SpriteType)
     {
         case ViewportInteractionItem::Scenery:
@@ -1073,11 +1071,10 @@ static void repaint_scenery_tool_down(const ScreenCoordsXY& windowPos, rct_widge
 
 static void scenery_eyedropper_tool_down(const ScreenCoordsXY& windowPos, rct_widgetindex widgetIndex)
 {
-    auto flags = VIEWPORT_INTERACTION_MASK_SCENERY & VIEWPORT_INTERACTION_MASK_WALL & VIEWPORT_INTERACTION_MASK_LARGE_SCENERY
-        & VIEWPORT_INTERACTION_MASK_BANNER & VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM;
-
+    auto flags = EnumsToFlags(
+        ViewportInteractionItem::Scenery, ViewportInteractionItem::Wall, ViewportInteractionItem::LargeScenery,
+        ViewportInteractionItem::Banner, ViewportInteractionItem::FootpathItem);
     auto info = get_map_coordinates_from_pos(windowPos, flags);
-
     switch (info.SpriteType)
     {
         case ViewportInteractionItem::Scenery:
@@ -1177,9 +1174,9 @@ static void sub_6E1F34_update_screen_coords_and_buttons_pressed(bool canRaiseIte
             if (InputTestPlaceObjectModifier(PLACE_OBJECT_MODIFIER_COPY_Z))
             {
                 // CTRL pressed
-                auto flags = VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_RIDE
-                    & VIEWPORT_INTERACTION_MASK_SCENERY & VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_WALL
-                    & VIEWPORT_INTERACTION_MASK_LARGE_SCENERY;
+                auto flags = EnumsToFlags(
+                    ViewportInteractionItem::Terrain, ViewportInteractionItem::Ride, ViewportInteractionItem::Scenery,
+                    ViewportInteractionItem::Footpath, ViewportInteractionItem::Wall, ViewportInteractionItem::LargeScenery);
                 auto info = get_map_coordinates_from_pos(screenPos, flags);
 
                 if (info.SpriteType != ViewportInteractionItem::None)
@@ -1347,7 +1344,7 @@ static void sub_6E1F34_small_scenery(
     // If CTRL not pressed
     if (!gSceneryCtrlPressed)
     {
-        auto flags = VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER;
+        auto flags = EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water);
 
         auto info = get_map_coordinates_from_pos(screenPos, flags);
         gridPos = info.Loc;
@@ -1441,8 +1438,7 @@ static void sub_6E1F34_path_item(
     sub_6E1F34_update_screen_coords_and_buttons_pressed(false, screenPos);
 
     // Path bits
-    auto flags = VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM;
-
+    auto flags = EnumsToFlags(ViewportInteractionItem::Footpath, ViewportInteractionItem::FootpathItem);
     auto info = get_map_coordinates_from_pos(screenPos, flags);
     gridPos = info.Loc;
 
@@ -1664,8 +1660,7 @@ static void sub_6E1F34_banner(
     sub_6E1F34_update_screen_coords_and_buttons_pressed(false, screenPos);
 
     // Banner
-    auto flags = VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM;
-
+    auto flags = EnumsToFlags(ViewportInteractionItem::Footpath, ViewportInteractionItem::FootpathItem);
     auto info = get_map_coordinates_from_pos(screenPos, flags);
     gridPos = info.Loc;
 
@@ -2368,7 +2363,8 @@ static void top_toolbar_tool_update_water(const ScreenCoordsXY& screenPos)
 
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
 
-    auto info = get_map_coordinates_from_pos(screenPos, VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER);
+    auto info = get_map_coordinates_from_pos(
+        screenPos, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Water));
 
     if (info.SpriteType == ViewportInteractionItem::None)
     {

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -124,7 +124,7 @@ static void window_viewport_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             if (mainWindow != nullptr)
             {
                 auto info = get_map_coordinates_from_pos(
-                    { w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2) }, VIEWPORT_INTERACTION_MASK_NONE);
+                    { w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2) }, ViewportInteractionItemAll);
                 window_scroll_to_location(mainWindow, { info.Loc, tile_element_height(info.Loc) });
             }
             break;

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -315,7 +315,7 @@ void lightfx_prepare_light_list()
                     paint_session* session = PaintSessionAlloc(&dpi, w->viewport->flags);
                     PaintSessionGenerate(session);
                     PaintSessionArrange(session);
-                    auto info = set_interaction_info_from_paint_session(session, VIEWPORT_INTERACTION_MASK_NONE);
+                    auto info = set_interaction_info_from_paint_session(session, ViewportInteractionItemAll);
                     PaintSessionFree(session);
 
                     //  log_warning("[%i, %i]", dpi->x, dpi->y);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -655,7 +655,7 @@ static int32_t cc_get(InteractiveConsole& console, const arguments_t& argv)
             {
                 rct_viewport* viewport = window_get_viewport(w);
                 auto info = get_map_coordinates_from_pos(
-                    { viewport->view_width / 2, viewport->view_height / 2 }, VIEWPORT_INTERACTION_MASK_TERRAIN);
+                    { viewport->view_width / 2, viewport->view_height / 2 }, EnumsToFlags(ViewportInteractionItem::Terrain));
 
                 auto tileMapCoord = TileCoordsXY(info.Loc);
                 console.WriteFormatLine("location %d %d", tileMapCoord.x, tileMapCoord.y);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1101,6 +1101,11 @@ std::optional<CoordsXY> screen_pos_to_map_pos(const ScreenCoordsXY& screenCoords
     return ret;
 }
 
+void rct_viewport::Invalidate() const
+{
+    viewport_invalidate(this, viewPos.x, viewPos.y, viewPos.x + view_width, viewPos.y + view_height);
+}
+
 CoordsXY viewport_coord_to_map_coord(const ScreenCoordsXY& coords, int32_t z)
 {
     constexpr uint8_t inverseRotationMapping[NumOrthogonalDirections] = { 0, 3, 2, 1 };
@@ -1701,7 +1706,7 @@ InteractionInfo get_map_coordinates_from_pos_window(rct_window* window, const Sc
 /**
  * Left, top, right and bottom represent 2D map coordinates at zoom 0.
  */
-void viewport_invalidate(rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void viewport_invalidate(const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     // if unknown viewport visibility, use the containing window to discover the status
     if (viewport->visibility == VisibilityCache::Unknown)

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1296,23 +1296,16 @@ void viewport_set_visibility(uint8_t mode)
  */
 static bool PSSpriteTypeIsInFilter(paint_struct* ps, uint16_t filter)
 {
-    if (ps->sprite_type == ViewportInteractionItem::None || ps->sprite_type == ViewportInteractionItem::Label
-        || ps->sprite_type > ViewportInteractionItem::Banner)
-        return false;
-
-    uint16_t mask;
-    if (ps->sprite_type == ViewportInteractionItem::Banner)
-        // I think CS made a typo here. Let's replicate the original behaviour.
-        mask = 1 << (EnumValue(ps->sprite_type) - 3);
-    else
-        mask = 1 << (EnumValue(ps->sprite_type) - 1);
-
-    if (filter & mask)
+    if (ps->sprite_type != ViewportInteractionItem::None && ps->sprite_type != ViewportInteractionItem::Label
+        && ps->sprite_type <= ViewportInteractionItem::Banner)
     {
-        return false;
+        auto mask = EnumToFlag(ps->sprite_type);
+        if (filter & mask)
+        {
+            return true;
+        }
     }
-
-    return true;
+    return false;
 }
 
 /**
@@ -1791,7 +1784,7 @@ std::optional<CoordsXY> screen_get_map_xy(const ScreenCoordsXY& screenCoords, rc
         return std::nullopt;
     }
     auto myViewport = window->viewport;
-    auto info = get_map_coordinates_from_pos_window(window, screenCoords, VIEWPORT_INTERACTION_MASK_TERRAIN);
+    auto info = get_map_coordinates_from_pos_window(window, screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain));
     if (info.SpriteType == ViewportInteractionItem::None)
     {
         return std::nullopt;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -161,7 +161,7 @@ bool ViewportInteractionRightClick(const ScreenCoordsXY& screenCoords);
 CoordsXY ViewportInteractionGetTileStartAtCursor(const ScreenCoordsXY& screenCoords);
 void sub_68B2B7(paint_session* session, const CoordsXY& mapCoords);
 
-void viewport_invalidate(rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom);
+void viewport_invalidate(const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
 std::optional<CoordsXY> screen_get_map_xy(const ScreenCoordsXY& screenCoords, rct_viewport** viewport);
 std::optional<CoordsXY> screen_get_map_xy_with_z(const ScreenCoordsXY& screenCoords, int16_t z);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -13,6 +13,7 @@
 #include "../world/Location.hpp"
 #include "Window.h"
 
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -66,21 +67,7 @@ enum class ViewportInteractionItem : uint8_t
     Banner
 };
 
-enum
-{
-    VIEWPORT_INTERACTION_MASK_NONE = 0,
-    VIEWPORT_INTERACTION_MASK_TERRAIN = ~(1 << (EnumValue(ViewportInteractionItem::Terrain) - 1)),
-    VIEWPORT_INTERACTION_MASK_ENTITY = ~(1 << (EnumValue(ViewportInteractionItem::Entity) - 1)),
-    VIEWPORT_INTERACTION_MASK_RIDE = ~(1 << (EnumValue(ViewportInteractionItem::Ride) - 1)),
-    VIEWPORT_INTERACTION_MASK_WATER = ~(1 << (EnumValue(ViewportInteractionItem::Water) - 1)),
-    VIEWPORT_INTERACTION_MASK_SCENERY = ~(1 << (EnumValue(ViewportInteractionItem::Scenery) - 1)),
-    VIEWPORT_INTERACTION_MASK_FOOTPATH = ~(1 << (EnumValue(ViewportInteractionItem::Footpath) - 1)),
-    VIEWPORT_INTERACTION_MASK_FOOTPATH_ITEM = ~(1 << (EnumValue(ViewportInteractionItem::FootpathItem) - 1)),
-    VIEWPORT_INTERACTION_MASK_PARK_ENTRANCE = ~(1 << (EnumValue(ViewportInteractionItem::ParkEntrance) - 1)),
-    VIEWPORT_INTERACTION_MASK_WALL = ~(1 << (EnumValue(ViewportInteractionItem::Wall) - 1)),
-    VIEWPORT_INTERACTION_MASK_LARGE_SCENERY = ~(1 << (EnumValue(ViewportInteractionItem::LargeScenery) - 1)),
-    VIEWPORT_INTERACTION_MASK_BANNER = ~(1 << (EnumValue(ViewportInteractionItem::Banner) - 2)), // Note the -2 for BANNER
-};
+constexpr uint16_t ViewportInteractionItemAll = std::numeric_limits<uint16_t>::max();
 
 struct InteractionInfo
 {

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -171,6 +171,8 @@ struct rct_viewport
     }
 
     [[nodiscard]] ScreenCoordsXY ScreenToViewportCoord(const ScreenCoordsXY& screenCoord) const;
+
+    void Invalidate() const;
 };
 
 /**

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5768,7 +5768,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
     CoordsXYZD entranceExitCoords{};
 
     gRideEntranceExitPlaceDirection = INVALID_DIRECTION;
-    auto info = get_map_coordinates_from_pos(screenCoords, 0xFFFB);
+    auto info = get_map_coordinates_from_pos(screenCoords, EnumsToFlags(ViewportInteractionItem::Ride));
     if (info.SpriteType != ViewportInteractionItem::None)
     {
         if (info.Element->GetType() == TILE_ELEMENT_TYPE_TRACK)

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -44,7 +44,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 20;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 21;
 
 struct ExpressionStringifier final
 {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -256,12 +256,12 @@ CoordsXY footpath_get_coordinates_from_pos(const ScreenCoordsXY& screenCoords, i
         return position;
     }
     auto viewport = window->viewport;
-    auto info = get_map_coordinates_from_pos_window(window, screenCoords, VIEWPORT_INTERACTION_MASK_FOOTPATH);
+    auto info = get_map_coordinates_from_pos_window(window, screenCoords, EnumsToFlags(ViewportInteractionItem::Footpath));
     if (info.SpriteType != ViewportInteractionItem::Footpath
         || !(viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)))
     {
         info = get_map_coordinates_from_pos_window(
-            window, screenCoords, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN);
+            window, screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath));
         if (info.SpriteType == ViewportInteractionItem::None)
         {
             auto position = info.Loc;
@@ -354,7 +354,7 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
         return ret;
     }
     auto viewport = window->viewport;
-    auto info = get_map_coordinates_from_pos_window(window, screenCoords, VIEWPORT_INTERACTION_MASK_RIDE);
+    auto info = get_map_coordinates_from_pos_window(window, screenCoords, EnumsToFlags(ViewportInteractionItem::Ride));
     *tileElement = info.Element;
     if (info.SpriteType == ViewportInteractionItem::Ride
         && viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)
@@ -374,7 +374,7 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
 
     info = get_map_coordinates_from_pos_window(
         window, screenCoords,
-        VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN);
+        EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath, ViewportInteractionItem::Ride));
     if (info.SpriteType == ViewportInteractionItem::Ride && (*tileElement)->GetType() == TILE_ELEMENT_TYPE_ENTRANCE)
     {
         int32_t directions = entrance_get_directions(*tileElement);


### PR DESCRIPTION
* Invalidate viewport when changing the location (without scrolling)
* Add filter to custom tools so that plugins can adjust the hit testing logic.
* Improve filter logic, reverse the logic (mask is now what you want to be enabled for hit testing).

I found the way the hit testing flags worked quite confusing, so I have changed it.