### PR TITLE
Fix #14067. Nullptr exception in vehicle measurement code

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1886,6 +1886,9 @@ void Vehicle::UpdateMeasurements()
                 continue;
 
             rct_scenery_entry* scenery = tileElement->AsSmallScenery()->GetEntry();
+            if (scenery == nullptr)
+                continue;
+
             if (scenery_small_entry_has_flag(scenery, SMALL_SCENERY_FLAG_FULL_TILE))
             {
                 coverFound = true;


### PR DESCRIPTION
Also:
fixes #13945,
fixes #13365,
fixes #13892 
fixes #13295