### PR TITLE
Fix #14111, #14112: Strange behaviour when selecting a new scenario

### DIFF
--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -336,7 +336,10 @@ static void window_scenarioselect_scrollmousedown(rct_window* w, int32_t scrollI
                     OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, w->windowPos.x + (w->width / 2));
                     gFirstTimeSaving = true;
                     _callback(listItem.scenario.scenario->path);
-                    window_close(w);
+                    if (_titleEditor)
+                    {
+                        window_close(w);
+                    }
                 }
                 break;
         }


### PR DESCRIPTION
When starting a new scenario, the window already gets closed and `w` ends up pointing to nothing or to another window.

Introduced in https://github.com/OpenRCT2/OpenRCT2/commit/d2a97ab43cb331b84bbe29cfc8a3fbd8dd49d913.