### PR TITLE
Fix #14058: Ride entry or exit can not be built in multiplayer

### DIFF
--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -191,10 +191,11 @@ GameActions::Result::Ptr LargeSceneryRemoveAction::Execute() const
 
 TileElement* LargeSceneryRemoveAction::FindLargeSceneryElement(const CoordsXYZ& pos, int32_t sequenceIndex) const
 {
+    const bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
     for (auto* sceneryElement : TileElementsView<LargeSceneryElement>(pos))
     {
         // If we are removing ghost elements
-        if ((GetFlags() & GAME_COMMAND_FLAG_GHOST) && sceneryElement->IsGhost() == false)
+        if (isGhost && sceneryElement->IsGhost() == false)
             continue;
 
         if (sceneryElement->GetDirection() != _loc.direction)

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
@@ -46,11 +46,13 @@ void RideEntranceExitRemoveAction::Serialise(DataSerialiser& stream)
 }
 
 static TileElement* FindEntranceElement(
-    const CoordsXY& loc, ride_id_t rideIndex, int32_t stationNum, int32_t entranceType, bool ghost)
+    const CoordsXY& loc, ride_id_t rideIndex, int32_t stationNum, int32_t entranceType, uint32_t flags)
 {
+    const bool isGhost = flags & GAME_COMMAND_FLAG_GHOST;
     for (auto* entranceElement : TileElementsView<EntranceElement>(loc))
     {
-        if (entranceElement->IsGhost() != ghost)
+        // If we are removing ghost elements
+        if (isGhost && entranceElement->IsGhost() == false)
             continue;
 
         if (entranceElement->GetRideIndex() != rideIndex)
@@ -91,10 +93,8 @@ GameActions::Result::Ptr RideEntranceExitRemoveAction::Query() const
         return MakeResult(GameActions::Status::InvalidParameters, STR_LAND_NOT_OWNED_BY_PARK);
     }
 
-    const bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
-
     auto* entranceElement = FindEntranceElement(
-        _loc, _rideIndex, _stationNum, _isExit ? ENTRANCE_TYPE_RIDE_EXIT : ENTRANCE_TYPE_RIDE_ENTRANCE, isGhost);
+        _loc, _rideIndex, _stationNum, _isExit ? ENTRANCE_TYPE_RIDE_EXIT : ENTRANCE_TYPE_RIDE_ENTRANCE, GetFlags());
 
     if (entranceElement == nullptr)
     {
@@ -125,7 +125,7 @@ GameActions::Result::Ptr RideEntranceExitRemoveAction::Execute() const
     }
 
     auto* entranceElement = FindEntranceElement(
-        _loc, _rideIndex, _stationNum, _isExit ? ENTRANCE_TYPE_RIDE_EXIT : ENTRANCE_TYPE_RIDE_ENTRANCE, isGhost);
+        _loc, _rideIndex, _stationNum, _isExit ? ENTRANCE_TYPE_RIDE_EXIT : ENTRANCE_TYPE_RIDE_ENTRANCE, GetFlags());
 
     if (entranceElement == nullptr)
     {

--- a/src/openrct2/actions/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.cpp
@@ -138,14 +138,19 @@ TileElement* SmallSceneryRemoveAction::FindSceneryElement() const
     const bool isGhost = GetFlags() & GAME_COMMAND_FLAG_GHOST;
     for (auto* sceneryElement : TileElementsView<SmallSceneryElement>(_loc))
     {
-        if (sceneryElement->IsGhost() != isGhost)
+        // If we are removing ghost elements
+        if (isGhost && sceneryElement->IsGhost() == false)
             continue;
+
         if (sceneryElement->GetSceneryQuadrant() != _quadrant)
             continue;
+
         if (sceneryElement->GetBaseZ() != _loc.z)
             continue;
+
         if (sceneryElement->GetEntryIndex() != _sceneryType)
             continue;
+
         return sceneryElement->as<TileElement>();
     }
     return nullptr;


### PR DESCRIPTION
Not entirely sure how only multiplayer was affected. I messed up the logic, it can only check for ghost if the flag is present, for entrances it expects it to just remove whatever entrance/exit was there.