### PR TITLE
Implement SRV dns resolving

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -1332,8 +1332,6 @@
 		9308D9FD209908090079EE96 /* Surface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Surface.h; sourceTree = "<group>"; };
 		930EEA6924FC00940070314E /* ScenarioSelect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScenarioSelect.cpp; sourceTree = "<group>"; };
 		9329D51F240C17C60054301C /* BenchUpdate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BenchUpdate.cpp; sourceTree = "<group>"; };
-		932A20CD22D73CEE00C57EDB /* GuestSetNameAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GuestSetNameAction.hpp; sourceTree = "<group>"; };
-		932A20CE22D73CEE00C57EDB /* RideSetVehiclesAction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RideSetVehiclesAction.hpp; sourceTree = "<group>"; };
 		932A20CF22D73CEE00C57EDB /* GameActionCompat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameActionCompat.cpp; sourceTree = "<group>"; };
 		932A20D322D73CEF00C57EDB /* GameActionRegistration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameActionRegistration.cpp; sourceTree = "<group>"; };
 		932A20F522D73CF300C57EDB /* GameAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameAction.h; sourceTree = "<group>"; };
@@ -5140,6 +5138,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-lresolv";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -5197,6 +5196,7 @@
 				LD_NO_PIE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-lresolv";
 				SDKROOT = macosx;
 			};
 			name = Release;

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -33,6 +33,13 @@ enum class NetworkReadPacket : int32_t
     Disconnected
 };
 
+typedef struct SRVRecord {
+    u_int16_t priority;
+    u_int16_t weight;
+    u_int16_t port;
+    char dname[255];
+} SRVRecord;
+
 /**
  * Represents an address and port.
  */


### PR DESCRIPTION
Just like minecraft, OpenRCT2 should resolve SRV records to allow servers to run on non-standard ports.

I'm not a C/C++ developer, but have been able to create a POC that works on my machine (Macbook Pro 2019, Catalina, Intel i7) but I will need some help to get this to the code standards OpenRCT2 needs.
Any help is appreciated 🙏

Some context about srv records: https://kb.porkbun.com/article/148-how-to-connect-your-domain-to-minecraft-using-srv-records
The SRV-resolving code has been based on https://oliver-kaestner.de/english-c-query-srv-dns-record-with-example/