### PR TITLE
Fix #14073: NPE in InputUpdateTooltip

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1442,7 +1442,7 @@ static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const
         if (gTooltipCursor == screenCoords)
         {
             _tooltipNotShownTicks++;
-            if (_tooltipNotShownTicks > 50 && WidgetIsVisible(w, widgetIndex))
+            if (_tooltipNotShownTicks > 50 && w != nullptr && WidgetIsVisible(w, widgetIndex))
             {
                 gTooltipTimeout = 0;
                 window_tooltip_open(w, widgetIndex, screenCoords);


### PR DESCRIPTION
All of them crash on the line `if (_tooltipNotShownTicks > 50 && WidgetIsVisible(w, widgetIndex))`. The only other use of w in this function checks for nullptr.