### PR TITLE
Add support for 5-button mice

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -413,6 +413,12 @@ public:
                             _cursorState.right = CURSOR_PRESSED;
                             _cursorState.old = 2;
                             break;
+                        case SDL_BUTTON_X1:
+                            StoreMouseInput(MouseState::FourPress, mousePos);
+                            break;
+                        case SDL_BUTTON_X2:
+                            StoreMouseInput(MouseState::FivePress, mousePos);
+                            break;
                     }
                     _cursorState.touch = false;
                     break;
@@ -439,6 +445,12 @@ public:
                             StoreMouseInput(MouseState::RightRelease, mousePos);
                             _cursorState.right = CURSOR_RELEASED;
                             _cursorState.old = 4;
+                            break;
+                        case SDL_BUTTON_X1:
+                            StoreMouseInput(MouseState::FourRelease, mousePos);
+                            break;
+                        case SDL_BUTTON_X2:
+                            StoreMouseInput(MouseState::FiveRelease, mousePos);
                             break;
                     }
                     _cursorState.touch = false;

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -262,6 +262,10 @@ static void InputScrollRight(const ScreenCoordsXY& screenCoords, MouseState stat
         case MouseState::LeftPress:
         case MouseState::LeftRelease:
         case MouseState::RightPress:
+        case MouseState::FourPress:
+        case MouseState::FourRelease:
+        case MouseState::FivePress:
+        case MouseState::FiveRelease:
             // Function only handles right button, so it's the only one relevant
             break;
     }
@@ -322,8 +326,23 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                         }
                     }
                     break;
+                case MouseState::FourPress:
+                    if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
+                    {
+                        window_rotate_camera(window_get_main(), 1);
+                    }
+                    break;
+                case MouseState::FivePress:
+                    if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
+                    {
+                        window_rotate_camera(window_get_main(), -1);
+                    }
+                    break;
+
                 case MouseState::LeftRelease:
                 case MouseState::RightRelease:
+                case MouseState::FourRelease:
+                case MouseState::FiveRelease:
                     // In this switch only button presses are relevant
                     break;
             }
@@ -359,6 +378,14 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                     // If the user pressed the right mouse button for less than 500 ticks, interpret as right click
                     ViewportInteractionRightClick(screenCoords);
                 }
+            }
+            else if (state == MouseState::FourPress)
+            {
+                window_rotate_camera(window_get_main(), 1);
+            }
+            else if (state == MouseState::FivePress)
+            {
+                window_rotate_camera(window_get_main(), -1);
             }
             break;
         case InputState::DropdownActive:
@@ -417,6 +444,10 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                 case MouseState::LeftPress:
                 case MouseState::RightPress:
                 case MouseState::RightRelease:
+                case MouseState::FourPress:
+                case MouseState::FourRelease:
+                case MouseState::FivePress:
+                case MouseState::FiveRelease:
                     // In this switch only left button release is relevant
                     break;
             }
@@ -433,6 +464,10 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                 case MouseState::LeftPress:
                 case MouseState::RightPress:
                 case MouseState::RightRelease:
+                case MouseState::FourPress:
+                case MouseState::FourRelease:
+                case MouseState::FivePress:
+                case MouseState::FiveRelease:
                     // In this switch only left button release is relevant
                     break;
             }

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -43,7 +43,11 @@ enum class MouseState : uint32_t
     LeftPress,
     LeftRelease,
     RightPress,
-    RightRelease
+    RightRelease,
+    FourPress,
+    FourRelease,
+    FivePress,
+    FiveRelease
 };
 
 enum class InputState


### PR DESCRIPTION
Allows rotating the camera with buttons 4 and 5 on 5-button-mice

Adds basic support for 5-button mice. Some high-end gaming and productivity mice have an additional 2 buttons, usually positioned underneath the thumb. These are usually used to provide easy access to additional actions like navigating forward and backward in a web browser, or undo and redo in a text editor. I have programed them so that they rotate the camera, both during normal input and during a right-click drag.