### PR TITLE
Add WIDX_OPERATE_NUMBER_OF_CIRCUITS flags to hold_down_widgets

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -163,6 +163,7 @@ The following people are not part of the development team, but have been contrib
 * Ben Johnston (gsckoco)
 * (evilclownattack)
 * Adam Bloom (adam-bloom)
+* Geoff B. (geoff-B)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,6 +47,7 @@
 - Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Fix: [#13961] Animation for Guests sliding down Spiral Slide is missing on close zoom levels.
 - Fix: [#14012] 'Finish 5 roller coasters' goal is listed incorrectly in scenario selector.
+- Fix: [#14095] Holding down [-][+] buttons does not decrease/increase num. of circuit
 - Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,7 +47,7 @@
 - Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Fix: [#13961] Animation for Guests sliding down Spiral Slide is missing on close zoom levels.
 - Fix: [#14012] 'Finish 5 roller coasters' goal is listed incorrectly in scenario selector.
-- Fix: [#14095] Holding down [-][+] buttons does not decrease/increase num. of circuit
+- Fix: [#14095] Holding down [-][+] buttons does not decrease/increase num. of circuit.
 - Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,7 +47,7 @@
 - Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Fix: [#13961] Animation for Guests sliding down Spiral Slide is missing on close zoom levels.
 - Fix: [#14012] 'Finish 5 roller coasters' goal is listed incorrectly in scenario selector.
-- Fix: [#14095] Holding down [-][+] buttons does not decrease/increase num. of circuit.
+- Fix: [#14095] Holding down [-][+] buttons does not decrease/increase number of circuits.
 - Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
 - Improved: [#13386] A GUI error message is now displayed if the language files are missing.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -503,7 +503,9 @@ static constexpr const uint64_t window_ride_page_hold_down_widgets[] = {
         (1ULL << WIDX_MINIMUM_LENGTH_INCREASE) |
         (1ULL << WIDX_MINIMUM_LENGTH_DECREASE) |
         (1ULL << WIDX_MAXIMUM_LENGTH_INCREASE) |
-        (1ULL << WIDX_MAXIMUM_LENGTH_DECREASE),
+        (1ULL << WIDX_MAXIMUM_LENGTH_DECREASE) |
+        (1ULL << WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE) |
+        (1ULL << WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE),
     0,
     0,
     0,


### PR DESCRIPTION
Fix #14095 : Holding down [-][+] buttons does not decrease/increase num. of circuit

My first contribution (to open source, ever), any feedback on the process is appreciated.