### PR TITLE
Randomize ride inspections

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3665,6 +3665,7 @@ STR_6408    :Please install “innoextract” to extract GOG Installer, then res
 STR_6409    :The selected file is not the offline GOG Installer for RollerCoaster Tycoon 2. You may have downloaded the GOG Galaxy downloader stub or selected the wrong file.
 STR_6410    :Zoom in/out
 STR_6411    :Show buttons for zooming in and out in the toolbar
+STR_6412    :{WINDOW_COLOUR_2}Station due for inspection: {BLACK}Station {COMMA16}
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4108,6 +4108,14 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_draw_string_left(dpi, stringId, &lastInspection, COLOUR_BLACK, screenCoords);
     screenCoords.y += 12;
 
+    if (ride->num_stations > 1)
+    {
+        uint16_t inspection_station = ride->inspection_station + 1;
+
+        gfx_draw_string_left(dpi, STR_RIDE_INSPECTION_STATION, &inspection_station, COLOUR_BLACK, screenCoords);
+        screenCoords.y += 12;
+    }
+
     // Last / current breakdown
     if (ride->breakdown_reason == BREAKDOWN_NONE)
         return;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3921,6 +3921,8 @@ enum
     STR_ZOOM_BUTTON_ON_TOOLBAR = 6410,
     STR_ZOOM_BUTTON_ON_TOOLBAR_TIP = 6411,
 
+    STR_RIDE_INSPECTION_STATION = 6412,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2314,7 +2314,7 @@ static void ride_inspection_update(Ride* ride)
     ride->lifecycle_flags |= RIDE_LIFECYCLE_DUE_INSPECTION;
     ride->mechanic_status = RIDE_MECHANIC_STATUS_CALLING;
 
-    auto stationIndex = ride_get_first_valid_station_exit(ride);
+    auto stationIndex = ride_get_random_valid_station_exit(ride);
     ride->inspection_station = (stationIndex != STATION_INDEX_NULL) ? stationIndex : 0;
 }
 

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -376,6 +376,28 @@ StationIndex ride_get_first_valid_station_exit(Ride* ride)
     return STATION_INDEX_NULL;
 }
 
+StationIndex ride_get_random_valid_station_exit(Ride* ride)
+{
+    uint8_t valid_stations_count = 0;
+    StationIndex valid_stations[MAX_STATIONS];
+
+    for (StationIndex i = 0; i < MAX_STATIONS; i++)
+    {
+        if (!ride->stations[i].Exit.isNull())
+        {
+            valid_stations[valid_stations_count] = i;
+            valid_stations_count++;
+        }
+    }
+
+    if (valid_stations_count > 0)
+    {
+        return valid_stations[scenario_rand() % valid_stations_count];
+    }
+
+    return STATION_INDEX_NULL;
+}
+
 StationIndex ride_get_first_valid_station_start(const Ride* ride)
 {
     for (StationIndex i = 0; i < MAX_STATIONS; i++)

--- a/src/openrct2/ride/Station.h
+++ b/src/openrct2/ride/Station.h
@@ -20,6 +20,7 @@ constexpr const StationIndex STATION_INDEX_NULL = 0xFF;
 
 void ride_update_station(Ride* ride, StationIndex stationIndex);
 StationIndex ride_get_first_valid_station_exit(Ride* ride);
+StationIndex ride_get_random_valid_station_exit(Ride* ride);
 StationIndex ride_get_first_valid_station_start(const Ride* ride);
 StationIndex ride_get_first_empty_station_start(const Ride* ride);
 


### PR DESCRIPTION
Currently regular inspection for multi-station ride is done only on Station 1.
This isn't very practical or realistic, so I propose randomizing the station chosen for inspection every time so that each station gets more uniform number of inspections.

Following is a monorail with 4 stations where each station is assigned to a mechanic.

![2021-02-16 02_44_41-OpenRCT2](https://user-images.githubusercontent.com/4215028/107982897-38355280-7008-11eb-860b-5999da217ddb.png)

Before the patch, station 1 got 12 inspections while other stations got zero inspections, mechanic 2 hasn't done anything at all

![2021-02-16 02_48_21-OpenRCT2](https://user-images.githubusercontent.com/4215028/107983070-8ba7a080-7008-11eb-9626-2e8a96f85076.png)

After the patch, each station gets more inspections and the mechanics assigned to them are actually doing their job
 

![2021-02-16 02_55_51-OpenRCT2](https://user-images.githubusercontent.com/4215028/107983261-db866780-7008-11eb-9285-0f1b0538c124.png)

I also added a label that is enabled when there is more than 1 station which notifies the user about the station that the mechanic is set to visit during inspection/repair. This can also help players proactively position mechanics for minimizing downtime.