### PR TITLE
Fix #14149: Numpad shortcut keys are not loaded correctly

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3686,6 +3686,8 @@ STR_6429    :Joy {INT32}
 STR_6430    :LMB
 STR_6431    :RMB
 STR_6432    :Mouse {INT32}
+STR_6433    :Remove
+STR_6434    :Remove all bindings for this shortcut.
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -220,52 +220,45 @@ std::string_view ShortcutInput::GetModifierName(uint32_t key, bool localised)
     }
 }
 
-std::string_view ShortcutInput::GetKeyName(uint32_t key, bool localised)
+std::string_view ShortcutInput::GetLocalisedKeyName(uint32_t key)
 {
-    static std::unordered_map<uint32_t, std::pair<const char*, rct_string_id>> keys{
-        { SDLK_LEFT, { "LEFT", STR_SHORTCUT_LEFT } },
-        { SDLK_RIGHT, { "RIGHT", STR_SHORTCUT_RIGHT } },
-        { SDLK_UP, { "UP", STR_SHORTCUT_UP } },
-        { SDLK_DOWN, { "DOWN", STR_SHORTCUT_DOWN } },
-        { SDLK_BACKSPACE, { "BACKSPACE", STR_SHORTCUT_BACKSPACE } },
-        { SDLK_ESCAPE, { "ESCAPE", STR_SHORTCUT_ESCAPE } },
-        { SDLK_SPACE, { "SPACE", STR_SHORTCUT_SPACEBAR } },
-        { SDLK_TAB, { "TAB", STR_SHORTCUT_TAB } },
-        { SDLK_RETURN, { "RETURN", STR_SHORTCUT_RETURN } },
-        { SDLK_PAGEUP, { "PAGE UP", STR_SHORTCUT_PGUP } },
-        { SDLK_PAGEDOWN, { "PAGE DOWN", STR_SHORTCUT_PGDN } },
-        { SDLK_INSERT, { "INSERT", STR_SHORTCUT_INSERT } },
-        { SDLK_DELETE, { "DELETE", STR_SHORTCUT_DELETE } },
-        { SDLK_KP_DIVIDE, { "NUMPAD /", STR_SHORTCUT_NUMPAD_DIVIDE } },
-        { SDLK_KP_MULTIPLY, { "NUMPAD *", STR_SHORTCUT_NUMPAD_MULTIPLY } },
-        { SDLK_KP_MINUS, { "NUMPAD -", STR_SHORTCUT_NUMPAD_MINUS } },
-        { SDLK_KP_PLUS, { "NUMPAD +", STR_SHORTCUT_NUMPAD_PLUS } },
-        { SDLK_KP_ENTER, { "NUMPAD ENTER", STR_SHORTCUT_NUMPAD_RETURN } },
-        { SDLK_KP_1, { "NUMPAD 1", STR_SHORTCUT_NUMPAD_1 } },
-        { SDLK_KP_2, { "NUMPAD 2", STR_SHORTCUT_NUMPAD_2 } },
-        { SDLK_KP_3, { "NUMPAD 3", STR_SHORTCUT_NUMPAD_3 } },
-        { SDLK_KP_4, { "NUMPAD 4", STR_SHORTCUT_NUMPAD_4 } },
-        { SDLK_KP_5, { "NUMPAD 5", STR_SHORTCUT_NUMPAD_5 } },
-        { SDLK_KP_6, { "NUMPAD 6", STR_SHORTCUT_NUMPAD_6 } },
-        { SDLK_KP_7, { "NUMPAD 7", STR_SHORTCUT_NUMPAD_7 } },
-        { SDLK_KP_8, { "NUMPAD 8", STR_SHORTCUT_NUMPAD_8 } },
-        { SDLK_KP_9, { "NUMPAD 9", STR_SHORTCUT_NUMPAD_9 } },
-        { SDLK_KP_0, { "NUMPAD 0", STR_SHORTCUT_NUMPAD_0 } },
-        { SDLK_KP_PERIOD, { "NUMPAD .", STR_SHORTCUT_NUMPAD_PERIOD } },
-        { SDLK_CAPSLOCK, { "CAPSLOCK", STR_SHORTCUT_NUMPAD_PERIOD } },
+    static std::unordered_map<uint32_t, rct_string_id> keys{
+        { SDLK_LEFT, STR_SHORTCUT_LEFT },
+        { SDLK_RIGHT, STR_SHORTCUT_RIGHT },
+        { SDLK_UP, STR_SHORTCUT_UP },
+        { SDLK_DOWN, STR_SHORTCUT_DOWN },
+        { SDLK_BACKSPACE, STR_SHORTCUT_BACKSPACE },
+        { SDLK_ESCAPE, STR_SHORTCUT_ESCAPE },
+        { SDLK_SPACE, STR_SHORTCUT_SPACEBAR },
+        { SDLK_TAB, STR_SHORTCUT_TAB },
+        { SDLK_RETURN, STR_SHORTCUT_RETURN },
+        { SDLK_PAGEUP, STR_SHORTCUT_PGUP },
+        { SDLK_PAGEDOWN, STR_SHORTCUT_PGDN },
+        { SDLK_INSERT, STR_SHORTCUT_INSERT },
+        { SDLK_DELETE, STR_SHORTCUT_DELETE },
+        { SDLK_KP_DIVIDE, STR_SHORTCUT_NUMPAD_DIVIDE },
+        { SDLK_KP_MULTIPLY, STR_SHORTCUT_NUMPAD_MULTIPLY },
+        { SDLK_KP_MINUS, STR_SHORTCUT_NUMPAD_MINUS },
+        { SDLK_KP_PLUS, STR_SHORTCUT_NUMPAD_PLUS },
+        { SDLK_KP_ENTER, STR_SHORTCUT_NUMPAD_RETURN },
+        { SDLK_KP_1, STR_SHORTCUT_NUMPAD_1 },
+        { SDLK_KP_2, STR_SHORTCUT_NUMPAD_2 },
+        { SDLK_KP_3, STR_SHORTCUT_NUMPAD_3 },
+        { SDLK_KP_4, STR_SHORTCUT_NUMPAD_4 },
+        { SDLK_KP_5, STR_SHORTCUT_NUMPAD_5 },
+        { SDLK_KP_6, STR_SHORTCUT_NUMPAD_6 },
+        { SDLK_KP_7, STR_SHORTCUT_NUMPAD_7 },
+        { SDLK_KP_8, STR_SHORTCUT_NUMPAD_8 },
+        { SDLK_KP_9, STR_SHORTCUT_NUMPAD_9 },
+        { SDLK_KP_0, STR_SHORTCUT_NUMPAD_0 },
+        { SDLK_KP_PERIOD, STR_SHORTCUT_NUMPAD_PERIOD },
+        { SDLK_CAPSLOCK, STR_SHORTCUT_NUMPAD_PERIOD },
     };
 
     auto r = keys.find(key);
     if (r != keys.end())
     {
-        if (localised && r->second.second != STR_NONE)
-        {
-            return language_get_string(r->second.second);
-        }
-        else
-        {
-            return r->second.first;
-        }
+        return language_get_string(r->second);
     }
     else
     {
@@ -295,23 +288,21 @@ std::string ShortcutInput::ToString(bool localised) const
     {
         if (Button != 0)
         {
-            auto text = GetKeyName(Button, localised);
-            if (text.empty())
+            if (localised)
             {
-                if (Button & SDLK_SCANCODE_MASK)
+                auto name = GetLocalisedKeyName(Button);
+                if (!name.empty())
                 {
-                    auto name = SDL_GetKeyName(Button);
-                    // auto name = SDL_GetScancodeName(static_cast<SDL_Scancode>(Button & ~SDLK_SCANCODE_MASK));
                     result += name;
                 }
                 else
                 {
-                    String::AppendCodepoint(result, std::toupper(Button));
+                    result += SDL_GetKeyName(Button);
                 }
             }
             else
             {
-                result += text;
+                result += SDL_GetKeyName(Button);
             }
         }
     }

--- a/src/openrct2-ui/input/ShortcutManager.cpp
+++ b/src/openrct2-ui/input/ShortcutManager.cpp
@@ -131,8 +131,10 @@ RegisteredShortcut* ShortcutManager::GetShortcut(std::string_view id)
 
 void ShortcutManager::RemoveShortcut(std::string_view id)
 {
-    Shortcuts.erase(std::remove_if(
-        Shortcuts.begin(), Shortcuts.end(), [id](const RegisteredShortcut& shortcut) { return shortcut.Id == id; }));
+    Shortcuts.erase(
+        std::remove_if(
+            Shortcuts.begin(), Shortcuts.end(), [id](const RegisteredShortcut& shortcut) { return shortcut.Id == id; }),
+        Shortcuts.end());
 }
 
 bool ShortcutManager::IsPendingShortcutChange() const

--- a/src/openrct2-ui/input/ShortcutManager.h
+++ b/src/openrct2-ui/input/ShortcutManager.h
@@ -47,7 +47,7 @@ namespace OpenRCT2::Ui
     private:
         bool AppendModifier(std::string& s, uint32_t left, uint32_t right, bool localised) const;
         static std::string_view GetModifierName(uint32_t key, bool localised);
-        static std::string_view GetKeyName(uint32_t key, bool localised);
+        static std::string_view GetLocalisedKeyName(uint32_t key);
         std::string ToString(bool localised) const;
     };
 

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -41,6 +41,7 @@ namespace OpenRCT2::Scripting
         {
             registeredShortcut.Default.emplace_back(binding);
         }
+        registeredShortcut.Current = registeredShortcut.Default;
         shortcutManager.RegisterShortcut(std::move(registeredShortcut));
         shortcutManager.LoadUserBindings();
     }

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -23,7 +23,7 @@ namespace OpenRCT2::Scripting
 {
     std::optional<CustomTool> ActiveCustomTool;
     std::vector<CustomToolbarMenuItem> CustomMenuItems;
-    std::vector<CustomShortcut> CustomShortcuts;
+    std::vector<std::unique_ptr<CustomShortcut>> CustomShortcuts;
 
     CustomShortcut::CustomShortcut(
         std::shared_ptr<Plugin> owner, std::string_view id, std::string_view text, const std::vector<std::string>& bindings,
@@ -130,7 +130,7 @@ namespace OpenRCT2::Scripting
         auto& shortcuts = CustomShortcuts;
         for (auto it = shortcuts.begin(); it != shortcuts.end();)
         {
-            if (it->Owner == owner)
+            if ((*it)->Owner == owner)
             {
                 it = shortcuts.erase(it);
             }

--- a/src/openrct2-ui/scripting/CustomMenu.h
+++ b/src/openrct2-ui/scripting/CustomMenu.h
@@ -94,7 +94,7 @@ namespace OpenRCT2::Scripting
 
     extern std::optional<CustomTool> ActiveCustomTool;
     extern std::vector<CustomToolbarMenuItem> CustomMenuItems;
-    extern std::vector<CustomShortcut> CustomShortcuts;
+    extern std::vector<std::unique_ptr<CustomShortcut>> CustomShortcuts;
 
     void InitialiseCustomMenuItems(ScriptEngine& scriptEngine);
     void InitialiseCustomTool(ScriptEngine& scriptEngine, const DukValue& dukValue);

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -327,7 +327,7 @@ namespace OpenRCT2::Scripting
                 }
 
                 auto callback = desc["callback"];
-                CustomShortcuts.emplace_back(owner, id, text, bindings, callback);
+                CustomShortcuts.emplace_back(std::make_unique<CustomShortcut>(owner, id, text, bindings, callback));
             }
             catch (const DukException&)
             {

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -48,11 +48,17 @@ static rct_widget window_shortcut_widgets[] = {
 
 static constexpr const rct_string_id CHANGE_WINDOW_TITLE = STR_SHORTCUT_CHANGE_TITLE;
 static constexpr const int32_t CHANGE_WW = 250;
-static constexpr const int32_t CHANGE_WH = 60;
+static constexpr const int32_t CHANGE_WH = 80;
+
+enum
+{
+    WIDX_REMOVE = 3
+};
 
 // clang-format off
 static rct_widget window_shortcut_change_widgets[] = {
     WINDOW_SHIM(CHANGE_WINDOW_TITLE, CHANGE_WW, CHANGE_WH),
+    MakeWidget({ 75, 56 }, { 100, 12 }, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_REMOVE, STR_SHORTCUT_REMOVE_TIP),
     { WIDGETS_END }
 };
 // clang-format on
@@ -60,6 +66,7 @@ static rct_widget window_shortcut_change_widgets[] = {
 class ChangeShortcutWindow final : public Window
 {
 private:
+    std::string _shortcutId;
     rct_string_id _shortcutLocalisedName{};
     std::string _shortcutCustomName;
 
@@ -74,6 +81,7 @@ public:
             auto w = WindowCreate<ChangeShortcutWindow>(WC_CHANGE_KEYBOARD_SHORTCUT, CHANGE_WW, CHANGE_WH, WF_CENTRE_SCREEN);
             if (w != nullptr)
             {
+                w->_shortcutId = shortcutId;
                 w->_shortcutLocalisedName = registeredShortcut->LocalisedName;
                 w->_shortcutCustomName = registeredShortcut->CustomName;
                 shortcutManager.SetPendingShortcutChange(registeredShortcut->Id);
@@ -86,7 +94,7 @@ public:
     void OnOpen() override
     {
         widgets = window_shortcut_change_widgets;
-        enabled_widgets = (1ULL << WIDX_CLOSE);
+        enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_REMOVE);
         WindowInitScrollWidgets(this);
     }
 
@@ -103,6 +111,9 @@ public:
         {
             case WIDX_CLOSE:
                 Close();
+                break;
+            case WIDX_REMOVE:
+                Remove();
                 break;
         }
     }
@@ -128,6 +139,17 @@ public:
 
 private:
     void NotifyShortcutKeysWindow();
+
+    void Remove()
+    {
+        auto& shortcutManager = GetShortcutManager();
+        auto* shortcut = shortcutManager.GetShortcut(_shortcutId);
+        if (shortcut != nullptr)
+        {
+            shortcut->Current.clear();
+        }
+        Close();
+    }
 };
 
 class ShortcutKeysWindow final : public Window

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -58,7 +58,7 @@ enum
 // clang-format off
 static rct_widget window_shortcut_change_widgets[] = {
     WINDOW_SHIM(CHANGE_WINDOW_TITLE, CHANGE_WW, CHANGE_WH),
-    MakeWidget({ 75, 56 }, { 100, 12 }, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_REMOVE, STR_SHORTCUT_REMOVE_TIP),
+    MakeWidget({ 75, 56 }, { 100, 14 }, WindowWidgetType::Button, WindowColour::Primary, STR_SHORTCUT_REMOVE, STR_SHORTCUT_REMOVE_TIP),
     { WIDGETS_END }
 };
 // clang-format on

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3946,6 +3946,9 @@ enum
     STR_SHORTCUT_MOUSE_RIGHT = 6431,
     STR_SHORTCUT_MOUSE_NUMBER = 6432,
 
+    STR_SHORTCUT_REMOVE = 6433,
+    STR_SHORTCUT_REMOVE_TIP = 6434,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
I decided it was too complicated and unnecessary storing our own internal strings for keyboard keys. Instead I just use the SDL2 internal name for serialisation / deserialisation to JSON. This means the JSON file will now store `Keypad 1`, where as the UI will still show the localised name: `Numpad 1`.

I have also added a remove button to the change shortcut window so that you can now clear all shortcut bindings for a single shortcut entry.

![image](https://user-images.githubusercontent.com/1482259/108911591-578f3980-761f-11eb-8958-c1b641823543.png)
