### PR TITLE
Reduce usage of gCurrentFontSpriteBase

### DIFF
--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -26,6 +26,12 @@ using namespace OpenRCT2::Ui;
 
 static InGameConsole _inGameConsole;
 
+static int32_t InGameConsoleGetLineHeight()
+{
+    auto fontSpriteBase = (gConfigInterface.console_small_font ? FONT_SPRITE_BASE_SMALL : FONT_SPRITE_BASE_MEDIUM);
+    return font_get_line_height(fontSpriteBase);
+}
+
 InGameConsole::InGameConsole()
 {
     InteractiveConsole::WriteLine(OPENRCT2_NAME " " OPENRCT2_VERSION);
@@ -268,7 +274,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
     // Set font
     gCurrentFontSpriteBase = (gConfigInterface.console_small_font ? FONT_SPRITE_BASE_SMALL : FONT_SPRITE_BASE_MEDIUM);
     uint8_t textColour = NOT_TRANSLUCENT(ThemeGetColour(WC_CONSOLE, 1));
-    const int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    const int32_t lineHeight = InGameConsoleGetLineHeight();
     const int32_t maxLines = GetNumVisibleLines();
 
     // This is something of a hack to ensure the text is actually black
@@ -350,7 +356,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
 // Calculates the amount of visible lines, based on the console size, excluding the input line.
 int32_t InGameConsole::GetNumVisibleLines() const
 {
-    const int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    const int32_t lineHeight = InGameConsoleGetLineHeight();
     const int32_t consoleHeight = _consoleBottom - _consoleTop;
     if (consoleHeight == 0)
         return 0;

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -188,7 +188,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_about_openrct2_common_paint(w, dpi);
 
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     ScreenCoordsXY aboutCoords(
         w->windowPos.x + (w->width / 2), w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight);
@@ -270,7 +270,7 @@ static void window_about_rct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto screenCoords = ScreenCoordsXY{ w->windowPos.x + 200, yPage + 5 };
 
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Credits
     gfx_draw_string_centred(dpi, STR_COPYRIGHT_CS, screenCoords, COLOUR_BLACK, nullptr);

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -187,7 +187,7 @@ static void window_changelog_scrollgetsize(
 {
     *width = _changelogLongestLineWidth + 4;
 
-    const int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    const int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
     *height = static_cast<int32_t>(_changelogLines.size() * lineHeight);
 }
 
@@ -215,7 +215,7 @@ static void window_changelog_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
 {
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    const int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    const int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     ScreenCoordsXY screenCoords(3, 3 - lineHeight);
     for (const auto& line : _changelogLines)

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -92,7 +92,7 @@ rct_window* window_error_open(std::string_view title, std::string_view message)
 
     _window_error_num_lines = numLines;
     width = width + 3;
-    height = (numLines + 1) * font_get_line_height(gCurrentFontSpriteBase) + 4;
+    height = (numLines + 1) * font_get_line_height(FONT_SPRITE_BASE_MEDIUM) + 4;
 
     window_error_widgets[WIDX_BACKGROUND].right = width;
     window_error_widgets[WIDX_BACKGROUND].bottom = height;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1260,7 +1260,7 @@ void window_guest_stats_update(rct_window* w)
 static void window_guest_stats_bars_paint(
     int32_t value, int32_t x, int32_t y, rct_window* w, rct_drawpixelinfo* dpi, int32_t colour, bool blinkFlag)
 {
-    if (font_get_line_height(gCurrentFontSpriteBase) > 10)
+    if (font_get_line_height(FONT_SPRITE_BASE_MEDIUM) > 10)
     {
         y += 1;
     }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -338,7 +338,7 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
 
     // Reset font sprite base and compute line height
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     // Base dimensions.
     const int32_t width = 450;

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -139,7 +139,7 @@ static void window_music_credits_mouseup(rct_window* w, rct_widgetindex widgetIn
  */
 static void window_music_credits_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
     *height = static_cast<int32_t>(std::size(music_credits) + std::size(music_credits_rct2)) * lineHeight + 12;
 }
 
@@ -158,7 +158,7 @@ static void window_music_credits_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void window_music_credits_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
 
     auto screenCoords = ScreenCoordsXY{ 245, 2 };
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2134,7 +2134,7 @@ static void window_options_advanced_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Apply vertical alignment if appropriate.
     int32_t widgetHeight = pathWidget.bottom - pathWidget.top;
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
     uint32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
     ScreenCoordsXY screenCoords = { w->windowPos.x + pathWidget.left + 1,
                                     w->windowPos.y + pathWidget.top + static_cast<int32_t>(padding) };

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -181,7 +181,7 @@ int32_t gfx_draw_string_left_wrapped(
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    TextPaint textPaint = { colour, gCurrentFontSpriteBase, false, TextAlignment::LEFT };
+    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, false, TextAlignment::LEFT };
     StaticLayout layout(buffer, textPaint, width);
     layout.Draw(dpi, coords);
 


### PR DESCRIPTION
I want to eliminate gCurrentFontSpriteBase in the longer run.