### PR TITLE
Refactor text drawing

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -29,7 +29,7 @@ namespace Graph
                 // Draw month text
                 auto ft = Formatter();
                 ft.Add<uint32_t>(DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)]);
-                gfx_draw_string_centred(dpi, STR_GRAPH_LABEL, screenCoords - ScreenCoordsXY{ 0, 10 }, COLOUR_BLACK, ft.Data());
+                DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft, { TextAlignment::CENTRE });
 
                 // Draw month mark
                 gfx_fill_rect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
@@ -170,8 +170,8 @@ namespace Graph
             {
                 // Draw month text
                 int32_t monthFormat = DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)];
-                gfx_draw_string_centred(
-                    dpi, STR_GRAPH_LABEL, screenCoords - ScreenCoordsXY{ 0, 10 }, COLOUR_BLACK, &monthFormat);
+                DrawTextBasic(
+                    dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, &monthFormat, { TextAlignment::CENTRE });
 
                 // Draw month mark
                 gfx_fill_rect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
@@ -273,8 +273,9 @@ namespace Graph
             gfx_draw_dashed_line(dpi, { info.coords, { info.coords.x, cursorPosition.y } }, DefaultDashedLength, 0);
         }
 
-        gfx_draw_string_centred(
-            dpi, STR_FINANCES_SUMMARY_EXPENDITURE_VALUE, info.coords - ScreenCoordsXY{ 0, 16 }, COLOUR_BLACK, &info.money);
+        DrawTextBasic(
+            dpi, info.coords - ScreenCoordsXY{ 0, 16 }, STR_FINANCES_SUMMARY_EXPENDITURE_VALUE, &info.money,
+            { TextAlignment::CENTRE });
 
         gfx_fill_rect(
             dpi, { { info.coords - ScreenCoordsXY{ 2, 2 } }, info.coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -322,7 +322,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
     {
         const size_t index = i + _consoleScrollPos;
         lineBuffer = colourFormatStr + _consoleLines[index];
-        gfx_draw_string(dpi, lineBuffer.c_str(), textColour, screenCoords);
+        gfx_draw_string(dpi, screenCoords, lineBuffer.c_str(), { textColour, InGameconsoleGetFontSpriteBase() });
         screenCoords.y += lineHeight;
     }
 

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -26,10 +26,14 @@ using namespace OpenRCT2::Ui;
 
 static InGameConsole _inGameConsole;
 
+static FontSpriteBase InGameconsoleGetFontSpriteBase()
+{
+    return (gConfigInterface.console_small_font ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM);
+}
+
 static int32_t InGameConsoleGetLineHeight()
 {
-    auto fontSpriteBase = (gConfigInterface.console_small_font ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM);
-    return font_get_line_height(fontSpriteBase);
+    return font_get_line_height(InGameconsoleGetFontSpriteBase());
 }
 
 InGameConsole::InGameConsole()
@@ -146,7 +150,7 @@ void InGameConsole::RefreshCaret(size_t position)
     _selectionStart = position;
     char tempString[TEXT_INPUT_SIZE] = { 0 };
     std::memcpy(tempString, &_consoleCurrentLine, _selectionStart);
-    _caretScreenPosX = gfx_get_string_width_no_formatting(tempString);
+    _caretScreenPosX = gfx_get_string_width_no_formatting(tempString, InGameconsoleGetFontSpriteBase());
 }
 
 void InGameConsole::Scroll(int32_t linesToScroll)
@@ -272,7 +276,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
         return;
 
     // Set font
-    gCurrentFontSpriteBase = (gConfigInterface.console_small_font ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM);
+    gCurrentFontSpriteBase = InGameconsoleGetFontSpriteBase();
     uint8_t textColour = NOT_TRANSLUCENT(ThemeGetColour(WC_CONSOLE, 1));
     const int32_t lineHeight = InGameConsoleGetLineHeight();
     const int32_t maxLines = GetNumVisibleLines();

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -26,14 +26,14 @@ using namespace OpenRCT2::Ui;
 
 static InGameConsole _inGameConsole;
 
-static FontSpriteBase InGameconsoleGetFontSpriteBase()
+static FontSpriteBase InGameConsoleGetFontSpriteBase()
 {
     return (gConfigInterface.console_small_font ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM);
 }
 
 static int32_t InGameConsoleGetLineHeight()
 {
-    return font_get_line_height(InGameconsoleGetFontSpriteBase());
+    return font_get_line_height(InGameConsoleGetFontSpriteBase());
 }
 
 InGameConsole::InGameConsole()
@@ -150,7 +150,7 @@ void InGameConsole::RefreshCaret(size_t position)
     _selectionStart = position;
     char tempString[TEXT_INPUT_SIZE] = { 0 };
     std::memcpy(tempString, &_consoleCurrentLine, _selectionStart);
-    _caretScreenPosX = gfx_get_string_width_no_formatting(tempString, InGameconsoleGetFontSpriteBase());
+    _caretScreenPosX = gfx_get_string_width_no_formatting(tempString, InGameConsoleGetFontSpriteBase());
 }
 
 void InGameConsole::Scroll(int32_t linesToScroll)
@@ -321,7 +321,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
     {
         const size_t index = i + _consoleScrollPos;
         lineBuffer = colourFormatStr + _consoleLines[index];
-        gfx_draw_string(dpi, screenCoords, lineBuffer.c_str(), { textColour, InGameconsoleGetFontSpriteBase() });
+        gfx_draw_string(dpi, screenCoords, lineBuffer.c_str(), { textColour, InGameConsoleGetFontSpriteBase() });
         screenCoords.y += lineHeight;
     }
 
@@ -329,7 +329,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
 
     // Draw current line
     lineBuffer = colourFormatStr + _consoleCurrentLine;
-    gfx_draw_string_no_formatting(dpi, screenCoords, lineBuffer.c_str(), { TEXT_COLOUR_255, InGameconsoleGetFontSpriteBase() });
+    gfx_draw_string_no_formatting(dpi, screenCoords, lineBuffer.c_str(), { TEXT_COLOUR_255, InGameConsoleGetFontSpriteBase() });
 
     // Draw caret
     if (_consoleCaretTicks < CONSOLE_CARET_FLASH_THRESHOLD)

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -28,7 +28,7 @@ static InGameConsole _inGameConsole;
 
 static int32_t InGameConsoleGetLineHeight()
 {
-    auto fontSpriteBase = (gConfigInterface.console_small_font ? FONT_SPRITE_BASE_SMALL : FONT_SPRITE_BASE_MEDIUM);
+    auto fontSpriteBase = (gConfigInterface.console_small_font ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM);
     return font_get_line_height(fontSpriteBase);
 }
 
@@ -272,7 +272,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
         return;
 
     // Set font
-    gCurrentFontSpriteBase = (gConfigInterface.console_small_font ? FONT_SPRITE_BASE_SMALL : FONT_SPRITE_BASE_MEDIUM);
+    gCurrentFontSpriteBase = (gConfigInterface.console_small_font ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM);
     uint8_t textColour = NOT_TRANSLUCENT(ThemeGetColour(WC_CONSOLE, 1));
     const int32_t lineHeight = InGameConsoleGetLineHeight();
     const int32_t maxLines = GetNumVisibleLines();

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -276,7 +276,6 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
         return;
 
     // Set font
-    gCurrentFontSpriteBase = InGameconsoleGetFontSpriteBase();
     uint8_t textColour = NOT_TRANSLUCENT(ThemeGetColour(WC_CONSOLE, 1));
     const int32_t lineHeight = InGameConsoleGetLineHeight();
     const int32_t maxLines = GetNumVisibleLines();
@@ -330,7 +329,7 @@ void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
 
     // Draw current line
     lineBuffer = colourFormatStr + _consoleCurrentLine;
-    gfx_draw_string_no_formatting(dpi, lineBuffer.c_str(), TEXT_COLOUR_255, screenCoords);
+    gfx_draw_string_no_formatting(dpi, screenCoords, lineBuffer.c_str(), { TEXT_COLOUR_255, InGameconsoleGetFontSpriteBase() });
 
     // Draw caret
     if (_consoleCaretTicks < CONSOLE_CARET_FLASH_THRESHOLD)

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -483,7 +483,7 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
         format_string(buffer, sizeof(buffer), stringId, formatArgs);
         auto ft = Formatter();
         ft.Add<utf8*>(buffer);
-        gfx_draw_string_left(dpi, STR_STRING, ft.Data(), colour, { l, t });
+        DrawTextBasic(dpi, { l, t }, STR_STRING, ft, { colour });
         textRight = l + gfx_get_string_width(buffer) + 1;
     }
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -333,7 +333,7 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
         return;
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    colour_t colour = w->colours[widget->colour];
     colour &= ~(COLOUR_FLAG_TRANSLUCENT);
     if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
@@ -362,7 +362,7 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     }
     else
     {
-        DrawTextEllipsised(dpi, coords, widget->width() - 2, stringId, ft, colour, TextAlignment::CENTRE);
+        DrawTextEllipsised(dpi, coords, widget->width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 }
 
@@ -563,7 +563,7 @@ static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     }
     topLeft.x += width / 2;
     DrawTextEllipsised(
-        dpi, topLeft, width, widget->text, Formatter::Common(), COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::CENTRE);
+        dpi, topLeft, width, widget->text, Formatter::Common(), { COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::CENTRE });
 }
 
 /**
@@ -600,7 +600,7 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
-    DrawTextEllipsised(dpi, topLeft, widget->width() - 2, widget->text, Formatter::Common(), colour, TextAlignment::CENTRE);
+    DrawTextEllipsised(dpi, topLeft, widget->width() - 2, widget->text, Formatter::Common(), { colour, TextAlignment::CENTRE });
 }
 
 /**
@@ -670,8 +670,6 @@ static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
     topLeft.y++;
     bottomRight.x--;
     bottomRight.y--;
-
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     // Horizontal scrollbar
     if (scroll->flags & HSCROLLBAR_VISIBLE)
@@ -1105,8 +1103,6 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     // gfx_fill_rect_inset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
     // Figure out where the text should be positioned vertically.
     topLeft.y = w->windowPos.y + widget->textTop();
 
@@ -1115,8 +1111,9 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
         if (w->widgets[widgetIndex].text != 0)
         {
             safe_strcpy(wrapped_string, w->widgets[widgetIndex].string, 512);
-            gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5, &no_lines);
-            gfx_draw_string_no_formatting(dpi, wrapped_string, w->colours[1], { topLeft.x + 2, topLeft.y });
+            gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5, FontSpriteBase::MEDIUM, &no_lines);
+            gfx_draw_string_no_formatting(
+                dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w->colours[1], FontSpriteBase::MEDIUM });
         }
         return;
     }
@@ -1125,9 +1122,9 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
 
     // String length needs to add 12 either side of box
     // +13 for cursor when max length.
-    gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5 - 6, &no_lines);
+    gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5 - 6, FontSpriteBase::MEDIUM, &no_lines);
 
-    gfx_draw_string_no_formatting(dpi, wrapped_string, w->colours[1], { topLeft.x + 2, topLeft.y });
+    gfx_draw_string_no_formatting(dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w->colours[1], FontSpriteBase::MEDIUM });
 
     size_t string_length = get_string_size(wrapped_string) - 1;
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -484,7 +484,7 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
         auto ft = Formatter();
         ft.Add<utf8*>(buffer);
         DrawTextBasic(dpi, { l, t }, STR_STRING, ft, { colour });
-        textRight = l + gfx_get_string_width(buffer) + 1;
+        textRight = l + gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) + 1;
     }
 
     // Border
@@ -1134,7 +1134,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     // Make a copy of the string for measuring the width.
     char temp_string[TEXT_INPUT_SIZE] = { 0 };
     std::memcpy(temp_string, wrapped_string, std::min(string_length, gTextInput->SelectionStart));
-    int32_t cur_x = topLeft.x + gfx_get_string_width_no_formatting(temp_string) + 3;
+    int32_t cur_x = topLeft.x + gfx_get_string_width_no_formatting(temp_string, FontSpriteBase::MEDIUM) + 3;
 
     int32_t width = 6;
     if (static_cast<uint32_t>(gTextInput->SelectionStart) < strlen(gTextBoxInput))
@@ -1143,7 +1143,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
         // of the character that the cursor is under.
         temp_string[1] = '\0';
         temp_string[0] = gTextBoxInput[gTextInput->SelectionStart];
-        width = std::max(gfx_get_string_width_no_formatting(temp_string) - 2, 4);
+        width = std::max(gfx_get_string_width_no_formatting(temp_string, FontSpriteBase::MEDIUM) - 2, 4);
     }
 
     if (gTextBoxFrameNo <= 15)

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -631,7 +631,7 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     // fill it when checkbox is pressed
     if (WidgetIsPressed(w, widgetIndex))
     {
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         gfx_draw_string(
             dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), { midLeft - ScreenCoordsXY{ 0, 5 } });
     }
@@ -671,7 +671,7 @@ static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
     bottomRight.x--;
     bottomRight.y--;
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     // Horizontal scrollbar
     if (scroll->flags & HSCROLLBAR_VISIBLE)
@@ -1087,7 +1087,7 @@ void WidgetSetCheckboxValue(rct_window* w, rct_widgetindex widgetIndex, int32_t 
 static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     int32_t no_lines = 0;
-    int32_t font_height = 0;
+    FontSpriteBase font_height = FontSpriteBase::SMALL;
     char wrapped_string[TEXT_INPUT_SIZE];
 
     // Get the widget
@@ -1106,7 +1106,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     // gfx_fill_rect_inset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     // Figure out where the text should be positioned vertically.
     topLeft.y = w->windowPos.y + widget->textTop();

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -1087,7 +1087,6 @@ void WidgetSetCheckboxValue(rct_window* w, rct_widgetindex widgetIndex, int32_t 
 static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     int32_t no_lines = 0;
-    FontSpriteBase font_height = FontSpriteBase::SMALL;
     char wrapped_string[TEXT_INPUT_SIZE];
 
     // Get the widget
@@ -1116,7 +1115,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
         if (w->widgets[widgetIndex].text != 0)
         {
             safe_strcpy(wrapped_string, w->widgets[widgetIndex].string, 512);
-            gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5, &no_lines, &font_height);
+            gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5, &no_lines);
             gfx_draw_string_no_formatting(dpi, wrapped_string, w->colours[1], { topLeft.x + 2, topLeft.y });
         }
         return;
@@ -1126,7 +1125,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
 
     // String length needs to add 12 either side of box
     // +13 for cursor when max length.
-    gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5 - 6, &no_lines, &font_height);
+    gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5 - 6, &no_lines);
 
     gfx_draw_string_no_formatting(dpi, wrapped_string, w->colours[1], { topLeft.x + 2, topLeft.y });
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -618,7 +618,7 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     ScreenCoordsXY midLeft = { topLeft.x, (topLeft.y + bottomRight.y) / 2 };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    colour_t colour = w->colours[widget->colour];
 
     // checkbox
     gfx_fill_rect_inset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
@@ -631,9 +631,9 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     // fill it when checkbox is pressed
     if (WidgetIsPressed(w, widgetIndex))
     {
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         gfx_draw_string(
-            dpi, static_cast<const char*>(CheckBoxMarkString), NOT_TRANSLUCENT(colour), { midLeft - ScreenCoordsXY{ 0, 5 } });
+            dpi, { midLeft - ScreenCoordsXY{ 0, 5 } }, static_cast<const char*>(CheckBoxMarkString),
+            { static_cast<colour_t>(NOT_TRANSLUCENT(colour)) });
     }
 
     // draw the text
@@ -735,7 +735,7 @@ static void WidgetHScrollbarDraw(
         uint8_t flags = (scroll->flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
         gfx_fill_rect_inset(dpi, { { l, t }, { l + (SCROLLBAR_WIDTH - 1), b } }, colour, flags);
-        gfx_draw_string(dpi, static_cast<const char*>(BlackLeftArrowString), COLOUR_BLACK, { l + 1, t });
+        gfx_draw_string(dpi, { l + 1, t }, static_cast<const char*>(BlackLeftArrowString), {});
     }
 
     // Thumb
@@ -752,7 +752,7 @@ static void WidgetHScrollbarDraw(
         uint8_t flags = (scroll->flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
         gfx_fill_rect_inset(dpi, { { r - (SCROLLBAR_WIDTH - 1), t }, { r, b } }, colour, flags);
-        gfx_draw_string(dpi, static_cast<const char*>(BlackRightArrowString), COLOUR_BLACK, { r - 6, t });
+        gfx_draw_string(dpi, { r - 6, t }, static_cast<const char*>(BlackRightArrowString), {});
     }
 }
 
@@ -772,7 +772,7 @@ static void WidgetVScrollbarDraw(
     gfx_fill_rect_inset(
         dpi, { { l, t }, { r, t + (SCROLLBAR_WIDTH - 1) } }, colour,
         ((scroll->flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    gfx_draw_string(dpi, static_cast<const char*>(BlackUpArrowString), COLOUR_BLACK, { l + 1, t - 1 });
+    gfx_draw_string(dpi, { l + 1, t - 1 }, static_cast<const char*>(BlackUpArrowString), {});
 
     // Thumb
     gfx_fill_rect_inset(
@@ -785,7 +785,7 @@ static void WidgetVScrollbarDraw(
     gfx_fill_rect_inset(
         dpi, { { l, b - (SCROLLBAR_WIDTH - 1) }, { r, b } }, colour,
         ((scroll->flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    gfx_draw_string(dpi, static_cast<const char*>(BlackDownArrowString), COLOUR_BLACK, { l + 1, b - (SCROLLBAR_WIDTH - 1) });
+    gfx_draw_string(dpi, { l + 1, b - (SCROLLBAR_WIDTH - 1) }, static_cast<const char*>(BlackDownArrowString), {});
 }
 
 /**

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -358,7 +358,7 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     ScreenCoordsXY coords = { (topLeft.x + r + 1) / 2 - 1, topLeft.y };
     if (widget->type == WindowWidgetType::LabelCentred)
     {
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), coords, widget->width() - 2, stringId, colour);
+        DrawTextWrapped(dpi, coords, widget->width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
     }
     else
     {
@@ -407,7 +407,7 @@ static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex wi
     ScreenCoordsXY coords = { l + 1, t };
     if (widget->type == WindowWidgetType::LabelCentred)
     {
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), coords, r - l, stringId, colour);
+        DrawTextWrapped(dpi, coords, r - l, stringId, ft, { colour, TextAlignment::CENTRE });
     }
     else
     {

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -681,13 +681,13 @@ void CustomListView::PaintHeading(
     {
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_UP);
-        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
     }
     else if (sortOrder == ColumnSortOrder::Descending)
     {
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_DOWN);
-        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
     }
 }
 

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -710,7 +710,7 @@ void CustomListView::PaintSeperator(
         // Draw string
         Formatter ft;
         ft.Add<const char*>(text);
-        gfx_draw_string_centred(dpi, STR_STRING, { centreX, pos.y }, baseColour, ft.Data());
+        DrawTextBasic(dpi, { centreX, pos.y }, STR_STRING, ft.Data(), { baseColour, TextAlignment::CENTRE });
 
         // Get string dimensions
         format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_STRING, ft.Data());

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -758,7 +758,7 @@ void CustomListView::PaintCell(
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(text);
-    DrawTextEllipsised(dpi, pos, size.width, stringId, ft, COLOUR_BLACK);
+    DrawTextEllipsised(dpi, pos, size.width, stringId, ft, {});
 }
 
 std::optional<RowColumn> CustomListView::GetItemIndexAt(const ScreenCoordsXY& pos)

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -714,7 +714,7 @@ void CustomListView::PaintSeperator(
 
         // Get string dimensions
         format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_STRING, ft.Data());
-        int32_t categoryStringHalfWidth = (gfx_get_string_width(gCommonStringFormatBuffer) / 2) + 4;
+        int32_t categoryStringHalfWidth = (gfx_get_string_width(gCommonStringFormatBuffer, FontSpriteBase::MEDIUM) / 2) + 4;
         int32_t strLeft = centreX - categoryStringHalfWidth;
         int32_t strRight = centreX + categoryStringHalfWidth;
 

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -179,9 +179,8 @@ namespace OpenRCT2::Scripting
 
         DukValue measureText(const std::string& text)
         {
-            gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-            auto width = gfx_get_string_width(text);
-            auto height = string_get_height_raw(text.c_str());
+            auto width = gfx_get_string_width(text, FontSpriteBase::MEDIUM);
+            auto height = string_get_height_raw(text.c_str(), FontSpriteBase::MEDIUM);
             return ToDuk<ScreenSize>(_ctx, { width, height });
         }
 
@@ -258,8 +257,7 @@ namespace OpenRCT2::Scripting
 
         void text(const std::string& text, int32_t x, int32_t y)
         {
-            gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-            gfx_draw_string(&_dpi, text.c_str(), _colour.value_or(0), { x, y });
+            gfx_draw_string(&_dpi, { x, y }, text.c_str(), { _colour.value_or(0) });
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -174,13 +174,14 @@ static void window_about_openrct2_common_paint(rct_window* w, rct_drawpixelinfo*
     {
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_TITLE_SEQUENCE_OPENRCT2);
-        gfx_draw_string_centred_wrapped(
-            dpi, ft.Data(), aboutOpenRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_AQUAMARINE);
+        DrawTextWrapped(
+            dpi, aboutOpenRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
     }
     {
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_TITLE_SEQUENCE_RCT2);
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), aboutRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_AQUAMARINE);
+        DrawTextWrapped(
+            dpi, aboutRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
     }
 }
 
@@ -194,8 +195,8 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
         w->windowPos.x + (w->width / 2), w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight);
     int32_t width = w->width - 20;
 
-    aboutCoords.y += gfx_draw_string_centred_wrapped(
-                         dpi, nullptr, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION, w->colours[2])
+    aboutCoords.y += DrawTextWrapped(
+                         dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION, {}, { w->colours[2], TextAlignment::CENTRE })
         + lineHeight;
 
     rct_size16 logoSize = gfx_get_sprite_size(SPR_G2_LOGO);
@@ -203,24 +204,28 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     aboutCoords.y += logoSize.height + lineHeight * 2;
 
     // About OpenRCT2 text
-    aboutCoords.y += gfx_draw_string_centred_wrapped(
-                         dpi, nullptr, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_2, w->colours[2])
+    aboutCoords.y += DrawTextWrapped(
+                         dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_2, {},
+                         { w->colours[2], TextAlignment::CENTRE })
         + lineHeight + 5;
 
     // Copyright disclaimer; hidden when using truetype fonts to prevent
     // the text from overlapping the changelog button.
     if (!LocalisationService_UseTrueTypeFont())
     {
-        gfx_draw_string_centred_wrapped(dpi, nullptr, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_3, w->colours[2]);
+        DrawTextWrapped(
+            dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_3, {}, { w->colours[2], TextAlignment::CENTRE });
     }
 
     // Version info
     utf8 buffer[256];
     utf8* ch = buffer;
     openrct2_write_full_version_info(ch, sizeof(buffer) - (ch - buffer));
+    auto ft = Formatter();
+    ft.Add<const char*>(buffer);
 
     aboutCoords.y = w->windowPos.y + WH - 25;
-    gfx_draw_string_centred_wrapped(dpi, &ch, aboutCoords, width, STR_STRING, w->colours[2]);
+    DrawTextWrapped(dpi, aboutCoords, width, STR_STRING, ft, { w->colours[2], TextAlignment::CENTRE });
 }
 
 static void window_about_openrct2_invalidate(rct_window* w)

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -188,7 +188,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     window_about_openrct2_common_paint(w, dpi);
 
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     ScreenCoordsXY aboutCoords(
         w->windowPos.x + (w->width / 2), w->windowPos.y + w->widgets[WIDX_PAGE_BACKGROUND].top + lineHeight);
@@ -270,7 +270,7 @@ static void window_about_rct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto screenCoords = ScreenCoordsXY{ w->windowPos.x + 200, yPage + 5 };
 
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Credits
     gfx_draw_string_centred(dpi, STR_COPYRIGHT_CS, screenCoords, COLOUR_BLACK, nullptr);

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -273,23 +273,23 @@ static void window_about_rct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Credits
-    gfx_draw_string_centred(dpi, STR_COPYRIGHT_CS, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_COPYRIGHT_CS, {}, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight + 74;
-    gfx_draw_string_centred(dpi, STR_DESIGNED_AND_PROGRAMMED_BY_CS, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_DESIGNED_AND_PROGRAMMED_BY_CS, {}, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight;
-    gfx_draw_string_centred(dpi, STR_GRAPHICS_BY_SF, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_GRAPHICS_BY_SF, {}, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight;
-    gfx_draw_string_centred(dpi, STR_SOUND_AND_MUSIC_BY_AB, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_SOUND_AND_MUSIC_BY_AB, {}, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight;
-    gfx_draw_string_centred(dpi, STR_ADDITIONAL_SOUNDS_RECORDED_BY_DE, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_ADDITIONAL_SOUNDS_RECORDED_BY_DE, {}, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight + 3;
-    gfx_draw_string_centred(dpi, STR_REPRESENTATION_BY_JL, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_REPRESENTATION_BY_JL, {}, { TextAlignment::CENTRE });
     screenCoords.y += 2 * lineHeight + 5;
-    gfx_draw_string_centred(dpi, STR_THANKS_TO, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_THANKS_TO, {}, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight;
-    gfx_draw_string_centred(dpi, STR_THANKS_TO_PEOPLE, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_THANKS_TO_PEOPLE, {}, { TextAlignment::CENTRE });
     screenCoords.y += 2 * lineHeight + 5;
-    gfx_draw_string_centred(dpi, STR_LICENSED_TO_INFOGRAMES_INTERACTIVE_INC, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_LICENSED_TO_INFOGRAMES_INTERACTIVE_INC, {}, { TextAlignment::CENTRE });
 
     // Images
     gfx_draw_sprite(dpi, SPR_CREDITS_CHRIS_SAWYER_SMALL, { w->windowPos.x + 92, yPage + 24 }, 0);

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -187,7 +187,7 @@ static void window_changelog_scrollgetsize(
 {
     *width = _changelogLongestLineWidth + 4;
 
-    const int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    const int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
     *height = static_cast<int32_t>(_changelogLines.size() * lineHeight);
 }
 
@@ -213,9 +213,9 @@ static void window_changelog_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
 static void window_changelog_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, [[maybe_unused]] int32_t scrollIndex)
 {
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
-    const int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    const int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     ScreenCoordsXY screenCoords(3, 3 - lineHeight);
     for (const auto& line : _changelogLines)
@@ -241,7 +241,7 @@ static void window_changelog_process_changelog_text(const std::string& text)
     // To get the last substring (or only, if delimiter is not found)
     _changelogLines.push_back(text.substr(prev));
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     _changelogLongestLineWidth = 0;
     for (const auto& line : _changelogLines)
     {

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -245,7 +245,7 @@ static void window_changelog_process_changelog_text(const std::string& text)
     _changelogLongestLineWidth = 0;
     for (const auto& line : _changelogLines)
     {
-        auto width = gfx_get_string_width(line.c_str());
+        auto width = gfx_get_string_width(line.c_str(), FontSpriteBase::MEDIUM);
         _changelogLongestLineWidth = std::max(width, _changelogLongestLineWidth);
     }
 }

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -213,8 +213,6 @@ static void window_changelog_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
 static void window_changelog_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, [[maybe_unused]] int32_t scrollIndex)
 {
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
     const int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     ScreenCoordsXY screenCoords(3, 3 - lineHeight);
@@ -241,7 +239,6 @@ static void window_changelog_process_changelog_text(const std::string& text)
     // To get the last substring (or only, if delimiter is not found)
     _changelogLines.push_back(text.substr(prev));
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     _changelogLongestLineWidth = 0;
     for (const auto& line : _changelogLines)
     {

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -224,7 +224,7 @@ static void window_changelog_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         if (screenCoords.y + lineHeight < dpi->y || screenCoords.y >= dpi->y + dpi->height)
             continue;
 
-        gfx_draw_string(dpi, line.c_str(), w->colours[0], screenCoords);
+        gfx_draw_string(dpi, screenCoords, line.c_str(), { w->colours[0] });
     }
 }
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -629,15 +629,15 @@ public:
             ft = Formatter();
             ft.Add<int32_t>(_yearSpinnerValue);
             DrawTextBasic(
-                &dpi, windowPos + ScreenCoordsXY{ X_RCOL, 198 }, STR_FORMAT_INTEGER, ft, colours[1], TextAlignment::RIGHT);
+                &dpi, windowPos + ScreenCoordsXY{ X_RCOL, 198 }, STR_FORMAT_INTEGER, ft, { colours[1], TextAlignment::RIGHT });
             ft = Formatter();
             ft.Add<int32_t>(actual_month);
             DrawTextBasic(
-                &dpi, windowPos + ScreenCoordsXY{ X_RCOL, 219 }, STR_FORMAT_MONTH, ft, colours[1], TextAlignment::RIGHT);
+                &dpi, windowPos + ScreenCoordsXY{ X_RCOL, 219 }, STR_FORMAT_MONTH, ft, { colours[1], TextAlignment::RIGHT });
             ft = Formatter();
             ft.Add<int32_t>(_daySpinnerValue);
             DrawTextBasic(
-                &dpi, windowPos + ScreenCoordsXY{ X_RCOL, 240 }, STR_FORMAT_INTEGER, ft, colours[1], TextAlignment::RIGHT);
+                &dpi, windowPos + ScreenCoordsXY{ X_RCOL, 240 }, STR_FORMAT_INTEGER, ft, { colours[1], TextAlignment::RIGHT });
         }
         else if (page == WINDOW_CHEATS_PAGE_MISC)
         {
@@ -653,7 +653,8 @@ public:
 
                 auto& widget = widgets[WIDX_PARK_RATING_SPINNER];
                 DrawTextBasic(
-                    &dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 2 }, STR_FORMAT_INTEGER, ft, colours[1]);
+                    &dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 2 }, STR_FORMAT_INTEGER, ft,
+                    { colours[1] });
             }
 
             {

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -614,7 +614,7 @@ public:
 
         if (page == WINDOW_CHEATS_PAGE_MONEY)
         {
-            uint8_t colour = colours[1];
+            auto colour = colours[1];
             auto ft = Formatter();
             ft.Add<money32>(_moneySpinnerValue);
             if (IsWidgetDisabled(WIDX_MONEY_SPINNER))
@@ -622,10 +622,10 @@ public:
                 colour |= COLOUR_FLAG_INSET;
             }
             int32_t actual_month = _monthSpinnerValue - 1;
-            gfx_draw_string_left(&dpi, STR_BOTTOM_TOOLBAR_CASH, ft.Data(), colour, windowPos + ScreenCoordsXY{ X_LCOL, 93 });
-            gfx_draw_string_left(&dpi, STR_YEAR, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 198 });
-            gfx_draw_string_left(&dpi, STR_MONTH, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 219 });
-            gfx_draw_string_left(&dpi, STR_DAY, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 240 });
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 93 }, STR_BOTTOM_TOOLBAR_CASH, ft, { colour });
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 198 }, STR_YEAR);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 219 }, STR_MONTH);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 240 }, STR_DAY);
             ft = Formatter();
             ft.Add<int32_t>(_yearSpinnerValue);
             DrawTextBasic(
@@ -643,8 +643,7 @@ public:
         {
             {
                 auto& widget = widgets[WIDX_WEATHER];
-                gfx_draw_string_left(
-                    &dpi, STR_CHANGE_WEATHER, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL - 3, widget.top + 1 });
+                DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL - 3, widget.top + 1 }, STR_CHANGE_WEATHER);
             }
 
             {
@@ -659,28 +658,19 @@ public:
 
             {
                 auto& widget = widgets[WIDX_STAFF_SPEED];
-                gfx_draw_string_left(
-                    &dpi, STR_CHEAT_STAFF_SPEED, nullptr, COLOUR_BLACK,
-                    windowPos + ScreenCoordsXY{ X_LCOL - 3, widget.top + 1 });
+                DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL - 3, widget.top + 1 }, STR_CHEAT_STAFF_SPEED);
             }
         }
         else if (page == WINDOW_CHEATS_PAGE_GUESTS)
         {
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_HAPPINESS, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 72 });
-            gfx_draw_string_left(&dpi, STR_CHEAT_GUEST_ENERGY, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 93 });
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_HUNGER, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 114 });
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_THIRST, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 135 });
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_NAUSEA, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 156 });
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_NAUSEA_TOLERANCE, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 177 });
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_TOILET, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 198 });
-            gfx_draw_string_left(
-                &dpi, STR_CHEAT_GUEST_PREFERRED_INTENSITY, nullptr, COLOUR_BLACK, windowPos + ScreenCoordsXY{ X_LCOL, 219 });
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 72 }, STR_CHEAT_GUEST_HAPPINESS);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 93 }, STR_CHEAT_GUEST_ENERGY);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 114 }, STR_CHEAT_GUEST_HUNGER);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 135 }, STR_CHEAT_GUEST_THIRST);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 156 }, STR_CHEAT_GUEST_NAUSEA);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 177 }, STR_CHEAT_GUEST_NAUSEA_TOLERANCE);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 198 }, STR_CHEAT_GUEST_TOILET);
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ X_LCOL, 219 }, STR_CHEAT_GUEST_PREFERRED_INTENSITY);
         }
     }
 

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -222,8 +222,8 @@ static void window_clear_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                     w->windowPos.y + window_clear_scenery_widgets[WIDX_PREVIEW].midY() };
     if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
-        gfx_draw_string_centred(
-            dpi, STR_LAND_TOOL_SIZE_VALUE, screenCoords - ScreenCoordsXY{ 0, 2 }, COLOUR_BLACK, &gLandToolSize);
+        DrawTextBasic(
+            dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, &gLandToolSize, { TextAlignment::CENTRE });
     }
 
     // Draw cost amount
@@ -231,6 +231,6 @@ static void window_clear_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         screenCoords.x = window_clear_scenery_widgets[WIDX_PREVIEW].midX() + w->windowPos.x;
         screenCoords.y = window_clear_scenery_widgets[WIDX_PREVIEW].bottom + w->windowPos.y + 5 + 27;
-        gfx_draw_string_centred(dpi, STR_COST_AMOUNT, screenCoords, COLOUR_BLACK, &gClearSceneryCost);
+        DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, &gClearSceneryCost, { TextAlignment::CENTRE });
     }
 }

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -233,7 +233,7 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
         + ScreenCoordsXY{ window_custom_currency_widgets[WIDX_SYMBOL_TEXT].left + 1,
                           window_custom_currency_widgets[WIDX_SYMBOL_TEXT].top };
 
-    gfx_draw_string(dpi, CurrencyDescriptors[EnumValue(CurrencyType::Custom)].symbol_unicode, w->colours[1], screenCoords);
+    gfx_draw_string(dpi, screenCoords, CurrencyDescriptors[EnumValue(CurrencyType::Custom)].symbol_unicode, { w->colours[1] });
 
     auto drawPos = w->windowPos
         + ScreenCoordsXY{ window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -218,17 +218,16 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 10, 30 };
 
-    gfx_draw_string_left(dpi, STR_RATE, nullptr, w->colours[1], screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_RATE, {}, { w->colours[1] });
 
     int32_t baseExchange = CurrencyDescriptors[EnumValue(CurrencyType::Pounds)].rate;
     ft = Formatter();
     ft.Add<int32_t>(baseExchange);
-    gfx_draw_string_left(
-        dpi, STR_CUSTOM_CURRENCY_EQUIVALENCY, ft.Data(), w->colours[1], screenCoords + ScreenCoordsXY{ 200, 0 });
+    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_CUSTOM_CURRENCY_EQUIVALENCY, ft, { w->colours[1] });
 
     screenCoords.y += 20;
 
-    gfx_draw_string_left(dpi, STR_CURRENCY_SYMBOL_TEXT, nullptr, w->colours[1], screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_CURRENCY_SYMBOL_TEXT, {}, { w->colours[1] });
 
     screenCoords = w->windowPos
         + ScreenCoordsXY{ window_custom_currency_widgets[WIDX_SYMBOL_TEXT].left + 1,
@@ -236,20 +235,11 @@ static void custom_currency_window_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     gfx_draw_string(dpi, CurrencyDescriptors[EnumValue(CurrencyType::Custom)].symbol_unicode, w->colours[1], screenCoords);
 
-    if (CurrencyDescriptors[EnumValue(CurrencyType::Custom)].affix_unicode == CurrencyAffix::Prefix)
-    {
-        gfx_draw_string_left(
-            dpi, STR_PREFIX, w, w->colours[1],
-            w->windowPos
-                + ScreenCoordsXY{ window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
-                                  window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top });
-    }
-    else
-    {
-        gfx_draw_string_left(
-            dpi, STR_SUFFIX, w, w->colours[1],
-            w->windowPos
-                + ScreenCoordsXY{ window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
-                                  window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top });
-    }
+    auto drawPos = w->windowPos
+        + ScreenCoordsXY{ window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].left + 1,
+                          window_custom_currency_widgets[WIDX_AFFIX_DROPDOWN].top };
+    rct_string_id stringId = (CurrencyDescriptors[EnumValue(CurrencyType::Custom)].affix_unicode == CurrencyAffix::Prefix)
+        ? STR_PREFIX
+        : STR_SUFFIX;
+    DrawTextBasic(dpi, drawPos, stringId, w, { w->colours[1] });
 }

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -130,7 +130,7 @@ static void window_debug_paint_invalidate(rct_window* w)
             auto stringIdx = w->widgets[widgetIndex].text;
             auto string = ls.GetString(stringIdx);
             Guard::ArgumentNotNull(string);
-            auto width = gfx_get_string_width(string);
+            auto width = gfx_get_string_width(string, FontSpriteBase::MEDIUM);
             newWidth = std::max<int16_t>(width, newWidth);
         }
 

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -170,7 +170,7 @@ static void window_ride_demolish_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<money32>(_demolishRideCost);
 
         ScreenCoordsXY stringCoords(w->windowPos.x + WW / 2, w->windowPos.y + (WH / 2) - 3);
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, WW - 4, stringId, COLOUR_BLACK);
+        DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
     }
 }
 
@@ -187,6 +187,6 @@ static void window_ride_refurbish_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<money32>(_demolishRideCost / 2);
 
         ScreenCoordsXY stringCoords(w->windowPos.x + WW / 2, w->windowPos.y + (WH / 2) - 3);
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, WW - 4, stringId, COLOUR_BLACK);
+        DrawTextWrapped(dpi, stringCoords, WW - 4, stringId, ft, { TextAlignment::CENTRE });
     }
 }

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -118,7 +118,7 @@ void WindowDropdownShowText(const ScreenCoordsXY& screenPos, int32_t extray, uin
     for (size_t i = 0; i < num_items; i++)
     {
         format_string(buffer, 256, gDropdownItemsFormat[i], static_cast<void*>(&gDropdownItemsArgs[i]));
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         string_width = gfx_get_string_width(buffer);
         max_string_width = std::max(string_width, max_string_width);
     }

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -118,7 +118,6 @@ void WindowDropdownShowText(const ScreenCoordsXY& screenPos, int32_t extray, uin
     for (size_t i = 0; i < num_items; i++)
     {
         format_string(buffer, 256, gDropdownItemsFormat[i], static_cast<void*>(&gDropdownItemsArgs[i]));
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         string_width = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
         max_string_width = std::max(string_width, max_string_width);
     }
@@ -287,7 +286,7 @@ void WindowDropdownClose()
 
 static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    int32_t cell_x, cell_y, l, t, r, b, item, image, colour;
+    int32_t cell_x, cell_y, l, t, r, b, item, image;
 
     WindowDrawWidgets(w, dpi);
 
@@ -362,7 +361,7 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 }
 
                 // Calculate colour
-                colour = NOT_TRANSLUCENT(w->colours[0]);
+                colour_t colour = NOT_TRANSLUCENT(w->colours[0]);
                 if (i == highlightedIndex)
                     colour = COLOUR_WHITE;
                 if (Dropdown::IsDisabled(i))
@@ -373,7 +372,7 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 ScreenCoordsXY screenCoords = { w->windowPos.x + 2 + (cell_x * _dropdown_item_width),
                                                 w->windowPos.y + 2 + (cell_y * _dropdown_item_height) };
                 Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItemsArgs[i]));
-                DrawTextEllipsised(dpi, screenCoords, w->width - 5, item, ft, colour);
+                DrawTextEllipsised(dpi, screenCoords, w->width - 5, item, ft, { colour });
             }
         }
     }

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -119,7 +119,7 @@ void WindowDropdownShowText(const ScreenCoordsXY& screenPos, int32_t extray, uin
     {
         format_string(buffer, 256, gDropdownItemsFormat[i], static_cast<void*>(&gDropdownItemsArgs[i]));
         gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-        string_width = gfx_get_string_width(buffer);
+        string_width = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
         max_string_width = std::max(string_width, max_string_width);
     }
 

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -434,9 +434,9 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 / 2
             + w->windowPos.x;
         int16_t stateY = w->height - 0x0C + w->windowPos.y;
-        gfx_draw_string_centred(
-            dpi, EditorStepNames[EnumValue(gS6Info.editor_step)], { stateX, stateY },
-            NOT_TRANSLUCENT(w->colours[2]) | COLOUR_FLAG_OUTLINE, nullptr);
+        DrawTextBasic(
+            dpi, { stateX, stateY }, EditorStepNames[EnumValue(gS6Info.editor_step)], {},
+            { static_cast<colour_t>(NOT_TRANSLUCENT(w->colours[2]) | COLOUR_FLAG_OUTLINE), TextAlignment::CENTRE });
 
         if (drawPreviousButton)
         {
@@ -447,7 +447,7 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                       window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_IMAGE].top + 6 },
                 0);
 
-            int32_t textColour = NOT_TRANSLUCENT(w->colours[1]);
+            colour_t textColour = NOT_TRANSLUCENT(w->colours[1]);
             if (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR
                 && gHoverWidget.widget_index == WIDX_PREVIOUS_STEP_BUTTON)
             {
@@ -464,8 +464,8 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
             if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
                 stringId = STR_EDITOR_STEP_OBJECT_SELECTION;
 
-            gfx_draw_string_centred(dpi, STR_BACK_TO_PREVIOUS_STEP, { textX, textY }, textColour, nullptr);
-            gfx_draw_string_centred(dpi, stringId, { textX, textY + 10 }, textColour, nullptr);
+            DrawTextBasic(dpi, { textX, textY }, STR_BACK_TO_PREVIOUS_STEP, {}, { textColour, TextAlignment::CENTRE });
+            DrawTextBasic(dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
         }
 
         if ((drawPreviousButton || drawNextButton) && gS6Info.editor_step != EditorStep::RollercoasterDesigner)
@@ -477,7 +477,7 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                       window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].top + 6 },
                 0);
 
-            int32_t textColour = NOT_TRANSLUCENT(w->colours[1]);
+            colour_t textColour = NOT_TRANSLUCENT(w->colours[1]);
 
             if (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_NEXT_STEP_BUTTON)
             {
@@ -494,8 +494,8 @@ void window_editor_bottom_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
             if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
                 stringId = STR_EDITOR_STEP_ROLLERCOASTER_DESIGNER;
 
-            gfx_draw_string_centred(dpi, STR_FORWARD_TO_NEXT_STEP, { textX, textY }, textColour, nullptr);
-            gfx_draw_string_centred(dpi, stringId, { textX, textY + 10 }, textColour, nullptr);
+            DrawTextBasic(dpi, { textX, textY }, STR_FORWARD_TO_NEXT_STEP, {}, { textColour, TextAlignment::CENTRE });
+            DrawTextBasic(dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
         }
     }
 }

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -561,7 +561,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     width = w->width - w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right - 6;
 
     auto [drawString, ft] = window_editor_inventions_list_prepare_name(researchItem, false);
-    DrawTextEllipsised(dpi, screenPos, width, drawString, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+    DrawTextEllipsised(dpi, screenPos, width, drawString, ft, { TextAlignment::CENTRE });
     screenPos.y += 15;
 
     // Item category
@@ -613,21 +613,18 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
         if (researchItem.Equals(&_editorInventionsListDraggedItem))
             continue;
 
-        uint8_t colour;
+        // TODO: this parameter by itself produces very light text.
+        // It needs a {BLACK} token in the string to work properly.
+        colour_t colour = COLOUR_BLACK;
+        FontSpriteBase fontSpriteBase = FontSpriteBase::MEDIUM;
+
         if (researchItem.IsAlwaysResearched())
         {
             if (w->research_item == &researchItem && _editorInventionsListDraggedItem.IsNull())
-                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_EXTRA_DARK;
+                fontSpriteBase = FontSpriteBase::MEDIUM_EXTRA_DARK;
             else
-                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
+                fontSpriteBase = FontSpriteBase::MEDIUM_DARK;
             colour = w->colours[1] | COLOUR_FLAG_INSET;
-        }
-        else
-        {
-            // TODO: this parameter by itself produces very light text.
-            // It needs a {BLACK} token in the string to work properly.
-            colour = COLOUR_BLACK;
-            gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         }
 
         const rct_string_id itemNameId = researchItem.GetName();
@@ -642,19 +639,22 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
             auto ft = Formatter();
             ft.Add<rct_string_id>(rideTypeName);
             DrawTextEllipsised(
-                dpi, { 1, itemY }, columnSplitOffset - 11, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, ft, colour);
+                dpi, { 1, itemY }, columnSplitOffset - 11, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, ft,
+                { colour, fontSpriteBase });
 
             // Draw vehicle name
             ft = Formatter();
             ft.Add<rct_string_id>(itemNameId);
-            DrawTextEllipsised(dpi, { columnSplitOffset + 1, itemY }, columnSplitOffset - 11, STR_BLACK_STRING, ft, colour);
+            DrawTextEllipsised(
+                dpi, { columnSplitOffset + 1, itemY }, columnSplitOffset - 11, STR_BLACK_STRING, ft,
+                { colour, fontSpriteBase });
         }
         else
         {
             // Scenery group, flat ride or shop
             auto ft = Formatter();
             ft.Add<rct_string_id>(itemNameId);
-            DrawTextEllipsised(dpi, { 1, itemY }, boxWidth, STR_BLACK_STRING, ft, colour);
+            DrawTextEllipsised(dpi, { 1, itemY }, boxWidth, STR_BLACK_STRING, ft, { colour, fontSpriteBase });
         }
     }
 }

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -509,12 +509,12 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     // Pre-researched items label
     screenPos = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_PRE_RESEARCHED_SCROLL].left, w->widgets[WIDX_PRE_RESEARCHED_SCROLL].top - 11 };
-    gfx_draw_string_left(dpi, STR_INVENTION_PREINVENTED_ITEMS, nullptr, COLOUR_BLACK, screenPos - ScreenCoordsXY{ 0, 1 });
+    DrawTextBasic(dpi, screenPos - ScreenCoordsXY{ 0, 1 }, STR_INVENTION_PREINVENTED_ITEMS);
 
     // Research order label
     screenPos = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_RESEARCH_ORDER_SCROLL].left, w->widgets[WIDX_RESEARCH_ORDER_SCROLL].top - 11 };
-    gfx_draw_string_left(dpi, STR_INVENTION_TO_BE_INVENTED_ITEMS, nullptr, COLOUR_BLACK, screenPos - ScreenCoordsXY{ 0, 1 });
+    DrawTextBasic(dpi, screenPos - ScreenCoordsXY{ 0, 1 }, STR_INVENTION_TO_BE_INVENTED_ITEMS);
 
     // Preview background
     widget = &w->widgets[WIDX_PREVIEW];
@@ -567,7 +567,7 @@ static void window_editor_inventions_list_paint(rct_window* w, rct_drawpixelinfo
     // Item category
     screenPos.x = w->windowPos.x + w->widgets[WIDX_RESEARCH_ORDER_SCROLL].right + 4;
     stringId = researchItem->GetCategoryInventionString();
-    gfx_draw_string_left(dpi, STR_INVENTION_RESEARCH_GROUP, &stringId, COLOUR_BLACK, screenPos);
+    DrawTextBasic(dpi, screenPos, STR_INVENTION_RESEARCH_GROUP, &stringId);
 }
 
 /**

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -757,7 +757,7 @@ static void window_editor_inventions_list_drag_paint(rct_window* w, rct_drawpixe
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 0, 2 };
 
     auto [drawString, ft] = window_editor_inventions_list_prepare_name(&_editorInventionsListDraggedItem, true);
-    DrawTextBasic(dpi, screenCoords, drawString, ft, COLOUR_BLACK | COLOUR_FLAG_OUTLINE);
+    DrawTextBasic(dpi, screenCoords, drawString, ft, { COLOUR_BLACK | COLOUR_FLAG_OUTLINE });
 }
 
 static std::pair<rct_string_id, Formatter> window_editor_inventions_list_prepare_name(

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -617,9 +617,9 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
         if (researchItem.IsAlwaysResearched())
         {
             if (w->research_item == &researchItem && _editorInventionsListDraggedItem.IsNull())
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK;
+                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_EXTRA_DARK;
             else
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
+                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
             colour = w->colours[1] | COLOUR_FLAG_INSET;
         }
         else
@@ -627,7 +627,7 @@ static void window_editor_inventions_list_scrollpaint(rct_window* w, rct_drawpix
             // TODO: this parameter by itself produces very light text.
             // It needs a {BLACK} token in the string to work properly.
             colour = COLOUR_BLACK;
-            gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+            gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         }
 
         const rct_string_id itemNameId = researchItem.GetName();

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -689,7 +689,7 @@ static void window_editor_inventions_list_drag_open(ResearchItem* researchItem)
         format_string(ptr, 256, stringId, nullptr);
     }
 
-    auto stringWidth = gfx_get_string_width(buffer);
+    auto stringWidth = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
     window_editor_inventions_list_drag_widgets[0].right = stringWidth;
 
     auto* w = WindowCreate(

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1155,12 +1155,15 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
             if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && (*listItem.flags & OBJECT_SELECTION_FLAG_SELECTED))
             {
                 screenCoords.x = 2;
-                gCurrentFontSpriteBase = highlighted ? FontSpriteBase::MEDIUM_EXTRA_DARK : FontSpriteBase::MEDIUM_DARK;
+                FontSpriteBase fontSpriteBase = highlighted ? FontSpriteBase::MEDIUM_EXTRA_DARK : FontSpriteBase::MEDIUM_DARK; 
+                gCurrentFontSpriteBase = fontSpriteBase;
                 colour2 = NOT_TRANSLUCENT(w->colours[1]);
                 if (*listItem.flags & (OBJECT_SELECTION_FLAG_IN_USE | OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED))
                     colour2 |= COLOUR_FLAG_INSET;
 
-                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), colour2, screenCoords);
+                gfx_draw_string(
+                    dpi, screenCoords, static_cast<const char*>(CheckBoxMarkString),
+                    { static_cast<colour_t>(colour2), fontSpriteBase });
             }
 
             screenCoords.x = gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER ? 0 : 15;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1006,7 +1006,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         auto ft = Formatter();
         ft.Add<uint16_t>(numSelected);
         ft.Add<uint16_t>(totalSelectable);
-        gfx_draw_string_left(dpi, STR_OBJECT_SELECTION_SELECTION_SIZE, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_OBJECT_SELECTION_SELECTION_SIZE, ft);
     }
 
     // Draw sort button text

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1070,8 +1070,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LIST].right + 4, widget->bottom + 18 };
         width = w->windowPos.x + w->width - screenPos.x - 4;
 
-        gfx_draw_string_left_wrapped(
-            dpi, ft.Data(), screenPos + ScreenCoordsXY{ 0, 5 }, width, STR_WINDOW_COLOUR_2_STRINGID, COLOUR_BLACK);
+        DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 0, 5 }, width, STR_WINDOW_COLOUR_2_STRINGID, ft);
     }
 
     auto screenPos = w->windowPos + ScreenCoordsXY{ w->width - 5, w->height - (LIST_ROW_HEIGHT * 5) };

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1080,14 +1080,14 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     if (get_selected_object_type(w) == ObjectType::Ride)
     {
         auto stringId = get_ride_type_string_id(listItem->repositoryItem);
-        DrawTextBasic(dpi, screenPos, stringId, {}, COLOUR_WHITE, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
     }
 
     screenPos.y += LIST_ROW_HEIGHT;
 
     // Draw object source
     auto stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
-    DrawTextBasic(dpi, screenPos, stringId, {}, COLOUR_WHITE, TextAlignment::RIGHT);
+    DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
     screenPos.y += LIST_ROW_HEIGHT;
 
     // Draw object dat name
@@ -1097,8 +1097,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(path);
         DrawTextBasic(
-            dpi, { w->windowPos.x + w->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft, COLOUR_BLACK,
-            TextAlignment::RIGHT);
+            dpi, { w->windowPos.x + w->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
+            { COLOUR_BLACK, TextAlignment::RIGHT });
         screenPos.y += LIST_ROW_HEIGHT;
     }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1018,7 +1018,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
                                                         : STR_NONE;
         ft.Add<rct_string_id>(stringId);
         auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
-        DrawTextEllipsised(dpi, screenPos, widget->width(), STR_OBJECTS_SORT_TYPE, ft, w->colours[1]);
+        DrawTextEllipsised(dpi, screenPos, widget->width(), STR_OBJECTS_SORT_TYPE, ft, { w->colours[1] });
     }
     widget = &w->widgets[WIDX_LIST_SORT_RIDE];
     if (widget->type != WindowWidgetType::Empty)
@@ -1028,7 +1028,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
                                                         : STR_NONE;
         ft.Add<rct_string_id>(stringId);
         auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
-        DrawTextEllipsised(dpi, screenPos, widget->width(), STR_OBJECTS_SORT_RIDE, ft, w->colours[1]);
+        DrawTextEllipsised(dpi, screenPos, widget->width(), STR_OBJECTS_SORT_RIDE, ft, { w->colours[1] });
     }
 
     if (w->selected_list_item == -1 || _loadedObject == nullptr)
@@ -1056,7 +1056,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(listItem->repositoryItem->Name.c_str());
-        DrawTextEllipsised(dpi, screenPos, width, STR_WINDOW_COLOUR_2_STRINGID, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+        DrawTextEllipsised(dpi, screenPos, width, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
     }
 
     // Draw description of object
@@ -1117,7 +1117,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         ft.Add<const char*>(authorsString.c_str());
         DrawTextEllipsised(
             dpi, { w->windowPos.x + w->width - 5, screenPos.y }, w->width - w->widgets[WIDX_LIST].right - 4,
-            STR_WINDOW_COLOUR_2_STRINGID, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+            STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::RIGHT });
     }
 }
 /**
@@ -1126,7 +1126,6 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
  */
 static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t colour, colour2;
     ScreenCoordsXY screenCoords;
 
     bool ridePage = (get_selected_object_type(w) == ObjectType::Ride);
@@ -1155,9 +1154,8 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
             if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && (*listItem.flags & OBJECT_SELECTION_FLAG_SELECTED))
             {
                 screenCoords.x = 2;
-                FontSpriteBase fontSpriteBase = highlighted ? FontSpriteBase::MEDIUM_EXTRA_DARK : FontSpriteBase::MEDIUM_DARK; 
-                gCurrentFontSpriteBase = fontSpriteBase;
-                colour2 = NOT_TRANSLUCENT(w->colours[1]);
+                FontSpriteBase fontSpriteBase = highlighted ? FontSpriteBase::MEDIUM_EXTRA_DARK : FontSpriteBase::MEDIUM_DARK;
+                colour_t colour2 = NOT_TRANSLUCENT(w->colours[1]);
                 if (*listItem.flags & (OBJECT_SELECTION_FLAG_IN_USE | OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED))
                     colour2 |= COLOUR_FLAG_INSET;
 
@@ -1171,15 +1169,12 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
             auto bufferWithColour = strcpy(gCommonStringFormatBuffer, highlighted ? "{WINDOW_COLOUR_2}" : "{BLACK}");
             auto buffer = strchr(bufferWithColour, '\0');
 
+            colour_t colour = COLOUR_BLACK;
+            FontSpriteBase fontSpriteBase = FontSpriteBase::MEDIUM;
             if (*listItem.flags & OBJECT_SELECTION_FLAG_6)
             {
                 colour = w->colours[1] & 0x7F;
-                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
-            }
-            else
-            {
-                colour = COLOUR_BLACK;
-                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
+                fontSpriteBase = FontSpriteBase::MEDIUM_DARK;
             }
 
             int32_t width_limit = w->widgets[WIDX_LIST].width() - screenCoords.x;
@@ -1192,7 +1187,7 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
                 safe_strcpy(buffer, language_get_string(rideTypeStringId), 256 - (buffer - bufferWithColour));
                 auto ft = Formatter();
                 ft.Add<const char*>(gCommonStringFormatBuffer);
-                DrawTextEllipsised(dpi, screenCoords, width_limit - 15, STR_STRING, ft, colour);
+                DrawTextEllipsised(dpi, screenCoords, width_limit - 15, STR_STRING, ft, { colour, fontSpriteBase });
                 screenCoords.x = w->widgets[WIDX_LIST_SORT_RIDE].left - w->widgets[WIDX_LIST].left;
             }
 
@@ -1207,7 +1202,7 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
             }
             auto ft = Formatter();
             ft.Add<const char*>(gCommonStringFormatBuffer);
-            DrawTextEllipsised(dpi, screenCoords, width_limit, STR_STRING, ft, colour);
+            DrawTextEllipsised(dpi, screenCoords, width_limit, STR_STRING, ft, { colour, fontSpriteBase });
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1156,7 +1156,7 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
             if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && (*listItem.flags & OBJECT_SELECTION_FLAG_SELECTED))
             {
                 screenCoords.x = 2;
-                gCurrentFontSpriteBase = highlighted ? FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK : FONT_SPRITE_BASE_MEDIUM_DARK;
+                gCurrentFontSpriteBase = highlighted ? FontSpriteBase::MEDIUM_EXTRA_DARK : FontSpriteBase::MEDIUM_DARK;
                 colour2 = NOT_TRANSLUCENT(w->colours[1]);
                 if (*listItem.flags & (OBJECT_SELECTION_FLAG_IN_USE | OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED))
                     colour2 |= COLOUR_FLAG_INSET;
@@ -1172,12 +1172,12 @@ static void window_editor_object_selection_scrollpaint(rct_window* w, rct_drawpi
             if (*listItem.flags & OBJECT_SELECTION_FLAG_6)
             {
                 colour = w->colours[1] & 0x7F;
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
+                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
             }
             else
             {
                 colour = COLOUR_BLACK;
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+                gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
             }
 
             int32_t width_limit = w->widgets[WIDX_LIST].width() - screenCoords.x;

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -913,7 +913,7 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(gS6Info.details);
-    gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, width, STR_BLACK_STRING, COLOUR_BLACK);
+    DrawTextWrapped(dpi, screenCoords, width, STR_BLACK_STRING, ft);
 
     // Scenario category label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CATEGORY].top };

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1101,7 +1101,9 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
             {
                 gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FontSpriteBase::MEDIUM_EXTRA_DARK
                                                                                   : FontSpriteBase::MEDIUM_DARK;
-                gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, { 2, y });
+                gfx_draw_string(
+                    dpi, { 2, y }, static_cast<const char*>(CheckBoxMarkString),
+                    { static_cast<colour_t>(w->colours[1] & 0x7F) });
             }
 
             // Ride name

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -797,12 +797,12 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
 
     // Objective label
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_OBJECTIVE].top };
-    gfx_draw_string_left(dpi, STR_OBJECTIVE_WINDOW, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_OBJECTIVE_WINDOW);
 
     // Objective value
     screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_OBJECTIVE].left + 1, w->widgets[WIDX_OBJECTIVE].top };
     stringId = ObjectiveDropdownOptionNames[gScenarioObjective.Type];
-    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, &stringId);
 
     if (w->widgets[WIDX_OBJECTIVE_ARG_1].type != WindowWidgetType::Empty)
     {
@@ -831,7 +831,7 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
                 stringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
                 break;
         }
-        gfx_draw_string_left(dpi, stringId, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, stringId);
 
         // Objective argument 1 value
         screenCoords = w->windowPos
@@ -863,20 +863,20 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
                 arg = gScenarioObjective.Currency;
                 break;
         }
-        gfx_draw_string_left(dpi, stringId, &arg, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, stringId, &arg, COLOUR_BLACK);
     }
 
     if (w->widgets[WIDX_OBJECTIVE_ARG_2].type != WindowWidgetType::Empty)
     {
         // Objective argument 2 label
         screenCoords = w->windowPos + ScreenCoordsXY{ 28, w->widgets[WIDX_OBJECTIVE_ARG_2].top };
-        gfx_draw_string_left(dpi, STR_WINDOW_OBJECTIVE_DATE, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
 
         // Objective argument 2 value
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_OBJECTIVE_ARG_2].left + 1, w->widgets[WIDX_OBJECTIVE_ARG_2].top };
         arg = (gScenarioObjective.Year * MONTH_COUNT) - 1;
-        gfx_draw_string_left(dpi, STR_WINDOW_OBJECTIVE_VALUE_DATE, &arg, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, &arg);
     }
 
     // Park name
@@ -904,7 +904,7 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
 
     // Scenario details label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_DETAILS].top };
-    gfx_draw_string_left(dpi, STR_WINDOW_PARK_DETAILS, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_PARK_DETAILS);
 
     // Scenario details value
     screenCoords = w->windowPos + ScreenCoordsXY{ 16, w->widgets[WIDX_DETAILS].top + 10 };
@@ -917,12 +917,12 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
 
     // Scenario category label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CATEGORY].top };
-    gfx_draw_string_left(dpi, STR_WINDOW_SCENARIO_GROUP, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_SCENARIO_GROUP);
 
     // Scenario category value
     screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_CATEGORY].left + 1, w->widgets[WIDX_CATEGORY].top };
     stringId = ScenarioCategoryStringIds[gS6Info.category];
-    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, &stringId);
 }
 
 /**
@@ -1062,9 +1062,8 @@ static void window_editor_objective_options_rides_paint(rct_window* w, rct_drawp
     WindowDrawWidgets(w, dpi);
     window_editor_objective_options_draw_tab_images(w, dpi);
 
-    gfx_draw_string_left(
-        dpi, STR_WINDOW_PRESERVATION_ORDER, nullptr, COLOUR_BLACK,
-        w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PAGE_BACKGROUND].top + 3 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PAGE_BACKGROUND].top + 3 }, STR_WINDOW_PRESERVATION_ORDER);
 }
 
 /**
@@ -1109,7 +1108,7 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
 
             Formatter ft;
             ride->FormatNameTo(ft);
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, { 15, y });
+            DrawTextBasic(dpi, { 15, y }, stringId, ft);
         }
     }
 }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1100,8 +1100,8 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
         {
             if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
             {
-                gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK
-                                                                                  : FONT_SPRITE_BASE_MEDIUM_DARK;
+                gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FontSpriteBase::MEDIUM_EXTRA_DARK
+                                                                                  : FontSpriteBase::MEDIUM_DARK;
                 gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, { 2, y });
             }
 

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -890,7 +890,7 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(parkName);
-        DrawTextEllipsised(dpi, screenCoords, width, STR_WINDOW_PARK_NAME, ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, screenCoords, width, STR_WINDOW_PARK_NAME, ft);
     }
 
     // Scenario name
@@ -900,7 +900,7 @@ static void window_editor_objective_options_main_paint(rct_window* w, rct_drawpi
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(gS6Info.name);
-    DrawTextEllipsised(dpi, screenCoords, width, STR_WINDOW_SCENARIO_NAME, ft, COLOUR_BLACK);
+    DrawTextEllipsised(dpi, screenCoords, width, STR_WINDOW_SCENARIO_NAME, ft);
 
     // Scenario details label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_DETAILS].top };
@@ -1099,11 +1099,11 @@ static void window_editor_objective_options_rides_scrollpaint(rct_window* w, rct
         {
             if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
             {
-                gCurrentFontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FontSpriteBase::MEDIUM_EXTRA_DARK
-                                                                                  : FontSpriteBase::MEDIUM_DARK;
+                FontSpriteBase fontSpriteBase = stringId == STR_WINDOW_COLOUR_2_STRINGID ? FontSpriteBase::MEDIUM_EXTRA_DARK
+                                                                                         : FontSpriteBase::MEDIUM_DARK;
                 gfx_draw_string(
                     dpi, { 2, y }, static_cast<const char*>(CheckBoxMarkString),
-                    { static_cast<colour_t>(w->colours[1] & 0x7F) });
+                    { static_cast<colour_t>(w->colours[1] & 0x7F), fontSpriteBase });
             }
 
             // Ride name

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -686,43 +686,43 @@ static void window_editor_scenario_options_financial_paint(rct_window* w, rct_dr
     if (w->widgets[WIDX_INITIAL_CASH].type != WindowWidgetType::Empty)
     {
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_INITIAL_CASH].top };
-        gfx_draw_string_left(dpi, STR_INIT_CASH_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_INIT_CASH_LABEL);
 
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_INITIAL_CASH].left + 1, w->widgets[WIDX_INITIAL_CASH].top };
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &gInitialCash, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &gInitialCash);
     }
 
     if (w->widgets[WIDX_INITIAL_LOAN].type != WindowWidgetType::Empty)
     {
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_INITIAL_LOAN].top };
-        gfx_draw_string_left(dpi, STR_INIT_LOAN_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_INIT_LOAN_LABEL);
 
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_INITIAL_LOAN].left + 1, w->widgets[WIDX_INITIAL_LOAN].top };
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &gBankLoan, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &gBankLoan);
     }
 
     if (w->widgets[WIDX_MAXIMUM_LOAN].type != WindowWidgetType::Empty)
     {
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_MAXIMUM_LOAN].top };
-        gfx_draw_string_left(dpi, STR_MAX_LOAN_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_MAX_LOAN_LABEL);
 
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_MAXIMUM_LOAN].left + 1, w->widgets[WIDX_MAXIMUM_LOAN].top };
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &gMaxBankLoan, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &gMaxBankLoan);
     }
 
     if (w->widgets[WIDX_INTEREST_RATE].type != WindowWidgetType::Empty)
     {
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_INTEREST_RATE].top };
-        gfx_draw_string_left(dpi, STR_INTEREST_RATE_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_INTEREST_RATE_LABEL);
 
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_INTEREST_RATE].left + 1, w->widgets[WIDX_INTEREST_RATE].top };
 
         int16_t interestRate = std::clamp<int16_t>(static_cast<int16_t>(gBankLoanInterestRate), INT16_MIN, INT16_MAX);
-        gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &interestRate, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, &interestRate);
     }
 }
 
@@ -965,44 +965,44 @@ static void window_editor_scenario_options_guests_paint(rct_window* w, rct_drawp
     {
         // Cash per guest label
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CASH_PER_GUEST].top };
-        gfx_draw_string_left(dpi, STR_CASH_PER_GUEST_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CASH_PER_GUEST_LABEL);
 
         // Cash per guest value
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_CASH_PER_GUEST].left + 1, w->widgets[WIDX_CASH_PER_GUEST].top };
         arg = gGuestInitialCash;
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &arg);
     }
 
     // Guest initial happiness label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top };
-    gfx_draw_string_left(dpi, STR_GUEST_INIT_HAPPINESS, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_INIT_HAPPINESS);
 
     // Guest initial happiness value
     screenCoords = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].left + 1, w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top };
     arg = (gGuestInitialHappiness * 100) / 255;
-    gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, &arg);
 
     // Guest initial hunger label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_GUEST_INITIAL_HUNGER].top };
-    gfx_draw_string_left(dpi, STR_GUEST_INIT_HUNGER, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_INIT_HUNGER);
 
     // Guest initial hunger value
     screenCoords = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_GUEST_INITIAL_HUNGER].left + 1, w->widgets[WIDX_GUEST_INITIAL_HUNGER].top };
     arg = ((255 - gGuestInitialHunger) * 100) / 255;
-    gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, &arg);
 
     // Guest initial thirst label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_GUEST_INITIAL_THIRST].top };
-    gfx_draw_string_left(dpi, STR_GUEST_INIT_THIRST, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_INIT_THIRST);
 
     // Guest initial thirst value
     screenCoords = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_GUEST_INITIAL_THIRST].left + 1, w->widgets[WIDX_GUEST_INITIAL_THIRST].top };
     arg = ((255 - gGuestInitialThirst) * 100) / 255;
-    gfx_draw_string_left(dpi, STR_PERCENT_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, &arg);
 }
 
 #pragma endregion
@@ -1327,26 +1327,26 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
     {
         // Cost to buy land label
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_LAND_COST].top };
-        gfx_draw_string_left(dpi, STR_LAND_COST_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_LAND_COST_LABEL);
 
         // Cost to buy land value
         screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LAND_COST].left + 1, w->widgets[WIDX_LAND_COST].top };
         arg = gLandPrice;
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &arg);
     }
 
     if (w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].type != WindowWidgetType::Empty)
     {
         // Cost to buy construction rights label
         screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top };
-        gfx_draw_string_left(dpi, STR_RIGHTS_COST_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_RIGHTS_COST_LABEL);
 
         // Cost to buy construction rights value
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].left + 1,
                               w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top };
         arg = gConstructionRightsPrice;
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &arg);
     }
 
     if (w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].type != WindowWidgetType::Empty)
@@ -1363,7 +1363,7 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
         else
             stringId = STR_PAY_PARK_ENTER;
 
-        gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, &stringId);
     }
 
     if (w->widgets[WIDX_ENTRY_PRICE].type != WindowWidgetType::Empty)
@@ -1371,22 +1371,22 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
         // Entry price label
         screenCoords = w->windowPos
             + ScreenCoordsXY{ w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].right + 8, w->widgets[WIDX_ENTRY_PRICE].top };
-        gfx_draw_string_left(dpi, STR_ENTRY_PRICE_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_ENTRY_PRICE_LABEL);
 
         // Entry price value
         screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_ENTRY_PRICE].left + 1, w->widgets[WIDX_ENTRY_PRICE].top };
         arg = gParkEntranceFee;
-        gfx_draw_string_left(dpi, STR_CURRENCY_FORMAT_LABEL, &arg, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, &arg);
     }
 
     // Climate label
     screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CLIMATE].top };
-    gfx_draw_string_left(dpi, STR_CLIMATE_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_CLIMATE_LABEL);
 
     // Climate value
     screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_CLIMATE].left + 1, w->widgets[WIDX_CLIMATE].top };
     stringId = ClimateNames[static_cast<uint8_t>(gClimate)];
-    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, &stringId, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, &stringId);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -84,7 +84,7 @@ rct_window* window_error_open(std::string_view title, std::string_view message)
         return nullptr;
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    width = gfx_get_string_width_new_lined(buffer.data());
+    width = gfx_get_string_width_new_lined(buffer.data(), FontSpriteBase::MEDIUM);
     width = std::clamp(width, 64, 196);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -56,7 +56,8 @@ rct_window* window_error_open(rct_string_id title, rct_string_id message, const 
 
 rct_window* window_error_open(std::string_view title, std::string_view message)
 {
-    int32_t numLines, fontHeight, width, height, maxY;
+    int32_t numLines, width, height, maxY;
+    FontSpriteBase fontHeight;
     rct_window* w;
 
     window_close_by_class(WC_ERROR);
@@ -83,16 +84,16 @@ rct_window* window_error_open(std::string_view title, std::string_view message)
     if (buffer.size() <= 1)
         return nullptr;
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     width = gfx_get_string_width_new_lined(buffer.data());
     width = std::clamp(width, 64, 196);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     gfx_wrap_string(buffer.data(), width + 1, &numLines, &fontHeight);
 
     _window_error_num_lines = numLines;
     width = width + 3;
-    height = (numLines + 1) * font_get_line_height(FONT_SPRITE_BASE_MEDIUM) + 4;
+    height = (numLines + 1) * font_get_line_height(FontSpriteBase::MEDIUM) + 4;
 
     window_error_widgets[WIDX_BACKGROUND].right = width;
     window_error_widgets[WIDX_BACKGROUND].bottom = height;

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -57,7 +57,6 @@ rct_window* window_error_open(rct_string_id title, rct_string_id message, const 
 rct_window* window_error_open(std::string_view title, std::string_view message)
 {
     int32_t numLines, width, height, maxY;
-    FontSpriteBase fontHeight;
     rct_window* w;
 
     window_close_by_class(WC_ERROR);
@@ -89,7 +88,7 @@ rct_window* window_error_open(std::string_view title, std::string_view message)
     width = std::clamp(width, 64, 196);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer.data(), width + 1, &numLines, &fontHeight);
+    gfx_wrap_string(buffer.data(), width + 1, &numLines);
 
     _window_error_num_lines = numLines;
     width = width + 3;

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -83,12 +83,10 @@ rct_window* window_error_open(std::string_view title, std::string_view message)
     if (buffer.size() <= 1)
         return nullptr;
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     width = gfx_get_string_width_new_lined(buffer.data(), FontSpriteBase::MEDIUM);
     width = std::clamp(width, 64, 196);
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer.data(), width + 1, &numLines);
+    gfx_wrap_string(buffer.data(), width + 1, FontSpriteBase::MEDIUM, &numLines);
 
     _window_error_num_lines = numLines;
     width = width + 3;
@@ -160,5 +158,5 @@ static void window_error_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     l = w->windowPos.x + (w->width + 1) / 2 - 1;
     t = w->windowPos.y + 1;
-    draw_string_centred_raw(dpi, { l, t }, _window_error_num_lines, _window_error_text.data());
+    draw_string_centred_raw(dpi, { l, t }, _window_error_num_lines, _window_error_text.data(), FontSpriteBase::MEDIUM);
 }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -530,7 +530,9 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 8, 51 };
 
     // Expenditure / Income heading
-    DrawTextBasic(dpi, screenCoords, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME, nullptr, COLOUR_BLACK, TextAlignment::LEFT, true);
+    DrawTextBasic(
+        dpi, screenCoords, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME, {},
+        { COLOUR_BLACK, TextUnderline::On, TextAlignment::LEFT });
     screenCoords.y += 14;
 
     // Expenditure / Income row labels
@@ -618,8 +620,8 @@ static void window_finances_summary_scrollpaint(rct_window* w, rct_drawpixelinfo
         ft.Add<uint16_t>(monthyear);
         DrawTextBasic(
             dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 },
-            monthyear == currentMonthYear ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING, ft, COLOUR_BLACK,
-            TextAlignment::RIGHT, true);
+            monthyear == currentMonthYear ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING, ft,
+            { TextUnderline::On, TextAlignment::RIGHT });
         screenCoords.y += 14;
 
         // Month expenditures
@@ -635,8 +637,7 @@ static void window_finances_summary_scrollpaint(rct_window* w, rct_drawpixelinfo
                 ft = Formatter();
                 ft.Add<money32>(expenditure);
                 DrawTextBasic(
-                    dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, COLOUR_BLACK,
-                    TextAlignment::RIGHT);
+                    dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, { TextAlignment::RIGHT });
             }
             screenCoords.y += TABLE_CELL_HEIGHT;
         }
@@ -646,8 +647,7 @@ static void window_finances_summary_scrollpaint(rct_window* w, rct_drawpixelinfo
         const rct_string_id format = profit >= 0 ? STR_FINANCES_SUMMARY_INCOME_VALUE : STR_FINANCES_SUMMARY_LOSS_VALUE;
         ft = Formatter();
         ft.Add<money32>(profit);
-        DrawTextBasic(
-            dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, { TextAlignment::RIGHT });
 
         gfx_fill_rect(
             dpi, { screenCoords + ScreenCoordsXY{ 10, -2 }, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, -2 } },
@@ -758,7 +758,7 @@ static void window_finances_financial_graph_paint(rct_window* w, rct_drawpixelin
         money32 axisValue = axisBase << yAxisScale;
         auto ft = Formatter();
         ft.Add<money32>(axisValue);
-        DrawTextBasic(dpi, { x + 70, y }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, { x + 70, y }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft, { TextAlignment::RIGHT });
         gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
@@ -863,7 +863,7 @@ static void window_finances_park_value_graph_paint(rct_window* w, rct_drawpixeli
         money32 axisValue = axisBase << yAxisScale;
         auto ft = Formatter();
         ft.Add<money32>(axisValue);
-        DrawTextBasic(dpi, { x + 70, y }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, { x + 70, y }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft, { TextAlignment::RIGHT });
         gfx_fill_rect_inset(dpi, x + 70, y + 5, graphLeft + 482, y + 5, w->colours[2], INSET_RECT_FLAG_BORDER_INSET);
         y += 39;
     }
@@ -969,8 +969,7 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
         auto ft = Formatter();
         ft.Add<money32>(axisValue);
         DrawTextBasic(
-            dpi, screenPos + ScreenCoordsXY{ 70, 0 }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft, COLOUR_BLACK,
-            TextAlignment::RIGHT);
+            dpi, screenPos + ScreenCoordsXY{ 70, 0 }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft, { TextAlignment::RIGHT });
         gfx_fill_rect_inset(
             dpi, screenPos.x + 70, screenPos.y + 5, graphLeft + 482, screenPos.y + 5, w->colours[2],
             INSET_RECT_FLAG_BORDER_INSET);

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -544,8 +544,7 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 dpi, { screenCoords - ScreenCoordsXY{ 0, 1 }, screenCoords + ScreenCoordsXY{ 121, (TABLE_CELL_HEIGHT - 2) } },
                 ColourMapA[w->colours[1]].lighter | 0x1000000);
 
-        gfx_draw_string_left(
-            dpi, window_finances_summary_row_labels[i], nullptr, COLOUR_BLACK, screenCoords - ScreenCoordsXY{ 0, 1 });
+        DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, window_finances_summary_row_labels[i]);
         screenCoords.y += TABLE_CELL_HEIGHT;
     }
 
@@ -555,15 +554,14 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
         INSET_RECT_FLAG_BORDER_INSET);
 
     // Loan and interest rate
-    gfx_draw_string_left(dpi, STR_FINANCES_SUMMARY_LOAN, nullptr, COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ 8, 279 });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 8, 279 }, STR_FINANCES_SUMMARY_LOAN);
     auto ft = Formatter();
     ft.Add<uint16_t>(gBankLoanInterestRate);
-    gfx_draw_string_left(
-        dpi, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, ft.Data(), COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ 167, 279 });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 167, 279 }, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, ft);
 
     // Current cash
     rct_string_id stringId = gCash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
-    gfx_draw_string_left(dpi, stringId, &gCash, COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ 8, 294 });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 8, 294 }, stringId, &gCash);
 
     // Objective related financial information
     if (gScenarioObjective.Type == OBJECTIVE_MONTHLY_FOOD_INCOME)
@@ -571,16 +569,14 @@ static void window_finances_summary_paint(rct_window* w, rct_drawpixelinfo* dpi)
         money32 lastMonthProfit = finance_get_last_month_shop_profit();
         ft = Formatter();
         ft.Add<money32>(lastMonthProfit);
-        gfx_draw_string_left(
-            dpi, STR_LAST_MONTH_PROFIT_FROM_FOOD_DRINK_MERCHANDISE_SALES_LABEL, ft.Data(), COLOUR_BLACK,
-            w->windowPos + ScreenCoordsXY{ 280, 279 });
+        DrawTextBasic(
+            dpi, w->windowPos + ScreenCoordsXY{ 280, 279 }, STR_LAST_MONTH_PROFIT_FROM_FOOD_DRINK_MERCHANDISE_SALES_LABEL, ft);
     }
     else
     {
         // Park value and company value
-        gfx_draw_string_left(dpi, STR_PARK_VALUE_LABEL, &gParkValue, COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ 280, 279 });
-        gfx_draw_string_left(
-            dpi, STR_COMPANY_VALUE_LABEL, &gCompanyValue, COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ 280, 294 });
+        DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 280, 279 }, STR_PARK_VALUE_LABEL, &gParkValue);
+        DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 280, 294 }, STR_COMPANY_VALUE_LABEL, &gCompanyValue);
     }
 }
 
@@ -723,11 +719,11 @@ static void window_finances_financial_graph_paint(rct_window* w, rct_drawpixelin
     // Cash (less loan)
     money32 cashLessLoan = gCash - gBankLoan;
 
-    gfx_draw_string_left(
-        dpi,
+    DrawTextBasic(
+        dpi, { graphLeft, graphTop - 11 },
         cashLessLoan >= 0 ? STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_POSITIVE
                           : STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_NEGATIVE,
-        &cashLessLoan, COLOUR_BLACK, { graphLeft, graphTop - 11 });
+        &cashLessLoan);
 
     // Graph
     gfx_fill_rect_inset(dpi, graphLeft, graphTop, graphRight, graphBottom, w->colours[1], INSET_RECT_F_30);
@@ -832,7 +828,7 @@ static void window_finances_park_value_graph_paint(rct_window* w, rct_drawpixeli
 
     // Park value
     money32 parkValue = gParkValue;
-    gfx_draw_string_left(dpi, STR_FINANCES_PARK_VALUE, &parkValue, COLOUR_BLACK, { graphLeft, graphTop - 11 });
+    DrawTextBasic(dpi, { graphLeft, graphTop - 11 }, STR_FINANCES_PARK_VALUE, &parkValue);
 
     // Graph
     gfx_fill_rect_inset(dpi, graphLeft, graphTop, graphRight, graphBottom, w->colours[1], INSET_RECT_F_30);
@@ -936,9 +932,9 @@ static void window_finances_profit_graph_paint(rct_window* w, rct_drawpixelinfo*
 
     // Weekly profit
     money32 weeklyPofit = gCurrentProfit;
-    gfx_draw_string_left(
-        dpi, weeklyPofit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE : STR_FINANCES_WEEKLY_PROFIT_LOSS, &weeklyPofit,
-        COLOUR_BLACK, { graphLeft, graphTop - 11 });
+    DrawTextBasic(
+        dpi, { graphLeft, graphTop - 11 },
+        weeklyPofit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE : STR_FINANCES_WEEKLY_PROFIT_LOSS, &weeklyPofit);
 
     // Graph
     gfx_fill_rect_inset(dpi, graphLeft, graphTop, graphRight, graphBottom, w->colours[1], INSET_RECT_F_30);
@@ -1107,16 +1103,16 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
 
         // Duration
         uint16_t weeksRemaining = campaign->WeeksLeft;
-        gfx_draw_string_left(
-            dpi, weeksRemaining == 1 ? STR_1_WEEK_REMAINING : STR_X_WEEKS_REMAINING, &weeksRemaining, COLOUR_BLACK,
-            screenCoords + ScreenCoordsXY{ 304, 0 });
+        DrawTextBasic(
+            dpi, screenCoords + ScreenCoordsXY{ 304, 0 }, weeksRemaining == 1 ? STR_1_WEEK_REMAINING : STR_X_WEEKS_REMAINING,
+            &weeksRemaining);
 
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     if (noCampaignsActive)
     {
-        gfx_draw_string_left(dpi, STR_MARKETING_CAMPAIGNS_NONE, nullptr, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ 4, 0 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, STR_MARKETING_CAMPAIGNS_NONE);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     screenCoords.y += 34;
@@ -1129,10 +1125,8 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
         {
             // Draw button text
             money32 pricePerWeek = AdvertisingCampaignPricePerWeek[i];
-            gfx_draw_string_left(
-                dpi, MarketingCampaignNames[i][0], nullptr, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ 4, 0 });
-            gfx_draw_string_left(
-                dpi, STR_MARKETING_PER_WEEK, &pricePerWeek, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ WH_SUMMARY, 0 });
+            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, MarketingCampaignNames[i][0]);
+            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ WH_SUMMARY, 0 }, STR_MARKETING_PER_WEEK, &pricePerWeek);
 
             screenCoords.y += BUTTON_FACE_HEIGHT + 2;
         }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1099,7 +1099,7 @@ static void window_finances_marketing_paint(rct_window* w, rct_drawpixelinfo* dp
         }
 
         // Advertisement
-        DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, 296, MarketingCampaignNames[i][1], ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, 296, MarketingCampaignNames[i][1], ft);
 
         // Duration
         uint16_t weeksRemaining = campaign->WeeksLeft;

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -618,7 +618,7 @@ static void window_footpath_paint(rct_window* w, rct_drawpixelinfo* dpi)
         screenCoords = w->windowPos
             + ScreenCoordsXY{ window_footpath_widgets[WIDX_CONSTRUCT].midX(),
                               window_footpath_widgets[WIDX_CONSTRUCT].bottom - 23 };
-        gfx_draw_string_centred(dpi, STR_BUILD_THIS, screenCoords, COLOUR_BLACK, nullptr);
+        DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::CENTRE });
     }
 
     // Draw cost
@@ -628,7 +628,7 @@ static void window_footpath_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
         {
-            gfx_draw_string_centred(dpi, STR_COST_LABEL, screenCoords, COLOUR_BLACK, &_window_footpath_cost);
+            DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, &_window_footpath_cost, { TextAlignment::CENTRE });
         }
     }
 }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -675,12 +675,13 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo* dpi,
     std::memcpy(&stringId, ft.Data(), sizeof(rct_string_id));
     if (stringId == STR_NONE)
     {
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), middleWidgetCoords, width, STR_TITLE_SEQUENCE_OPENRCT2, w->colours[0]);
+        DrawTextWrapped(
+            dpi, middleWidgetCoords, width, STR_TITLE_SEQUENCE_OPENRCT2, ft, { w->colours[0], TextAlignment::CENTRE });
     }
     else
     {
         // Show tooltip in bottom toolbar
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), middleWidgetCoords, width, STR_STRINGID, w->colours[0]);
+        DrawTextWrapped(dpi, middleWidgetCoords, width, STR_STRINGID, ft, { w->colours[0], TextAlignment::CENTRE });
     }
 }
 

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -109,7 +109,7 @@ rct_window* window_game_bottom_toolbar_open()
     int32_t screenHeight = context_get_height();
 
     // Figure out how much line height we have to work with.
-    uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    uint32_t line_height = font_get_line_height(FontSpriteBase::MEDIUM);
     uint32_t toolbar_height = line_height * 2 + 12;
 
     rct_window* window = WindowCreate(
@@ -222,7 +222,7 @@ static OpenRCT2String window_game_bottom_toolbar_tooltip(
 static void window_game_bottom_toolbar_invalidate(rct_window* w)
 {
     // Figure out how much line height we have to work with.
-    uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    uint32_t line_height = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Reset dimensions as appropriate -- in case we're switching languages.
     w->height = line_height * 2 + 12;
@@ -397,7 +397,7 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
         w->windowPos.y + window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom - 1, w->colours[1], INSET_RECT_F_30);
 
     // Figure out how much line height we have to work with.
-    uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    uint32_t line_height = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Draw money
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -508,7 +508,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
         ft.Data());
 
     // Figure out how much line height we have to work with.
-    uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    uint32_t line_height = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Temperature
     screenCoords = { w->windowPos.x + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 15,
@@ -663,7 +663,7 @@ static void window_game_bottom_toolbar_draw_middle_panel(rct_drawpixelinfo* dpi,
         INSET_RECT_F_30);
 
     // Figure out how much line height we have to work with.
-    uint32_t line_height = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    uint32_t line_height = font_get_line_height(FontSpriteBase::MEDIUM);
 
     ScreenCoordsXY middleWidgetCoords(
         w->windowPos.x + middleOutsetWidget->midX(), w->windowPos.y + middleOutsetWidget->top + line_height + 1);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -523,7 +523,7 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
     }
     ft = Formatter();
     ft.Add<int16_t>(temperature);
-    gfx_draw_string_left(dpi, format, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ 0, 6 });
+    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 0, 6 }, format, ft);
     screenCoords.x += 30;
 
     // Current weather

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -406,14 +406,14 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
         auto screenCoords = ScreenCoordsXY{ w->windowPos.x + widget.midX(),
                                             w->windowPos.y + widget.midY() - (line_height == 10 ? 5 : 6) };
 
+        colour_t colour
+            = (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_MONEY
+                   ? COLOUR_WHITE
+                   : NOT_TRANSLUCENT(w->colours[0]));
+        rct_string_id stringId = gCash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
         auto ft = Formatter();
         ft.Add<money32>(gCash);
-        gfx_draw_string_centred(
-            dpi, (gCash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH), screenCoords,
-            (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_MONEY
-                 ? COLOUR_WHITE
-                 : NOT_TRANSLUCENT(w->colours[0])),
-            ft.Data());
+        DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 
     static constexpr const rct_string_id guestCountFormats[] = {
@@ -433,14 +433,15 @@ static void window_game_bottom_toolbar_draw_left_panel(rct_drawpixelinfo* dpi, r
         rct_widget widget = window_game_bottom_toolbar_widgets[WIDX_GUESTS];
         auto screenCoords = ScreenCoordsXY{ w->windowPos.x + widget.midX(), w->windowPos.y + widget.midY() - 6 };
 
-        gfx_draw_string_centred(
-            dpi,
-            gNumGuestsInPark == 1 ? guestCountFormatsSingular[gGuestChangeModifier] : guestCountFormats[gGuestChangeModifier],
-            screenCoords,
-            (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_GUESTS
-                 ? COLOUR_WHITE
-                 : NOT_TRANSLUCENT(w->colours[0])),
-            &gNumGuestsInPark);
+        rct_string_id stringId = gNumGuestsInPark == 1 ? guestCountFormatsSingular[gGuestChangeModifier]
+                                                       : guestCountFormats[gGuestChangeModifier];
+        colour_t colour
+            = (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_GUESTS
+                   ? COLOUR_WHITE
+                   : NOT_TRANSLUCENT(w->colours[0]));
+        auto ft = Formatter();
+        ft.Add<uint32_t>(gNumGuestsInPark);
+        DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 
     // Draw park rating
@@ -495,17 +496,16 @@ static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo* dpi, 
     int32_t month = date_get_month(gDateMonthsElapsed);
     int32_t day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
 
+    colour_t colour
+        = (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_DATE
+               ? COLOUR_WHITE
+               : NOT_TRANSLUCENT(w->colours[0]));
     rct_string_id stringId = DateFormatStringFormatIds[gConfigGeneral.date_format];
     auto ft = Formatter();
     ft.Add<rct_string_id>(DateDayNames[day]);
     ft.Add<int16_t>(month);
     ft.Add<int16_t>(year);
-    gfx_draw_string_centred(
-        dpi, stringId, screenCoords,
-        (gHoverWidget.window_classification == WC_BOTTOM_TOOLBAR && gHoverWidget.widget_index == WIDX_DATE
-             ? COLOUR_WHITE
-             : NOT_TRANSLUCENT(w->colours[0])),
-        ft.Data());
+    DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
 
     // Figure out how much line height we have to work with.
     uint32_t line_height = font_get_line_height(FontSpriteBase::MEDIUM);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1318,7 +1318,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
                           window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
     // Happiness
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_HAPPINESS_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_HAPPINESS_LABEL);
 
     int32_t happiness = NormalizeGuestStatValue(peep->Happiness, PEEP_MAX_HAPPINESS, 10);
     int32_t barColour = COLOUR_BRIGHT_GREEN;
@@ -1327,7 +1327,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Energy
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_ENERGY_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_ENERGY_LABEL);
 
     int32_t energy = NormalizeGuestStatValue(peep->Energy - PEEP_MIN_ENERGY, PEEP_MAX_ENERGY - PEEP_MIN_ENERGY, 10);
     barColour = COLOUR_BRIGHT_GREEN;
@@ -1336,7 +1336,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Hunger
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_HUNGER_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_HUNGER_LABEL);
 
     int32_t hunger = NormalizeGuestStatValue(peep->Hunger - 32, 158, 0);
     hunger = 255 - hunger; // the bar should be longer when peep->Hunger is low
@@ -1346,7 +1346,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Thirst
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_THIRST_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_THIRST_LABEL);
 
     int32_t thirst = NormalizeGuestStatValue(peep->Thirst - 32, 158, 0);
     thirst = 255 - thirst; // the bar should be longer when peep->Thirst is low
@@ -1356,7 +1356,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Nausea
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_NAUSEA_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_NAUSEA_LABEL);
 
     int32_t nausea = NormalizeGuestStatValue(peep->Nausea - 32, 223, 0);
     barColour = COLOUR_BRIGHT_RED;
@@ -1365,7 +1365,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Toilet
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_TOILET_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_TOILET_LABEL);
 
     int32_t toilet = NormalizeGuestStatValue(peep->Toilet - 64, 178, 0);
     barColour = COLOUR_BRIGHT_RED;
@@ -1380,7 +1380,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         int32_t timeInPark = (gScenarioTicks - guestEntryTime) >> 11;
         auto ft = Formatter();
         ft.Add<uint16_t>(timeInPark & 0xFFFF);
-        gfx_draw_string_left(dpi, STR_GUEST_STAT_TIME_IN_PARK, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_TIME_IN_PARK, ft);
     }
 
     screenCoords.y += LIST_ROW_HEIGHT + 9;
@@ -1389,7 +1389,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         INSET_RECT_FLAG_BORDER_INSET);
 
     // Preferred Ride
-    gfx_draw_string_left(dpi, STR_GUEST_STAT_PREFERRED_RIDE, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_PREFERRED_RIDE);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Intensity
@@ -1410,7 +1410,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
             ft.Add<uint16_t>(maxIntensity);
         }
 
-        gfx_draw_string_left(dpi, string_id, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ 4, 0 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, string_id, ft);
     }
 
     // Nausea tolerance
@@ -1425,7 +1425,7 @@ void window_guest_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto nausea_tolerance = EnumValue(peep->NauseaTolerance) & 0x3;
         auto ft = Formatter();
         ft.Add<rct_string_id>(nauseaTolerances[nausea_tolerance]);
-        gfx_draw_string_left(dpi, STR_GUEST_STAT_NAUSEA_TOLERANCE, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_NAUSEA_TOLERANCE, ft);
     }
 }
 
@@ -1570,7 +1570,7 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
         + ScreenCoordsXY{ window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].left + 2,
                           window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].top + 2 };
 
-    gfx_draw_string_left(dpi, STR_GUEST_LABEL_RIDES_BEEN_ON, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_LABEL_RIDES_BEEN_ON);
 
     screenCoords.y = w->windowPos.y + window_guest_rides_widgets[WIDX_PAGE_BACKGROUND].bottom - 12;
 
@@ -1612,7 +1612,7 @@ void window_guest_rides_scroll_paint(rct_window* w, rct_drawpixelinfo* dpi, int3
         {
             auto ft = Formatter();
             ride->FormatNameTo(ft);
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, { 0, y - 1 });
+            DrawTextBasic(dpi, { 0, y - 1 }, stringId, ft);
         }
     }
 }
@@ -1659,7 +1659,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<money32>(peep->CashInPocket);
-        gfx_draw_string_left(dpi, STR_GUEST_STAT_CASH_IN_POCKET, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_CASH_IN_POCKET, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
@@ -1667,7 +1667,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<money32>(peep->CashSpent);
-        gfx_draw_string_left(dpi, STR_GUEST_STAT_CASH_SPENT, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_GUEST_STAT_CASH_SPENT, ft);
         screenCoords.y += LIST_ROW_HEIGHT * 2;
     }
 
@@ -1679,7 +1679,7 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<money32>(peep->PaidToEnter);
-        gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_ENTRANCE_FEE, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_ENTRANCE_FEE, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     // Paid on rides
@@ -1689,11 +1689,11 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<uint16_t>(peep->GuestNumRides);
         if (peep->GuestNumRides != 1)
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_RIDE_PLURAL, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_RIDE_PLURAL, ft);
         }
         else
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_RIDE, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_RIDE, ft);
         }
         screenCoords.y += LIST_ROW_HEIGHT;
     }
@@ -1704,11 +1704,11 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<uint16_t>(peep->AmountOfFood);
         if (peep->AmountOfFood != 1)
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_FOOD_PLURAL, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_FOOD_PLURAL, ft);
         }
         else
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_FOOD, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_FOOD, ft);
         }
         screenCoords.y += LIST_ROW_HEIGHT;
     }
@@ -1720,11 +1720,11 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<uint16_t>(peep->AmountOfDrinks);
         if (peep->AmountOfDrinks != 1)
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_DRINK_PLURAL, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_DRINK_PLURAL, ft);
         }
         else
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_DRINK, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_DRINK, ft);
         }
         screenCoords.y += LIST_ROW_HEIGHT;
     }
@@ -1735,11 +1735,11 @@ void window_guest_finance_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<uint16_t>(peep->AmountOfSouvenirs);
         if (peep->AmountOfSouvenirs != 1)
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_SOUVENIR_PLURAL, ft);
         }
         else
         {
-            gfx_draw_string_left(dpi, STR_GUEST_EXPENSES_SOUVENIR, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_GUEST_EXPENSES_SOUVENIR, ft);
         }
     }
 }
@@ -1793,7 +1793,7 @@ void window_guest_thoughts_paint(rct_window* w, rct_drawpixelinfo* dpi)
         + ScreenCoordsXY{ window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].left + 4,
                           window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-    gfx_draw_string_left(dpi, STR_GUEST_RECENT_THOUGHTS_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUEST_RECENT_THOUGHTS_LABEL);
 
     screenCoords.y += 10;
     for (rct_peep_thought* thought = peep->Thoughts; thought < &peep->Thoughts[PEEP_MAX_THOUGHTS]; ++thought)
@@ -1979,7 +1979,7 @@ void window_guest_inventory_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t maxY = w->windowPos.y + w->height - 22;
     int32_t numItems = 0;
 
-    gfx_draw_string_left(dpi, STR_CARRYING, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_CARRYING);
     screenCoords.y += 10;
 
     for (ShopItem item = ShopItem::Balloon; item < ShopItem::Count; item++)
@@ -1996,7 +1996,7 @@ void window_guest_inventory_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (numItems == 0)
     {
-        gfx_draw_string_left(dpi, STR_NOTHING, nullptr, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_NOTHING);
     }
 }
 
@@ -2035,7 +2035,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<uint32_t>(peep->sprite_index);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_SPRITE_INDEX, ft.Data(), 0, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_SPRITE_INDEX, ft);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
     {
@@ -2043,7 +2043,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<int32_t>(peep->x);
         ft.Add<int32_t>(peep->y);
         ft.Add<int32_t>(peep->z);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_POSITION, ft.Data(), 0, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_POSITION, ft);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
     {
@@ -2072,7 +2072,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<int32_t>(peep->DestinationX);
         ft.Add<int32_t>(peep->DestinationY);
         ft.Add<int32_t>(peep->DestinationTolerance);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_DEST, ft.Data(), 0, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_DEST, ft);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
     {
@@ -2081,10 +2081,10 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<int32_t>(peep->PathfindGoal.y);
         ft.Add<int32_t>(peep->PathfindGoal.z);
         ft.Add<int32_t>(peep->PathfindGoal.direction);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_GOAL, ft.Data(), 0, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_PATHFIND_GOAL, ft);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
-    gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_HISTORY, nullptr, 0, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_PATHFIND_HISTORY);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     screenCoords.x += 10;
@@ -2095,7 +2095,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<int32_t>(point.y);
         ft.Add<int32_t>(point.z);
         ft.Add<int32_t>(point.direction);
-        gfx_draw_string_left(dpi, STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM, ft.Data(), 0, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PEEP_DEBUG_PATHFIND_HISTORY_ITEM, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     screenCoords.x -= 10;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -978,7 +978,7 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter();
         peep->FormatActionTo(ft);
         int32_t width = widget->width();
-        DrawTextEllipsised(dpi, screenPos, width, STR_BLACK_STRING, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+        DrawTextEllipsised(dpi, screenPos, width, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
     }
 
     // Draw the marquee thought
@@ -1585,7 +1585,7 @@ void window_guest_rides_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<rct_string_id>(STR_PEEP_FAVOURITE_RIDE_NOT_AVAILABLE);
     }
 
-    DrawTextEllipsised(dpi, screenCoords, w->width - 14, STR_FAVOURITE_RIDE, ft, COLOUR_BLACK);
+    DrawTextEllipsised(dpi, screenCoords, w->width - 14, STR_FAVOURITE_RIDE, ft);
 }
 
 /**

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1260,7 +1260,7 @@ void window_guest_stats_update(rct_window* w)
 static void window_guest_stats_bars_paint(
     int32_t value, int32_t x, int32_t y, rct_window* w, rct_drawpixelinfo* dpi, int32_t colour, bool blinkFlag)
 {
-    if (font_get_line_height(FONT_SPRITE_BASE_MEDIUM) > 10)
+    if (font_get_line_height(FontSpriteBase::MEDIUM) > 10)
     {
         y += 1;
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1016,7 +1016,7 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         peep_thought_set_format_args(&peep->Thoughts[i], ft);
-        DrawTextBasic(&dpi_marquee, { screenPos.x, 0 }, STR_WINDOW_COLOUR_2_STRINGID, ft, COLOUR_BLACK);
+        DrawTextBasic(&dpi_marquee, { screenPos.x, 0 }, STR_WINDOW_COLOUR_2_STRINGID, ft, {});
     }
 }
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1808,7 +1808,7 @@ void window_guest_thoughts_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         auto ft = Formatter();
         peep_thought_set_format_args(thought, ft);
-        screenCoords.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, width, STR_BLACK_STRING, COLOUR_BLACK);
+        screenCoords.y += DrawTextWrapped(dpi, screenCoords, width, STR_BLACK_STRING, ft);
 
         // If this is the last visible line end drawing.
         if (screenCoords.y > w->windowPos.y + window_guest_thoughts_widgets[WIDX_PAGE_BACKGROUND].bottom - 32)
@@ -1990,7 +1990,7 @@ void window_guest_inventory_paint(rct_window* w, rct_drawpixelinfo* dpi)
             continue;
 
         auto [stringId, ft] = window_guest_inventory_format_item(guest, item);
-        screenCoords.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, itemNameWidth, stringId, COLOUR_BLACK);
+        screenCoords.y += DrawTextWrapped(dpi, screenCoords, itemNameWidth, stringId, ft);
         numItems++;
     }
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -2064,7 +2064,7 @@ void window_guest_debug_paint(rct_window* w, rct_drawpixelinfo* dpi)
             format_string(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SLOPE, ft2.Data());
             safe_strcat(buffer, buffer2, sizeof(buffer));
         }
-        gfx_draw_string(dpi, buffer, 0, screenCoords);
+        gfx_draw_string(dpi, screenCoords, buffer, {});
     }
     screenCoords.y += LIST_ROW_HEIGHT;
     {

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -755,7 +755,7 @@ private:
                 ft = Formatter();
                 ft.Add<rct_string_id>(STR_GUESTS_COUNT_COMMA_SEP);
                 ft.Add<uint32_t>(group.NumGuests);
-                DrawTextBasic(&dpi, { 326, y }, format, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+                DrawTextBasic(&dpi, { 326, y }, format, ft, { TextAlignment::RIGHT });
             }
             y += SUMMARISED_GUEST_ROW_HEIGHT;
             index++;

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -481,9 +481,9 @@ public:
             screenCoords = windowPos + ScreenCoordsXY{ 4, widgets[WIDX_GUEST_LIST].bottom + 2 };
             auto ft = Formatter();
             ft.Add<int32_t>(static_cast<int32_t>(_guestList.size()));
-            gfx_draw_string_left(
-                &dpi, (_guestList.size() == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL), ft.Data(),
-                COLOUR_BLACK, screenCoords);
+            DrawTextBasic(
+                &dpi, screenCoords, (_guestList.size() == 1 ? STR_FORMAT_NUM_GUESTS_SINGULAR : STR_FORMAT_NUM_GUESTS_PLURAL),
+                ft);
         }
     }
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -472,7 +472,7 @@ public:
 
         {
             Formatter ft(_filterArguments.args);
-            DrawTextEllipsised(&dpi, screenCoords, 310, format, ft, COLOUR_BLACK);
+            DrawTextEllipsised(&dpi, screenCoords, 310, format, ft);
         }
 
         // Number of guests (list items)
@@ -677,7 +677,7 @@ private:
                 }
                 auto ft = Formatter();
                 peep->FormatNameTo(ft);
-                DrawTextEllipsised(&dpi, { 0, y }, 113, format, ft, COLOUR_BLACK);
+                DrawTextEllipsised(&dpi, { 0, y }, 113, format, ft);
 
                 switch (_selectedView)
                 {
@@ -692,7 +692,7 @@ private:
                         // Action
                         ft = Formatter();
                         peep->FormatActionTo(ft);
-                        DrawTextEllipsised(&dpi, { 133, y }, 314, format, ft, COLOUR_BLACK);
+                        DrawTextEllipsised(&dpi, { 133, y }, 314, format, ft);
                         break;
                     case GuestViewType::Thoughts:
                         // For each thought
@@ -707,7 +707,7 @@ private:
 
                             ft = Formatter();
                             peep_thought_set_format_args(&thought, ft);
-                            DrawTextEllipsised(&dpi, { 118, y }, 329, format, ft, COLOUR_BLACK);
+                            DrawTextEllipsised(&dpi, { 118, y }, 329, format, ft);
                             break;
                         }
                         break;
@@ -749,7 +749,7 @@ private:
 
                 // Draw action
                 Formatter ft(group.Arguments.args);
-                DrawTextEllipsised(&dpi, { 0, y }, 414, format, ft, COLOUR_BLACK);
+                DrawTextEllipsised(&dpi, { 0, y }, 414, format, ft);
 
                 // Draw guest count
                 ft = Formatter();

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -234,7 +234,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto trackName = _trackName.c_str();
         auto ft = Formatter();
         ft.Add<const char*>(trackName);
-        gfx_draw_string_left(dpi, STR_TRACK_DESIGN_NAME, ft.Data(), COLOUR_BLACK, screenPos - ScreenCoordsXY{ 1, 0 });
+        DrawTextBasic(dpi, screenPos - ScreenCoordsXY{ 1, 0 }, STR_TRACK_DESIGN_NAME, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
@@ -255,7 +255,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             ft.Add<rct_string_id>(GetRideTypeDescriptor(td6->type).Naming.Name);
         }
 
-        gfx_draw_string_left(dpi, STR_TRACK_DESIGN_TYPE, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_DESIGN_TYPE, ft);
         screenPos.y += LIST_ROW_HEIGHT + 4;
     }
 
@@ -264,21 +264,21 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         fixed32_2dp rating = td6->excitement * 10;
         auto ft = Formatter();
         ft.Add<int32_t>(rating);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
     {
         fixed32_2dp rating = td6->intensity * 10;
         auto ft = Formatter();
         ft.Add<int32_t>(rating);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
     {
         fixed32_2dp rating = td6->nausea * 10;
         auto ft = Formatter();
         ft.Add<int32_t>(rating);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, ft);
         screenPos.y += LIST_ROW_HEIGHT + 4;
     }
 
@@ -290,7 +290,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             uint16_t holes = td6->holes & 0x1F;
             auto ft = Formatter();
             ft.Add<uint16_t>(holes);
-            gfx_draw_string_left(dpi, STR_HOLES, ft.Data(), COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_HOLES, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
         else
@@ -300,7 +300,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 uint16_t speed = ((td6->max_speed << 16) * 9) >> 18;
                 auto ft = Formatter();
                 ft.Add<uint16_t>(speed);
-                gfx_draw_string_left(dpi, STR_MAX_SPEED, ft.Data(), COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_MAX_SPEED, ft);
                 screenPos.y += LIST_ROW_HEIGHT;
             }
             // Average speed
@@ -308,7 +308,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 uint16_t speed = ((td6->average_speed << 16) * 9) >> 18;
                 auto ft = Formatter();
                 ft.Add<uint16_t>(speed);
-                gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, ft.Data(), COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_AVERAGE_SPEED, ft);
                 screenPos.y += LIST_ROW_HEIGHT;
             }
         }
@@ -328,7 +328,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             int32_t gForces = td6->max_positive_vertical_g * 32;
             auto ft = Formatter();
             ft.Add<int32_t>(gForces);
-            gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, ft.Data(), COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
         // Maximum negative vertical Gs
@@ -336,7 +336,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             int32_t gForces = td6->max_negative_vertical_g * 32;
             auto ft = Formatter();
             ft.Add<int32_t>(gForces);
-            gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, ft.Data(), COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
         // Maximum lateral Gs
@@ -344,7 +344,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             int32_t gForces = td6->max_lateral_g * 32;
             auto ft = Formatter();
             ft.Add<int32_t>(gForces);
-            gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, ft.Data(), COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
         if (td6->total_air_time != 0)
@@ -353,7 +353,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             int32_t airTime = td6->total_air_time * 25;
             auto ft = Formatter();
             ft.Add<int32_t>(airTime);
-            gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, ft.Data(), COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
     }
@@ -364,11 +364,11 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         uint16_t drops = td6->drops & 0x3F;
         auto ft = Formatter();
         ft.Add<uint16_t>(drops);
-        gfx_draw_string_left(dpi, STR_DROPS, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_DROPS, ft);
         screenPos.y += LIST_ROW_HEIGHT;
 
         // Drop height is multiplied by 0.75
-        gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_HIGHEST_DROP_HEIGHT, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
@@ -380,7 +380,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
             // Inversions
             auto ft = Formatter();
             ft.Add<uint16_t>(inversions);
-            gfx_draw_string_left(dpi, STR_INVERSIONS, ft.Data(), COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_INVERSIONS, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
     }
@@ -392,7 +392,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter();
         ft.Add<uint16_t>(td6->space_required_x);
         ft.Add<uint16_t>(td6->space_required_y);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
@@ -400,7 +400,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<uint32_t>(td6->cost);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
     }
 }
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -220,7 +220,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             DrawTextEllipsised(
-                dpi, screenPos, 308, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, COLOUR_BLACK, TextAlignment::CENTRE);
+                dpi, screenPos, 308, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::CENTRE });
             screenPos.y -= LIST_ROW_HEIGHT;
         }
     }
@@ -317,7 +317,7 @@ static void window_install_track_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
         ft.Add<uint16_t>(td6->ride_length);
-        DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -328,8 +328,8 @@ static void window_land_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
         screenCoords = { w->windowPos.x + previewWidget->midX(), w->windowPos.y + previewWidget->midY() };
-        gfx_draw_string_centred(
-            dpi, STR_LAND_TOOL_SIZE_VALUE, screenCoords - ScreenCoordsXY{ 0, 2 }, COLOUR_BLACK, &gLandToolSize);
+        DrawTextBasic(
+            dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, &gLandToolSize, { TextAlignment::CENTRE });
     }
     else if (gLandMountainMode)
     {
@@ -346,12 +346,12 @@ static void window_land_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         // Draw raise cost amount
         if (gLandToolRaiseCost != MONEY32_UNDEFINED && gLandToolRaiseCost != 0)
-            gfx_draw_string_centred(dpi, STR_RAISE_COST_AMOUNT, screenCoords, COLOUR_BLACK, &gLandToolRaiseCost);
+            DrawTextBasic(dpi, screenCoords, STR_RAISE_COST_AMOUNT, &gLandToolRaiseCost, { TextAlignment::CENTRE });
         screenCoords.y += 10;
 
         // Draw lower cost amount
         if (gLandToolLowerCost != MONEY32_UNDEFINED && gLandToolLowerCost != 0)
-            gfx_draw_string_centred(dpi, STR_LOWER_COST_AMOUNT, screenCoords, COLOUR_BLACK, &gLandToolLowerCost);
+            DrawTextBasic(dpi, screenCoords, STR_LOWER_COST_AMOUNT, &gLandToolLowerCost, { TextAlignment::CENTRE });
         screenCoords.y += 50;
 
         // Draw paint price
@@ -375,7 +375,7 @@ static void window_land_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             auto ft = Formatter();
             ft.Add<money32>(price);
-            gfx_draw_string_centred(dpi, STR_COST_AMOUNT, screenCoords, COLOUR_BLACK, ft.Data());
+            DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft.Data(), { TextAlignment::CENTRE });
         }
     }
 }

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -262,8 +262,8 @@ static void window_land_rights_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw number for tool sizes bigger than 7
     if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
-        gfx_draw_string_centred(
-            dpi, STR_LAND_TOOL_SIZE_VALUE, screenCoords - ScreenCoordsXY{ 0, 2 }, COLOUR_BLACK, &gLandToolSize);
+        DrawTextBasic(
+            dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, &gLandToolSize, { TextAlignment::CENTRE });
     }
 
     // Draw cost amount
@@ -271,7 +271,7 @@ static void window_land_rights_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         screenCoords = { window_land_rights_widgets[WIDX_PREVIEW].midX() + w->windowPos.x,
                          window_land_rights_widgets[WIDX_PREVIEW].bottom + w->windowPos.y + 32 };
-        gfx_draw_string_centred(dpi, STR_COST_AMOUNT, screenCoords, COLOUR_BLACK, &_landRightsCost);
+        DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, &_landRightsCost, { TextAlignment::CENTRE });
     }
 }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -1206,7 +1206,7 @@ static void window_overwrite_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ft.Add<char*>(_window_overwrite_prompt_name);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + w->width / 2, w->windowPos.y + (w->height / 2) - 3);
-    gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, COLOUR_BLACK);
+    DrawTextWrapped(dpi, stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, ft, { TextAlignment::CENTRE });
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -714,8 +714,9 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Draw name button indicator.
     rct_widget sort_name_widget = window_loadsave_widgets[WIDX_SORT_NAME];
-    gfx_draw_string_left(
-        dpi, STR_NAME, &id, COLOUR_GREY, w->windowPos + ScreenCoordsXY{ sort_name_widget.left + 11, sort_name_widget.top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ sort_name_widget.left + 11, sort_name_widget.top + 1 }, STR_NAME, &id,
+        { COLOUR_GREY });
 
     // Date button text
     if (gConfigGeneral.load_save_sort == Sort::DateAscending)
@@ -726,8 +727,9 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
         id = STR_NONE;
 
     rct_widget sort_date_widget = window_loadsave_widgets[WIDX_SORT_DATE];
-    gfx_draw_string_left(
-        dpi, STR_DATE, &id, COLOUR_GREY, w->windowPos + ScreenCoordsXY{ sort_date_widget.left + 5, sort_date_widget.top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ sort_date_widget.left + 5, sort_date_widget.top + 1 }, STR_DATE, &id,
+        { COLOUR_GREY });
 }
 
 static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
@@ -760,7 +762,7 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         {
             auto ft = Formatter();
             ft.Add<rct_string_id>(STR_RIGHTGUILLEMET);
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, { 0, y });
+            DrawTextBasic(dpi, { 0, y }, stringId, ft);
         }
 
         // Print filename

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -692,7 +692,7 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (_shortenedDirectory[0] == '\0')
     {
-        shorten_path(_shortenedDirectory, sizeof(_shortenedDirectory), _directory, w->width - 8);
+        shorten_path(_shortenedDirectory, sizeof(_shortenedDirectory), _directory, w->width - 8, FontSpriteBase::MEDIUM);
     }
 
     // Format text
@@ -703,7 +703,7 @@ static void window_loadsave_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw path text
     auto ft = Formatter();
     ft.Add<const char*>(Platform::StrDecompToPrecomp(buffer.data()));
-    DrawTextEllipsised(dpi, { w->windowPos.x + 4, w->windowPos.y + 20 }, w->width - 8, STR_STRING, ft, COLOUR_BLACK);
+    DrawTextEllipsised(dpi, { w->windowPos.x + 4, w->windowPos.y + 20 }, w->width - 8, STR_STRING, ft);
 
     // Name button text
     rct_string_id id = STR_NONE;
@@ -770,7 +770,7 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<char*>(_listItems[i].name.c_str());
         int32_t max_file_width = w->widgets[WIDX_SORT_NAME].width() - 10;
-        DrawTextEllipsised(dpi, { 10, y }, max_file_width, stringId, ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, { 10, y }, max_file_width, stringId, ft);
 
         // Print formatted modified date, if this is a file
         if (_listItems[i].type == TYPE_FILE)
@@ -778,13 +778,12 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
             ft = Formatter();
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<char*>(_listItems[i].date_formatted.c_str());
-            DrawTextEllipsised(
-                dpi, { dateAnchor - DATE_TIME_GAP, y }, maxDateWidth, stringId, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+            DrawTextEllipsised(dpi, { dateAnchor - DATE_TIME_GAP, y }, maxDateWidth, stringId, ft, { TextAlignment::RIGHT });
 
             ft = Formatter();
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<char*>(_listItems[i].time_formatted.c_str());
-            DrawTextEllipsised(dpi, { dateAnchor + DATE_TIME_GAP, y }, maxTimeWidth, stringId, ft, COLOUR_BLACK);
+            DrawTextEllipsised(dpi, { dateAnchor + DATE_TIME_GAP, y }, maxTimeWidth, stringId, ft);
         }
     }
 }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -643,7 +643,7 @@ static void window_loadsave_compute_max_date_width()
 
     // Check how this date is represented (e.g. 2000-02-20, or 00/02/20)
     std::string date = Platform::FormatShortDate(long_time);
-    maxDateWidth = gfx_get_string_width(date.c_str()) + DATE_TIME_GAP;
+    maxDateWidth = gfx_get_string_width(date.c_str(), FontSpriteBase::MEDIUM) + DATE_TIME_GAP;
 
     // Some locales do not use leading zeros for months and days, so let's try October, too.
     tm.tm_mon = 10;
@@ -652,11 +652,11 @@ static void window_loadsave_compute_max_date_width()
 
     // Again, check how this date is represented (e.g. 2000-10-20, or 00/10/20)
     date = Platform::FormatShortDate(long_time);
-    maxDateWidth = std::max(maxDateWidth, gfx_get_string_width(date.c_str()) + DATE_TIME_GAP);
+    maxDateWidth = std::max(maxDateWidth, gfx_get_string_width(date.c_str(), FontSpriteBase::MEDIUM) + DATE_TIME_GAP);
 
     // Time appears to be universally represented with two digits for minutes, so 12:00 or 00:00 should be representable.
     std::string time = Platform::FormatTime(long_time);
-    maxTimeWidth = gfx_get_string_width(time.c_str()) + DATE_TIME_GAP;
+    maxTimeWidth = gfx_get_string_width(time.c_str(), FontSpriteBase::MEDIUM) + DATE_TIME_GAP;
 }
 
 static void window_loadsave_invalidate(rct_window* w)

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -852,7 +852,7 @@ static void window_map_paint(rct_window* w, rct_drawpixelinfo* dpi)
             {
                 gfx_fill_rect(
                     dpi, { screenCoords + ScreenCoordsXY{ 0, 2 }, screenCoords + ScreenCoordsXY{ 6, 8 } }, RideKeyColours[i]);
-                gfx_draw_string_left(dpi, mapLabels[i], w, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ LIST_ROW_HEIGHT, 0 });
+                DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ LIST_ROW_HEIGHT, 0 }, mapLabels[i], w);
                 screenCoords.y += LIST_ROW_HEIGHT;
                 if (i == 3)
                 {
@@ -863,9 +863,9 @@ static void window_map_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
     else if (!WidgetIsActiveTool(w, WIDX_SET_LAND_RIGHTS))
     {
-        gfx_draw_string_left(
-            dpi, STR_MAP_SIZE, nullptr, w->colours[1],
-            w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_MAP_SIZE_SPINNER].top + 1 });
+        DrawTextBasic(
+            dpi, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_MAP_SIZE_SPINNER].top + 1 }, STR_MAP_SIZE, {},
+            { w->colours[1] });
     }
 }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -819,8 +819,9 @@ static void window_map_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Draw land tool size
     if (WidgetIsActiveTool(w, WIDX_SET_LAND_RIGHTS) && _landRightsToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
     {
-        gfx_draw_string_centred(
-            dpi, STR_LAND_TOOL_SIZE_VALUE, screenCoords - ScreenCoordsXY{ 0, 2 }, COLOUR_BLACK, &_landRightsToolSize);
+        DrawTextBasic(
+            dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, &_landRightsToolSize,
+            { TextAlignment::CENTRE });
     }
     screenCoords.y = w->windowPos.y + window_map_widgets[WIDX_LAND_TOOL].bottom + 5;
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -691,36 +691,34 @@ static void window_mapgen_base_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_mapgen_draw_tab_images(dpi, w);
 
-    const uint8_t textColour = w->colours[1];
+    const auto textColour = w->colours[1];
 
-    gfx_draw_string_left(
-        dpi, STR_MAP_SIZE, nullptr, textColour, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_MAP_SIZE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_BASE_HEIGHT_LABEL, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_BASE_HEIGHT].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_WATER_LEVEL_LABEL, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_WATER_LEVEL].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_TERRAIN_LABEL, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_FLOOR_TEXTURE].top + 1 });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_MAP_SIZE].top + 1 }, STR_MAP_SIZE, {}, { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_BASE_HEIGHT].top + 1 }, STR_BASE_HEIGHT_LABEL, {},
+        { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, {},
+        { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_FLOOR_TEXTURE].top + 1 }, STR_TERRAIN_LABEL, {}, { textColour });
 
     // The practical map size is 2 lower than the technical map size
     // This needs to be cast down to a uint16_t because that's what the STR_RESOLUTION_X_BY_Y string takes.
     uint16_t mapSizeArgs[] = { static_cast<uint16_t>(_mapSize - 2), static_cast<uint16_t>(_mapSize - 2) };
-    gfx_draw_string_left(
-        dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_MAP_SIZE].left + 1, w->widgets[WIDX_MAP_SIZE].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_MAP_SIZE].left + 1, w->widgets[WIDX_MAP_SIZE].top + 1 },
+        STR_RESOLUTION_X_BY_Y, &mapSizeArgs, { w->colours[1] });
 
     arg = (_baseHeight - 12) / 2;
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &arg, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_BASE_HEIGHT].left + 1, w->widgets[WIDX_BASE_HEIGHT].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_BASE_HEIGHT].left + 1, w->widgets[WIDX_BASE_HEIGHT].top + 1 },
+        STR_COMMA16, &arg, { w->colours[1] });
 
     arg = (_waterLevel - 12) / 2;
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &arg, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_WATER_LEVEL].left + 1, w->widgets[WIDX_WATER_LEVEL].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_WATER_LEVEL].left + 1, w->widgets[WIDX_WATER_LEVEL].top + 1 },
+        STR_COMMA16, &arg, { w->colours[1] });
 }
 
 #pragma endregion
@@ -1012,56 +1010,60 @@ static void window_mapgen_simplex_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     const uint8_t textColour = w->colours[1];
 
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_LOW_, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_LOW].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_HIGH, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_HIGH].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_MAP_SIZE, nullptr, textColour, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_WATER_LEVEL_LABEL, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_LOW].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_LOW_, {},
+        { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_HIGH].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_HIGH, {},
+        { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 },
+        STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, {}, { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES, {},
+        { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1 }, STR_MAP_SIZE, {}, { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, {},
+        { textColour });
 
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &_simplex_low, textColour,
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_LOW].left + 1, w->widgets[WIDX_SIMPLEX_LOW].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &_simplex_high, textColour,
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_HIGH].left + 1, w->widgets[WIDX_SIMPLEX_HIGH].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &_simplex_base_freq, textColour,
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_LOW].left + 1, w->widgets[WIDX_SIMPLEX_LOW].top + 1 },
+        STR_COMMA16, &_simplex_low, { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_HIGH].left + 1, w->widgets[WIDX_SIMPLEX_HIGH].top + 1 },
+        STR_COMMA16, &_simplex_high, { textColour });
+    DrawTextBasic(
+        dpi,
         w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_BASE_FREQ].left + 1, w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &_simplex_octaves, textColour,
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_OCTAVES].left + 1, w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_TERRAIN_LABEL, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_OPTION_PLACE_TREES, nullptr, textColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_PLACE_TREES_CHECKBOX].top + 1 });
+            + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_BASE_FREQ].left + 1, w->widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 },
+        STR_WINDOW_OBJECTIVE_VALUE_RATING, &_simplex_base_freq, { textColour });
+    DrawTextBasic(
+        dpi,
+        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_OCTAVES].left + 1, w->widgets[WIDX_SIMPLEX_OCTAVES].top + 1 },
+        STR_COMMA16, &_simplex_octaves, { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX].top + 1 }, STR_TERRAIN_LABEL,
+        {}, { textColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_SIMPLEX_PLACE_TREES_CHECKBOX].top + 1 },
+        STR_MAPGEN_OPTION_PLACE_TREES, {}, { textColour });
 
     // The practical map size is 2 lower than the technical map size.
     // This needs to be cast down to a uint16_t because that's what the STR_RESOLUTION_X_BY_Y string takes.
     uint16_t mapSizeArgs[] = { static_cast<uint16_t>(_mapSize - 2), static_cast<uint16_t>(_mapSize - 2) };
-    gfx_draw_string_left(
-        dpi, STR_RESOLUTION_X_BY_Y, &mapSizeArgs, textColour,
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_MAP_SIZE].left + 1, w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1 });
+    DrawTextBasic(
+        dpi,
+        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_MAP_SIZE].left + 1, w->widgets[WIDX_SIMPLEX_MAP_SIZE].top + 1 },
+        STR_RESOLUTION_X_BY_Y, &mapSizeArgs, { textColour });
 
     arg = (_waterLevel - 12) / 2;
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &arg, textColour,
+    DrawTextBasic(
+        dpi,
         w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_WATER_LEVEL].left + 1, w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1 });
+            + ScreenCoordsXY{ w->widgets[WIDX_SIMPLEX_WATER_LEVEL].left + 1, w->widgets[WIDX_SIMPLEX_WATER_LEVEL].top + 1 },
+        STR_COMMA16, &arg, { textColour });
 }
 
 #pragma endregion
@@ -1209,49 +1211,50 @@ static void window_mapgen_heightmap_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_mapgen_draw_tab_images(dpi, w);
 
-    const uint8_t enabledColour = w->colours[1];
-    const uint8_t disabledColour = enabledColour | COLOUR_FLAG_INSET;
+    const colour_t enabledColour = w->colours[1];
+    const colour_t disabledColour = enabledColour | COLOUR_FLAG_INSET;
 
     // Smooth strength label and value
-    const uint8_t strengthColour = _heightmapSmoothMap ? enabledColour : disabledColour;
+    const colour_t strengthColour = _heightmapSmoothMap ? enabledColour : disabledColour;
     int16_t strength = _heightmapSmoothStrength;
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SMOOTH_STRENGTH, nullptr, strengthColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &strength, strengthColour,
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 }, STR_MAPGEN_SMOOTH_STRENGTH, {},
+        { strengthColour });
+    DrawTextBasic(
+        dpi,
         w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_STRENGTH].left + 1, w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 });
+            + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_STRENGTH].left + 1, w->widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 },
+        STR_COMMA16, &strength, { strengthColour });
 
     // Low label and value
-    const uint8_t labelColour = _heightmapLoaded ? enabledColour : disabledColour;
+    const colour_t labelColour = _heightmapLoaded ? enabledColour : disabledColour;
     int16_t low = _heightmapLow;
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_LOW_, nullptr, labelColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_LOW].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &low, labelColour,
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_LOW].left + 1, w->widgets[WIDX_HEIGHTMAP_LOW].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_LOW].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_LOW_, {},
+        { labelColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_LOW].left + 1, w->widgets[WIDX_HEIGHTMAP_LOW].top + 1 },
+        STR_COMMA16, &low, { labelColour });
 
     // High label and value
     int16_t high = _heightmapHigh;
-    gfx_draw_string_left(
-        dpi, STR_MAPGEN_SIMPLEX_NOISE_HIGH, nullptr, labelColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &high, labelColour,
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_HIGH].left + 1, w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_HIGH, {},
+        { labelColour });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_HIGH].left + 1, w->widgets[WIDX_HEIGHTMAP_HIGH].top + 1 },
+        STR_COMMA16, &high, { labelColour });
 
     // Water level label and value
     int16_t waterLevel = _waterLevel;
-    gfx_draw_string_left(
-        dpi, STR_WATER_LEVEL_LABEL, nullptr, labelColour,
-        w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_COMMA16, &waterLevel, labelColour,
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 5, w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, {},
+        { labelColour });
+    DrawTextBasic(
+        dpi,
         w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].left + 1,
-                              w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1 });
+            + ScreenCoordsXY{ w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].left + 1, w->widgets[WIDX_HEIGHTMAP_WATER_LEVEL].top + 1 },
+        STR_COMMA16, &waterLevel, { labelColour });
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -145,6 +145,5 @@ static void window_map_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     ScreenCoordsXY stringCoords(w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2));
-    gfx_draw_string_centred_wrapped(
-        dpi, _mapTooltipArgs.Data(), stringCoords, w->width, STR_MAP_TOOLTIP_STRINGID, COLOUR_BLACK);
+    DrawTextWrapped(dpi, stringCoords, w->width, STR_MAP_TOOLTIP_STRINGID, _mapTooltipArgs, { TextAlignment::CENTRE });
 }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -337,13 +337,14 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
     }
 
     // Reset font sprite base and compute line height
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Base dimensions.
     const int32_t width = 450;
     int32_t height = 55;
-    int32_t numLines, fontSpriteBase;
+    int32_t numLines;
+    FontSpriteBase fontSpriteBase;
 
     // Server name is displayed word-wrapped, so figure out how high it will be.
     {

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -434,21 +434,21 @@ static void window_multiplayer_information_paint(rct_window* w, rct_drawpixelinf
         const utf8* providerName = network_get_server_provider_name();
         if (!str_is_null_or_empty(providerName))
         {
-            gfx_draw_string_left(dpi, STR_PROVIDER_NAME, static_cast<void*>(&providerName), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_PROVIDER_NAME, static_cast<void*>(&providerName));
             screenCoords.y += LIST_ROW_HEIGHT;
         }
 
         const utf8* providerEmail = network_get_server_provider_email();
         if (!str_is_null_or_empty(providerEmail))
         {
-            gfx_draw_string_left(dpi, STR_PROVIDER_EMAIL, static_cast<void*>(&providerEmail), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_PROVIDER_EMAIL, static_cast<void*>(&providerEmail));
             screenCoords.y += LIST_ROW_HEIGHT;
         }
 
         const utf8* providerWebsite = network_get_server_provider_website();
         if (!str_is_null_or_empty(providerWebsite))
         {
-            gfx_draw_string_left(dpi, STR_PROVIDER_WEBSITE, static_cast<void*>(&providerWebsite), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_PROVIDER_WEBSITE, static_cast<void*>(&providerWebsite));
         }
     }
 }
@@ -561,7 +561,7 @@ static void window_multiplayer_players_paint(rct_window* w, rct_drawpixelinfo* d
     // Number of players
     stringId = w->no_list_items == 1 ? STR_MULTIPLAYER_PLAYER_COUNT : STR_MULTIPLAYER_PLAYER_COUNT_PLURAL;
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_LIST].bottom + 2 };
-    gfx_draw_string_left(dpi, stringId, &w->no_list_items, w->colours[2], screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &w->no_list_items, { w->colours[2] });
 }
 
 static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
@@ -853,7 +853,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         + ScreenCoordsXY{ window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4,
                           window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].top + 4 };
 
-    gfx_draw_string_left(dpi, STR_DEFAULT_GROUP, nullptr, w->colours[2], screenPos);
+    DrawTextBasic(dpi, screenPos, STR_DEFAULT_GROUP, {}, { w->colours[2] });
 
     screenPos.y += 20;
 
@@ -909,7 +909,7 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
             // Draw action name
             auto ft = Formatter();
             ft.Add<uint16_t>(network_get_action_name_string_id(i));
-            gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, ft.Data(), COLOUR_BLACK, { 10, screenCoords.y });
+            DrawTextBasic(dpi, { 10, screenCoords.y }, STR_WINDOW_COLOUR_2_STRINGID, ft);
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -418,16 +418,16 @@ static void window_multiplayer_information_paint(rct_window* w, rct_drawpixelinf
 
         const utf8* name = network_get_server_name();
         {
-            screenCoords.y += gfx_draw_string_left_wrapped(
-                dpi, static_cast<void*>(&name), screenCoords, width, STR_STRING, w->colours[1]);
+            screenCoords.y += DrawTextWrapped(
+                dpi, screenCoords, width, STR_STRING, static_cast<void*>(&name), { w->colours[1] });
             screenCoords.y += LIST_ROW_HEIGHT / 2;
         }
 
         const utf8* description = network_get_server_description();
         if (!str_is_null_or_empty(description))
         {
-            screenCoords.y += gfx_draw_string_left_wrapped(
-                dpi, static_cast<void*>(&description), screenCoords, width, STR_STRING, w->colours[1]);
+            screenCoords.y += DrawTextWrapped(
+                dpi, screenCoords, width, STR_STRING, static_cast<void*>(&description), { w->colours[1] });
             screenCoords.y += LIST_ROW_HEIGHT / 2;
         }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -344,12 +344,11 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
     const int32_t width = 450;
     int32_t height = 55;
     int32_t numLines;
-    FontSpriteBase fontSpriteBase;
 
     // Server name is displayed word-wrapped, so figure out how high it will be.
     {
         utf8* buffer = _strdup(network_get_server_name());
-        gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
+        gfx_wrap_string(buffer, width, &numLines);
         free(buffer);
         height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
@@ -359,7 +358,7 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
     if (!str_is_null_or_empty(descString))
     {
         utf8* buffer = _strdup(descString);
-        gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
+        gfx_wrap_string(buffer, width, &numLines);
         free(buffer);
         height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
     }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -336,8 +336,6 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
         return _windowInformationSize;
     }
 
-    // Reset font sprite base and compute line height
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // Base dimensions.
@@ -348,7 +346,7 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
     // Server name is displayed word-wrapped, so figure out how high it will be.
     {
         utf8* buffer = _strdup(network_get_server_name());
-        gfx_wrap_string(buffer, width, &numLines);
+        gfx_wrap_string(buffer, width, FontSpriteBase::MEDIUM, &numLines);
         free(buffer);
         height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
@@ -358,7 +356,7 @@ static ScreenCoordsXY window_multiplayer_information_get_size()
     if (!str_is_null_or_empty(descString))
     {
         utf8* buffer = _strdup(descString);
-        gfx_wrap_string(buffer, width, &numLines);
+        gfx_wrap_string(buffer, width, FontSpriteBase::MEDIUM, &numLines);
         free(buffer);
         height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
@@ -602,7 +600,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
                 buffer += network_get_player_name(i);
             }
             screenCoords.x = 0;
-            gfx_clip_string(buffer.data(), 230);
+            gfx_clip_string(buffer.data(), 230, FontSpriteBase::MEDIUM);
             gfx_draw_string(dpi, screenCoords, buffer.c_str(), { colour });
 
             // Draw group name
@@ -613,7 +611,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
                 buffer += "{BLACK}";
                 screenCoords.x = 173;
                 buffer += network_get_group_name(group);
-                gfx_clip_string(buffer.data(), 80);
+                gfx_clip_string(buffer.data(), 80, FontSpriteBase::MEDIUM);
                 gfx_draw_string(dpi, screenCoords, buffer.c_str(), { colour });
             }
 
@@ -628,7 +626,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             {
                 ft.Add<rct_string_id>(STR_ACTION_NA);
             }
-            DrawTextEllipsised(dpi, { 256, screenCoords.y }, 100, STR_BLACK_STRING, ft, COLOUR_BLACK);
+            DrawTextEllipsised(dpi, { 256, screenCoords.y }, 100, STR_BLACK_STRING, ft);
 
             // Draw ping
             buffer.resize(0);
@@ -845,7 +843,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         ft.Add<const char*>(buffer.c_str());
         DrawTextEllipsised(
             dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
-            COLOUR_BLACK, TextAlignment::CENTRE);
+            { TextAlignment::CENTRE });
     }
 
     auto screenPos = w->windowPos
@@ -869,7 +867,7 @@ static void window_multiplayer_groups_paint(rct_window* w, rct_drawpixelinfo* dp
         ft.Add<const char*>(buffer.c_str());
         DrawTextEllipsised(
             dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
-            COLOUR_BLACK, TextAlignment::CENTRE);
+            { TextAlignment::CENTRE });
     }
 }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -581,7 +581,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             buffer.clear();
 
             // Draw player name
-            int32_t colour = COLOUR_BLACK;
+            colour_t colour = COLOUR_BLACK;
             if (i == w->selected_list_item)
             {
                 gfx_filter_rect(
@@ -603,7 +603,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             }
             screenCoords.x = 0;
             gfx_clip_string(buffer.data(), 230);
-            gfx_draw_string(dpi, buffer.c_str(), colour, screenCoords);
+            gfx_draw_string(dpi, screenCoords, buffer.c_str(), { colour });
 
             // Draw group name
             buffer.resize(0);
@@ -614,7 +614,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
                 screenCoords.x = 173;
                 buffer += network_get_group_name(group);
                 gfx_clip_string(buffer.data(), 80);
-                gfx_draw_string(dpi, buffer.c_str(), colour, screenCoords);
+                gfx_draw_string(dpi, screenCoords, buffer.c_str(), { colour });
             }
 
             // Draw last action
@@ -651,7 +651,7 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             buffer += pingBuffer;
 
             screenCoords.x = 356;
-            gfx_draw_string(dpi, buffer.c_str(), colour, screenCoords);
+            gfx_draw_string(dpi, screenCoords, buffer.c_str(), { colour });
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }
@@ -901,7 +901,7 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
                 if (network_can_perform_action(groupindex, static_cast<NetworkPermission>(i)))
                 {
                     screenCoords.x = 0;
-                    gfx_draw_string(dpi, u8"{WINDOW_COLOUR_2}✓", COLOUR_BLACK, screenCoords);
+                    gfx_draw_string(dpi, screenCoords, u8"{WINDOW_COLOUR_2}✓", {});
                 }
             }
 

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -139,7 +139,7 @@ static void window_music_credits_mouseup(rct_window* w, rct_widgetindex widgetIn
  */
 static void window_music_credits_scrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
 {
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
     *height = static_cast<int32_t>(std::size(music_credits) + std::size(music_credits_rct2)) * lineHeight + 12;
 }
 
@@ -158,7 +158,7 @@ static void window_music_credits_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void window_music_credits_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     auto screenCoords = ScreenCoordsXY{ 245, 2 };
 

--- a/src/openrct2-ui/windows/MusicCredits.cpp
+++ b/src/openrct2-ui/windows/MusicCredits.cpp
@@ -164,13 +164,13 @@ static void window_music_credits_scrollpaint(rct_window* w, rct_drawpixelinfo* d
 
     for (size_t i = 0; i < std::size(music_credits); i++)
     {
-        gfx_draw_string_centred(dpi, music_credits[i], screenCoords, COLOUR_BLACK, nullptr);
+        DrawTextBasic(dpi, screenCoords, music_credits[i], nullptr, { TextAlignment::CENTRE });
         screenCoords.y += lineHeight;
     }
 
     // Add 4 more space before "Original recordings ...".
     screenCoords.y += 4;
-    gfx_draw_string_centred(dpi, STR_MUSIC_ACKNOWLEDGEMENTS_ORIGINAL_RECORDINGS, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_MUSIC_ACKNOWLEDGEMENTS_ORIGINAL_RECORDINGS, nullptr, { TextAlignment::CENTRE });
     screenCoords.y += lineHeight;
 
     // Draw the separator
@@ -180,7 +180,7 @@ static void window_music_credits_scrollpaint(rct_window* w, rct_drawpixelinfo* d
 
     for (size_t i = 0; i < std::size(music_credits_rct2); i++)
     {
-        gfx_draw_string_centred(dpi, music_credits_rct2[i], screenCoords, COLOUR_BLACK, nullptr);
+        DrawTextBasic(dpi, screenCoords, music_credits_rct2[i], nullptr, { TextAlignment::CENTRE });
         screenCoords.y += lineHeight;
     }
 }

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -383,13 +383,12 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
 
         // Received stats.
         {
-            gfx_draw_string_left(dpi, STR_NETWORK_RECEIVE, nullptr, PALETTE_INDEX_10, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_NETWORK_RECEIVE, {}, { PALETTE_INDEX_10 });
 
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesInSec);
             gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
 
-            gfx_draw_string_left(
-                dpi, STR_NETWORK_TOTAL_RECEIVED, nullptr, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY{ 200, 0 });
+            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_NETWORK_TOTAL_RECEIVED, {}, { PALETTE_INDEX_10 });
 
             format_readable_size(
                 textBuffer, sizeof(textBuffer), _networkStats.bytesReceived[EnumValue(NetworkStatisticsGroup::Total)]);
@@ -403,13 +402,12 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
 
         // Sent stats.
         {
-            gfx_draw_string_left(dpi, STR_NETWORK_SEND, nullptr, PALETTE_INDEX_10, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_NETWORK_SEND, {}, { PALETTE_INDEX_10 });
 
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesOutSec);
             gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
 
-            gfx_draw_string_left(
-                dpi, STR_NETWORK_TOTAL_SENT, nullptr, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY{ 200, 0 });
+            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_NETWORK_TOTAL_SENT, {}, { PALETTE_INDEX_10 });
 
             format_readable_size(
                 textBuffer, sizeof(textBuffer), _networkStats.bytesSent[EnumValue(NetworkStatisticsGroup::Total)]);

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -433,9 +433,9 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
                 // Draw text.
                 gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(10, 0));
 
-                gfx_get_string_width(textBuffer);
+                gfx_get_string_width(textBuffer, FontSpriteBase::MEDIUM);
 
-                screenCoords.x += gfx_get_string_width(textBuffer) + 20;
+                screenCoords.x += gfx_get_string_width(textBuffer, FontSpriteBase::MEDIUM) + 20;
             }
         }
     }

--- a/src/openrct2-ui/windows/Network.cpp
+++ b/src/openrct2-ui/windows/Network.cpp
@@ -386,13 +386,13 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
             DrawTextBasic(dpi, screenCoords, STR_NETWORK_RECEIVE, {}, { PALETTE_INDEX_10 });
 
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesInSec);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
+            gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(70, 0), textBuffer, { PALETTE_INDEX_10 });
 
             DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_NETWORK_TOTAL_RECEIVED, {}, { PALETTE_INDEX_10 });
 
             format_readable_size(
                 textBuffer, sizeof(textBuffer), _networkStats.bytesReceived[EnumValue(NetworkStatisticsGroup::Total)]);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(300, 0));
+            gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(300, 0), textBuffer, { PALETTE_INDEX_10 });
             screenCoords.y += textHeight + padding;
 
             window_network_draw_graph(
@@ -405,13 +405,13 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
             DrawTextBasic(dpi, screenCoords, STR_NETWORK_SEND, {}, { PALETTE_INDEX_10 });
 
             format_readable_speed(textBuffer, sizeof(textBuffer), _bytesOutSec);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(70, 0));
+            gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(70, 0), textBuffer, { PALETTE_INDEX_10 });
 
             DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 200, 0 }, STR_NETWORK_TOTAL_SENT, {}, { PALETTE_INDEX_10 });
 
             format_readable_size(
                 textBuffer, sizeof(textBuffer), _networkStats.bytesSent[EnumValue(NetworkStatisticsGroup::Total)]);
-            gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(300, 0));
+            gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(300, 0), textBuffer, { PALETTE_INDEX_10 });
             screenCoords.y += textHeight + padding;
 
             window_network_draw_graph(
@@ -431,7 +431,7 @@ static void window_network_information_paint(rct_window* w, rct_drawpixelinfo* d
                     NetworkTrafficGroupColors[i]);
 
                 // Draw text.
-                gfx_draw_string(dpi, textBuffer, PALETTE_INDEX_10, screenCoords + ScreenCoordsXY(10, 0));
+                gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(10, 0), textBuffer, { PALETTE_INDEX_10 });
 
                 gfx_get_string_width(textBuffer, FontSpriteBase::MEDIUM);
 

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -155,7 +155,7 @@ static void window_network_status_invalidate(rct_window* w)
 static void window_network_status_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     WindowDrawWidgets(w, dpi);
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     thread_local std::string buffer;
     buffer.assign("{BLACK}");

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -163,5 +163,5 @@ static void window_network_status_paint(rct_window* w, rct_drawpixelinfo* dpi)
     gfx_clip_string(buffer.data(), w->widgets[WIDX_BACKGROUND].right - 50);
     ScreenCoordsXY screenCoords(w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2));
     screenCoords.x -= gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2;
-    gfx_draw_string(dpi, buffer.c_str(), COLOUR_BLACK, screenCoords);
+    gfx_draw_string(dpi, screenCoords, buffer.c_str());
 }

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -155,12 +155,11 @@ static void window_network_status_invalidate(rct_window* w)
 static void window_network_status_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     WindowDrawWidgets(w, dpi);
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     thread_local std::string buffer;
     buffer.assign("{BLACK}");
     buffer += window_network_status_text;
-    gfx_clip_string(buffer.data(), w->widgets[WIDX_BACKGROUND].right - 50);
+    gfx_clip_string(buffer.data(), w->widgets[WIDX_BACKGROUND].right - 50, FontSpriteBase::MEDIUM);
     ScreenCoordsXY screenCoords(w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2));
     screenCoords.x -= gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2;
     gfx_draw_string(dpi, screenCoords, buffer.c_str());

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -162,6 +162,6 @@ static void window_network_status_paint(rct_window* w, rct_drawpixelinfo* dpi)
     buffer += window_network_status_text;
     gfx_clip_string(buffer.data(), w->widgets[WIDX_BACKGROUND].right - 50);
     ScreenCoordsXY screenCoords(w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2));
-    screenCoords.x -= gfx_get_string_width(buffer) / 2;
+    screenCoords.x -= gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2;
     gfx_draw_string(dpi, buffer.c_str(), COLOUR_BLACK, screenCoords);
 }

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -374,20 +374,20 @@ static void window_new_campaign_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Number of weeks
     rct_widget* spinnerWidget = &window_new_campaign_widgets[WIDX_WEEKS_SPINNER];
-    gfx_draw_string_left(
-        dpi, w->campaign.no_weeks == 1 ? STR_MARKETING_1_WEEK : STR_X_WEEKS, &w->campaign.no_weeks, w->colours[0],
-        w->windowPos + ScreenCoordsXY{ spinnerWidget->left + 1, spinnerWidget->top });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ spinnerWidget->left + 1, spinnerWidget->top },
+        w->campaign.no_weeks == 1 ? STR_MARKETING_1_WEEK : STR_X_WEEKS, &w->campaign.no_weeks, { w->colours[0] });
 
     screenCoords = w->windowPos + ScreenCoordsXY{ 14, 60 };
 
     // Price per week
     money32 pricePerWeek = AdvertisingCampaignPricePerWeek[w->campaign.campaign_type];
-    gfx_draw_string_left(dpi, STR_MARKETING_COST_PER_WEEK, &pricePerWeek, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_MARKETING_COST_PER_WEEK, &pricePerWeek);
     screenCoords.y += 13;
 
     // Total price
     money32 totalPrice = AdvertisingCampaignPricePerWeek[w->campaign.campaign_type] * w->campaign.no_weeks;
-    gfx_draw_string_left(dpi, STR_MARKETING_TOTAL_COST, &totalPrice, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_MARKETING_TOTAL_COST, &totalPrice);
 }
 
 void WindowCampaignRefreshRides()

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -954,7 +954,7 @@ static void window_new_ride_paint_ride_information(
 
         ft = Formatter();
         ft.Add<money32>(price);
-        DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ width, 51 }, stringId, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ width, 51 }, stringId, ft, { TextAlignment::RIGHT });
     }
 }
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -911,7 +911,7 @@ static void window_new_ride_paint_ride_information(
         const char* drawString = availabilityString;
         ft = Formatter();
         ft.Add<const char*>(drawString);
-        DrawTextEllipsised(dpi, screenPos + ScreenCoordsXY{ 0, 39 }, WW - 2, STR_AVAILABLE_VEHICLES, ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, screenPos + ScreenCoordsXY{ 0, 39 }, WW - 2, STR_AVAILABLE_VEHICLES, ft);
     }
 
     ft = Formatter();

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -936,7 +936,7 @@ static void window_new_ride_paint_ride_information(
             break;
     }
 
-    gfx_draw_string_left(dpi, designCountStringId, ft.Data(), COLOUR_BLACK, screenPos + ScreenCoordsXY{ 0, 51 });
+    DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
 
     // Price
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -901,7 +901,7 @@ static void window_new_ride_paint_ride_information(
     auto ft = Formatter();
     ft.Add<rct_string_id>(rideNaming.Name);
     ft.Add<rct_string_id>(rideNaming.Description);
-    gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, width, STR_NEW_RIDE_NAME_AND_DESCRIPTION, COLOUR_BLACK);
+    DrawTextWrapped(dpi, screenPos, width, STR_NEW_RIDE_NAME_AND_DESCRIPTION, ft);
 
     char availabilityString[AVAILABILITY_STRING_SIZE];
     window_new_ride_list_vehicles_for(item.Type, rideEntry, availabilityString, sizeof(availabilityString));

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -92,7 +92,7 @@ rct_window* window_news_open()
 
 static int32_t window_news_get_item_height()
 {
-    return 4 * font_get_line_height(gCurrentFontSpriteBase) + 2;
+    return 4 * font_get_line_height(FontSpriteBase::SMALL) + 2;
 }
 
 /**
@@ -218,7 +218,7 @@ static void window_news_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t lineHeight = font_get_line_height(gCurrentFontSpriteBase);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::SMALL);
     int32_t itemHeight = window_news_get_item_height();
 
     int32_t y = 0;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -243,7 +243,7 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
             auto ft = Formatter();
             ft.Add<rct_string_id>(DateDayNames[newsItem.Day - 1]);
             ft.Add<rct_string_id>(DateGameMonthNames[date_get_month(newsItem.MonthYear)]);
-            gfx_draw_string_left(dpi, STR_NEWS_DATE_FORMAT, ft.Data(), COLOUR_WHITE, { 2, y });
+            DrawTextBasic(dpi, { 2, y }, STR_NEWS_DATE_FORMAT, ft, { COLOUR_WHITE });
         }
         // Item text
         {

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -249,8 +249,7 @@ static void window_news_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32
         {
             auto ft = Formatter();
             ft.Add<const char*>(newsItem.Text.c_str());
-            gfx_draw_string_left_wrapped(
-                dpi, ft.Data(), { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, COLOUR_BRIGHT_GREEN);
+            DrawTextWrapped(dpi, { 2, y + lineHeight }, 325, STR_BOTTOM_TOOLBAR_NEWS_TEXT, ft);
         }
         // Subject button
         if ((newsItem.TypeHasSubject()) && !(newsItem.HasButton()))

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -547,7 +547,7 @@ static void window_object_load_error_paint(rct_window* w, rct_drawpixelinfo* dpi
     ft = Formatter();
     ft.Add<rct_string_id>(STR_OBJECT_ERROR_WINDOW_FILE);
     ft.Add<utf8*>(file_path.c_str());
-    DrawTextEllipsised(dpi, { w->windowPos.x + 5, w->windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft, COLOUR_BLACK);
+    DrawTextEllipsised(dpi, { w->windowPos.x + 5, w->windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft);
 }
 
 static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -578,7 +578,7 @@ static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinf
 
         // Draw the actual object entry's name...
         screenCoords.x = NAME_COL_LEFT - 3;
-        gfx_draw_string(dpi, strndup(_invalid_entries[i].name, 8), COLOUR_DARK_GREEN, screenCoords);
+        gfx_draw_string(dpi, screenCoords, strndup(_invalid_entries[i].name, 8), { COLOUR_DARK_GREEN });
 
         // ... source game ...
         rct_string_id sourceStringId = object_manager_get_source_game_string(_invalid_entries[i].GetSourceGame());

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -541,8 +541,7 @@ static void window_object_load_error_paint(rct_window* w, rct_drawpixelinfo* dpi
     // Draw explanatory message
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_OBJECT_ERROR_WINDOW_EXPLANATION);
-    gfx_draw_string_left_wrapped(
-        dpi, ft.Data(), w->windowPos + ScreenCoordsXY{ 5, 18 }, WW - 10, STR_BLACK_STRING, COLOUR_BLACK);
+    DrawTextWrapped(dpi, w->windowPos + ScreenCoordsXY{ 5, 18 }, WW - 10, STR_BLACK_STRING, ft);
 
     // Draw file name
     ft = Formatter();

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -583,11 +583,11 @@ static void window_object_load_error_scrollpaint(rct_window* w, rct_drawpixelinf
 
         // ... source game ...
         rct_string_id sourceStringId = object_manager_get_source_game_string(_invalid_entries[i].GetSourceGame());
-        gfx_draw_string_left(dpi, sourceStringId, nullptr, COLOUR_DARK_GREEN, { SOURCE_COL_LEFT - 3, screenCoords.y });
+        DrawTextBasic(dpi, { SOURCE_COL_LEFT - 3, screenCoords.y }, sourceStringId, {}, { COLOUR_DARK_GREEN });
 
         // ... and type
         rct_string_id type = get_object_type_string(&_invalid_entries[i]);
-        gfx_draw_string_left(dpi, type, nullptr, COLOUR_DARK_GREEN, { TYPE_COL_LEFT - 3, screenCoords.y });
+        DrawTextBasic(dpi, { TYPE_COL_LEFT - 3, screenCoords.y }, type, {}, { COLOUR_DARK_GREEN });
     }
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2140,7 +2140,7 @@ static void window_options_advanced_paint(rct_window* w, rct_drawpixelinfo* dpi)
     uint32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
     ScreenCoordsXY screenCoords = { w->windowPos.x + pathWidget.left + 1,
                                     w->windowPos.y + pathWidget.top + static_cast<int32_t>(padding) };
-    DrawTextEllipsised(dpi, screenCoords, 277, STR_STRING, ft, w->colours[1]);
+    DrawTextEllipsised(dpi, screenCoords, 277, STR_STRING, ft, { w->colours[1] });
 }
 
 static OpenRCT2String window_options_advanced_tooltip(

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -893,31 +893,31 @@ static void window_options_display_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_options_draw_tab_images(dpi, w);
 
-    gfx_draw_string_left(
-        dpi, STR_FULLSCREEN_MODE, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_display_widgets[WIDX_FULLSCREEN].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_display_widgets[WIDX_FULLSCREEN].top + 1 }, STR_FULLSCREEN_MODE,
+        w, { w->colours[1] });
 
     // Disable resolution dropdown on "Windowed" and "Fullscreen (desktop)"
-    int32_t colour = w->colours[1];
+    colour_t colour = w->colours[1];
     if (gConfigGeneral.fullscreen_mode != static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::FULLSCREEN))
     {
         colour |= COLOUR_FLAG_INSET;
     }
-    gfx_draw_string_left(
-        dpi, STR_DISPLAY_RESOLUTION, w, colour,
-        w->windowPos + ScreenCoordsXY{ 10 + 15, window_options_display_widgets[WIDX_RESOLUTION].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10 + 15, window_options_display_widgets[WIDX_RESOLUTION].top + 1 },
+        STR_DISPLAY_RESOLUTION, w, { colour });
 
-    gfx_draw_string_left(
-        dpi, STR_UI_SCALING_DESC, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_display_widgets[WIDX_SCALE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_DRAWING_ENGINE, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_display_widgets[WIDX_DRAWING_ENGINE].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_display_widgets[WIDX_SCALE].top + 1 }, STR_UI_SCALING_DESC, w,
+        { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_display_widgets[WIDX_DRAWING_ENGINE].top + 1 },
+        STR_DRAWING_ENGINE, w, { w->colours[1] });
 
     int32_t scale = static_cast<int32_t>(gConfigGeneral.window_scale * 100);
-    gfx_draw_string_left(
-        dpi, STR_WINDOW_OBJECTIVE_VALUE_RATING, &scale, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SCALE].left + 1, w->widgets[WIDX_SCALE].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_SCALE].left + 1, w->widgets[WIDX_SCALE].top + 1 },
+        STR_WINDOW_OBJECTIVE_VALUE_RATING, &scale, { w->colours[1] });
 
     colour = w->colours[1];
     if (gConfigGeneral.drawing_engine == DrawingEngine::Software
@@ -925,9 +925,9 @@ static void window_options_display_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         colour |= COLOUR_FLAG_INSET;
     }
-    gfx_draw_string_left(
-        dpi, STR_SCALING_QUALITY, w, colour,
-        w->windowPos + ScreenCoordsXY{ 25, window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 25, window_options_display_widgets[WIDX_SCALE_QUALITY].top + 1 },
+        STR_SCALING_QUALITY, w, { colour });
 }
 
 #pragma region Rendering Tab
@@ -1328,24 +1328,24 @@ static void window_options_culture_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_options_draw_tab_images(dpi, w);
 
-    gfx_draw_string_left(
-        dpi, STR_OPTIONS_LANGUAGE, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_LANGUAGE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_CURRENCY, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_CURRENCY].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_DISTANCE_AND_SPEED, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_DISTANCE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_TEMPERATURE, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_TEMPERATURE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_HEIGHT_LABELS, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_HEIGHT_LABELS].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_DATE_FORMAT, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_DATE_FORMAT].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_LANGUAGE].top + 1 }, STR_OPTIONS_LANGUAGE,
+        w, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_CURRENCY].top + 1 }, STR_CURRENCY, w,
+        { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_DISTANCE].top + 1 }, STR_DISTANCE_AND_SPEED,
+        w, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_TEMPERATURE].top + 1 }, STR_TEMPERATURE, w,
+        { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_HEIGHT_LABELS].top + 1 }, STR_HEIGHT_LABELS,
+        w, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_culture_widgets[WIDX_DATE_FORMAT].top + 1 }, STR_DATE_FORMAT, w,
+        { w->colours[1] });
 }
 
 #pragma region Audio Tab
@@ -1744,13 +1744,13 @@ static void window_options_controls_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_options_draw_tab_images(dpi, w);
 
-    gfx_draw_string_left(
-        dpi, STR_SHOW_TOOLBAR_BUTTONS_FOR, w, w->colours[1],
-        w->windowPos
-            + ScreenCoordsXY{ 10, window_options_controls_and_interface_widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15 });
-    gfx_draw_string_left(
-        dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_controls_and_interface_widgets[WIDX_THEMES].top + 1 });
+    DrawTextBasic(
+        dpi,
+        w->windowPos + ScreenCoordsXY{ 10, window_options_controls_and_interface_widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15 },
+        STR_SHOW_TOOLBAR_BUTTONS_FOR, w, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_controls_and_interface_widgets[WIDX_THEMES].top + 1 },
+        STR_THEMES_LABEL_CURRENT_THEME, {}, { w->colours[1] });
 }
 
 #pragma region Miscellaneous Tab
@@ -1945,15 +1945,15 @@ static void window_options_misc_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_options_draw_tab_images(dpi, w);
 
-    gfx_draw_string_left(
-        dpi, STR_TITLE_SEQUENCE, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_OPTIONS_SCENARIO_GROUPING, nullptr, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_misc_widgets[WIDX_SCENARIO_GROUPING].top + 1 });
-    gfx_draw_string_left(
-        dpi, STR_DEFAULT_INSPECTION_INTERVAL, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 10, window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_misc_widgets[WIDX_TITLE_SEQUENCE].top + 1 }, STR_TITLE_SEQUENCE,
+        w, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_misc_widgets[WIDX_SCENARIO_GROUPING].top + 1 },
+        STR_OPTIONS_SCENARIO_GROUPING, {}, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 10, window_options_misc_widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1 },
+        STR_DEFAULT_INSPECTION_INTERVAL, w, { w->colours[1] });
 }
 
 #pragma region Advanced Tab
@@ -2111,21 +2111,23 @@ static void window_options_advanced_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     window_options_draw_tab_images(dpi, w);
 
-    gfx_draw_string_left(
-        dpi, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 24, window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1 });
-    gfx_draw_string_left(
-        dpi, window_options_autosave_names[gConfigGeneral.autosave_frequency], nullptr, w->colours[1],
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 24, window_options_advanced_widgets[WIDX_AUTOSAVE].top + 1 },
+        STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, w, { w->colours[1] });
+    DrawTextBasic(
+        dpi,
         w->windowPos
             + ScreenCoordsXY{ window_options_advanced_widgets[WIDX_AUTOSAVE].left + 1,
-                              window_options_advanced_widgets[WIDX_AUTOSAVE].top });
-    gfx_draw_string_left(
-        dpi, STR_AUTOSAVE_AMOUNT, w, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 24, window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 });
+                              window_options_advanced_widgets[WIDX_AUTOSAVE].top },
+        window_options_autosave_names[gConfigGeneral.autosave_frequency], {}, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 24, window_options_advanced_widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
+        STR_AUTOSAVE_AMOUNT, w, { w->colours[1] });
     int32_t autosavesToKeep = static_cast<int32_t>(gConfigGeneral.autosave_amount);
-    gfx_draw_string_left(
-        dpi, STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, &autosavesToKeep, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 });
+    DrawTextBasic(
+        dpi,
+        w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, w->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
+        STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, &autosavesToKeep, { w->colours[1] });
 
     auto ft = Formatter();
     ft.Add<utf8*>(Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2134,7 +2134,7 @@ static void window_options_advanced_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Apply vertical alignment if appropriate.
     int32_t widgetHeight = pathWidget.bottom - pathWidget.top;
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
     uint32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
     ScreenCoordsXY screenCoords = { w->windowPos.x + pathWidget.left + 1,
                                     w->windowPos.y + pathWidget.top + static_cast<int32_t>(padding) };

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -898,9 +898,7 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     rct_widget* widget = &window_park_rating_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
-    gfx_draw_string_left(
-        dpi, STR_PARK_RATING_LABEL, &gParkRating, COLOUR_BLACK,
-        screenPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 });
+    DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_PARK_RATING_LABEL, &gParkRating);
 
     // Graph border
     gfx_fill_rect_inset(
@@ -1033,9 +1031,8 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
     rct_widget* widget = &window_park_guests_widgets[WIDX_PAGE_BACKGROUND];
 
     // Current value
-    gfx_draw_string_left(
-        dpi, STR_GUESTS_IN_PARK_LABEL, &gNumGuestsInPark, COLOUR_BLACK,
-        screenPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 });
+    DrawTextBasic(
+        dpi, screenPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_GUESTS_IN_PARK_LABEL, &gNumGuestsInPark);
 
     // Graph border
     gfx_fill_rect_inset(
@@ -1180,12 +1177,12 @@ static void window_park_price_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto screenCoords = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_PAGE_BACKGROUND].left + 4, w->widgets[WIDX_PAGE_BACKGROUND].top + 30 };
-    gfx_draw_string_left(dpi, STR_INCOME_FROM_ADMISSIONS, &gTotalIncomeFromAdmissions, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_INCOME_FROM_ADMISSIONS, &gTotalIncomeFromAdmissions);
 
     money32 parkEntranceFee = park_get_entrance_fee();
     auto stringId = parkEntranceFee == 0 ? STR_FREE : STR_BOTTOM_TOOLBAR_CASH;
     screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_PRICE].left + 1, w->widgets[WIDX_PRICE].top + 1 };
-    gfx_draw_string_left(dpi, stringId, &parkEntranceFee, w->colours[1], screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &parkEntranceFee, { w->colours[1] });
 }
 
 #pragma endregion
@@ -1288,7 +1285,7 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
     auto ft = Formatter();
     ft.Add<uint32_t>(parkSize);
-    gfx_draw_string_left(dpi, stringIndex, ft.Data(), COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringIndex, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Draw number of rides / attractions
@@ -1296,7 +1293,7 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ft = Formatter();
         ft.Add<uint32_t>(w->list_information_type);
-        gfx_draw_string_left(dpi, STR_NUMBER_OF_RIDES_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_NUMBER_OF_RIDES_LABEL, ft);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
 
@@ -1305,18 +1302,18 @@ static void window_park_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ft = Formatter();
         ft.Add<uint32_t>(w->numberOfStaff);
-        gfx_draw_string_left(dpi, STR_STAFF_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_STAFF_LABEL, ft);
     }
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Draw number of guests in park
     ft = Formatter();
     ft.Add<uint32_t>(gNumGuestsInPark);
-    gfx_draw_string_left(dpi, STR_GUESTS_IN_PARK_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_GUESTS_IN_PARK_LABEL, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
     ft = Formatter();
     ft.Add<uint32_t>(gTotalAdmissions);
-    gfx_draw_string_left(dpi, STR_TOTAL_ADMISSIONS, ft.Data(), COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_TOTAL_ADMISSIONS, ft);
 }
 
 #pragma endregion
@@ -1466,7 +1463,7 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
     screenCoords.y += 5;
 
     // Your objective:
-    gfx_draw_string_left(dpi, STR_OBJECTIVE_LABEL, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_OBJECTIVE_LABEL);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Objective
@@ -1631,7 +1628,7 @@ static void window_park_awards_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     if (count == 0)
-        gfx_draw_string_left(dpi, STR_NO_RECENT_AWARDS, nullptr, COLOUR_BLACK, screenCoords + ScreenCoordsXY{ 6, 6 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 6, 6 }, STR_NO_RECENT_AWARDS);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -916,7 +916,7 @@ static void window_park_rating_paint(rct_window* w, rct_drawpixelinfo* dpi)
         uint32_t axisValue = i * 200;
         auto ft = Formatter();
         ft.Add<uint32_t>(axisValue);
-        DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, STR_GRAPH_AXIS_LABEL, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, STR_GRAPH_AXIS_LABEL, ft, { TextAlignment::RIGHT });
         gfx_fill_rect_inset(
             dpi, { screenPos + ScreenCoordsXY{ 15, 5 }, screenPos + ScreenCoordsXY{ w->width - 32, 5 } }, w->colours[2],
             INSET_RECT_FLAG_BORDER_INSET);
@@ -1051,7 +1051,7 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
         uint32_t axisValue = i * 1000;
         auto ft = Formatter();
         ft.Add<uint32_t>(axisValue);
-        DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, STR_GRAPH_AXIS_LABEL, ft, COLOUR_BLACK, TextAlignment::RIGHT);
+        DrawTextBasic(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, STR_GRAPH_AXIS_LABEL, ft, { TextAlignment::RIGHT });
         gfx_fill_rect_inset(
             dpi, { screenPos + ScreenCoordsXY{ 15, 5 }, screenPos + ScreenCoordsXY{ w->width - 32, 5 } }, w->colours[2],
             INSET_RECT_FLAG_BORDER_INSET);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -729,7 +729,7 @@ static void window_park_entrance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     labelWidget = &window_park_entrance_widgets[WIDX_STATUS];
     DrawTextEllipsised(
         dpi, w->windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width(), STR_BLACK_STRING, ft,
-        COLOUR_BLACK, TextAlignment::CENTRE);
+        { TextAlignment::CENTRE });
 }
 
 /**

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1459,7 +1459,7 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(gScenarioDetails.c_str());
-    screenCoords.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 222, STR_BLACK_STRING, COLOUR_BLACK);
+    screenCoords.y += DrawTextWrapped(dpi, screenCoords, 222, STR_BLACK_STRING, ft);
     screenCoords.y += 5;
 
     // Your objective:
@@ -1488,8 +1488,7 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
             ft.Add<money32>(gScenarioObjective.Currency);
     }
 
-    screenCoords.y += gfx_draw_string_left_wrapped(
-        dpi, ft.Data(), screenCoords, 221, ObjectiveNames[gScenarioObjective.Type], COLOUR_BLACK);
+    screenCoords.y += DrawTextWrapped(dpi, screenCoords, 221, ObjectiveNames[gScenarioObjective.Type], ft);
     screenCoords.y += 5;
 
     // Objective outcome
@@ -1498,14 +1497,14 @@ static void window_park_objective_paint(rct_window* w, rct_drawpixelinfo* dpi)
         if (gScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
         {
             // Objective failed
-            gfx_draw_string_left_wrapped(dpi, nullptr, screenCoords, 222, STR_OBJECTIVE_FAILED, COLOUR_BLACK);
+            DrawTextWrapped(dpi, screenCoords, 222, STR_OBJECTIVE_FAILED);
         }
         else
         {
             // Objective completed
             ft = Formatter();
             ft.Add<money32>(gScenarioCompletedCompanyValue);
-            gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 222, STR_OBJECTIVE_ACHIEVED, COLOUR_BLACK);
+            DrawTextWrapped(dpi, screenCoords, 222, STR_OBJECTIVE_ACHIEVED, ft);
         }
     }
 }
@@ -1620,8 +1619,7 @@ static void window_park_awards_paint(rct_window* w, rct_drawpixelinfo* dpi)
             continue;
 
         gfx_draw_sprite(dpi, ParkAwards[award->Type].sprite, screenCoords, 0);
-        gfx_draw_string_left_wrapped(
-            dpi, nullptr, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, ParkAwards[award->Type].text, COLOUR_BLACK);
+        DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, ParkAwards[award->Type].text);
 
         screenCoords.y += 32;
         count++;

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -349,7 +349,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
     char ping[64];
     snprintf(ping, 64, "%d ms", network_get_player_ping(player));
-    gfx_draw_string(dpi, ping, w->colours[2], screenCoords + ScreenCoordsXY(30, 0));
+    gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(30, 0), ping, { w->colours[2] });
 
     // Draw last action
     screenCoords = w->windowPos + ScreenCoordsXY{ w->width / 2, w->height - 13 };

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -346,7 +346,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_PING);
-    gfx_draw_string_left(dpi, STR_WINDOW_COLOUR_2_STRINGID, ft.Data(), 0, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
     char ping[64];
     snprintf(ping, 64, "%d ms", network_get_player_ping(player));
     gfx_draw_string(dpi, ping, w->colours[2], screenCoords + ScreenCoordsXY(30, 0));
@@ -513,13 +513,13 @@ void window_player_statistics_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto ft = Formatter();
     ft.Add<uint32_t>(network_get_player_commands_ran(player));
-    gfx_draw_string_left(dpi, STR_COMMANDS_RAN, ft.Data(), COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_COMMANDS_RAN, ft);
 
     screenCoords.y += LIST_ROW_HEIGHT;
 
     ft = Formatter();
     ft.Add<uint32_t>(network_get_player_money_spent(player));
-    gfx_draw_string_left(dpi, STR_MONEY_SPENT, ft.Data(), COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_MONEY_SPENT, ft);
 }
 
 static void window_player_set_page(rct_window* w, int32_t page)

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -338,7 +338,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         DrawTextEllipsised(
             dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
-            COLOUR_BLACK, TextAlignment::CENTRE);
+            { TextAlignment::CENTRE });
     }
 
     // Draw ping
@@ -364,7 +364,7 @@ void window_player_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ft.Add<rct_string_id>(STR_ACTION_NA);
     }
-    DrawTextEllipsised(dpi, screenCoords, width, STR_LAST_ACTION_RAN, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+    DrawTextEllipsised(dpi, screenCoords, width, STR_LAST_ACTION_RAN, ft, { TextAlignment::CENTRE });
 
     if (w->viewport != nullptr && w->var_492 != -1)
     {

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -309,7 +309,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         {
             auto ft = Formatter();
             ft.Add<rct_string_id>(STR_RESEARCH_STAGE_UNKNOWN);
-            gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
         }
     }
     else
@@ -362,7 +362,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         {
             ft.Add<rct_string_id>(STR_RESEARCH_STAGE_UNKNOWN);
         }
-        gfx_draw_string_left(dpi, STR_RESEARCH_EXPECTED_LABEL, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
     }
 
     // Last development
@@ -562,8 +562,7 @@ void window_research_funding_page_paint(rct_window* w, rct_drawpixelinfo* dpi, r
 
     int32_t currentResearchLevel = gResearchFundingLevel;
     money32 currentResearchCostPerWeek = research_cost_table[currentResearchLevel];
-    gfx_draw_string_left(
-        dpi, STR_RESEARCH_COST_PER_MONTH, &currentResearchCostPerWeek, COLOUR_BLACK, w->windowPos + ScreenCoordsXY{ 10, 77 });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 10, 77 }, STR_RESEARCH_COST_PER_MONTH, &currentResearchCostPerWeek);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -295,14 +295,14 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
         {
             auto ft = Formatter();
             ft.Add<rct_string_id>(STR_RESEARCH_UNKNOWN);
-            gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 296, STR_RESEARCH_TYPE_LABEL, COLOUR_BLACK);
+            DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_TYPE_LABEL, ft);
             screenCoords.y += 25;
         }
         // Progress
         {
             auto ft = Formatter();
             ft.Add<rct_string_id>(STR_RESEARCH_COMPLETED_AL);
-            gfx_draw_string_left_wrapped(dpi, ft.Data(), screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, COLOUR_BLACK);
+            DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
             screenCoords.y += 15;
         }
 
@@ -341,12 +341,12 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
                 }
             }
         }
-        gfx_draw_string_left_wrapped(dpi, &strings, screenCoords, 296, label, COLOUR_BLACK);
+        DrawTextWrapped(dpi, screenCoords, 296, label, &strings);
         screenCoords.y += 25;
 
         // Progress
         stringId = ResearchStageNames[gResearchProgressStage];
-        gfx_draw_string_left_wrapped(dpi, &stringId, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, COLOUR_BLACK);
+        DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, &stringId);
         screenCoords.y += 15;
 
         // Expected
@@ -395,7 +395,7 @@ void window_research_development_page_paint(rct_window* w, rct_drawpixelinfo* dp
             }
         }
 
-        gfx_draw_string_left_wrapped(dpi, &strings, screenCoords, 266, lastDevelopmentFormat, COLOUR_BLACK);
+        DrawTextWrapped(dpi, screenCoords, 266, lastDevelopmentFormat, &strings);
     }
 }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2668,9 +2668,9 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     widget = &window_ride_main_widgets[WIDX_VIEW];
-    gfx_draw_string_centred(
-        dpi, STR_WINDOW_COLOUR_2_STRINGID,
-        { w->windowPos.x + (widget->left + widget->right - 11) / 2, w->windowPos.y + widget->top }, COLOUR_BLACK, ft.Data());
+    DrawTextBasic(
+        dpi, { w->windowPos.x + (widget->left + widget->right - 11) / 2, w->windowPos.y + widget->top },
+        STR_WINDOW_COLOUR_2_STRINGID, ft.Data(), { TextAlignment::CENTRE });
 
     // Status
     ft = Formatter();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2952,19 +2952,19 @@ static void window_ride_vehicle_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 8, 64 };
 
     // Description
-    screenCoords.y += gfx_draw_string_left_wrapped(
+    screenCoords.y += gfx_draw_string_centred_wrapped(
         dpi, &rideEntry->naming.Description, screenCoords, 300, STR_BLACK_STRING, COLOUR_BLACK);
     screenCoords.y += 2;
 
     // Capacity
-    gfx_draw_string_left(dpi, STR_CAPACITY, &rideEntry->capacity, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_CAPACITY, &rideEntry->capacity, COLOUR_BLACK);
 
     // Excitement Factor
     auto factor = static_cast<int16_t>(rideEntry->excitement_multiplier);
     if (factor > 0)
     {
         screenCoords.y += LIST_ROW_HEIGHT;
-        gfx_draw_string_left(dpi, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_EXCITEMENT_FACTOR, &factor, COLOUR_BLACK);
     }
 
     // Intensity Factor
@@ -2977,7 +2977,7 @@ static void window_ride_vehicle_paint(rct_window* w, rct_drawpixelinfo* dpi)
         else
             screenCoords.y += LIST_ROW_HEIGHT;
 
-        gfx_draw_string_left(dpi, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_INTENSITY_FACTOR, &factor, COLOUR_BLACK);
 
         if (lineHeight != 10)
             screenCoords.x -= 150;
@@ -2988,7 +2988,7 @@ static void window_ride_vehicle_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (factor > 0)
     {
         screenCoords.y += LIST_ROW_HEIGHT;
-        gfx_draw_string_left(dpi, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_NAUSEA_FACTOR, &factor, COLOUR_BLACK);
     }
 }
 
@@ -3684,9 +3684,9 @@ static void window_ride_operating_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride->IsBlockSectioned())
     {
         auto blockSections = ride->num_block_brakes + ride->num_stations;
-        gfx_draw_string_left(
-            dpi, STR_BLOCK_SECTIONS, &blockSections, COLOUR_BLACK,
-            w->windowPos + ScreenCoordsXY{ 21, ride->mode == RideMode::PoweredLaunchBlockSectioned ? 89 : 61 });
+        DrawTextBasic(
+            dpi, w->windowPos + ScreenCoordsXY{ 21, ride->mode == RideMode::PoweredLaunchBlockSectioned ? 89 : 61 },
+            STR_BLOCK_SECTIONS, &blockSections, COLOUR_BLACK);
     }
 }
 
@@ -4079,20 +4079,20 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Inspection label
     widget = &window_ride_maintenance_widgets[WIDX_INSPECTION_INTERVAL];
     screenCoords = w->windowPos + ScreenCoordsXY{ 4, widget->top + 1 };
-    gfx_draw_string_left(dpi, STR_INSPECTION, nullptr, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_INSPECTION);
 
     // Reliability
     widget = &window_ride_maintenance_widgets[WIDX_PAGE_BACKGROUND];
     screenCoords = w->windowPos + ScreenCoordsXY{ widget->left + 4, widget->top + 4 };
 
     uint16_t reliability = ride->reliability_percentage;
-    gfx_draw_string_left(dpi, STR_RELIABILITY_LABEL_1757, &reliability, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_RELIABILITY_LABEL_1757, &reliability);
     window_ride_maintenance_draw_bar(
         w, dpi, screenCoords.x + 103, screenCoords.y, std::max<int32_t>(10, reliability), COLOUR_BRIGHT_GREEN);
     screenCoords.y += 11;
 
     uint16_t downTime = ride->downtime;
-    gfx_draw_string_left(dpi, STR_DOWN_TIME_LABEL_1889, &downTime, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_DOWN_TIME_LABEL_1889, &downTime);
     window_ride_maintenance_draw_bar(w, dpi, screenCoords.x + 103, screenCoords.y, downTime, COLOUR_BRIGHT_RED);
     screenCoords.y += 26;
 
@@ -4108,7 +4108,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
     else
         stringId = STR_TIME_SINCE_LAST_INSPECTION_MORE_THAN_4_HOURS;
 
-    gfx_draw_string_left(dpi, stringId, &lastInspection, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &lastInspection);
     screenCoords.y += 12;
 
     // Last / current breakdown
@@ -4117,7 +4117,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     stringId = (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
     rct_string_id breakdownMessage = RideBreakdownReasonNames[ride->breakdown_reason];
-    gfx_draw_string_left(dpi, stringId, &breakdownMessage, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &breakdownMessage);
     screenCoords.y += 10;
 
     // Mechanic status
@@ -4155,7 +4155,8 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             if (stringId == STR_CALLING_MECHANIC || stringId == STR_NO_MECHANICS_ARE_HIRED_MESSAGE)
             {
-                gfx_draw_string_left_wrapped(dpi, nullptr, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
+                gfx_draw_string_centred_wrapped(
+                    dpi, nullptr, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
             }
             else
             {
@@ -4164,7 +4165,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     auto ft = Formatter();
                     staff->FormatNameTo(ft);
-                    gfx_draw_string_left_wrapped(
+                    gfx_draw_string_centred_wrapped(
                         dpi, ft.Data(), screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
                 }
             }
@@ -5604,7 +5605,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
             ft.Add<rct_string_id>(ratingName);
             rct_string_id stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE
                                                                                : STR_EXCITEMENT_RATING;
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             // Intensity
@@ -5619,7 +5620,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
             else if (ride->intensity >= RIDE_RATING(10, 00))
                 stringId = STR_INTENSITY_RATING_RED;
 
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             // Nausea
@@ -5628,7 +5629,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
             ft.Add<uint32_t>(ride->nausea);
             ft.Add<rct_string_id>(ratingName);
             stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += 2 * LIST_ROW_HEIGHT;
 
             // Horizontal rule
@@ -5642,19 +5643,19 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                 {
                     // Holes
                     holes = ride->holes;
-                    gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_HOLES, &holes);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
                 else
                 {
                     // Max speed
                     maxSpeed = (ride->max_speed * 9) >> 18;
-                    gfx_draw_string_left(dpi, STR_MAX_SPEED, &maxSpeed, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_MAX_SPEED, &maxSpeed);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Average speed
                     averageSpeed = (ride->average_speed * 9) >> 18;
-                    gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &averageSpeed, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_AVERAGE_SPEED, &averageSpeed);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Ride time
@@ -5738,25 +5739,25 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     maxPositiveVerticalGs = ride->max_positive_vertical_g;
                     stringId = maxPositiveVerticalGs >= RIDE_G_FORCES_RED_POS_VERTICAL ? STR_MAX_POSITIVE_VERTICAL_G_RED
                                                                                        : STR_MAX_POSITIVE_VERTICAL_G;
-                    gfx_draw_string_left(dpi, stringId, &maxPositiveVerticalGs, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, stringId, &maxPositiveVerticalGs);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Max. negative vertical G's
                     maxNegativeVerticalGs = ride->max_negative_vertical_g;
                     stringId = maxNegativeVerticalGs <= RIDE_G_FORCES_RED_NEG_VERTICAL ? STR_MAX_NEGATIVE_VERTICAL_G_RED
                                                                                        : STR_MAX_NEGATIVE_VERTICAL_G;
-                    gfx_draw_string_left(dpi, stringId, &maxNegativeVerticalGs, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, stringId, &maxNegativeVerticalGs);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Max lateral G's
                     maxLateralGs = ride->max_lateral_g;
                     stringId = maxLateralGs >= RIDE_G_FORCES_RED_LATERAL ? STR_MAX_LATERAL_G_RED : STR_MAX_LATERAL_G;
-                    gfx_draw_string_left(dpi, stringId, &maxLateralGs, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, stringId, &maxLateralGs);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Total 'air' time
                     totalAirTime = ride->total_air_time * 3;
-                    gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &totalAirTime, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_TOTAL_AIR_TIME, &totalAirTime);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
 
@@ -5764,12 +5765,12 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                 {
                     // Drops
                     drops = ride->drops & 0x3F;
-                    gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_DROPS, &drops);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Highest drop height
                     highestDropHeight = (ride->highest_drop_height * 3) / 4;
-                    gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight, COLOUR_BLACK, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
 
@@ -5779,7 +5780,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     inversions = ride->inversions;
                     if (inversions != 0)
                     {
-                        gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, screenCoords);
+                        DrawTextBasic(dpi, screenCoords, STR_INVERSIONS, &inversions);
                         screenCoords.y += LIST_ROW_HEIGHT;
                     }
                 }
@@ -5787,7 +5788,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
         }
         else
         {
-            gfx_draw_string_left(dpi, STR_NO_TEST_RESULTS_YET, nullptr, COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_NO_TEST_RESULTS_YET);
         }
     }
 }
@@ -6120,7 +6121,7 @@ static void window_ride_graphs_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         if (listType == GRAPH_ALTITUDE)
             scaled_yUnit /= 2;
 
-        gfx_draw_string_left(dpi, stringID, &scaled_yUnit, COLOUR_BLACK, { w->scrolls[0].h_left + 1, y - 4 });
+        DrawTextBasic(dpi, { w->scrolls[0].h_left + 1, y - 4 }, stringID, &scaled_yUnit);
     }
 
     // Time marks
@@ -6128,7 +6129,7 @@ static void window_ride_graphs_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
     for (int32_t x = 0; x < dpi->x + dpi->width; x += 80)
     {
         if (x + 80 >= dpi->x)
-            gfx_draw_string_left(dpi, STR_RIDE_STATS_TIME, &time, COLOUR_BLACK, { x + 2, 1 });
+            DrawTextBasic(dpi, { x + 2, 1 }, STR_RIDE_STATS_TIME, &time);
         time += 5;
     }
 
@@ -6682,7 +6683,7 @@ static void window_ride_income_paint(rct_window* w, rct_drawpixelinfo* dpi)
             stringId = STR_LOSS_PER_ITEM_SOLD;
         }
 
-        gfx_draw_string_left(dpi, stringId, &profit, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, stringId, &profit);
     }
     screenCoords.y += 44;
 
@@ -6703,33 +6704,33 @@ static void window_ride_income_paint(rct_window* w, rct_drawpixelinfo* dpi)
             stringId = STR_LOSS_PER_ITEM_SOLD;
         }
 
-        gfx_draw_string_left(dpi, stringId, &profit, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, stringId, &profit);
     }
     screenCoords.y += 18;
 
     // Income per hour
     if (ride->income_per_hour != MONEY32_UNDEFINED)
     {
-        gfx_draw_string_left(dpi, STR_INCOME_PER_HOUR, &ride->income_per_hour, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_INCOME_PER_HOUR, &ride->income_per_hour);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     // Running cost per hour
     costPerHour = ride->upkeep_cost * 16;
     stringId = ride->upkeep_cost == MONEY16_UNDEFINED ? STR_RUNNING_COST_UNKNOWN : STR_RUNNING_COST_PER_HOUR;
-    gfx_draw_string_left(dpi, stringId, &costPerHour, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &costPerHour);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Profit per hour
     if (ride->profit != MONEY32_UNDEFINED)
     {
-        gfx_draw_string_left(dpi, STR_PROFIT_PER_HOUR, &ride->profit, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_PROFIT_PER_HOUR, &ride->profit);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     screenCoords.y += 5;
 
     // Total profit
-    gfx_draw_string_left(dpi, STR_TOTAL_PROFIT, &ride->total_profit, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_TOTAL_PROFIT, &ride->total_profit);
 }
 
 #pragma endregion
@@ -6881,13 +6882,13 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride->IsRide())
     {
         int16_t customersOnRide = ride->num_riders;
-        gfx_draw_string_left(dpi, STR_CUSTOMERS_ON_RIDE, &customersOnRide, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_CUSTOMERS_ON_RIDE, &customersOnRide);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     // Customers per hour
     customersPerHour = ride_customers_per_hour(ride);
-    gfx_draw_string_left(dpi, STR_CUSTOMERS_PER_HOUR, &customersPerHour, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_CUSTOMERS_PER_HOUR, &customersPerHour);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Popularity
@@ -6901,7 +6902,7 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
         stringId = STR_POPULARITY_PERCENT;
         popularity *= 4;
     }
-    gfx_draw_string_left(dpi, stringId, &popularity, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &popularity);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Satisfaction
@@ -6915,7 +6916,7 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
         stringId = STR_SATISFACTION_PERCENT;
         satisfaction *= 5;
     }
-    gfx_draw_string_left(dpi, stringId, &satisfaction, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &satisfaction);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Queue time
@@ -6923,7 +6924,7 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         queueTime = ride->GetMaxQueueTime();
         stringId = queueTime == 1 ? STR_QUEUE_TIME_MINUTE : STR_QUEUE_TIME_MINUTES;
-        screenCoords.y += gfx_draw_string_left_wrapped(dpi, &queueTime, screenCoords, 308, stringId, COLOUR_BLACK);
+        screenCoords.y += gfx_draw_string_centred_wrapped(dpi, &queueTime, screenCoords, 308, stringId, COLOUR_BLACK);
         screenCoords.y += 5;
     }
 
@@ -6934,7 +6935,7 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter();
         ft.Add<rct_string_id>(GetShopItemDescriptor(shopItem).Naming.Plural);
         ft.Add<uint32_t>(ride->no_primary_items_sold);
-        gfx_draw_string_left(dpi, STR_ITEMS_SOLD, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_ITEMS_SOLD, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
@@ -6946,19 +6947,19 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto ft = Formatter();
         ft.Add<rct_string_id>(GetShopItemDescriptor(shopItem).Naming.Plural);
         ft.Add<uint32_t>(ride->no_secondary_items_sold);
-        gfx_draw_string_left(dpi, STR_ITEMS_SOLD, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_ITEMS_SOLD, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     // Total customers
-    gfx_draw_string_left(dpi, STR_TOTAL_CUSTOMERS, &ride->total_customers, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_TOTAL_CUSTOMERS, &ride->total_customers);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Guests favourite
     if (ride->IsRide())
     {
         stringId = ride->guests_favourite == 1 ? STR_FAVOURITE_RIDE_OF_GUEST : STR_FAVOURITE_RIDE_OF_GUESTS;
-        gfx_draw_string_left(dpi, stringId, &ride->guests_favourite, COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, stringId, &ride->guests_favourite);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     screenCoords.y += 2;
@@ -6967,7 +6968,7 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // If the ride has a build date that is in the future, show it as built this year.
     int16_t age = std::max(date_get_year(ride->GetAge()), 0);
     stringId = age == 0 ? STR_BUILT_THIS_YEAR : age == 1 ? STR_BUILT_LAST_YEAR : STR_BUILT_YEARS_AGO;
-    gfx_draw_string_left(dpi, stringId, &age, COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, stringId, &age);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2678,7 +2678,7 @@ static void window_ride_main_paint(rct_window* w, rct_drawpixelinfo* dpi)
     rct_string_id rideStatus = window_ride_get_status(w, ft);
     DrawTextEllipsised(
         dpi, w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width(), rideStatus, ft,
-        COLOUR_BLACK, TextAlignment::CENTRE);
+        { TextAlignment::CENTRE });
 }
 
 #pragma endregion
@@ -4891,7 +4891,7 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
             }
         }
 
-        DrawTextEllipsised(dpi, { w->windowPos.x + 3, w->windowPos.y + 103 }, 97, STR_STATION_STYLE, {}, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, { w->windowPos.x + 3, w->windowPos.y + 103 }, 97, STR_STATION_STYLE, {});
     }
 }
 
@@ -5688,7 +5688,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                     ft.Add<uint16_t>(0);
                     ft.Add<uint16_t>(0);
                     ft.Add<uint16_t>(0);
-                    DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_TIME, ft, COLOUR_BLACK);
+                    DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_TIME, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
 
@@ -5726,7 +5726,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
                 ft.Add<uint16_t>(0);
                 ft.Add<uint16_t>(0);
                 ft.Add<uint16_t>(0);
-                DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_LENGTH, ft, COLOUR_BLACK);
+                DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_LENGTH, ft);
 
                 screenCoords.y += LIST_ROW_HEIGHT;
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2971,7 +2971,7 @@ static void window_ride_vehicle_paint(rct_window* w, rct_drawpixelinfo* dpi)
     factor = rideEntry->intensity_multiplier;
     if (factor > 0)
     {
-        int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+        int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
         if (lineHeight != 10)
             screenCoords.x += 150;
         else

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2952,8 +2952,8 @@ static void window_ride_vehicle_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 8, 64 };
 
     // Description
-    screenCoords.y += gfx_draw_string_centred_wrapped(
-        dpi, &rideEntry->naming.Description, screenCoords, 300, STR_BLACK_STRING, COLOUR_BLACK);
+    screenCoords.y += DrawTextWrapped(
+        dpi, screenCoords, 300, STR_BLACK_STRING, &rideEntry->naming.Description, { TextAlignment::CENTRE });
     screenCoords.y += 2;
 
     // Capacity
@@ -4155,8 +4155,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             if (stringId == STR_CALLING_MECHANIC || stringId == STR_NO_MECHANICS_ARE_HIRED_MESSAGE)
             {
-                gfx_draw_string_centred_wrapped(
-                    dpi, nullptr, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
+                DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, {}, { TextAlignment::CENTRE });
             }
             else
             {
@@ -4165,8 +4164,7 @@ static void window_ride_maintenance_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     auto ft = Formatter();
                     staff->FormatNameTo(ft);
-                    gfx_draw_string_centred_wrapped(
-                        dpi, ft.Data(), screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, COLOUR_BLACK);
+                    DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 4, 0 }, 280, stringId, ft, { TextAlignment::CENTRE });
                 }
             }
         }
@@ -5578,8 +5576,7 @@ static void window_ride_measurements_paint(rct_window* w, rct_drawpixelinfo* dpi
         rct_widget* widget = &window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND];
 
         ScreenCoordsXY widgetCoords(w->windowPos.x + widget->width() / 2, w->windowPos.y + widget->top + 40);
-        gfx_draw_string_centred_wrapped(
-            dpi, nullptr, widgetCoords, w->width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, COLOUR_BLACK);
+        DrawTextWrapped(dpi, widgetCoords, w->width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::CENTRE });
 
         widgetCoords.x = w->windowPos.x + 4;
         widgetCoords.y = w->windowPos.y + window_ride_measurements_widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;
@@ -6073,7 +6070,7 @@ static void window_ride_graphs_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         // No measurement message
         ScreenCoordsXY stringCoords(widget->width() / 2, widget->height() / 2 - 5);
         int32_t width = widget->width() - 2;
-        gfx_draw_string_centred_wrapped(dpi, message.args.Data(), stringCoords, width, message.str, COLOUR_BLACK);
+        DrawTextWrapped(dpi, stringCoords, width, message.str, message.args, { TextAlignment::CENTRE });
         return;
     }
 
@@ -6924,7 +6921,7 @@ static void window_ride_customer_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         queueTime = ride->GetMaxQueueTime();
         stringId = queueTime == 1 ? STR_QUEUE_TIME_MINUTE : STR_QUEUE_TIME_MINUTES;
-        screenCoords.y += gfx_draw_string_centred_wrapped(dpi, &queueTime, screenCoords, 308, stringId, COLOUR_BLACK);
+        screenCoords.y += DrawTextWrapped(dpi, screenCoords, 308, stringId, &queueTime, { TextAlignment::CENTRE });
         screenCoords.y += 5;
     }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2323,12 +2323,12 @@ static void window_ride_construction_paint(rct_window* w, rct_drawpixelinfo* dpi
     // Draw cost
     screenCoords = { w->windowPos.x + widget->midX(), w->windowPos.y + widget->bottom - 23 };
     if (_rideConstructionState != RIDE_CONSTRUCTION_STATE_PLACE)
-        gfx_draw_string_centred(dpi, STR_BUILD_THIS, screenCoords, COLOUR_BLACK, w);
+        DrawTextBasic(dpi, screenCoords, STR_BUILD_THIS, w, { TextAlignment::CENTRE });
 
     screenCoords.y += 11;
     if (_currentTrackPrice != MONEY32_UNDEFINED && !(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        gfx_draw_string_centred(dpi, STR_COST_LABEL, screenCoords, COLOUR_BLACK, static_cast<void*>(&_currentTrackPrice));
+        DrawTextBasic(dpi, screenCoords, STR_COST_LABEL, static_cast<void*>(&_currentTrackPrice), { TextAlignment::CENTRE });
     }
 }
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -560,9 +560,9 @@ static void window_ride_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_ride_list_draw_tab_images(dpi, w);
 
     // Draw number of attractions on bottom
-    gfx_draw_string_left(
-        dpi, ride_list_statusbar_count_strings[w->page], &w->no_list_items, COLOUR_BLACK,
-        w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_LIST].bottom + 2 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_LIST].bottom + 2 }, ride_list_statusbar_count_strings[w->page],
+        &w->no_list_items);
 }
 
 /**

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -594,7 +594,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         // Ride name
         auto ft = Formatter();
         ride->FormatNameTo(ft);
-        DrawTextEllipsised(dpi, { 0, y - 1 }, 159, format, ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, { 0, y - 1 }, 159, format, ft);
 
         // Ride information
         ft = Formatter();
@@ -746,7 +746,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
             ft.Rewind();
             ft.Add<rct_string_id>(formatSecondary);
         }
-        DrawTextEllipsised(dpi, { 160, y - 1 }, 157, format, ft, COLOUR_BLACK);
+        DrawTextEllipsised(dpi, { 160, y - 1 }, 157, format, ft);
         y += SCROLLABLE_ROW_HEIGHT;
     }
 }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -483,9 +483,9 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         shorten_path(path, sizeof(path), scenario->path, w->width - 6);
 
         const utf8* pathPtr = path;
-        gfx_draw_string_left(
-            dpi, STR_STRING, static_cast<void*>(&pathPtr), w->colours[1],
-            w->windowPos + ScreenCoordsXY{ 3, w->height - 3 - 11 });
+        DrawTextBasic(
+            dpi, w->windowPos + ScreenCoordsXY{ 3, w->height - 3 - 11 }, STR_STRING, static_cast<void*>(&pathPtr),
+            { w->colours[1] });
     }
 
     // Scenario name

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -110,6 +110,11 @@ static void window_scenarioselect_invalidate(rct_window *w);
 static void window_scenarioselect_paint(rct_window *w, rct_drawpixelinfo *dpi);
 static void window_scenarioselect_scrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
 
+static bool ScenarioSelectUseSmallFont()
+{
+    return ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT;
+}
+
 static rct_window_event_list window_scenarioselect_events([](auto& events)
 {
     events.close = &window_scenarioselect_close;
@@ -432,8 +437,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     WindowDrawWidgets(w, dpi);
 
-    format = (ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT) ? STR_SMALL_WINDOW_COLOUR_2_STRINGID
-                                                                                   : STR_WINDOW_COLOUR_2_STRINGID;
+    format = ScenarioSelectUseSmallFont() ? STR_SMALL_WINDOW_COLOUR_2_STRINGID : STR_WINDOW_COLOUR_2_STRINGID;
 
     // Text for each tab
     for (uint32_t i = 0; i < std::size(ScenarioOriginStringIds); i++)
@@ -550,12 +554,8 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     gfx_clear(dpi, paletteIndex);
 
-    rct_string_id highlighted_format = (ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT)
-        ? STR_WHITE_STRING
-        : STR_WINDOW_COLOUR_2_STRINGID;
-    rct_string_id unhighlighted_format = (ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT)
-        ? STR_WHITE_STRING
-        : STR_BLACK_STRING;
+    rct_string_id highlighted_format = ScenarioSelectUseSmallFont() ? STR_WHITE_STRING : STR_WINDOW_COLOUR_2_STRINGID;
+    rct_string_id unhighlighted_format = ScenarioSelectUseSmallFont() ? STR_WHITE_STRING : STR_BLACK_STRING;
 
     bool wide = gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN || _titleEditor;
 
@@ -655,7 +655,7 @@ static void draw_category_heading(
     // Get string dimensions
     utf8* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, stringId, nullptr);
-    int32_t categoryStringHalfWidth = (gfx_get_string_width(buffer) / 2) + 4;
+    int32_t categoryStringHalfWidth = (gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2) + 4;
     int32_t strLeft = centreX - categoryStringHalfWidth;
     int32_t strRight = centreX + categoryStringHalfWidth;
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -453,7 +453,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         }
 
         ScreenCoordsXY stringCoords(widget->midX() + w->windowPos.x, widget->midY() + w->windowPos.y - 3);
-        gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, 87, format, COLOUR_AQUAMARINE);
+        DrawTextWrapped(dpi, stringCoords, 87, format, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
     }
 
     // Return if no scenario highlighted
@@ -468,8 +468,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                   window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5 };
             DrawTextEllipsised(
                 dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, {}, COLOUR_BLACK, TextAlignment::CENTRE);
-            gfx_draw_string_left_wrapped(
-                dpi, nullptr, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_LOCKED_DESC, COLOUR_BLACK);
+            DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_LOCKED_DESC);
         }
         return;
     }
@@ -503,7 +502,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->details);
-    screenPos.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, 170, STR_BLACK_STRING, COLOUR_BLACK) + 5;
+    screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_BLACK_STRING, ft) + 5;
 
     // Scenario objective
     ft = Formatter();
@@ -527,7 +526,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         else
             ft.Add<money32>(scenario->objective_arg_2);
     }
-    screenPos.y += gfx_draw_string_left_wrapped(dpi, ft.Data(), screenPos, 170, STR_OBJECTIVE, COLOUR_BLACK) + 5;
+    screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_OBJECTIVE, ft) + 5;
 
     // Scenario score
     if (scenario->highscore != nullptr)
@@ -542,8 +541,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<const char*>(completedByName);
         ft.Add<money32>(scenario->highscore->company_value);
-        screenPos.y += gfx_draw_string_left_wrapped(
-            dpi, ft.Data(), screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, COLOUR_BLACK);
+        screenPos.y += DrawTextWrapped(dpi, screenPos, 170, STR_COMPLETED_BY_WITH_COMPANY_VALUE, ft);
     }
 }
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -285,10 +285,10 @@ static int32_t get_scenario_list_item_size()
         return 24;
 
     // Scenario title
-    int32_t lineHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     // 'Completed by' line
-    lineHeight += font_get_line_height(FONT_SPRITE_BASE_SMALL);
+    lineHeight += font_get_line_height(FontSpriteBase::SMALL);
 
     return lineHeight;
 }
@@ -479,7 +479,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         utf8 path[MAX_PATH];
 
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         shorten_path(path, sizeof(path), scenario->path, w->width - 6);
 
         const utf8* pathPtr = path;
@@ -569,7 +569,7 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
     const int32_t scenarioItemHeight = get_scenario_list_item_size();
 
     // Scenario title
-    int32_t scenarioTitleHeight = font_get_line_height(FONT_SPRITE_BASE_MEDIUM);
+    int32_t scenarioTitleHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     int32_t y = 0;
     for (const auto& listItem : _listItems)
@@ -613,7 +613,7 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                 colour = isDisabled ? w->colours[1] | COLOUR_FLAG_INSET : COLOUR_BLACK;
                 if (isDisabled)
                 {
-                    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
+                    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
                 }
                 gfx_draw_string_centred(dpi, format, { wide ? 270 : 210, y + 1 }, colour, ft.Data());
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -438,6 +438,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
 
     format = ScenarioSelectUseSmallFont() ? STR_SMALL_WINDOW_COLOUR_2_STRINGID : STR_WINDOW_COLOUR_2_STRINGID;
+    FontSpriteBase fontSpriteBase = ScenarioSelectUseSmallFont() ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM;
 
     // Text for each tab
     for (uint32_t i = 0; i < std::size(ScenarioOriginStringIds); i++)
@@ -457,7 +458,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
         }
 
         ScreenCoordsXY stringCoords(widget->midX() + w->windowPos.x, widget->midY() + w->windowPos.y - 3);
-        DrawTextWrapped(dpi, stringCoords, 87, format, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, stringCoords, 87, format, ft, { COLOUR_AQUAMARINE, fontSpriteBase, TextAlignment::CENTRE });
     }
 
     // Return if no scenario highlighted
@@ -471,7 +472,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 + ScreenCoordsXY{ window_scenarioselect_widgets[WIDX_SCENARIOLIST].right + 4,
                                   window_scenarioselect_widgets[WIDX_TABCONTENT].top + 5 };
             DrawTextEllipsised(
-                dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, {}, COLOUR_BLACK, TextAlignment::CENTRE);
+                dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_SCENARIO_LOCKED, {}, { TextAlignment::CENTRE });
             DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 0, 15 }, 170, STR_SCENARIO_LOCKED_DESC);
         }
         return;
@@ -482,8 +483,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         utf8 path[MAX_PATH];
 
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-        shorten_path(path, sizeof(path), scenario->path, w->width - 6);
+        shorten_path(path, sizeof(path), scenario->path, w->width - 6, FontSpriteBase::MEDIUM);
 
         const utf8* pathPtr = path;
         DrawTextBasic(
@@ -499,7 +499,7 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ft.Add<rct_string_id>(STR_STRING);
     ft.Add<const char*>(scenario->name);
     DrawTextEllipsised(
-        dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_WINDOW_COLOUR_2_STRINGID, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+        dpi, screenPos + ScreenCoordsXY{ 85, 0 }, 170, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
     screenPos.y += 15;
 
     // Scenario details
@@ -607,11 +607,8 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                 ft.Add<rct_string_id>(STR_STRING);
                 ft.Add<char*>(buffer);
                 colour_t colour = isDisabled ? w->colours[1] | COLOUR_FLAG_INSET : COLOUR_BLACK;
-                if (isDisabled)
-                {
-                    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
-                }
-                DrawTextBasic(dpi, { wide ? 270 : 210, y + 1 }, format, ft, { colour, TextAlignment::CENTRE });
+                FontSpriteBase fontSpriteBase = isDisabled ? FontSpriteBase::MEDIUM_DARK : FontSpriteBase::MEDIUM;
+                DrawTextBasic(dpi, { wide ? 270 : 210, y + 1 }, format, ft, { colour, fontSpriteBase, TextAlignment::CENTRE });
 
                 // Check if scenario is completed
                 if (isCompleted)

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -549,8 +549,6 @@ static void window_scenarioselect_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
 static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
 {
-    int32_t colour;
-
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     gfx_clear(dpi, paletteIndex);
 
@@ -610,12 +608,12 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                 auto ft = Formatter();
                 ft.Add<rct_string_id>(STR_STRING);
                 ft.Add<char*>(buffer);
-                colour = isDisabled ? w->colours[1] | COLOUR_FLAG_INSET : COLOUR_BLACK;
+                colour_t colour = isDisabled ? w->colours[1] | COLOUR_FLAG_INSET : COLOUR_BLACK;
                 if (isDisabled)
                 {
                     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
                 }
-                gfx_draw_string_centred(dpi, format, { wide ? 270 : 210, y + 1 }, colour, ft.Data());
+                DrawTextBasic(dpi, { wide ? 270 : 210, y + 1 }, format, ft, { colour, TextAlignment::CENTRE });
 
                 // Check if scenario is completed
                 if (isCompleted)
@@ -634,8 +632,8 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                     ft.Add<rct_string_id>(STR_COMPLETED_BY);
                     ft.Add<rct_string_id>(STR_STRING);
                     ft.Add<char*>(buffer);
-                    gfx_draw_string_centred(
-                        dpi, format, { wide ? 270 : 210, y + scenarioTitleHeight + 1 }, COLOUR_BLACK, ft.Data());
+                    DrawTextBasic(
+                        dpi, { wide ? 270 : 210, y + scenarioTitleHeight + 1 }, format, ft, { TextAlignment::CENTRE });
                 }
 
                 y += scenarioItemHeight;
@@ -648,13 +646,13 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
 static void draw_category_heading(
     rct_window* w, rct_drawpixelinfo* dpi, int32_t left, int32_t right, int32_t y, rct_string_id stringId)
 {
-    uint8_t baseColour = w->colours[1];
-    uint8_t lightColour = ColourMapA[baseColour].lighter;
-    uint8_t darkColour = ColourMapA[baseColour].mid_dark;
+    colour_t baseColour = w->colours[1];
+    colour_t lightColour = ColourMapA[baseColour].lighter;
+    colour_t darkColour = ColourMapA[baseColour].mid_dark;
 
     // Draw string
     int32_t centreX = (left + right) / 2;
-    gfx_draw_string_centred(dpi, stringId, { centreX, y }, baseColour, nullptr);
+    DrawTextBasic(dpi, { centreX, y }, stringId, {}, { baseColour, TextAlignment::CENTRE });
 
     // Get string dimensions
     utf8* buffer = gCommonStringFormatBuffer;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1178,8 +1178,7 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     auto ft = Formatter();
     ft.Add<rct_string_id>(sceneryEntry != nullptr ? sceneryEntry->name : static_cast<rct_string_id>(STR_UNKNOWN_OBJECT_TYPE));
-    DrawTextEllipsised(
-        dpi, { w->windowPos.x + 3, w->windowPos.y + w->height - 13 }, w->width - 19, STR_BLACK_STRING, ft, COLOUR_BLACK);
+    DrawTextEllipsised(dpi, { w->windowPos.x + 3, w->windowPos.y + w->height - 13 }, w->width - 19, STR_BLACK_STRING, ft);
 }
 
 /**

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1172,8 +1172,8 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
         // -14
         DrawTextBasic(
-            dpi, w->windowPos + ScreenCoordsXY{ w->width - 0x1A, w->height - 13 }, STR_COST_LABEL, ft, COLOUR_BLACK,
-            TextAlignment::RIGHT);
+            dpi, w->windowPos + ScreenCoordsXY{ w->width - 0x1A, w->height - 13 }, STR_COST_LABEL, ft,
+            { TextAlignment::RIGHT });
     }
 
     auto ft = Formatter();

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -216,7 +216,8 @@ static void window_scenery_scatter_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto preview = window_scenery_scatter_widgets[WIDX_PREVIEW];
         auto screenCoords = ScreenCoordsXY{ w->windowPos.x + preview.midX(), w->windowPos.y + preview.midY() };
-        gfx_draw_string_centred(
-            dpi, STR_LAND_TOOL_SIZE_VALUE, screenCoords - ScreenCoordsXY{ 0, 2 }, COLOUR_BLACK, &gWindowSceneryScatterSize);
+        DrawTextBasic(
+            dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, &gWindowSceneryScatterSize,
+            { TextAlignment::CENTRE });
     }
 }

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -400,20 +400,20 @@ static void window_server_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     WindowDrawWidgets(w, dpi);
 
-    gfx_draw_string_left(
-        dpi, STR_PLAYER_NAME, nullptr, COLOUR_WHITE,
-        w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PLAYER_NAME_INPUT].top });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PLAYER_NAME_INPUT].top }, STR_PLAYER_NAME, nullptr,
+        { COLOUR_WHITE });
 
     // Draw version number
     std::string version = network_get_version();
     const char* versionCStr = version.c_str();
-    gfx_draw_string_left(
-        dpi, STR_NETWORK_VERSION, static_cast<void*>(&versionCStr), COLOUR_WHITE,
-        w->windowPos + ScreenCoordsXY{ 324, w->widgets[WIDX_START_SERVER].top + 1 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 324, w->widgets[WIDX_START_SERVER].top + 1 }, STR_NETWORK_VERSION,
+        static_cast<void*>(&versionCStr), { COLOUR_WHITE });
 
-    gfx_draw_string_left(
-        dpi, _statusText, static_cast<void*>(&_numPlayersOnline), COLOUR_WHITE,
-        w->windowPos + ScreenCoordsXY{ 8, w->height - 15 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 8, w->height - 15 }, _statusText, static_cast<void*>(&_numPlayersOnline),
+        { COLOUR_WHITE });
 }
 
 static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -442,7 +442,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
             w->widgets[WIDX_LIST].tooltip = STR_NETWORK_VERSION_TIP;
         }
 
-        int32_t colour = w->colours[1];
+        colour_t colour = w->colours[1];
         if (serverDetails.Favourite)
         {
             colour = COLOUR_YELLOW;
@@ -475,7 +475,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         // Finally, draw the server information.
         auto ft = Formatter();
         ft.Add<const char*>(serverInfoToShow);
-        DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, colour);
+        DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, { colour });
 
         int32_t right = width - 7 - SCROLLBAR_WIDTH;
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -460,7 +460,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         {
             snprintf(players, sizeof(players), "%d/%d", serverDetails.Players, serverDetails.MaxPlayers);
         }
-        const int16_t numPlayersStringWidth = gfx_get_string_width(players);
+        const int16_t numPlayersStringWidth = gfx_get_string_width(players, FontSpriteBase::MEDIUM);
 
         // How much space we have for the server info depends on the size of everything rendered after.
         const int16_t spaceAvailableForInfo = width - numPlayersStringWidth - SCROLLBAR_WIDTH - 35;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -506,7 +506,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
 
         // Draw number of players
         screenCoords.x = right - numPlayersStringWidth;
-        gfx_draw_string(dpi, players, w->colours[1], screenCoords + ScreenCoordsXY{ 0, 3 });
+        gfx_draw_string(dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, players, { w->colours[1] });
 
         screenCoords.y += ITEM_HEIGHT;
     }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -319,20 +319,19 @@ static void window_server_start_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     WindowDrawWidgets(w, dpi);
 
-    gfx_draw_string_left(
-        dpi, STR_PORT, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PORT_INPUT].top });
-    gfx_draw_string_left(
-        dpi, STR_SERVER_NAME, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_NAME_INPUT].top });
-    gfx_draw_string_left(
-        dpi, STR_SERVER_DESCRIPTION, nullptr, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_DESCRIPTION_INPUT].top });
-    gfx_draw_string_left(
-        dpi, STR_SERVER_GREETING, nullptr, w->colours[1],
-        w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_GREETING_INPUT].top });
-    gfx_draw_string_left(
-        dpi, STR_PASSWORD, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PASSWORD_INPUT].top });
-    gfx_draw_string_left(
-        dpi, STR_MAX_PLAYERS, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_MAXPLAYERS].top });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PORT_INPUT].top }, STR_PORT, {}, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_NAME_INPUT].top }, STR_SERVER_NAME, {}, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_DESCRIPTION_INPUT].top }, STR_SERVER_DESCRIPTION, {},
+        { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, {},
+        { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PASSWORD_INPUT].top }, STR_PASSWORD, {}, { w->colours[1] });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_MAXPLAYERS].top }, STR_MAX_PLAYERS, {}, { w->colours[1] });
 }
 
 #endif

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -526,14 +526,14 @@ private:
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<const char*>(shortcut.CustomString.c_str());
         }
-        DrawTextEllipsised(&dpi, { 0, y - 1 }, bindingOffset, format, ft, COLOUR_BLACK);
+        DrawTextEllipsised(&dpi, { 0, y - 1 }, bindingOffset, format, ft);
 
         if (!shortcut.Binding.empty())
         {
             ft = Formatter();
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<const char*>(shortcut.Binding.c_str());
-            DrawTextEllipsised(&dpi, { bindingOffset, y - 1 }, 150, format, ft, COLOUR_BLACK);
+            DrawTextEllipsised(&dpi, { bindingOffset, y - 1 }, 150, format, ft);
         }
     }
 };

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -134,7 +134,7 @@ public:
             ft.Add<rct_string_id>(STR_STRING);
             ft.Add<const char*>(_shortcutCustomName.c_str());
         }
-        gfx_draw_string_centred_wrapped(&dpi, ft.Data(), stringCoords, 242, STR_SHORTCUT_CHANGE_PROMPT, COLOUR_BLACK);
+        DrawTextWrapped(&dpi, stringCoords, 242, STR_SHORTCUT_CHANGE_PROMPT, ft, { TextAlignment::CENTRE });
     }
 
 private:

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1097,13 +1097,13 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<money32>(GetStaffWage(peep->AssignedStaffType));
-        gfx_draw_string_left(dpi, STR_STAFF_STAT_WAGES, ft.Data(), COLOUR_BLACK, screenCoords);
+        DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     auto ft = Formatter();
     ft.Add<int32_t>(peep->GetHireDate());
-    gfx_draw_string_left(dpi, STR_STAFF_STAT_EMPLOYED_FOR, ft.Data(), COLOUR_BLACK, screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_EMPLOYED_FOR, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     switch (peep->AssignedStaffType)
@@ -1111,32 +1111,32 @@ void window_staff_stats_paint(rct_window* w, rct_drawpixelinfo* dpi)
         case StaffType::Handyman:
             ft = Formatter();
             ft.Add<uint16_t>(peep->StaffLawnsMown);
-            gfx_draw_string_left(dpi, STR_STAFF_STAT_LAWNS_MOWN, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_LAWNS_MOWN, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             ft = Formatter();
             ft.Add<uint16_t>(peep->StaffGardensWatered);
-            gfx_draw_string_left(dpi, STR_STAFF_STAT_GARDENS_WATERED, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_GARDENS_WATERED, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             ft = Formatter();
             ft.Add<uint16_t>(peep->StaffLitterSwept);
-            gfx_draw_string_left(dpi, STR_STAFF_STAT_LITTER_SWEPT, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_LITTER_SWEPT, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             ft = Formatter();
             ft.Add<uint16_t>(peep->StaffBinsEmptied);
-            gfx_draw_string_left(dpi, STR_STAFF_STAT_BINS_EMPTIED, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_BINS_EMPTIED, ft);
             break;
         case StaffType::Mechanic:
             ft = Formatter();
             ft.Add<uint16_t>(peep->StaffRidesInspected);
-            gfx_draw_string_left(dpi, STR_STAFF_STAT_RIDES_INSPECTED, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_RIDES_INSPECTED, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             ft = Formatter();
             ft.Add<uint16_t>(peep->StaffRidesFixed);
-            gfx_draw_string_left(dpi, STR_STAFF_STAT_RIDES_FIXED, ft.Data(), COLOUR_BLACK, screenCoords);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_RIDES_FIXED, ft);
             break;
         case StaffType::Security:
         case StaffType::Entertainer:

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -943,7 +943,7 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];
     auto screenPos = w->windowPos + ScreenCoordsXY{ widget->midX(), widget->top };
     int32_t width = widget->width();
-    DrawTextEllipsised(dpi, screenPos, width, STR_BLACK_STRING, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+    DrawTextEllipsised(dpi, screenPos, width, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
 }
 
 /**

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -104,5 +104,5 @@ static void window_staff_fire_paint(rct_window* w, rct_drawpixelinfo* dpi)
     peep->FormatNameTo(ft);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + WW / 2, w->windowPos.y + (WH / 2) - 3);
-    gfx_draw_string_centred_wrapped(dpi, ft.Data(), stringCoords, WW - 4, STR_FIRE_STAFF_ID, COLOUR_BLACK);
+    DrawTextWrapped(dpi, stringCoords, WW - 4, STR_FIRE_STAFF_ID, ft, { TextAlignment::CENTRE });
 }

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -287,15 +287,14 @@ public:
         {
             auto ft = Formatter();
             ft.Add<money32>(GetStaffWage(GetSelectedStaffType()));
-            gfx_draw_string_left(
-                &dpi, STR_COST_PER_MONTH, ft.Data(), COLOUR_BLACK, windowPos + ScreenCoordsXY{ width - 155, 32 });
+            DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ width - 155, 32 }, STR_COST_PER_MONTH, ft);
         }
 
         if (GetSelectedStaffType() != StaffType::Entertainer)
         {
-            gfx_draw_string_left(
-                &dpi, STR_UNIFORM_COLOUR, nullptr, COLOUR_BLACK,
-                windowPos + ScreenCoordsXY{ 6, widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + 1 });
+            DrawTextBasic(
+                &dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].top + 1 },
+                STR_UNIFORM_COLOUR);
         }
 
         auto namingConvention = GetStaffNamingConvention(GetSelectedStaffType());
@@ -305,9 +304,8 @@ public:
         ft.Add<uint16_t>(_staffList.size());
         ft.Add<rct_string_id>(staffTypeStringId);
 
-        gfx_draw_string_left(
-            &dpi, STR_STAFF_LIST_COUNTER, ft.Data(), COLOUR_BLACK,
-            windowPos + ScreenCoordsXY{ 4, widgets[WIDX_STAFF_LIST_LIST].bottom + 2 });
+        DrawTextBasic(
+            &dpi, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_STAFF_LIST_LIST].bottom + 2 }, STR_STAFF_LIST_COUNTER, ft);
     }
 
     ScreenSize OnScrollGetSize(int32_t scrollIndex) override

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -407,11 +407,11 @@ public:
 
                 auto ft = Formatter();
                 peep->FormatNameTo(ft);
-                DrawTextEllipsised(&dpi, { 0, y }, nameColumnSize, format, ft, COLOUR_BLACK);
+                DrawTextEllipsised(&dpi, { 0, y }, nameColumnSize, format, ft);
 
                 ft = Formatter();
                 peep->FormatActionTo(ft);
-                DrawTextEllipsised(&dpi, { actionOffset, y }, actionColumnSize, format, ft, COLOUR_BLACK);
+                DrawTextEllipsised(&dpi, { actionOffset, y }, actionColumnSize, format, ft);
 
                 // True if a patrol path is set for the worker
                 if (gStaffModes[peep->StaffId] == StaffMode::Patrol)

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -325,7 +325,7 @@ private:
             &dpi, { screenCoords - ScreenCoordsXY{ 1, 1 }, screenCoords + ScreenCoordsXY{ width + 1, height + 1 } },
             PALETTE_INDEX_12);
         gfx_fill_rect(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ width, height } }, PALETTE_INDEX_0);
-        gfx_draw_string(&dpi, static_cast<const char*>(gTextInput->ImeBuffer), COLOUR_DARK_GREEN, screenCoords);
+        gfx_draw_string(&dpi, screenCoords, static_cast<const char*>(gTextInput->ImeBuffer), { COLOUR_DARK_GREEN });
     }
 
     void ExecuteCallback(bool hasValue)

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -199,7 +199,6 @@ public:
         screenCoords.y = windowPos.y + 25;
 
         int32_t no_lines = 0;
-        FontSpriteBase font_height = FontSpriteBase::SMALL;
 
         if (_descriptionStringId == STR_NONE)
         {
@@ -223,7 +222,7 @@ public:
 
         // String length needs to add 12 either side of box
         // +13 for cursor when max length.
-        gfx_wrap_string(wrapped_string, WW - (24 + 13), &no_lines, &font_height);
+        gfx_wrap_string(wrapped_string, WW - (24 + 13), &no_lines);
 
         gfx_fill_rect_inset(
             &dpi, { { windowPos.x + 10, screenCoords.y }, { windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3 } },
@@ -310,8 +309,7 @@ public:
 
         // String length needs to add 12 either side of box +13 for cursor when max length.
         int32_t numLines{};
-        FontSpriteBase fontHeight = FontSpriteBase::SMALL;
-        gfx_wrap_string(wrappedString.data(), WW - (24 + 13), &numLines, &fontHeight);
+        gfx_wrap_string(wrappedString.data(), WW - (24 + 13), &numLines);
         return numLines * 10 + WH;
     }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -199,7 +199,7 @@ public:
         screenCoords.y = windowPos.y + 25;
 
         int32_t no_lines = 0;
-        int32_t font_height = 0;
+        FontSpriteBase font_height = FontSpriteBase::SMALL;
 
         if (_descriptionStringId == STR_NONE)
         {
@@ -215,7 +215,7 @@ public:
 
         screenCoords.y += 25;
 
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
         char wrapped_string[TEXT_INPUT_SIZE];
         safe_strcpy(wrapped_string, _buffer.data(), TEXT_INPUT_SIZE);
@@ -309,7 +309,7 @@ public:
 
         // String length needs to add 12 either side of box +13 for cursor when max length.
         int32_t numLines{};
-        int32_t fontHeight{};
+        FontSpriteBase fontHeight = FontSpriteBase::SMALL;
         gfx_wrap_string(wrappedString.data(), WW - (24 + 13), &numLines, &fontHeight);
         return numLines * 10 + WH;
     }

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -215,14 +215,12 @@ public:
 
         screenCoords.y += 25;
 
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
         char wrapped_string[TEXT_INPUT_SIZE];
         safe_strcpy(wrapped_string, _buffer.data(), TEXT_INPUT_SIZE);
 
         // String length needs to add 12 either side of box
         // +13 for cursor when max length.
-        gfx_wrap_string(wrapped_string, WW - (24 + 13), &no_lines);
+        gfx_wrap_string(wrapped_string, WW - (24 + 13), FontSpriteBase::MEDIUM, &no_lines);
 
         gfx_fill_rect_inset(
             &dpi, { { windowPos.x + 10, screenCoords.y }, { windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3 } },
@@ -239,7 +237,7 @@ public:
         for (int32_t line = 0; line <= no_lines; line++)
         {
             screenCoords.x = windowPos.x + 12;
-            gfx_draw_string_no_formatting(&dpi, wrap_pointer, colours[1], screenCoords);
+            gfx_draw_string_no_formatting(&dpi, screenCoords, wrap_pointer, { colours[1], FontSpriteBase::MEDIUM });
 
             size_t string_length = get_string_size(wrap_pointer) - 1;
 
@@ -309,7 +307,7 @@ public:
 
         // String length needs to add 12 either side of box +13 for cursor when max length.
         int32_t numLines{};
-        gfx_wrap_string(wrappedString.data(), WW - (24 + 13), &numLines);
+        gfx_wrap_string(wrappedString.data(), WW - (24 + 13), FontSpriteBase::MEDIUM, &numLines);
         return numLines * 10 + WH;
     }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -248,7 +248,7 @@ public:
                 // Make a copy of the string for measuring the width.
                 char temp_string[TEXT_INPUT_SIZE] = { 0 };
                 std::memcpy(temp_string, wrap_pointer, gTextInput->SelectionStart - char_count);
-                cursorX = windowPos.x + 13 + gfx_get_string_width_no_formatting(temp_string);
+                cursorX = windowPos.x + 13 + gfx_get_string_width_no_formatting(temp_string, FontSpriteBase::MEDIUM);
                 cursorY = screenCoords.y;
 
                 int32_t textWidth = 6;
@@ -259,7 +259,7 @@ public:
                     utf8 tmp[5] = { 0 }; // This is easier than setting temp_string[0..5]
                     uint32_t codepoint = utf8_get_next(_buffer.data() + gTextInput->SelectionStart, nullptr);
                     utf8_write_codepoint(tmp, codepoint);
-                    textWidth = std::max(gfx_get_string_width_no_formatting(tmp) - 2, 4);
+                    textWidth = std::max(gfx_get_string_width_no_formatting(tmp, FontSpriteBase::MEDIUM) - 2, 4);
                 }
 
                 if (_cursorBlink > 15)
@@ -316,7 +316,7 @@ public:
 private:
     static void DrawIMEComposition(rct_drawpixelinfo& dpi, int32_t cursorX, int32_t cursorY)
     {
-        int compositionWidth = gfx_get_string_width(gTextInput->ImeBuffer);
+        int compositionWidth = gfx_get_string_width(gTextInput->ImeBuffer, FontSpriteBase::MEDIUM);
         ScreenCoordsXY screenCoords(cursorX - (compositionWidth / 2), cursorY + 13);
         int width = compositionWidth;
         int height = 10;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -204,13 +204,14 @@ public:
         if (_descriptionStringId == STR_NONE)
         {
             auto* text = _description.c_str();
-            gfx_draw_string_centred_wrapped(&dpi, &text, { windowPos.x + WW / 2, screenCoords.y }, WW, STR_STRING, colours[1]);
+            DrawTextWrapped(
+                &dpi, { windowPos.x + WW / 2, screenCoords.y }, WW, STR_STRING, &text, { colours[1], TextAlignment::CENTRE });
         }
         else
         {
-            gfx_draw_string_centred_wrapped(
-                &dpi, &TextInputDescriptionArgs, { windowPos.x + WW / 2, screenCoords.y }, WW, _descriptionStringId,
-                colours[1]);
+            DrawTextWrapped(
+                &dpi, { windowPos.x + WW / 2, screenCoords.y }, WW, _descriptionStringId, &TextInputDescriptionArgs,
+                { colours[1], TextAlignment::CENTRE });
         }
 
         screenCoords.y += 25;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -833,7 +833,7 @@ void window_themes_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto width = w->windowPos.x + window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].left
             - window_themes_widgets[WIDX_THEMES_PRESETS].left - 4;
 
-        DrawTextEllipsised(dpi, screenPos, width, STR_STRING, ft, w->colours[1]);
+        DrawTextEllipsised(dpi, screenPos, width, STR_STRING, ft, { w->colours[1] });
     }
 }
 
@@ -911,7 +911,6 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_E0);
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
-                    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
                     gfx_draw_string(
                         dpi, topLeft, static_cast<const char*>(CheckBoxMarkString),
                         { static_cast<colour_t>(w->colours[1] & 0x7F), FontSpriteBase::MEDIUM_DARK });

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -818,9 +818,9 @@ void window_themes_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)
     {
-        gfx_draw_string_left(
-            dpi, STR_THEMES_LABEL_CURRENT_THEME, nullptr, w->colours[1],
-            w->windowPos + ScreenCoordsXY{ 10, window_themes_widgets[WIDX_THEMES_PRESETS].top + 1 });
+        DrawTextBasic(
+            dpi, w->windowPos + ScreenCoordsXY{ 10, window_themes_widgets[WIDX_THEMES_PRESETS].top + 1 },
+            STR_THEMES_LABEL_CURRENT_THEME, {}, { w->colours[1] });
 
         size_t activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
         const utf8* activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
@@ -896,7 +896,7 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
             int32_t numColours = ThemeDescGetNumColours(wc);
             for (uint8_t j = 0; j < numColours; j++)
             {
-                gfx_draw_string_left(dpi, ThemeDescGetName(wc), nullptr, w->colours[1], { 2, screenCoords.y + 4 });
+                DrawTextBasic(dpi, { 2, screenCoords.y + 4 }, ThemeDescGetName(wc), {}, { w->colours[1] });
 
                 uint8_t colour = ThemeGetColour(wc, j);
                 uint32_t image = SPRITE_ID_PALETTE_COLOUR_1(colour & ~COLOUR_FLAG_TRANSLUCENT) | SPR_PALETTE_BTN;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -911,7 +911,7 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_E0);
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
-                    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM_DARK;
+                    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
                     gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, topLeft);
                 }
             }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -912,7 +912,9 @@ void window_themes_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t sc
                 if (colour & COLOUR_FLAG_TRANSLUCENT)
                 {
                     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM_DARK;
-                    gfx_draw_string(dpi, static_cast<const char*>(CheckBoxMarkString), w->colours[1] & 0x7F, topLeft);
+                    gfx_draw_string(
+                        dpi, topLeft, static_cast<const char*>(CheckBoxMarkString),
+                        { static_cast<colour_t>(w->colours[1] & 0x7F), FontSpriteBase::MEDIUM_DARK });
                 }
             }
         }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1751,8 +1751,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ScreenCoordsXY screenCoords(w->windowPos.x, w->windowPos.y);
 
     // Draw coordinates
-    gfx_draw_string(dpi, "X:", COLOUR_WHITE, screenCoords + ScreenCoordsXY(5, 24));
-    gfx_draw_string(dpi, "Y:", COLOUR_WHITE, screenCoords + ScreenCoordsXY(74, 24));
+    gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(5, 24), "X:", { COLOUR_WHITE });
+    gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(74, 24), "Y:", { COLOUR_WHITE });
     if (windowTileInspectorTileSelected)
     {
         auto tileCoords = TileCoordsXY{ windowTileInspectorToolMap };
@@ -1767,8 +1767,8 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
     else
     {
-        gfx_draw_string(dpi, "-", COLOUR_WHITE, screenCoords + ScreenCoordsXY(43 - 7, 24));
-        gfx_draw_string(dpi, "-", COLOUR_WHITE, screenCoords + ScreenCoordsXY(113, 24));
+        gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(43 - 7, 24), "-", { COLOUR_WHITE });
+        gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(113, 24), "-", { COLOUR_WHITE });
     }
 
     if (windowTileInspectorSelectedIndex != -1)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1713,7 +1713,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
 
     // Set medium font size
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     // Draw column headers
     rct_widget* widget;
@@ -2245,7 +2245,7 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
 
     const TileElement* tileElement = map_get_first_element_at(windowTileInspectorToolMap);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     do
     {
         if (tileElement == nullptr)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1758,11 +1758,12 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
         auto tileCoords = TileCoordsXY{ windowTileInspectorToolMap };
         auto ft = Formatter();
         ft.Add<int32_t>(tileCoords.x);
-        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 43, 24 }, STR_FORMAT_INTEGER, ft, COLOUR_WHITE, TextAlignment::RIGHT);
+        DrawTextBasic(
+            dpi, screenCoords + ScreenCoordsXY{ 43, 24 }, STR_FORMAT_INTEGER, ft, { COLOUR_WHITE, TextAlignment::RIGHT });
         ft = Formatter();
         ft.Add<int32_t>(tileCoords.y);
         DrawTextBasic(
-            dpi, screenCoords + ScreenCoordsXY{ 113, 24 }, STR_FORMAT_INTEGER, ft, COLOUR_WHITE, TextAlignment::RIGHT);
+            dpi, screenCoords + ScreenCoordsXY{ 113, 24 }, STR_FORMAT_INTEGER, ft, { COLOUR_WHITE, TextAlignment::RIGHT });
     }
     else
     {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1712,40 +1712,37 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     WindowDrawWidgets(w, dpi);
 
-    // Set medium font size
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
     // Draw column headers
     rct_widget* widget;
     if ((widget = &w->widgets[WIDX_COLUMN_TYPE])->type != WindowWidgetType::Empty)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_ELEMENT_TYPE, {}, w->colours[1]);
+            STR_TILE_INSPECTOR_ELEMENT_TYPE, {}, { w->colours[1] });
     }
     if ((widget = &w->widgets[WIDX_COLUMN_BASEHEIGHT])->type != WindowWidgetType::Empty)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT, {}, w->colours[1]);
+            STR_TILE_INSPECTOR_BASE_HEIGHT_SHORT, {}, { w->colours[1] });
     }
     if ((widget = &w->widgets[WIDX_COLUMN_CLEARANCEHEIGHT])->type != WindowWidgetType::Empty)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, {}, w->colours[1]);
+            STR_TILE_INSPECTOR_CLEARANGE_HEIGHT_SHORT, {}, { w->colours[1] });
     }
     if ((widget = &w->widgets[WIDX_COLUMN_GHOSTFLAG])->type != WindowWidgetType::Empty)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_FLAG_GHOST_SHORT, {}, w->colours[1]);
+            STR_TILE_INSPECTOR_FLAG_GHOST_SHORT, {}, { w->colours[1] });
     }
     if ((widget = &w->widgets[WIDX_COLUMN_LASTFLAG])->type != WindowWidgetType::Empty)
     {
         DrawTextEllipsised(
             dpi, { w->windowPos.x + widget->left + 1, w->windowPos.y + widget->top + 1 }, widget->width(),
-            STR_TILE_INSPECTOR_FLAG_LAST_SHORT, {}, w->colours[1]);
+            STR_TILE_INSPECTOR_FLAG_LAST_SHORT, {}, { w->colours[1] });
     }
 
     ScreenCoordsXY screenCoords(w->windowPos.x, w->windowPos.y);
@@ -2247,7 +2244,6 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
 
     const TileElement* tileElement = map_get_first_element_at(windowTileInspectorToolMap);
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     do
     {
         if (tileElement == nullptr)
@@ -2333,8 +2329,7 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
         ft.Add<char*>(typeName);
-        DrawTextEllipsised(
-            dpi, screenCoords + ScreenCoordsXY{ COL_X_TYPE + 3, 0 }, COL_X_BH, stringFormat, ft, COLOUR_BLACK); // 3px padding
+        DrawTextEllipsised(dpi, screenCoords + ScreenCoordsXY{ COL_X_TYPE + 3, 0 }, COL_X_BH, stringFormat, ft); // 3px padding
 
         // Base height
         ft = Formatter();

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1792,7 +1792,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     terrainNameId = surfaceStyle->NameStringId;
                 }
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_SURFACE_TERAIN, &terrainNameId, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SURFACE_TERAIN, &terrainNameId, { COLOUR_WHITE });
 
                 // Edge texture name
                 rct_string_id terrainEdgeNameId = STR_EMPTY;
@@ -1801,9 +1801,9 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     terrainEdgeNameId = edgeStyle->NameStringId;
                 }
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_SURFACE_EDGE, &terrainEdgeNameId, COLOUR_WHITE,
-                    screenCoords + ScreenCoordsXY{ 0, 11 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_SURFACE_EDGE, &terrainEdgeNameId,
+                    { COLOUR_WHITE });
 
                 // Land ownership
                 rct_string_id landOwnership;
@@ -1817,31 +1817,31 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     landOwnership = STR_CONSTRUCTION_RIGHTS_SALE;
                 else
                     landOwnership = STR_TILE_INSPECTOR_LAND_NOT_OWNED_AND_NOT_AVAILABLE;
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_SURFACE_OWNERSHIP, &landOwnership, COLOUR_WHITE,
-                    screenCoords + ScreenCoordsXY{ 0, 22 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_SURFACE_OWNERSHIP, &landOwnership,
+                    { COLOUR_WHITE });
 
                 // Water level
                 uint32_t waterLevel = tileElement->AsSurface()->GetWaterHeight();
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_SURFACE_WATER_LEVEL, &waterLevel, COLOUR_WHITE,
-                    screenCoords + ScreenCoordsXY{ 0, 33 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_SURFACE_WATER_LEVEL, &waterLevel,
+                    { COLOUR_WHITE });
 
                 // Properties
                 // Raise / lower label
                 screenCoords = w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_GROUPBOX_DETAILS].left + 7, w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].top };
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
 
                 // Raised corners
                 screenCoords = w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_GROUPBOX_DETAILS].left + 7, w->widgets[WIDX_SURFACE_CHECK_CORNER_E].top };
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_SURFACE_CORNERS, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SURFACE_CORNERS, {}, { COLOUR_WHITE });
                 break;
             }
 
@@ -1850,7 +1850,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Details
                 // Path name
                 rct_string_id pathNameId = tileElement->AsPath()->GetSurfaceEntry()->string_idx;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_PATH_NAME, &pathNameId, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_PATH_NAME, &pathNameId, { COLOUR_WHITE });
 
                 // Path addition
                 if (tileElement->AsPath()->HasAddition())
@@ -1860,30 +1860,30 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     rct_string_id additionNameId = sceneryElement != nullptr
                         ? sceneryElement->name
                         : static_cast<rct_string_id>(STR_UNKNOWN_OBJECT_TYPE);
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_PATH_ADDITIONS, &additionNameId, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 11 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS, &additionNameId,
+                        { COLOUR_WHITE });
                 }
                 else
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_PATH_ADDITIONS_NONE, nullptr, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 11 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS_NONE, {},
+                        { COLOUR_WHITE });
 
                 // Properties
                 // Raise / lower label
                 screenCoords = w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_GROUPBOX_DETAILS].left + 7, w->widgets[WIDX_PATH_SPINNER_HEIGHT].top };
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_PATH_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
 
                 // Path connections
                 screenCoords = w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_GROUPBOX_DETAILS].left + 7, w->widgets[WIDX_PATH_CHECK_EDGE_W].top };
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, {}, { COLOUR_WHITE });
                 break;
             }
 
@@ -1897,34 +1897,34 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 if (ride != nullptr)
                 {
                     auto rideName = ride->GetRideTypeDescriptor().Naming.Name;
-                    gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, &rideName, COLOUR_WHITE, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_TRACK_RIDE_TYPE, &rideName, { COLOUR_WHITE });
                 }
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_TRACK_RIDE_ID, &rideId, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 11 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_TRACK_RIDE_ID, &rideId, { COLOUR_WHITE });
                 if (ride != nullptr)
                 {
                     auto ft = Formatter();
                     ride->FormatNameTo(ft);
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, ft.Data(), COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 22 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_TRACK_RIDE_NAME, ft, { COLOUR_WHITE });
                 }
                 // Track
                 auto trackType = trackElement->GetTrackType();
                 int16_t sequenceNumber = trackElement->GetSequenceIndex();
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_TRACK_PIECE_ID, &trackType, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 33 });
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_TRACK_SEQUENCE, &sequenceNumber, COLOUR_WHITE,
-                    screenCoords + ScreenCoordsXY{ 0, 44 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_TRACK_PIECE_ID, &trackType,
+                    { COLOUR_WHITE });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 44 }, STR_TILE_INSPECTOR_TRACK_SEQUENCE, &sequenceNumber,
+                    { COLOUR_WHITE });
                 if (trackElement->IsStation())
                 {
                     int16_t stationIndex = trackElement->GetStationIndex();
                     auto ft = Formatter();
                     ft.Add<rct_string_id>(STR_COMMA16);
                     ft.Add<int16_t>(stationIndex);
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, ft.Data(), COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 55 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 55 }, STR_TILE_INSPECTOR_STATION_INDEX, ft, { COLOUR_WHITE });
                 }
                 else
                 {
@@ -1932,23 +1932,24 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     auto ft = Formatter();
                     ft.Add<rct_string_id>(STR_STRING);
                     ft.Add<char*>(stationNone);
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, ft.Data(), COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 55 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 55 }, STR_TILE_INSPECTOR_STATION_INDEX, ft, { COLOUR_WHITE });
                 }
 
                 rct_string_id colourScheme = ColourSchemeNames[trackElement->GetColourScheme()];
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_COLOUR_SCHEME, &colourScheme, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 66 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 66 }, STR_TILE_INSPECTOR_COLOUR_SCHEME, &colourScheme,
+                    { COLOUR_WHITE });
 
                 // Properties
                 // Raise / lower label
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
                 break;
             }
 
@@ -1957,7 +1958,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Details
                 // Age
                 int16_t age = tileElement->AsSmallScenery()->GetAge();
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_SCENERY_AGE, &age, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SCENERY_AGE, &age, { COLOUR_WHITE });
 
                 // Quadrant value
                 const rct_scenery_entry* sceneryEntry = get_small_scenery_entry(tileElement->AsSmallScenery()->GetEntryIndex());
@@ -1968,35 +1969,35 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                                                                    STR_TILE_INSPECTOR_SCENERY_QUADRANT_NW,
                                                                    STR_TILE_INSPECTOR_SCENERY_QUADRANT_NE,
                                                                    STR_TILE_INSPECTOR_SCENERY_QUADRANT_SE };
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_SCENERY_QUADRANT, &quadrant_string_idx[quadrant], COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 11 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_SCENERY_QUADRANT,
+                        &quadrant_string_idx[quadrant], { COLOUR_WHITE });
                 }
 
                 // Scenery ID
                 int16_t idx = tileElement->AsSmallScenery()->GetEntryIndex();
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_SCENERY_ENTRY_IDX, &idx, COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 22 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_SCENERY_ENTRY_IDX, &idx, { COLOUR_WHITE });
 
                 // Properties
                 // Raise / Lower
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
 
                 // Quarter tile
                 screenCoords = w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                       w->widgets[WIDX_SCENERY_CHECK_QUARTER_E].top };
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, {}, { COLOUR_WHITE });
 
                 // Collision
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_SCENERY_CHECK_COLLISION_E].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_COLLISSION, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_COLLISSION, {}, { COLOUR_WHITE });
                 break;
             }
 
@@ -2005,16 +2006,16 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Details
                 // Entrance type
                 rct_string_id entranceType = EntranceTypeStringIds[tileElement->AsEntrance()->GetEntranceType()];
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_ENTRANCE_TYPE, &entranceType, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_ENTRANCE_TYPE, &entranceType, { COLOUR_WHITE });
 
                 if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                 {
                     // TODO: Make this work with Left/Right park entrance parts
                     int16_t parkEntranceIndex = park_entrance_get_index(
                         { windowTileInspectorToolMap, tileElement->GetBaseZ() });
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, &parkEntranceIndex, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 11 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID,
+                        &parkEntranceIndex, { COLOUR_WHITE });
                 }
                 else
                 {
@@ -2022,16 +2023,16 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
                     {
                         // Ride entrance ID
-                        gfx_draw_string_left(
-                            dpi, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, &rideEntranceIndex, COLOUR_WHITE,
-                            screenCoords + ScreenCoordsXY{ 0, 11 });
+                        DrawTextBasic(
+                            dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID,
+                            &rideEntranceIndex, { COLOUR_WHITE });
                     }
                     else
                     {
                         // Ride exit ID
-                        gfx_draw_string_left(
-                            dpi, STR_TILE_INSPECTOR_ENTRANCE_EXIT_ID, &rideEntranceIndex, COLOUR_WHITE,
-                            screenCoords + ScreenCoordsXY{ 0, 11 });
+                        DrawTextBasic(
+                            dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_EXIT_ID,
+                            &rideEntranceIndex, { COLOUR_WHITE });
                     }
                 }
 
@@ -2039,36 +2040,36 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     // Entrance part
                     rct_string_id entrancePart = ParkEntrancePartStringIds[tileElement->AsEntrance()->GetSequenceIndex()];
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_ENTRANCE_PART, &entrancePart, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 22 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRANCE_PART, &entrancePart,
+                        { COLOUR_WHITE });
                 }
                 else
                 {
                     // Ride ID
                     int16_t rideId = tileElement->AsEntrance()->GetRideIndex();
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_ENTRANCE_RIDE_ID, &rideId, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 22 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRANCE_RIDE_ID, &rideId,
+                        { COLOUR_WHITE });
                     // Station index
                     int16_t stationIndex = tileElement->AsEntrance()->GetStationIndex();
                     auto ft = Formatter();
                     ft.Add<rct_string_id>(STR_COMMA16);
                     ft.Add<int16_t>(stationIndex);
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_STATION_INDEX, ft.Data(), COLOUR_WHITE, screenCoords + ScreenCoordsXY{ 0, 33 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 33 }, STR_TILE_INSPECTOR_STATION_INDEX, ft, { COLOUR_WHITE });
                 }
 
                 // Properties
                 // Raise / Lower
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].left + 3;
                 auto ft = Formatter();
                 ft.Add<int32_t>(tileElement->base_height);
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, ft.Data(), COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { COLOUR_WHITE });
                 break;
             }
 
@@ -2077,7 +2078,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Details
                 // Type
                 int16_t wallType = tileElement->AsWall()->GetEntryIndex();
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_WALL_TYPE, &wallType, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_TYPE, &wallType, { COLOUR_WHITE });
 
                 // Banner info
                 rct_wall_scenery_entry wallEntry = get_wall_entry(wallType)->wall;
@@ -2088,46 +2089,46 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     {
                         Formatter ft;
                         banner->FormatTextTo(ft);
-                        gfx_draw_string_left(
-                            dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft.Data(), COLOUR_WHITE,
-                            screenCoords + ScreenCoordsXY{ 0, 11 });
+                        DrawTextBasic(
+                            dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft,
+                            { COLOUR_WHITE });
                     }
                 }
                 else
                 {
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, nullptr, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 11 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
+                        { COLOUR_WHITE });
                 }
 
                 // Properties
                 // Raise / lower label
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_WALL_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_WALL_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
 
                 // Slope label
                 screenCoords = w->windowPos
                     + ScreenCoordsXY{ w->widgets[WIDX_GROUPBOX_DETAILS].left + 7, w->widgets[WIDX_WALL_DROPDOWN_SLOPE].top };
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_WALL_SLOPE, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_SLOPE, {}, { COLOUR_WHITE });
 
                 // Animation frame label
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_WALL_SPINNER_ANIMATION_FRAME].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME, {}, { COLOUR_WHITE });
 
                 // Current animation frame
-                uint8_t colour = COLOUR_WHITE;
+                colour_t colour = COLOUR_WHITE;
                 if (WidgetIsDisabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME))
                 {
                     colour = w->colours[0] | COLOUR_FLAG_INSET;
                 }
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_WALL_SPINNER_ANIMATION_FRAME].left + 3;
                 int32_t animationFrame = tileElement->AsWall()->GetAnimationFrame();
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &animationFrame, colour, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &animationFrame, { colour });
                 break;
             }
 
@@ -2137,13 +2138,13 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Type
                 auto sceneryElement = tileElement->AsLargeScenery();
                 int16_t largeSceneryType = sceneryElement->GetEntryIndex();
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_LARGE_SCENERY_TYPE, &largeSceneryType, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_LARGE_SCENERY_TYPE, &largeSceneryType, { COLOUR_WHITE });
 
                 // Part ID
                 int16_t pieceID = sceneryElement->GetSequenceIndex();
-                gfx_draw_string_left(
-                    dpi, STR_TILE_INSPECTOR_LARGE_SCENERY_PIECE_ID, &pieceID, COLOUR_WHITE,
-                    screenCoords + ScreenCoordsXY{ 0, 11 });
+                DrawTextBasic(
+                    dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_LARGE_SCENERY_PIECE_ID, &pieceID,
+                    { COLOUR_WHITE });
 
                 // Banner info
                 rct_scenery_entry* largeSceneryEntry = get_large_scenery_entry(largeSceneryType);
@@ -2154,27 +2155,27 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     {
                         Formatter ft;
                         banner->FormatTextTo(ft);
-                        gfx_draw_string_left(
-                            dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft.Data(), COLOUR_WHITE,
-                            screenCoords + ScreenCoordsXY{ 0, 22 });
+                        DrawTextBasic(
+                            dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft,
+                            { COLOUR_WHITE });
                     }
                 }
                 else
                 {
-                    gfx_draw_string_left(
-                        dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, nullptr, COLOUR_WHITE,
-                        screenCoords + ScreenCoordsXY{ 0, 22 });
+                    DrawTextBasic(
+                        dpi, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
+                        { COLOUR_WHITE });
                 }
 
                 // Properties
                 // Raise / lower label
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
                 break;
             }
 
@@ -2187,23 +2188,23 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 {
                     Formatter ft;
                     banner->FormatTextTo(ft);
-                    gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft.Data(), COLOUR_WHITE, screenCoords);
+                    DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_ENTRY_BANNER_TEXT, ft, { COLOUR_WHITE });
                 }
 
                 // Properties
                 // Raise / lower label
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_BANNER_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_BANNER_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
 
                 // Blocked paths
                 screenCoords.y += 28;
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, {}, { COLOUR_WHITE });
                 break;
             }
 
@@ -2212,12 +2213,12 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 // Properties
                 // Raise / lower label
                 screenCoords.y = w->windowPos.y + w->widgets[WIDX_CORRUPT_SPINNER_HEIGHT].top;
-                gfx_draw_string_left(dpi, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, nullptr, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { COLOUR_WHITE });
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_CORRUPT_SPINNER_HEIGHT].left + 3;
                 int32_t baseHeight = tileElement->base_height;
-                gfx_draw_string_left(dpi, STR_FORMAT_INTEGER, &baseHeight, COLOUR_WHITE, screenCoords);
+                DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, &baseHeight, { COLOUR_WHITE });
                 break;
             }
 
@@ -2339,13 +2340,13 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
         ft = Formatter();
         ft.Add<rct_string_id>(STR_FORMAT_INTEGER);
         ft.Add<int32_t>(baseHeight);
-        gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_BH, 0 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ COL_X_BH, 0 }, stringFormat, ft);
 
         // Clearance height
         ft = Formatter();
         ft.Add<rct_string_id>(STR_FORMAT_INTEGER);
         ft.Add<int32_t>(clearanceHeight);
-        gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_CH, 0 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ COL_X_CH, 0 }, stringFormat, ft);
 
         // Checkmarks for ghost and last for tile
         ft = Formatter();
@@ -2353,11 +2354,11 @@ static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* 
         ft.Add<char*>(CheckBoxMarkString);
         if (ghost)
         {
-            gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_GF, 0 });
+            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ COL_X_GF, 0 }, stringFormat, ft);
         }
         if (last)
         {
-            gfx_draw_string_left(dpi, stringFormat, ft.Data(), COLOUR_BLACK, screenCoords + ScreenCoordsXY{ COL_X_LF, 0 });
+            DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ COL_X_LF, 0 }, stringFormat, ft);
         }
 
         screenCoords.y -= SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -763,8 +763,8 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
     TITLE_COMMAND_ORDER command_info = get_command_info(_command.Type);
 
     // "Command:" label
-    gfx_draw_string_left(
-        dpi, STR_TITLE_COMMAND_EDITOR_COMMAND_LABEL, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ WS, BY - 14 });
+    DrawTextBasic(
+        dpi, w->windowPos + ScreenCoordsXY{ WS, BY - 14 }, STR_TITLE_COMMAND_EDITOR_COMMAND_LABEL, {}, { w->colours[1] });
 
     // Command dropdown name
     DrawTextEllipsised(
@@ -773,7 +773,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
         w->colours[1]);
 
     // Label (e.g. "Location:")
-    gfx_draw_string_left(dpi, command_info.descStringId, nullptr, w->colours[1], w->windowPos + ScreenCoordsXY{ WS, BY2 - 14 });
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ WS, BY2 - 14 }, command_info.descStringId, {}, { w->colours[1] });
 
     if (_command.Type == TitleScript::Speed)
     {

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -770,7 +770,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
     DrawTextEllipsised(
         dpi, { w->windowPos.x + w->widgets[WIDX_COMMAND].left + 1, w->windowPos.y + w->widgets[WIDX_COMMAND].top },
         w->widgets[WIDX_COMMAND_DROPDOWN].left - w->widgets[WIDX_COMMAND].left - 4, command_info.nameStringId, {},
-        w->colours[1]);
+        { w->colours[1] });
 
     // Label (e.g. "Location:")
     DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ WS, BY2 - 14 }, command_info.descStringId, {}, { w->colours[1] });
@@ -780,7 +780,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
         DrawTextEllipsised(
             dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
             w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, SpeedNames[_command.Speed - 1], {},
-            w->colours[1]);
+            { w->colours[1] });
     }
     if (_command.Type == TitleScript::Follow)
     {
@@ -803,7 +803,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
               { w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_VIEWPORT].right, w->widgets[WIDX_VIEWPORT].bottom } } });
         DrawTextEllipsised(
             dpi, { w->windowPos.x + w->widgets[WIDX_VIEWPORT].left + 2, w->windowPos.y + w->widgets[WIDX_VIEWPORT].top + 1 },
-            w->widgets[WIDX_VIEWPORT].width() - 2, spriteString, ft, colour);
+            w->widgets[WIDX_VIEWPORT].width() - 2, spriteString, ft, { colour });
     }
     else if (_command.Type == TitleScript::Load)
     {
@@ -812,7 +812,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
                 w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4,
-                STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, {}, w->colours[1]);
+                STR_TITLE_COMMAND_EDITOR_NO_SAVE_SELECTED, {}, { w->colours[1] });
         }
         else
         {
@@ -820,7 +820,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             ft.Add<utf8*>(_sequence->Saves[_command.SaveIndex].c_str());
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
-                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, STR_STRING, ft, w->colours[1]);
+                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, STR_STRING, ft, { w->colours[1] });
         }
     }
     else if (_command.Type == TitleScript::LoadSc)
@@ -830,7 +830,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
                 w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4,
-                STR_TITLE_COMMAND_EDITOR_NO_SCENARIO_SELECTED, {}, w->colours[1]);
+                STR_TITLE_COMMAND_EDITOR_NO_SCENARIO_SELECTED, {}, { w->colours[1] });
         }
         else
         {
@@ -849,7 +849,7 @@ static void window_title_command_editor_paint(rct_window* w, rct_drawpixelinfo* 
             ft.Add<const char*>(name);
             DrawTextEllipsised(
                 dpi, { w->windowPos.x + w->widgets[WIDX_INPUT].left + 1, w->windowPos.y + w->widgets[WIDX_INPUT].top },
-                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, nameString, ft, w->colours[1]);
+                w->widgets[WIDX_INPUT_DROPDOWN].left - w->widgets[WIDX_INPUT].left - 4, nameString, ft, { w->colours[1] });
         }
     }
 }

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -807,9 +807,9 @@ static void window_title_editor_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         case WINDOW_TITLE_EDITOR_TAB_PRESETS:
         {
-            gfx_draw_string_left(
-                dpi, STR_TITLE_SEQUENCE, nullptr, w->colours[1],
-                w->windowPos + ScreenCoordsXY{ 10, window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top + 1 });
+            DrawTextBasic(
+                dpi, w->windowPos + ScreenCoordsXY{ 10, window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].top + 1 },
+                STR_TITLE_SEQUENCE, {}, { w->colours[1] });
 
             auto ft = Formatter();
             ft.Add<const char*>(_sequenceName);
@@ -886,7 +886,7 @@ static void window_title_editor_scrollpaint_saves(rct_window* w, rct_drawpixelin
             ft.Add<rct_string_id>(STR_STRING);
         }
         ft.Add<const char*>(saveName);
-        gfx_draw_string_left(dpi, STR_STRINGID, ft.Data(), w->colours[1], screenCoords + ScreenCoordsXY{ 5, 0 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 5, 0 }, STR_STRINGID, ft, { w->colours[1] });
     }
 }
 
@@ -1045,7 +1045,7 @@ static void window_title_editor_scrollpaint_commands(rct_window* w, rct_drawpixe
                 log_warning("Unknown command %d", command.Type);
             }
         }
-        gfx_draw_string_left(dpi, STR_STRINGID, ft.Data(), w->colours[1], screenCoords + ScreenCoordsXY{ 5, 0 });
+        DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 5, 0 }, STR_STRINGID, ft, { w->colours[1] });
     }
 }
 

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -819,7 +819,7 @@ static void window_title_editor_paint(rct_window* w, rct_drawpixelinfo* dpi)
             auto width = w->windowPos.x + window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS_DROPDOWN].left
                 - window_title_editor_widgets[WIDX_TITLE_EDITOR_PRESETS].left - 4;
 
-            DrawTextEllipsised(dpi, screenPos, width, STR_STRING, ft, w->colours[1]);
+            DrawTextEllipsised(dpi, screenPos, width, STR_STRING, ft, { w->colours[1] });
             break;
         }
         case WINDOW_TITLE_EDITOR_TAB_SAVES:

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -56,14 +56,15 @@ static int32_t FormatTextForTooltip(const OpenRCT2String& message)
     OpenRCT2String formattedMessage{ STR_STRING_TOOLTIP, Formatter() };
     formattedMessage.args.Add<const char*>(tempBuffer);
     format_string(_tooltipText, sizeof(_tooltipText), formattedMessage.str, formattedMessage.args.Data());
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     auto textWidth = gfx_get_string_width_new_lined(_tooltipText);
     textWidth = std::min(textWidth, 196);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
-    int32_t numLines, fontSpriteBase;
+    int32_t numLines;
+    FontSpriteBase fontSpriteBase;
     textWidth = gfx_wrap_string(_tooltipText, textWidth + 1, &numLines, &fontSpriteBase);
     _tooltipNumLines = numLines;
     return textWidth;
@@ -77,7 +78,7 @@ void window_tooltip_show(const OpenRCT2String& message, ScreenCoordsXY screenCoo
 
     int32_t textWidth = FormatTextForTooltip(message);
     int32_t width = textWidth + 3;
-    int32_t height = ((_tooltipNumLines + 1) * font_get_line_height(FONT_SPRITE_BASE_MEDIUM)) + 4;
+    int32_t height = ((_tooltipNumLines + 1) * font_get_line_height(FontSpriteBase::MEDIUM)) + 4;
     window_tooltip_widgets[WIDX_BACKGROUND].right = width;
     window_tooltip_widgets[WIDX_BACKGROUND].bottom = height;
 

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -58,7 +58,7 @@ static int32_t FormatTextForTooltip(const OpenRCT2String& message)
     format_string(_tooltipText, sizeof(_tooltipText), formattedMessage.str, formattedMessage.args.Data());
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
-    auto textWidth = gfx_get_string_width_new_lined(_tooltipText);
+    auto textWidth = gfx_get_string_width_new_lined(_tooltipText, FontSpriteBase::MEDIUM);
     textWidth = std::min(textWidth, 196);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -64,8 +64,7 @@ static int32_t FormatTextForTooltip(const OpenRCT2String& message)
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     int32_t numLines;
-    FontSpriteBase fontSpriteBase;
-    textWidth = gfx_wrap_string(_tooltipText, textWidth + 1, &numLines, &fontSpriteBase);
+    textWidth = gfx_wrap_string(_tooltipText, textWidth + 1, &numLines);
     _tooltipNumLines = numLines;
     return textWidth;
 }

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -56,15 +56,12 @@ static int32_t FormatTextForTooltip(const OpenRCT2String& message)
     OpenRCT2String formattedMessage{ STR_STRING_TOOLTIP, Formatter() };
     formattedMessage.args.Add<const char*>(tempBuffer);
     format_string(_tooltipText, sizeof(_tooltipText), formattedMessage.str, formattedMessage.args.Data());
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
-    auto textWidth = gfx_get_string_width_new_lined(_tooltipText, FontSpriteBase::MEDIUM);
+    auto textWidth = gfx_get_string_width_new_lined(_tooltipText, FontSpriteBase::SMALL);
     textWidth = std::min(textWidth, 196);
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
     int32_t numLines;
-    textWidth = gfx_wrap_string(_tooltipText, textWidth + 1, &numLines);
+    textWidth = gfx_wrap_string(_tooltipText, textWidth + 1, FontSpriteBase::SMALL, &numLines);
     _tooltipNumLines = numLines;
     return textWidth;
 }
@@ -77,7 +74,7 @@ void window_tooltip_show(const OpenRCT2String& message, ScreenCoordsXY screenCoo
 
     int32_t textWidth = FormatTextForTooltip(message);
     int32_t width = textWidth + 3;
-    int32_t height = ((_tooltipNumLines + 1) * font_get_line_height(FontSpriteBase::MEDIUM)) + 4;
+    int32_t height = ((_tooltipNumLines + 1) * font_get_line_height(FontSpriteBase::SMALL)) + 4;
     window_tooltip_widgets[WIDX_BACKGROUND].right = width;
     window_tooltip_widgets[WIDX_BACKGROUND].bottom = height;
 
@@ -192,5 +189,5 @@ static void window_tooltip_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Text
     left = w->windowPos.x + ((w->width + 1) / 2) - 1;
     top = w->windowPos.y + 1;
-    draw_string_centred_raw(dpi, { left, top }, _tooltipNumLines, _tooltipText);
+    draw_string_centred_raw(dpi, { left, top }, _tooltipNumLines, _tooltipText, FontSpriteBase::SMALL);
 }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -981,7 +981,7 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         // Draw number of players.
         auto ft = Formatter();
         ft.Add<int32_t>(network_get_num_players());
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         DrawTextBasic(
             dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, COLOUR_WHITE | COLOUR_FLAG_OUTLINE,
             TextAlignment::RIGHT);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -981,7 +981,6 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         // Draw number of players.
         auto ft = Formatter();
         ft.Add<int32_t>(network_get_num_players());
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         DrawTextBasic(
             dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft,
             { COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -904,7 +904,7 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             DrawTextBasic(
                 dpi, screenPos + ScreenCoordsXY{ 26, 2 }, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, {},
-                COLOUR_DARK_ORANGE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT);
+                { COLOUR_DARK_ORANGE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });
         }
     }
 
@@ -983,8 +983,8 @@ static void window_top_toolbar_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft.Add<int32_t>(network_get_num_players());
         gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         DrawTextBasic(
-            dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, COLOUR_WHITE | COLOUR_FLAG_OUTLINE,
-            TextAlignment::RIGHT);
+            dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft,
+            { COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });
     }
 }
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -243,9 +243,9 @@ static void window_track_delete_prompt_paint(rct_window* w, rct_drawpixelinfo* d
 {
     WindowDrawWidgets(w, dpi);
 
-    gfx_draw_string_centred_wrapped(
-        dpi, &_trackDesignFileReference->name, { w->windowPos.x + 125, w->windowPos.y + 28 }, 246,
-        STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, COLOUR_BLACK);
+    DrawTextWrapped(
+        dpi, { w->windowPos.x + 125, w->windowPos.y + 28 }, 246, STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK,
+        &_trackDesignFileReference->name, { TextAlignment::CENTRE });
 }
 
 static void window_track_design_list_reload_tracks()

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -496,8 +496,9 @@ static void window_track_place_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Price
     if (_window_track_place_last_cost != MONEY32_UNDEFINED && !(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
-        gfx_draw_string_centred(
-            dpi, STR_COST_LABEL, w->windowPos + ScreenCoordsXY{ 88, 94 }, COLOUR_BLACK, &_window_track_place_last_cost);
+        DrawTextBasic(
+            dpi, w->windowPos + ScreenCoordsXY{ 88, 94 }, STR_COST_LABEL, &_window_track_place_last_cost,
+            { TextAlignment::CENTRE });
     }
 }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -541,7 +541,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         && !(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
     {
         // Vehicle design not available
-        DrawTextEllipsised(dpi, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, {}, COLOUR_BLACK, TextAlignment::CENTRE);
+        DrawTextEllipsised(dpi, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, {}, { TextAlignment::CENTRE });
         screenPos.y -= SCROLLABLE_ROW_HEIGHT;
     }
 
@@ -551,7 +551,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Scenery not available
             DrawTextEllipsised(
-                dpi, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, COLOUR_BLACK, TextAlignment::CENTRE);
+                dpi, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::CENTRE });
             screenPos.y -= SCROLLABLE_ROW_HEIGHT;
         }
     }
@@ -559,7 +559,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Track design name
     auto ft = Formatter();
     ft.Add<utf8*>(_trackDesigns[trackIndex].name);
-    DrawTextEllipsised(dpi, screenPos, 368, STR_TRACK_PREVIEW_NAME_FORMAT, ft, COLOUR_BLACK, TextAlignment::CENTRE);
+    DrawTextEllipsised(dpi, screenPos, 368, STR_TRACK_PREVIEW_NAME_FORMAT, ft, { TextAlignment::CENTRE });
 
     // Information
     screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->bottom + 2 };
@@ -606,7 +606,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
             ft = Formatter();
             ft.Add<rct_string_id>(STR_RIDE_LENGTH_ENTRY);
             ft.Add<uint16_t>(_loadedTrackDesign->ride_length);
-            DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft, COLOUR_BLACK);
+            DrawTextEllipsised(dpi, screenPos, 214, STR_TRACK_LIST_RIDE_LENGTH, ft);
             screenPos.y += LIST_ROW_HEIGHT;
         }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -566,15 +566,15 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Stats
     fixed32_2dp rating = _loadedTrackDesign->excitement * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_EXCITEMENT_RATING, &rating, COLOUR_BLACK, screenPos);
+    DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_EXCITEMENT_RATING, &rating);
     screenPos.y += LIST_ROW_HEIGHT;
 
     rating = _loadedTrackDesign->intensity * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_INTENSITY_RATING, &rating, COLOUR_BLACK, screenPos);
+    DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_INTENSITY_RATING, &rating);
     screenPos.y += LIST_ROW_HEIGHT;
 
     rating = _loadedTrackDesign->nausea * 10;
-    gfx_draw_string_left(dpi, STR_TRACK_LIST_NAUSEA_RATING, &rating, COLOUR_BLACK, screenPos);
+    DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_NAUSEA_RATING, &rating);
     screenPos.y += LIST_ROW_HEIGHT + 4;
 
     // Information for tracked rides.
@@ -586,19 +586,19 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
             {
                 // Holes
                 uint16_t holes = _loadedTrackDesign->holes & 0x1F;
-                gfx_draw_string_left(dpi, STR_HOLES, &holes, COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_HOLES, &holes);
                 screenPos.y += LIST_ROW_HEIGHT;
             }
             else
             {
                 // Maximum speed
                 uint16_t speed = ((_loadedTrackDesign->max_speed << 16) * 9) >> 18;
-                gfx_draw_string_left(dpi, STR_MAX_SPEED, &speed, COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_MAX_SPEED, &speed);
                 screenPos.y += LIST_ROW_HEIGHT;
 
                 // Average speed
                 speed = ((_loadedTrackDesign->average_speed << 16) * 9) >> 18;
-                gfx_draw_string_left(dpi, STR_AVERAGE_SPEED, &speed, COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_AVERAGE_SPEED, &speed);
                 screenPos.y += LIST_ROW_HEIGHT;
             }
 
@@ -614,24 +614,24 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Maximum positive vertical Gs
             int32_t gForces = _loadedTrackDesign->max_positive_vertical_g * 32;
-            gfx_draw_string_left(dpi, STR_MAX_POSITIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_MAX_POSITIVE_VERTICAL_G, &gForces);
             screenPos.y += LIST_ROW_HEIGHT;
 
             // Maximum negative vertical Gs
             gForces = _loadedTrackDesign->max_negative_vertical_g * 32;
-            gfx_draw_string_left(dpi, STR_MAX_NEGATIVE_VERTICAL_G, &gForces, COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_MAX_NEGATIVE_VERTICAL_G, &gForces);
             screenPos.y += LIST_ROW_HEIGHT;
 
             // Maximum lateral Gs
             gForces = _loadedTrackDesign->max_lateral_g * 32;
-            gfx_draw_string_left(dpi, STR_MAX_LATERAL_G, &gForces, COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_MAX_LATERAL_G, &gForces);
             screenPos.y += LIST_ROW_HEIGHT;
 
             if (_loadedTrackDesign->total_air_time != 0)
             {
                 // Total air time
                 int32_t airTime = _loadedTrackDesign->total_air_time * 25;
-                gfx_draw_string_left(dpi, STR_TOTAL_AIR_TIME, &airTime, COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_TOTAL_AIR_TIME, &airTime);
                 screenPos.y += LIST_ROW_HEIGHT;
             }
         }
@@ -640,12 +640,12 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         {
             // Drops
             uint16_t drops = _loadedTrackDesign->drops & 0x3F;
-            gfx_draw_string_left(dpi, STR_DROPS, &drops, COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_DROPS, &drops);
             screenPos.y += LIST_ROW_HEIGHT;
 
             // Drop height is multiplied by 0.75
             uint16_t highestDropHeight = (_loadedTrackDesign->highest_drop_height * 3) / 4;
-            gfx_draw_string_left(dpi, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight, COLOUR_BLACK, screenPos);
+            DrawTextBasic(dpi, screenPos, STR_HIGHEST_DROP_HEIGHT, &highestDropHeight);
             screenPos.y += LIST_ROW_HEIGHT;
         }
 
@@ -655,7 +655,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
             if (inversions != 0)
             {
                 // Inversions
-                gfx_draw_string_left(dpi, STR_INVERSIONS, &inversions, COLOUR_BLACK, screenPos);
+                DrawTextBasic(dpi, screenPos, STR_INVERSIONS, &inversions);
                 screenPos.y += LIST_ROW_HEIGHT;
             }
         }
@@ -668,7 +668,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
         ft = Formatter();
         ft.Add<uint16_t>(_loadedTrackDesign->space_required_x);
         ft.Add<uint16_t>(_loadedTrackDesign->space_required_y);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_SPACE_REQUIRED, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_SPACE_REQUIRED, ft);
         screenPos.y += LIST_ROW_HEIGHT;
     }
 
@@ -676,7 +676,7 @@ static void window_track_list_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ft = Formatter();
         ft.Add<uint32_t>(_loadedTrackDesign->cost);
-        gfx_draw_string_left(dpi, STR_TRACK_LIST_COST_AROUND, ft.Data(), COLOUR_BLACK, screenPos);
+        DrawTextBasic(dpi, screenPos, STR_TRACK_LIST_COST_AROUND, ft);
     }
 }
 
@@ -696,8 +696,7 @@ static void window_track_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
         if (_trackDesigns.empty())
         {
             // No track designs
-            gfx_draw_string_left(
-                dpi, STR_NO_TRACK_DESIGNS_OF_THIS_TYPE, nullptr, COLOUR_BLACK, screenCoords - ScreenCoordsXY{ 0, 1 });
+            DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, STR_NO_TRACK_DESIGNS_OF_THIS_TYPE);
             return;
         }
     }
@@ -719,7 +718,7 @@ static void window_track_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
         }
 
         rct_string_id stringId2 = STR_BUILD_CUSTOM_DESIGN;
-        gfx_draw_string_left(dpi, stringId, &stringId2, COLOUR_BLACK, screenCoords - ScreenCoordsXY{ 0, 1 });
+        DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, &stringId2);
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
         listIndex++;
     }
@@ -746,7 +745,7 @@ static void window_track_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi,
             auto ft = Formatter();
             ft.Add<rct_string_id>(STR_TRACK_LIST_NAME_FORMAT);
             ft.Add<utf8*>(_trackDesigns[i].name);
-            gfx_draw_string_left(dpi, stringId, ft.Data(), COLOUR_BLACK, screenCoords - ScreenCoordsXY{ 0, 1 });
+            DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, ft);
         }
 
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -381,7 +381,7 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Clip height value
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CLIP_HEIGHT_VALUE].top };
-    gfx_draw_string_left(dpi, STR_VIEW_CLIPPING_HEIGHT_VALUE, nullptr, w->colours[0], screenCoords);
+    DrawTextBasic(dpi, screenCoords, STR_VIEW_CLIPPING_HEIGHT_VALUE, {}, { w->colours[0] });
 
     screenCoords = w->windowPos
         + ScreenCoordsXY{ w->widgets[WIDX_CLIP_HEIGHT_VALUE].left + 1, w->widgets[WIDX_CLIP_HEIGHT_VALUE].top };
@@ -394,8 +394,8 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         case DISPLAY_TYPE::DISPLAY_RAW:
         default:
-            gfx_draw_string_left(
-                dpi, STR_FORMAT_INTEGER, &clipHeightRawValue, w->colours[0], screenCoords); // Printing the raw value.
+            DrawTextBasic(
+                dpi, screenCoords, STR_FORMAT_INTEGER, &clipHeightRawValue, { w->colours[0] }); // Printing the raw value.
             break;
 
         case DISPLAY_TYPE::DISPLAY_UNITS:
@@ -404,9 +404,9 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
             {
                 // Height label is Units.
                 clipHeightValueInUnits = static_cast<fixed16_1dp>(FIXED_1DP(gClipHeight, 0) / 2 - FIXED_1DP(7, 0));
-                gfx_draw_string_left(
-                    dpi, STR_UNIT1DP_NO_SUFFIX, &clipHeightValueInUnits, w->colours[0],
-                    screenCoords); // Printing the value in Height Units.
+                DrawTextBasic(
+                    dpi, screenCoords, STR_UNIT1DP_NO_SUFFIX, &clipHeightValueInUnits,
+                    { w->colours[0] }); // Printing the value in Height Units.
             }
             else
             {
@@ -418,13 +418,13 @@ static void window_view_clipping_paint(rct_window* w, rct_drawpixelinfo* dpi)
                     case MeasurementFormat::SI:
                         clipHeightValueInMeters = static_cast<fixed32_2dp>(
                             FIXED_2DP(gClipHeight, 0) / 2 * 1.5f - FIXED_2DP(10, 50));
-                        gfx_draw_string_left(
-                            dpi, STR_UNIT2DP_SUFFIX_METRES, &clipHeightValueInMeters, w->colours[0], screenCoords);
+                        DrawTextBasic(
+                            dpi, screenCoords, STR_UNIT2DP_SUFFIX_METRES, &clipHeightValueInMeters, { w->colours[0] });
                         break;
                     case MeasurementFormat::Imperial:
                         clipHeightValueInFeet = static_cast<fixed16_1dp>(
                             FIXED_1DP(gClipHeight, 0) / 2.0f * 5 - FIXED_1DP(35, 0));
-                        gfx_draw_string_left(dpi, STR_UNIT1DP_SUFFIX_FEET, &clipHeightValueInFeet, w->colours[0], screenCoords);
+                        DrawTextBasic(dpi, screenCoords, STR_UNIT1DP_SUFFIX_FEET, &clipHeightValueInFeet, { w->colours[0] });
                         break;
                 }
             }

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -146,8 +146,9 @@ public:
         // Draw number for tool sizes bigger than 7
         if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
         {
-            gfx_draw_string_centred(
-                &dpi, STR_LAND_TOOL_SIZE_VALUE, screenCoords - ScreenCoordsXY{ 0, 2 }, COLOUR_BLACK, &gLandToolSize);
+            DrawTextBasic(
+                &dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, &gLandToolSize,
+                { TextAlignment::CENTRE });
         }
 
         if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
@@ -157,14 +158,14 @@ public:
                              window_water_widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };
             if (gWaterToolRaiseCost != MONEY32_UNDEFINED && gWaterToolRaiseCost != 0)
             {
-                gfx_draw_string_centred(&dpi, STR_RAISE_COST_AMOUNT, screenCoords, COLOUR_BLACK, &gWaterToolRaiseCost);
+                DrawTextBasic(&dpi, screenCoords, STR_RAISE_COST_AMOUNT, &gWaterToolRaiseCost, { TextAlignment::CENTRE });
             }
             screenCoords.y += 10;
 
             // Draw lower cost amount
             if (gWaterToolLowerCost != MONEY32_UNDEFINED && gWaterToolLowerCost != 0)
             {
-                gfx_draw_string_centred(&dpi, STR_LOWER_COST_AMOUNT, screenCoords, COLOUR_BLACK, &gWaterToolLowerCost);
+                DrawTextBasic(&dpi, screenCoords, STR_LOWER_COST_AMOUNT, &gWaterToolLowerCost, { TextAlignment::CENTRE });
             }
         }
     }

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -170,7 +170,7 @@ int32_t gfx_clip_string(utf8* text, int32_t width)
  * num_lines (edi) - out
  * font_height (ebx) - out
  */
-int32_t gfx_wrap_string(utf8* text, int32_t width, int32_t* outNumLines, FontSpriteBase* outFontHeight)
+int32_t gfx_wrap_string(utf8* text, int32_t width, int32_t* outNumLines)
 {
     constexpr size_t NULL_INDEX = std::numeric_limits<size_t>::max();
     thread_local std::string buffer;
@@ -259,7 +259,6 @@ int32_t gfx_wrap_string(utf8* text, int32_t width, int32_t* outNumLines, FontSpr
 
     std::memcpy(text, buffer.data(), buffer.size() + 1);
     *outNumLines = static_cast<int32_t>(numLines);
-    *outFontHeight = gCurrentFontSpriteBase;
     return maxWidth;
 }
 
@@ -272,7 +271,7 @@ void gfx_draw_string_left_centred(
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, format, args);
-    int32_t height = string_get_height_raw(buffer);
+    int32_t height = string_get_height_raw(buffer, FontSpriteBase::MEDIUM);
     gfx_draw_string(dpi, buffer, colour, coords - ScreenCoordsXY{ 0, (height / 2) });
 }
 
@@ -352,14 +351,12 @@ void draw_string_centred_raw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coord
         }
         text = const_cast<char*>(ch + 1);
 
-        screenCoords.y += font_get_line_height(gCurrentFontSpriteBase);
+        screenCoords.y += font_get_line_height(FontSpriteBase::MEDIUM);
     }
 }
 
-int32_t string_get_height_raw(std::string_view text)
+int32_t string_get_height_raw(std::string_view text, FontSpriteBase fontBase)
 {
-    auto fontBase = gCurrentFontSpriteBase;
-
     int32_t height = 0;
     if (fontBase <= FontSpriteBase::MEDIUM)
         height += 10;
@@ -431,7 +428,6 @@ void gfx_draw_string_centred_wrapped_partial(
     int32_t ticks)
 {
     int32_t numLines, lineHeight, lineY;
-    FontSpriteBase fontSpriteBase;
     utf8* buffer = gCommonStringFormatBuffer;
     ScreenCoordsXY screenCoords(dpi->x, dpi->y);
 
@@ -440,8 +436,8 @@ void gfx_draw_string_centred_wrapped_partial(
     format_string(buffer, 256, format, args);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
-    lineHeight = font_get_line_height(fontSpriteBase);
+    gfx_wrap_string(buffer, width, &numLines);
+    lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     int32_t numCharactersDrawn = 0;
     int32_t numCharactersToDraw = ticks;

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -266,13 +266,13 @@ int32_t gfx_wrap_string(utf8* text, int32_t width, int32_t* outNumLines)
  * Draws text that is left aligned and vertically centred.
  */
 void gfx_draw_string_left_centred(
-    rct_drawpixelinfo* dpi, rct_string_id format, void* args, int32_t colour, const ScreenCoordsXY& coords)
+    rct_drawpixelinfo* dpi, rct_string_id format, void* args, colour_t colour, const ScreenCoordsXY& coords)
 {
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, format, args);
     int32_t height = string_get_height_raw(buffer, FontSpriteBase::MEDIUM);
-    gfx_draw_string(dpi, buffer, colour, coords - ScreenCoordsXY{ 0, (height / 2) });
+    gfx_draw_string(dpi, coords - ScreenCoordsXY{ 0, (height / 2) }, buffer, { colour });
 }
 
 /**
@@ -334,13 +334,13 @@ void draw_string_centred_raw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coord
 {
     ScreenCoordsXY screenCoords(dpi->x, dpi->y);
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_draw_string(dpi, "", COLOUR_BLACK, screenCoords);
+    gfx_draw_string(dpi, screenCoords, "", { COLOUR_BLACK });
     screenCoords = coords;
 
     for (int32_t i = 0; i <= numLines; i++)
     {
-        int32_t width = gfx_get_string_width(text, gCurrentFontSpriteBase);
-        gfx_draw_string(dpi, text, TEXT_COLOUR_254, screenCoords - ScreenCoordsXY{ width / 2, 0 });
+        int32_t width = gfx_get_string_width(text, FontSpriteBase::MEDIUM);
+        gfx_draw_string(dpi, screenCoords - ScreenCoordsXY{ width / 2, 0 }, text, { TEXT_COLOUR_254 });
 
         const utf8* ch = text;
         const utf8* nextCh = nullptr;
@@ -424,7 +424,7 @@ int32_t string_get_height_raw(std::string_view text, FontSpriteBase fontBase)
  * ticks    : ebp >> 16
  */
 void gfx_draw_string_centred_wrapped_partial(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, int32_t colour, rct_string_id format, void* args,
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, rct_string_id format, void* args,
     int32_t ticks)
 {
     int32_t numLines, lineHeight, lineY;
@@ -432,7 +432,7 @@ void gfx_draw_string_centred_wrapped_partial(
     ScreenCoordsXY screenCoords(dpi->x, dpi->y);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_draw_string(dpi, "", colour, screenCoords);
+    gfx_draw_string(dpi, screenCoords, "", { colour });
     format_string(buffer, 256, format, args);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
@@ -445,7 +445,7 @@ void gfx_draw_string_centred_wrapped_partial(
     lineY = coords.y - ((numLines * lineHeight) / 2);
     for (int32_t line = 0; line <= numLines; line++)
     {
-        int32_t halfWidth = gfx_get_string_width(buffer, gCurrentFontSpriteBase) / 2;
+        int32_t halfWidth = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2;
 
         FmtString fmt(buffer);
         for (const auto& token : fmt)
@@ -471,7 +471,7 @@ void gfx_draw_string_centred_wrapped_partial(
         }
 
         screenCoords = { coords.x - halfWidth, lineY };
-        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, screenCoords);
+        gfx_draw_string(dpi, screenCoords, buffer, { TEXT_COLOUR_254 });
 
         if (numCharactersDrawn > numCharactersToDraw)
         {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -85,8 +85,6 @@ void PaletteMap::Copy(size_t dstIndex, const PaletteMap& src, size_t srcIndex, s
 thread_local int32_t gLastDrawStringX;
 thread_local int32_t gLastDrawStringY;
 
-thread_local FontSpriteBase gCurrentFontSpriteBase;
-
 uint8_t gGamePalette[256 * 4];
 uint32_t gPaletteEffectFrame;
 

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -85,7 +85,7 @@ void PaletteMap::Copy(size_t dstIndex, const PaletteMap& src, size_t srcIndex, s
 thread_local int32_t gLastDrawStringX;
 thread_local int32_t gLastDrawStringY;
 
-thread_local int16_t gCurrentFontSpriteBase;
+thread_local FontSpriteBase gCurrentFontSpriteBase;
 
 uint8_t gGamePalette[256 * 4];
 uint32_t gPaletteEffectFrame;

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -14,6 +14,7 @@
 #include "../interface/Colour.h"
 #include "../interface/ZoomLevel.h"
 #include "../world/Location.hpp"
+#include "Font.h"
 #include "Text.h"
 
 #include <memory>
@@ -652,7 +653,7 @@ void FASTCALL BlitPixels(const uint8_t* src, uint8_t* dst, const PaletteMap& pal
 
 #define MAX_SCROLLING_TEXT_MODES 38
 
-extern thread_local int16_t gCurrentFontSpriteBase;
+extern thread_local FontSpriteBase gCurrentFontSpriteBase;
 
 extern GamePalette gPalette;
 extern uint8_t gGamePalette[256 * 4];
@@ -760,7 +761,7 @@ void gfx_draw_string_with_y_offsets(
     rct_drawpixelinfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont);
 
-int32_t gfx_wrap_string(char* buffer, int32_t width, int32_t* num_lines, int32_t* font_height);
+int32_t gfx_wrap_string(char* buffer, int32_t width, int32_t* num_lines, FontSpriteBase* font_height);
 int32_t gfx_get_string_width(std::string_view text);
 int32_t gfx_get_string_width_new_lined(std::string_view text);
 int32_t gfx_get_string_width_no_formatting(std::string_view text);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -749,11 +749,11 @@ void gfx_draw_string_with_y_offsets(
     rct_drawpixelinfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont);
 
-int32_t gfx_wrap_string(char* buffer, int32_t width, int32_t* num_lines, FontSpriteBase* font_height);
+int32_t gfx_wrap_string(char* buffer, int32_t width, int32_t* num_lines);
 int32_t gfx_get_string_width(std::string_view text);
 int32_t gfx_get_string_width_new_lined(std::string_view text);
 int32_t gfx_get_string_width_no_formatting(std::string_view text);
-int32_t string_get_height_raw(std::string_view text);
+int32_t string_get_height_raw(std::string_view text, FontSpriteBase fontBase);
 int32_t gfx_clip_string(char* buffer, int32_t width);
 void shorten_path(utf8* buffer, size_t bufferSize, const utf8* path, int32_t availableWidth);
 void ttf_draw_string(

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -742,9 +742,6 @@ void gfx_draw_string_no_formatting(
 /** @deprecated */
 void gfx_draw_string_left(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords);
-/** @deprecated */
-void gfx_draw_string_centred(
-    rct_drawpixelinfo* dpi, rct_string_id format, const ScreenCoordsXY& coords, uint8_t colour, const void* args);
 
 int32_t gfx_draw_string_left_wrapped(
     rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -750,9 +750,9 @@ void gfx_draw_string_with_y_offsets(
     bool forceSpriteFont);
 
 int32_t gfx_wrap_string(char* buffer, int32_t width, int32_t* num_lines);
-int32_t gfx_get_string_width(std::string_view text);
-int32_t gfx_get_string_width_new_lined(std::string_view text);
-int32_t gfx_get_string_width_no_formatting(std::string_view text);
+int32_t gfx_get_string_width(std::string_view text, FontSpriteBase fontSpriteBase);
+int32_t gfx_get_string_width_new_lined(std::string_view text, FontSpriteBase fontSpriteBase);
+int32_t gfx_get_string_width_no_formatting(std::string_view text, FontSpriteBase fontSpriteBase);
 int32_t string_get_height_raw(std::string_view text, FontSpriteBase fontBase);
 int32_t gfx_clip_string(char* buffer, int32_t width);
 void shorten_path(utf8* buffer, size_t bufferSize, const utf8* path, int32_t availableWidth);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -735,15 +735,15 @@ void FASTCALL gfx_draw_sprite_raw_masked_software(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& scrCoords, int32_t maskImage, int32_t colourImage);
 
 // string
-void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
+void gfx_draw_string(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});
 void gfx_draw_string_no_formatting(
     rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
 
 void gfx_draw_string_left_centred(
-    rct_drawpixelinfo* dpi, rct_string_id format, void* args, int32_t colour, const ScreenCoordsXY& coords);
+    rct_drawpixelinfo* dpi, rct_string_id format, void* args, colour_t colour, const ScreenCoordsXY& coords);
 void draw_string_centred_raw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text);
 void gfx_draw_string_centred_wrapped_partial(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, int32_t colour, rct_string_id format, void* args,
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, rct_string_id format, void* args,
     int32_t ticks);
 void gfx_draw_string_with_y_offsets(
     rct_drawpixelinfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -739,11 +739,6 @@ void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t co
 void gfx_draw_string_no_formatting(
     rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
 
-int32_t gfx_draw_string_left_wrapped(
-    rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour);
-int32_t gfx_draw_string_centred_wrapped(
-    rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour);
-
 void gfx_draw_string_left_centred(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, int32_t colour, const ScreenCoordsXY& coords);
 void draw_string_centred_raw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -739,10 +739,6 @@ void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t co
 void gfx_draw_string_no_formatting(
     rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
 
-/** @deprecated */
-void gfx_draw_string_left(
-    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords);
-
 int32_t gfx_draw_string_left_wrapped(
     rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour);
 int32_t gfx_draw_string_centred_wrapped(

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -653,8 +653,6 @@ void FASTCALL BlitPixels(const uint8_t* src, uint8_t* dst, const PaletteMap& pal
 
 #define MAX_SCROLLING_TEXT_MODES 38
 
-extern thread_local FontSpriteBase gCurrentFontSpriteBase;
-
 extern GamePalette gPalette;
 extern uint8_t gGamePalette[256 * 4];
 extern uint32_t gPaletteEffectFrame;
@@ -737,27 +735,29 @@ void FASTCALL gfx_draw_sprite_raw_masked_software(
 // string
 void gfx_draw_string(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});
 void gfx_draw_string_no_formatting(
-    rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords);
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint);
 
 void gfx_draw_string_left_centred(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, colour_t colour, const ScreenCoordsXY& coords);
-void draw_string_centred_raw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text);
+void draw_string_centred_raw(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontSpriteBase fontSpriteBase);
 void gfx_draw_string_centred_wrapped_partial(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, rct_string_id format, void* args,
     int32_t ticks);
 void gfx_draw_string_with_y_offsets(
     rct_drawpixelinfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
-    bool forceSpriteFont);
+    bool forceSpriteFont, FontSpriteBase fontSpriteBase);
 
-int32_t gfx_wrap_string(char* buffer, int32_t width, int32_t* num_lines);
+int32_t gfx_wrap_string(char* buffer, int32_t width, FontSpriteBase fontSpriteBase, int32_t* num_lines);
 int32_t gfx_get_string_width(std::string_view text, FontSpriteBase fontSpriteBase);
 int32_t gfx_get_string_width_new_lined(std::string_view text, FontSpriteBase fontSpriteBase);
 int32_t gfx_get_string_width_no_formatting(std::string_view text, FontSpriteBase fontSpriteBase);
 int32_t string_get_height_raw(std::string_view text, FontSpriteBase fontBase);
-int32_t gfx_clip_string(char* buffer, int32_t width);
-void shorten_path(utf8* buffer, size_t bufferSize, const utf8* path, int32_t availableWidth);
+int32_t gfx_clip_string(char* buffer, int32_t width, FontSpriteBase fontSpriteBase);
+void shorten_path(utf8* buffer, size_t bufferSize, const utf8* path, int32_t availableWidth, FontSpriteBase fontSpriteBase);
 void ttf_draw_string(
-    rct_drawpixelinfo* dpi, const_utf8string text, int32_t colour, const ScreenCoordsXY& coords, bool noFormatting);
+    rct_drawpixelinfo* dpi, const_utf8string text, int32_t colour, const ScreenCoordsXY& coords, bool noFormatting,
+    FontSpriteBase fontSpriteBase);
 
 // scrolling text
 void scrolling_text_initialise_bitmaps();

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -283,12 +283,11 @@ int32_t font_sprite_get_codepoint_offset(int32_t codepoint)
     return codepoint - 32;
 }
 
-int32_t font_sprite_get_codepoint_width(uint16_t fontSpriteBase, int32_t codepoint)
+int32_t font_sprite_get_codepoint_width(FontSpriteBase fontSpriteBase, int32_t codepoint)
 {
-    if (fontSpriteBase == static_cast<uint16_t>(FONT_SPRITE_BASE_MEDIUM_DARK)
-        || fontSpriteBase == static_cast<uint16_t>(FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK))
+    if (fontSpriteBase == FontSpriteBase::MEDIUM_DARK || fontSpriteBase == FontSpriteBase::MEDIUM_EXTRA_DARK)
     {
-        fontSpriteBase = static_cast<uint16_t>(FONT_SPRITE_BASE_MEDIUM);
+        fontSpriteBase = FontSpriteBase::MEDIUM;
     }
 
     int32_t glyphIndex = font_sprite_get_codepoint_offset(codepoint);
@@ -312,46 +311,47 @@ int32_t font_sprite_get_codepoint_width(uint16_t fontSpriteBase, int32_t codepoi
     return _spriteFontCharacterWidths[baseFontIndex][glyphIndex];
 }
 
-int32_t font_sprite_get_codepoint_sprite(int32_t fontSpriteBase, int32_t codepoint)
+int32_t font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t codepoint)
 {
+    int32_t offset = static_cast<int32_t>(fontSpriteBase);
     auto codePointOffset = font_sprite_get_codepoint_offset(codepoint);
     if (codePointOffset > FONT_SPRITE_GLYPH_COUNT)
     {
-        fontSpriteBase = font_get_font_index_from_sprite_base(fontSpriteBase) * SPR_G2_GLYPH_COUNT;
+        offset = font_get_font_index_from_sprite_base(fontSpriteBase) * SPR_G2_GLYPH_COUNT;
     }
 
-    return SPR_CHAR_START + (IMAGE_TYPE_REMAP | (fontSpriteBase + codePointOffset));
+    return SPR_CHAR_START + (IMAGE_TYPE_REMAP | (offset + codePointOffset));
 }
 
-int32_t font_get_font_index_from_sprite_base(uint16_t spriteBase)
+int32_t font_get_font_index_from_sprite_base(FontSpriteBase spriteBase)
 {
     switch (spriteBase)
     {
-        case FONT_SPRITE_BASE_TINY:
+        case FontSpriteBase::TINY:
             return FONT_SIZE_TINY;
-        case FONT_SPRITE_BASE_SMALL:
+        case FontSpriteBase::SMALL:
             return FONT_SIZE_SMALL;
         default:
-        case FONT_SPRITE_BASE_MEDIUM:
+        case FontSpriteBase::MEDIUM:
             return FONT_SIZE_MEDIUM;
     }
 }
 
-int32_t font_get_size_from_sprite_base(uint16_t spriteBase)
+int32_t font_get_size_from_sprite_base(FontSpriteBase spriteBase)
 {
     switch (spriteBase)
     {
-        case FONT_SPRITE_BASE_TINY:
+        case FontSpriteBase::TINY:
             return 0;
-        case FONT_SPRITE_BASE_SMALL:
+        case FontSpriteBase::SMALL:
             return 1;
         default:
-        case FONT_SPRITE_BASE_MEDIUM:
+        case FontSpriteBase::MEDIUM:
             return 2;
     }
 }
 
-int32_t font_get_line_height(int32_t fontSpriteBase)
+int32_t font_get_line_height(FontSpriteBase fontSpriteBase)
 {
     int32_t fontSize = font_get_size_from_sprite_base(fontSpriteBase);
 #ifndef NO_TTF
@@ -368,7 +368,7 @@ int32_t font_get_line_height(int32_t fontSpriteBase)
 #endif // NO_TTF
 }
 
-int32_t font_get_line_height_small(int32_t fontSpriteBase)
+int32_t font_get_line_height_small(FontSpriteBase fontSpriteBase)
 {
     return font_get_line_height(fontSpriteBase) / 2;
 }

--- a/src/openrct2/drawing/Font.h
+++ b/src/openrct2/drawing/Font.h
@@ -12,6 +12,8 @@
 
 #include "../common.h"
 
+constexpr const uint16_t FONT_SPRITE_GLYPH_COUNT = 224;
+
 enum
 {
     FONT_SIZE_TINY = 2,
@@ -20,15 +22,14 @@ enum
     FONT_SIZE_COUNT = 3
 };
 
-enum
+enum class FontSpriteBase : int16_t
 {
-    FONT_SPRITE_GLYPH_COUNT = 224,
-    FONT_SPRITE_BASE_MEDIUM_EXTRA_DARK = -2,
-    FONT_SPRITE_BASE_MEDIUM_DARK = -1,
+    MEDIUM_EXTRA_DARK = -2,
+    MEDIUM_DARK = -1,
 
-    FONT_SPRITE_BASE_TINY = FONT_SIZE_TINY * FONT_SPRITE_GLYPH_COUNT,
-    FONT_SPRITE_BASE_SMALL = FONT_SIZE_SMALL * FONT_SPRITE_GLYPH_COUNT,
-    FONT_SPRITE_BASE_MEDIUM = FONT_SIZE_MEDIUM * FONT_SPRITE_GLYPH_COUNT,
+    TINY = FONT_SIZE_TINY * FONT_SPRITE_GLYPH_COUNT,
+    SMALL = FONT_SIZE_SMALL * FONT_SPRITE_GLYPH_COUNT,
+    MEDIUM = FONT_SIZE_MEDIUM * FONT_SPRITE_GLYPH_COUNT,
 };
 
 #ifndef NO_TTF
@@ -58,12 +59,12 @@ extern TTFFontSetDescriptor* gCurrentTTFFontSet;
 
 void font_sprite_initialise_characters();
 int32_t font_sprite_get_codepoint_offset(int32_t codepoint);
-int32_t font_sprite_get_codepoint_width(uint16_t fontSpriteBase, int32_t codepoint);
-int32_t font_sprite_get_codepoint_sprite(int32_t fontSpriteBase, int32_t codepoint);
-int32_t font_get_font_index_from_sprite_base(uint16_t spriteBase);
-int32_t font_get_size_from_sprite_base(uint16_t spriteBase);
-int32_t font_get_line_height(int32_t fontSpriteBase);
-int32_t font_get_line_height_small(int32_t fontSpriteBase);
+int32_t font_sprite_get_codepoint_width(FontSpriteBase fontSpriteBase, int32_t codepoint);
+int32_t font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t codepoint);
+int32_t font_get_font_index_from_sprite_base(FontSpriteBase spriteBase);
+int32_t font_get_size_from_sprite_base(FontSpriteBase spriteBase);
+int32_t font_get_line_height(FontSpriteBase fontSpriteBase);
+int32_t font_get_line_height_small(FontSpriteBase fontSpriteBase);
 bool font_supports_string_sprite(const utf8* text);
 bool font_supports_string_ttf(const utf8* text, int32_t fontSize);
 bool font_supports_string(const utf8* text, int32_t fontSize);

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -57,7 +57,8 @@ void scrolling_text_initialise_bitmaps()
     for (int32_t i = 0; i < FONT_SPRITE_GLYPH_COUNT; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(SPR_CHAR_START + FONT_SPRITE_BASE_TINY + i), { -1, 0 });
+        gfx_draw_sprite_software(
+            &dpi, ImageId::FromUInt32(SPR_CHAR_START + static_cast<uint32_t>(FontSpriteBase::TINY) + i), { -1, 0 });
 
         for (int32_t x = 0; x < 8; x++)
         {
@@ -1510,7 +1511,7 @@ static void scrolling_text_set_bitmap_for_sprite(
                 CodepointView codepoints(token.text);
                 for (auto codepoint : codepoints)
                 {
-                    auto characterWidth = font_sprite_get_codepoint_width(FONT_SPRITE_BASE_TINY, codepoint);
+                    auto characterWidth = font_sprite_get_codepoint_width(FontSpriteBase::TINY, codepoint);
                     auto characterBitmap = font_sprite_get_codepoint_bitmap(codepoint);
                     for (; characterWidth != 0; characterWidth--, characterBitmap++)
                     {
@@ -1558,7 +1559,7 @@ static void scrolling_text_set_bitmap_for_ttf(
     std::string_view text, int32_t scroll, uint8_t* bitmap, const int16_t* scrollPositionOffsets, colour_t colour)
 {
 #ifndef NO_TTF
-    auto fontDesc = ttf_get_font_from_sprite_base(FONT_SPRITE_BASE_TINY);
+    auto fontDesc = ttf_get_font_from_sprite_base(FontSpriteBase::TINY);
     if (fontDesc->font == nullptr)
     {
         scrolling_text_set_bitmap_for_sprite(text, scroll, bitmap, scrollPositionOffsets, colour);

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -346,7 +346,7 @@ uint32_t ttf_getwidth_cache_get_or_add(TTF_Font* font, std::string_view text)
     return entry->width;
 }
 
-TTFFontDescriptor* ttf_get_font_from_sprite_base(uint16_t spriteBase)
+TTFFontDescriptor* ttf_get_font_from_sprite_base(FontSpriteBase spriteBase)
 {
     FontLockHelper<std::mutex> lock(_mutex);
     return &gCurrentTTFFontSet->size[font_get_size_from_sprite_base(spriteBase)];

--- a/src/openrct2/drawing/TTF.h
+++ b/src/openrct2/drawing/TTF.h
@@ -26,7 +26,7 @@ struct TTFSurface
     int32_t pitch;
 };
 
-TTFFontDescriptor* ttf_get_font_from_sprite_base(uint16_t spriteBase);
+TTFFontDescriptor* ttf_get_font_from_sprite_base(FontSpriteBase spriteBase);
 void ttf_toggle_hinting();
 TTFSurface* ttf_surface_cache_get_or_add(TTF_Font* font, std::string_view text);
 uint32_t ttf_getwidth_cache_get_or_add(TTF_Font* font, std::string_view text);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -163,12 +163,6 @@ void gfx_draw_string_left(
     DrawTextBasic(dpi, coords, format, args, { colour, TextAlignment::LEFT });
 }
 
-void gfx_draw_string_centred(
-    rct_drawpixelinfo* dpi, rct_string_id format, const ScreenCoordsXY& coords, uint8_t colour, const void* args)
-{
-    DrawTextBasic(dpi, coords, format, args, { colour, TextAlignment::CENTRE });
-}
-
 // Wrapping
 int32_t gfx_draw_string_left_wrapped(
     rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -156,13 +156,6 @@ void gfx_draw_string_no_formatting(
     DrawText(dpi, coords, textPaint, buffer, true);
 }
 
-// Basic
-void gfx_draw_string_left(
-    rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
-{
-    DrawTextBasic(dpi, coords, format, args, { colour, TextAlignment::LEFT });
-}
-
 // Wrapping
 int32_t gfx_draw_string_left_wrapped(
     rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -156,39 +156,37 @@ void gfx_draw_string_no_formatting(
     DrawText(dpi, coords, textPaint, buffer, true);
 }
 
-// Wrapping
-int32_t gfx_draw_string_left_wrapped(
-    rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour)
+int32_t DrawTextWrapped(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const void* args,
+    TextPaint textPaint)
 {
     utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
+    gCurrentFontSpriteBase = textPaint.SpriteBase;
 
-    TextPaint textPaint = { colour, FontSpriteBase::MEDIUM, TextUnderline::Off, TextAlignment::LEFT };
     StaticLayout layout(buffer, textPaint, width);
-    layout.Draw(dpi, coords);
+
+    if (textPaint.Alignment == TextAlignment::CENTRE)
+    {
+        // The original tried to vertically centre the text, but used line count - 1
+        int32_t lineCount = layout.GetLineCount();
+        int32_t lineHeight = layout.GetHeight() / lineCount;
+        int32_t yOffset = (lineCount - 1) * lineHeight / 2;
+
+        layout.Draw(dpi, coords - ScreenCoordsXY{ layout.GetWidth() / 2, yOffset });
+    }
+    else
+    {
+        layout.Draw(dpi, coords);
+    }
 
     return layout.GetHeight();
 }
 
-int32_t gfx_draw_string_centred_wrapped(
-    rct_drawpixelinfo* dpi, void* args, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, uint8_t colour)
+int32_t DrawTextWrapped(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
+    TextPaint textPaint)
 {
-    utf8 buffer[512];
-    format_string(buffer, sizeof(buffer), format, args);
-
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
-    TextPaint textPaint = { colour, gCurrentFontSpriteBase, TextUnderline::Off, TextAlignment::CENTRE };
-    StaticLayout layout(buffer, textPaint, width);
-
-    // The original tried to vertically centre the text, but used line count - 1
-    int32_t lineCount = layout.GetLineCount();
-    int32_t lineHeight = layout.GetHeight() / lineCount;
-    int32_t yOffset = (lineCount - 1) * lineHeight / 2;
-
-    layout.Draw(dpi, coords - ScreenCoordsXY{ layout.GetWidth() / 2, yOffset });
-
-    return layout.GetHeight();
+    return DrawTextWrapped(dpi, coords, width, format, ft.Data(), textPaint);
 }

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -23,12 +23,10 @@ StaticLayout::StaticLayout(utf8string source, const TextPaint& paint, int32_t wi
     Buffer = source;
     Paint = paint;
 
-    FontSpriteBase fontSpriteBase;
-
     gCurrentFontSpriteBase = paint.SpriteBase;
-    MaxWidth = gfx_wrap_string(Buffer, width, &LineCount, &fontSpriteBase);
+    MaxWidth = gfx_wrap_string(Buffer, width, &LineCount);
     LineCount += 1;
-    LineHeight = font_get_line_height(fontSpriteBase);
+    LineHeight = font_get_line_height(gCurrentFontSpriteBase);
 }
 
 void StaticLayout::Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -117,19 +117,31 @@ static void DrawText(
 }
 
 void DrawTextBasic(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, TextPaint textPaint)
+{
+    gCurrentFontSpriteBase = textPaint.SpriteBase;
+    DrawText(dpi, coords, textPaint, format, args);
+}
+
+void DrawTextBasic(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, TextPaint textPaint)
+{
+    DrawTextBasic(dpi, coords, format, ft.Data(), textPaint);
+}
+
+void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, colour_t colour,
     TextAlignment alignment, bool underline)
 {
     TextPaint textPaint = { colour, FontSpriteBase::MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    DrawText(dpi, coords, textPaint, format, args);
+    DrawTextBasic(dpi, coords, format, args, textPaint);
 }
 
 void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, colour_t colour,
     TextAlignment alignment, bool underline)
 {
-    return DrawTextBasic(dpi, coords, format, ft.Data(), colour, alignment, underline);
+    DrawTextBasic(dpi, coords, format, ft.Data(), colour, alignment, underline);
 }
 
 void DrawTextEllipsised(

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -75,7 +75,8 @@ int32_t StaticLayout::GetLineCount()
 static void DrawText(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
 {
-    int32_t width = noFormatting ? gfx_get_string_width_no_formatting(text) : gfx_get_string_width(text);
+    int32_t width = noFormatting ? gfx_get_string_width_no_formatting(text, paint.SpriteBase)
+                                 : gfx_get_string_width(text, paint.SpriteBase);
 
     auto alignedCoords = coords;
     switch (paint.Alignment)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -142,9 +142,8 @@ void DrawTextEllipsised(
     DrawText(dpi, coords, textPaint, buffer);
 }
 
-void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords)
+void gfx_draw_string(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
 {
-    TextPaint textPaint = { colour, gCurrentFontSpriteBase, TextUnderline::Off, TextAlignment::LEFT };
     DrawText(dpi, coords, textPaint, buffer);
 }
 

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -129,21 +129,6 @@ void DrawTextBasic(
     DrawTextBasic(dpi, coords, format, ft.Data(), textPaint);
 }
 
-void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, colour_t colour,
-    TextAlignment alignment, bool underline)
-{
-    TextPaint textPaint = { colour, FontSpriteBase::MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
-    DrawTextBasic(dpi, coords, format, args, textPaint);
-}
-
-void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, colour_t colour,
-    TextAlignment alignment, bool underline)
-{
-    DrawTextBasic(dpi, coords, format, ft.Data(), colour, alignment, underline);
-}
-
 void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
     colour_t colour, TextAlignment alignment, bool underline)
@@ -175,13 +160,13 @@ void gfx_draw_string_no_formatting(
 void gfx_draw_string_left(
     rct_drawpixelinfo* dpi, rct_string_id format, void* args, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    DrawTextBasic(dpi, coords, format, args, colour, TextAlignment::LEFT);
+    DrawTextBasic(dpi, coords, format, args, { colour, TextAlignment::LEFT });
 }
 
 void gfx_draw_string_centred(
     rct_drawpixelinfo* dpi, rct_string_id format, const ScreenCoordsXY& coords, uint8_t colour, const void* args)
 {
-    DrawTextBasic(dpi, coords, format, args, colour, TextAlignment::CENTRE);
+    DrawTextBasic(dpi, coords, format, args, { colour, TextAlignment::CENTRE });
 }
 
 // Wrapping

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -23,7 +23,7 @@ StaticLayout::StaticLayout(utf8string source, const TextPaint& paint, int32_t wi
     Buffer = source;
     Paint = paint;
 
-    int32_t fontSpriteBase;
+    FontSpriteBase fontSpriteBase;
 
     gCurrentFontSpriteBase = paint.SpriteBase;
     MaxWidth = gfx_wrap_string(Buffer, width, &LineCount, &fontSpriteBase);
@@ -120,8 +120,8 @@ void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, colour_t colour,
     TextAlignment alignment, bool underline)
 {
-    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    TextPaint textPaint = { colour, FontSpriteBase::MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     DrawText(dpi, coords, textPaint, format, args);
 }
 
@@ -136,8 +136,8 @@ void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
     colour_t colour, TextAlignment alignment, bool underline)
 {
-    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    TextPaint textPaint = { colour, FontSpriteBase::MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, ft.Data());
@@ -179,9 +179,9 @@ int32_t gfx_draw_string_left_wrapped(
     utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
-    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, TextUnderline::Off, TextAlignment::LEFT };
+    TextPaint textPaint = { colour, FontSpriteBase::MEDIUM, TextUnderline::Off, TextAlignment::LEFT };
     StaticLayout layout(buffer, textPaint, width);
     layout.Draw(dpi, coords);
 
@@ -194,7 +194,7 @@ int32_t gfx_draw_string_centred_wrapped(
     utf8 buffer[512];
     format_string(buffer, sizeof(buffer), format, args);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     TextPaint textPaint = { colour, gCurrentFontSpriteBase, TextUnderline::Off, TextAlignment::CENTRE };
     StaticLayout layout(buffer, textPaint, width);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -94,7 +94,7 @@ static void DrawText(
 
     ttf_draw_string(dpi, text, paint.Colour, alignedCoords, noFormatting);
 
-    if (paint.UnderlineText)
+    if (paint.UnderlineText == TextUnderline::On)
     {
         gfx_fill_rect(
             dpi, { { alignedCoords + ScreenCoordsXY{ 0, 11 } }, { alignedCoords + ScreenCoordsXY{ width, 11 } } },
@@ -120,7 +120,7 @@ void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, colour_t colour,
     TextAlignment alignment, bool underline)
 {
-    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, underline, alignment };
+    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
     DrawText(dpi, coords, textPaint, format, args);
 }
@@ -136,7 +136,7 @@ void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
     colour_t colour, TextAlignment alignment, bool underline)
 {
-    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, underline, alignment };
+    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, underline ? TextUnderline::On : TextUnderline::Off, alignment };
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
     utf8 buffer[512];
@@ -148,14 +148,14 @@ void DrawTextEllipsised(
 
 void gfx_draw_string(rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    TextPaint textPaint = { colour, gCurrentFontSpriteBase, false, TextAlignment::LEFT };
+    TextPaint textPaint = { colour, gCurrentFontSpriteBase, TextUnderline::Off, TextAlignment::LEFT };
     DrawText(dpi, coords, textPaint, buffer);
 }
 
 void gfx_draw_string_no_formatting(
     rct_drawpixelinfo* dpi, const_utf8string buffer, uint8_t colour, const ScreenCoordsXY& coords)
 {
-    TextPaint textPaint = { colour, gCurrentFontSpriteBase, false, TextAlignment::LEFT };
+    TextPaint textPaint = { colour, gCurrentFontSpriteBase, TextUnderline::Off, TextAlignment::LEFT };
     DrawText(dpi, coords, textPaint, buffer, true);
 }
 
@@ -181,7 +181,7 @@ int32_t gfx_draw_string_left_wrapped(
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, false, TextAlignment::LEFT };
+    TextPaint textPaint = { colour, FONT_SPRITE_BASE_MEDIUM, TextUnderline::Off, TextAlignment::LEFT };
     StaticLayout layout(buffer, textPaint, width);
     layout.Draw(dpi, coords);
 
@@ -196,7 +196,7 @@ int32_t gfx_draw_string_centred_wrapped(
 
     gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
 
-    TextPaint textPaint = { colour, gCurrentFontSpriteBase, false, TextAlignment::CENTRE };
+    TextPaint textPaint = { colour, gCurrentFontSpriteBase, TextUnderline::Off, TextAlignment::CENTRE };
     StaticLayout layout(buffer, textPaint, width);
 
     // The original tried to vertically centre the text, but used line count - 1

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -152,3 +152,9 @@ void DrawTextBasic(
 void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
     colour_t colour, TextAlignment alignment = TextAlignment::LEFT, bool underline = false);
+int32_t DrawTextWrapped(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft = {},
+    TextPaint textPaint = {});
+int32_t DrawTextWrapped(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const void* args,
+    TextPaint textPaint = {});

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -151,7 +151,7 @@ void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, TextPaint textPaint = {});
 void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
-    colour_t colour, TextAlignment alignment = TextAlignment::LEFT, bool underline = false);
+    TextPaint textPaint = {});
 int32_t DrawTextWrapped(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft = {},
     TextPaint textPaint = {});

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -33,7 +33,7 @@ enum class TextUnderline
 struct TextPaint
 {
     colour_t Colour = COLOUR_BLACK;
-    FontSpriteBase SpriteBase = FontSpriteBase::SMALL;
+    FontSpriteBase SpriteBase = FontSpriteBase::MEDIUM;
     TextUnderline UnderlineText = TextUnderline::Off;
     TextAlignment Alignment = TextAlignment::LEFT;
 

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -37,7 +37,7 @@ struct TextPaint
     TextUnderline UnderlineText = TextUnderline::Off;
     TextAlignment Alignment = TextAlignment::LEFT;
 
-    explicit TextPaint()
+    TextPaint()
     {
     }
     TextPaint(colour_t colour)
@@ -80,6 +80,11 @@ struct TextPaint
     }
     TextPaint(FontSpriteBase spriteBase, TextAlignment alignment)
         : SpriteBase(spriteBase)
+        , Alignment(alignment)
+    {
+    }
+    TextPaint(TextUnderline underlineText, TextAlignment alignment)
+        : UnderlineText(underlineText)
         , Alignment(alignment)
     {
     }
@@ -142,12 +147,6 @@ void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, TextPaint textPaint);
 void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, TextPaint textPaint);
-void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, colour_t colour,
-    TextAlignment alignment = TextAlignment::LEFT, bool underline = false);
-void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, colour_t colour,
-    TextAlignment alignment = TextAlignment::LEFT, bool underline = false);
 void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
     colour_t colour, TextAlignment alignment = TextAlignment::LEFT, bool underline = false);

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "Font.h"
 
 struct ScreenCoordsXY;
 struct rct_drawpixelinfo;
@@ -31,7 +32,7 @@ enum class TextUnderline
 struct TextPaint
 {
     uint8_t Colour = 0;
-    int16_t SpriteBase = 0;
+    FontSpriteBase SpriteBase = FontSpriteBase::SMALL;
     TextUnderline UnderlineText = TextUnderline::Off;
     TextAlignment Alignment = TextAlignment::LEFT;
 };

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -139,6 +139,10 @@ public:
 };
 
 void DrawTextBasic(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, TextPaint textPaint);
+void DrawTextBasic(
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, TextPaint textPaint);
+void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, colour_t colour,
     TextAlignment alignment = TextAlignment::LEFT, bool underline = false);
 void DrawTextBasic(

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../interface/Colour.h"
 #include "Font.h"
 
 struct ScreenCoordsXY;
@@ -31,7 +32,7 @@ enum class TextUnderline
 
 struct TextPaint
 {
-    uint8_t Colour = 0;
+    colour_t Colour = COLOUR_BLACK;
     FontSpriteBase SpriteBase = FontSpriteBase::SMALL;
     TextUnderline UnderlineText = TextUnderline::Off;
     TextAlignment Alignment = TextAlignment::LEFT;

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "../interface/Colour.h"
+#include "../localisation/Formatter.h"
 #include "Font.h"
 
 struct ScreenCoordsXY;
@@ -144,9 +145,10 @@ public:
 };
 
 void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft, TextPaint textPaint);
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft = {},
+    TextPaint textPaint = {});
 void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, TextPaint textPaint);
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const void* args, TextPaint textPaint = {});
 void DrawTextEllipsised(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, rct_string_id format, const Formatter& ft,
     colour_t colour, TextAlignment alignment = TextAlignment::LEFT, bool underline = false);

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -36,6 +36,86 @@ struct TextPaint
     FontSpriteBase SpriteBase = FontSpriteBase::SMALL;
     TextUnderline UnderlineText = TextUnderline::Off;
     TextAlignment Alignment = TextAlignment::LEFT;
+
+    explicit TextPaint()
+    {
+    }
+    TextPaint(colour_t colour)
+        : Colour(colour)
+    {
+    }
+    TextPaint(FontSpriteBase spriteBase)
+        : SpriteBase(spriteBase)
+    {
+    }
+    TextPaint(TextUnderline underlineText)
+        : UnderlineText(underlineText)
+    {
+    }
+    TextPaint(TextAlignment alignment)
+        : Alignment(alignment)
+    {
+    }
+
+    TextPaint(colour_t colour, FontSpriteBase spriteBase)
+        : Colour(colour)
+        , SpriteBase(spriteBase)
+    {
+    }
+    TextPaint(colour_t colour, TextUnderline underlineText)
+        : Colour(colour)
+        , UnderlineText(underlineText)
+    {
+    }
+    TextPaint(colour_t colour, TextAlignment alignment)
+        : Colour(colour)
+        , Alignment(alignment)
+    {
+    }
+
+    TextPaint(FontSpriteBase spriteBase, TextUnderline underlineText)
+        : SpriteBase(spriteBase)
+        , UnderlineText(underlineText)
+    {
+    }
+    TextPaint(FontSpriteBase spriteBase, TextAlignment alignment)
+        : SpriteBase(spriteBase)
+        , Alignment(alignment)
+    {
+    }
+
+    TextPaint(colour_t colour, FontSpriteBase spriteBase, TextUnderline underlineText)
+        : Colour(colour)
+        , SpriteBase(spriteBase)
+        , UnderlineText(underlineText)
+    {
+    }
+    TextPaint(colour_t colour, FontSpriteBase spriteBase, TextAlignment alignment)
+        : Colour(colour)
+        , SpriteBase(spriteBase)
+        , Alignment(alignment)
+    {
+    }
+    TextPaint(colour_t colour, TextUnderline underlineText, TextAlignment alignment)
+        : Colour(colour)
+        , UnderlineText(underlineText)
+        , Alignment(alignment)
+    {
+    }
+    TextPaint(FontSpriteBase spriteBase, TextUnderline underlineText, TextAlignment alignment)
+        : SpriteBase(spriteBase)
+        , UnderlineText(underlineText)
+        , Alignment(alignment)
+    {
+    }
+
+    TextPaint(colour_t colour, FontSpriteBase spriteBase, TextUnderline underlineText, TextAlignment alignment)
+        : Colour(colour)
+        , SpriteBase(spriteBase)
+        , UnderlineText(underlineText)
+        , Alignment(alignment)
+    {
+    }
 };
 
 class StaticLayout

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -22,11 +22,17 @@ enum class TextAlignment
     RIGHT
 };
 
+enum class TextUnderline
+{
+    Off,
+    On,
+};
+
 struct TextPaint
 {
     uint8_t Colour = 0;
     int16_t SpriteBase = 0;
-    bool UnderlineText = false;
+    TextUnderline UnderlineText = TextUnderline::Off;
     TextAlignment Alignment = TextAlignment::LEFT;
 };
 

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -274,8 +274,9 @@ static int32_t chat_history_draw_string(
     auto buffer = gCommonStringFormatBuffer;
     FormatStringToBuffer(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), "{OUTLINE}{WHITE}{STRING}", text);
 
-    int32_t fontSpriteBase, numLines;
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    int32_t numLines;
+    FontSpriteBase fontSpriteBase;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
     auto lineHeight = font_get_line_height(fontSpriteBase);
 
@@ -299,14 +300,15 @@ static int32_t chat_history_draw_string(
 // Almost the same as gfx_draw_string_left_wrapped
 int32_t chat_string_wrapped_get_height(void* args, int32_t width)
 {
-    int32_t fontSpriteBase, lineHeight, lineY, numLines;
+    int32_t lineHeight, lineY, numLines;
+    FontSpriteBase fontSpriteBase;
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, STR_STRING, args);
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
     gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
     lineHeight = font_get_line_height(fontSpriteBase);
 

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -275,8 +275,7 @@ static int32_t chat_history_draw_string(
     FormatStringToBuffer(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), "{OUTLINE}{WHITE}{STRING}", text);
 
     int32_t numLines;
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer, width, &numLines);
+    gfx_wrap_string(buffer, width, FontSpriteBase::MEDIUM, &numLines);
     auto lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     int32_t expectedY = screenCoords.y - (numLines * lineHeight);
@@ -299,18 +298,14 @@ static int32_t chat_history_draw_string(
 // Almost the same as gfx_draw_string_left_wrapped
 int32_t chat_string_wrapped_get_height(void* args, int32_t width)
 {
-    int32_t lineHeight, lineY, numLines;
-
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-
     char* buffer = gCommonStringFormatBuffer;
     format_string(buffer, 256, STR_STRING, args);
 
-    gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer, width, &numLines);
-    lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
+    int32_t numLines;
+    gfx_wrap_string(buffer, width, FontSpriteBase::MEDIUM, &numLines);
+    int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
-    lineY = 0;
+    int32_t lineY = 0;
     for (int32_t line = 0; line <= numLines; ++line)
     {
         buffer = get_string_end(buffer) + 1;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -288,7 +288,7 @@ static int32_t chat_history_draw_string(
     auto lineY = screenCoords.y;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        gfx_draw_string(dpi, buffer, TEXT_COLOUR_254, { screenCoords.x, lineY - (numLines * lineHeight) });
+        gfx_draw_string(dpi, { screenCoords.x, lineY - (numLines * lineHeight) }, buffer, { TEXT_COLOUR_254 });
         buffer = get_string_end(buffer) + 1;
         lineY += lineHeight;
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -189,9 +189,9 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
         screenCoords.y = _chatBottom - inputLineHeight - 5;
 
         auto lineCh = lineBuffer.c_str();
-        inputLineHeight = gfx_draw_string_left_wrapped(
-            dpi, static_cast<void*>(&lineCh), screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING,
-            TEXT_COLOUR_255);
+        inputLineHeight = DrawTextWrapped(
+            dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING, static_cast<void*>(&lineCh),
+            { TEXT_COLOUR_255 });
         gfx_set_dirty_blocks({ screenCoords, { screenCoords + ScreenCoordsXY{ _chatWidth, inputLineHeight + 15 } } });
 
         // TODO: Show caret if the input text has multiple lines

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -195,10 +195,10 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
         gfx_set_dirty_blocks({ screenCoords, { screenCoords + ScreenCoordsXY{ _chatWidth, inputLineHeight + 15 } } });
 
         // TODO: Show caret if the input text has multiple lines
-        if (_chatCaretTicks < 15 && gfx_get_string_width(lineBuffer) < (_chatWidth - 10))
+        if (_chatCaretTicks < 15 && gfx_get_string_width(lineBuffer, FontSpriteBase::MEDIUM) < (_chatWidth - 10))
         {
             lineBuffer.assign(_chatCurrentLine, _chatTextInputSession->SelectionStart);
-            int32_t caretX = screenCoords.x + gfx_get_string_width(lineBuffer);
+            int32_t caretX = screenCoords.x + gfx_get_string_width(lineBuffer, FontSpriteBase::MEDIUM);
             int32_t caretY = screenCoords.y + 14;
 
             gfx_fill_rect(dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PALETTE_INDEX_56);

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -275,10 +275,9 @@ static int32_t chat_history_draw_string(
     FormatStringToBuffer(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), "{OUTLINE}{WHITE}{STRING}", text);
 
     int32_t numLines;
-    FontSpriteBase fontSpriteBase;
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
-    auto lineHeight = font_get_line_height(fontSpriteBase);
+    gfx_wrap_string(buffer, width, &numLines);
+    auto lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     int32_t expectedY = screenCoords.y - (numLines * lineHeight);
     if (expectedY < 50)
@@ -301,7 +300,6 @@ static int32_t chat_history_draw_string(
 int32_t chat_string_wrapped_get_height(void* args, int32_t width)
 {
     int32_t lineHeight, lineY, numLines;
-    FontSpriteBase fontSpriteBase;
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
@@ -309,8 +307,8 @@ int32_t chat_string_wrapped_get_height(void* args, int32_t width)
     format_string(buffer, 256, STR_STRING, args);
 
     gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-    gfx_wrap_string(buffer, width, &numLines, &fontSpriteBase);
-    lineHeight = font_get_line_height(fontSpriteBase);
+    gfx_wrap_string(buffer, width, &numLines);
+    lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
 
     lineY = 0;
     for (int32_t line = 0; line <= numLines; ++line)

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -17,7 +17,7 @@
 /**
  * Colour IDs as used by the colour dropdown, NOT palette indices.
  */
-enum
+enum : colour_t
 {
     COLOUR_BLACK,
     COLOUR_GREY,

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -48,7 +48,7 @@ void MusicObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t hei
     // Write (no image)
     int32_t x = width / 2;
     int32_t y = height / 2;
-    gfx_draw_string_centred(dpi, STR_WINDOW_NO_IMAGE, { x, y }, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
 }
 
 void MusicObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -52,7 +52,7 @@ void WaterObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t hei
 {
     // Write (no image)
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    gfx_draw_string_centred(dpi, STR_WINDOW_NO_IMAGE, screenCoords, COLOUR_BLACK, nullptr);
+    DrawTextBasic(dpi, screenCoords, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
 }
 
 void WaterObject::ReadJson([[maybe_unused]] IReadObjectContext* context, json_t& root)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -952,7 +952,7 @@ void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, paint_string_struct* ps)
     {
         char buffer[256]{};
         format_string(buffer, sizeof(buffer), ps->string_id, &ps->args);
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
         // Use sprite font unless the currency contains characters unsupported by the sprite font
         auto forceSpriteFont = false;

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -952,7 +952,6 @@ void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, paint_string_struct* ps)
     {
         char buffer[256]{};
         format_string(buffer, sizeof(buffer), ps->string_id, &ps->args);
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
 
         // Use sprite font unless the currency contains characters unsupported by the sprite font
         auto forceSpriteFont = false;
@@ -963,6 +962,7 @@ void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, paint_string_struct* ps)
         }
 
         gfx_draw_string_with_y_offsets(
-            dpi, buffer, COLOUR_BLACK, { ps->x, ps->y }, reinterpret_cast<int8_t*>(ps->y_offsets), forceSpriteFont);
+            dpi, buffer, COLOUR_BLACK, { ps->x, ps->y }, reinterpret_cast<int8_t*>(ps->y_offsets), forceSpriteFont,
+            FontSpriteBase::MEDIUM);
     } while ((ps = ps->next) != nullptr);
 }

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -91,7 +91,7 @@ void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
     screenCoords.x = screenCoords.x - stringWidth;
 
     if (((gCurrentTicks >> 1) & 0xF) > 4)
-        gfx_draw_string(dpi, buffer, COLOUR_SATURATED_RED, screenCoords);
+        gfx_draw_string(dpi, screenCoords, buffer, { COLOUR_SATURATED_RED });
 
     // Make area dirty so the text doesn't get drawn over the last
     gfx_set_dirty_blocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
@@ -109,7 +109,7 @@ void Painter::PaintFPS(rct_drawpixelinfo* dpi)
     // Draw Text
     int32_t stringWidth = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
     screenCoords.x = screenCoords.x - (stringWidth / 2);
-    gfx_draw_string(dpi, buffer, 0, screenCoords);
+    gfx_draw_string(dpi, screenCoords, buffer);
 
     // Make area dirty so the text doesn't get drawn over the last
     gfx_set_dirty_blocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { gLastDrawStringX + 16, 16 } });

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -87,7 +87,7 @@ void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
     char buffer[64]{};
     FormatStringToBuffer(buffer, sizeof(buffer), "{MEDIUMFONT}{OUTLINE}{RED}{STRING}", text);
 
-    auto stringWidth = gfx_get_string_width(buffer);
+    auto stringWidth = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
     screenCoords.x = screenCoords.x - stringWidth;
 
     if (((gCurrentTicks >> 1) & 0xF) > 4)
@@ -107,7 +107,7 @@ void Painter::PaintFPS(rct_drawpixelinfo* dpi)
     FormatStringToBuffer(buffer, sizeof(buffer), "{MEDIUMFONT}{OUTLINE}{WHITE}{INT32}", _currentFPS);
 
     // Draw Text
-    int32_t stringWidth = gfx_get_string_width(buffer);
+    int32_t stringWidth = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
     screenCoords.x = screenCoords.x - (stringWidth / 2);
     gfx_draw_string(dpi, buffer, 0, screenCoords);
 

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -115,7 +115,7 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
 
     gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
-    uint16_t string_width = gfx_get_string_width(gCommonStringFormatBuffer);
+    uint16_t string_width = gfx_get_string_width(gCommonStringFormatBuffer, FontSpriteBase::TINY);
     uint16_t scroll = (gCurrentTicks / 2) % string_width;
     auto scrollIndex = scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, COLOUR_BLACK);
     PaintAddImageAsChild(

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -113,7 +113,7 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
         format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
 
-    gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
+    gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
     uint16_t string_width = gfx_get_string_width(gCommonStringFormatBuffer);
     uint16_t scroll = (gCurrentTicks / 2) % string_width;

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -113,8 +113,6 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
         format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
 
-    gCurrentFontSpriteBase = FontSpriteBase::TINY;
-
     uint16_t string_width = gfx_get_string_width(gCommonStringFormatBuffer, FontSpriteBase::TINY);
     uint16_t scroll = (gCurrentTicks / 2) % string_width;
     auto scrollIndex = scrolling_text_setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, COLOUR_BLACK);

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -183,8 +183,6 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
             format_string(entrance_string, sizeof(entrance_string), STR_BANNER_TEXT_FORMAT, ft.Data());
         }
 
-        gCurrentFontSpriteBase = FontSpriteBase::TINY;
-
         uint16_t stringWidth = gfx_get_string_width(entrance_string, FontSpriteBase::TINY);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
@@ -290,8 +288,6 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
                 {
                     format_string(park_name, sizeof(park_name), STR_BANNER_TEXT_FORMAT, ft.Data());
                 }
-
-                gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
                 uint16_t stringWidth = gfx_get_string_width(park_name, FontSpriteBase::TINY);
                 uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -185,7 +185,7 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
 
         gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
-        uint16_t stringWidth = gfx_get_string_width(entrance_string);
+        uint16_t stringWidth = gfx_get_string_width(entrance_string, FontSpriteBase::TINY);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
         PaintAddImageAsChild(
@@ -293,7 +293,7 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
 
                 gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
-                uint16_t stringWidth = gfx_get_string_width(park_name);
+                uint16_t stringWidth = gfx_get_string_width(park_name, FontSpriteBase::TINY);
                 uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
                 if (entrance->scrolling_mode == SCROLLING_MODE_NONE)

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -183,7 +183,7 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
             format_string(entrance_string, sizeof(entrance_string), STR_BANNER_TEXT_FORMAT, ft.Data());
         }
 
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
+        gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
         uint16_t stringWidth = gfx_get_string_width(entrance_string);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
@@ -291,7 +291,7 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
                     format_string(park_name, sizeof(park_name), STR_BANNER_TEXT_FORMAT, ft.Data());
                 }
 
-                gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
+                gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
                 uint16_t stringWidth = gfx_get_string_width(park_name);
                 uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -442,7 +442,7 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
 
         gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
-        uint16_t stringWidth = gfx_get_string_width(signString);
+        uint16_t stringWidth = gfx_get_string_width(signString, FontSpriteBase::TINY);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
         PaintAddImageAsChild(
             session, scrolling_text_setup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollMode, textColour), 0, 0, 1, 1, 21,

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -440,7 +440,7 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
             format_string(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
         }
 
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
+        gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
         uint16_t stringWidth = gfx_get_string_width(signString);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -440,8 +440,6 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
             format_string(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
         }
 
-        gCurrentFontSpriteBase = FontSpriteBase::TINY;
-
         uint16_t stringWidth = gfx_get_string_width(signString, FontSpriteBase::TINY);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
         PaintAddImageAsChild(

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -470,7 +470,7 @@ static void sub_6A4101(
                 format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
             }
 
-            gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
+            gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
             uint16_t stringWidth = gfx_get_string_width(gCommonStringFormatBuffer);
             uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -470,8 +470,6 @@ static void sub_6A4101(
                 format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
             }
 
-            gCurrentFontSpriteBase = FontSpriteBase::TINY;
-
             uint16_t stringWidth = gfx_get_string_width(gCommonStringFormatBuffer, FontSpriteBase::TINY);
             uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -472,7 +472,7 @@ static void sub_6A4101(
 
             gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
-            uint16_t stringWidth = gfx_get_string_width(gCommonStringFormatBuffer);
+            uint16_t stringWidth = gfx_get_string_width(gCommonStringFormatBuffer, FontSpriteBase::TINY);
             uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
             PaintAddImageAsChild(

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -446,7 +446,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
             format_string(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
         }
 
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_TINY;
+        gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
         uint16_t stringWidth = gfx_get_string_width(signString);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -446,8 +446,6 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
             format_string(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
         }
 
-        gCurrentFontSpriteBase = FontSpriteBase::TINY;
-
         uint16_t stringWidth = gfx_get_string_width(signString, FontSpriteBase::TINY);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -448,7 +448,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
 
         gCurrentFontSpriteBase = FontSpriteBase::TINY;
 
-        uint16_t stringWidth = gfx_get_string_width(signString);
+        uint16_t stringWidth = gfx_get_string_width(signString, FontSpriteBase::TINY);
         uint16_t scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
 
         PaintAddImageAsChild(

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -443,7 +443,7 @@ void DrawOpenRCT2(rct_drawpixelinfo* dpi, const ScreenCoordsXY& screenCoords)
     gfx_draw_string(dpi, buffer.c_str(), COLOUR_BLACK, screenCoords + ScreenCoordsXY(5, 5 - 13));
 
     // Invalidate screen area
-    int16_t width = static_cast<int16_t>(gfx_get_string_width(buffer));
+    int16_t width = static_cast<int16_t>(gfx_get_string_width(buffer, FontSpriteBase::MEDIUM));
     gfx_set_dirty_blocks(
         { screenCoords, screenCoords + ScreenCoordsXY{ width, 30 } }); // 30 is an arbitrary height to catch both strings
 

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -440,7 +440,7 @@ void DrawOpenRCT2(rct_drawpixelinfo* dpi, const ScreenCoordsXY& screenCoords)
 
     // Write name and version information
     buffer += gVersionInfoFull;
-    gfx_draw_string(dpi, buffer.c_str(), COLOUR_BLACK, screenCoords + ScreenCoordsXY(5, 5 - 13));
+    gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(5, 5 - 13), buffer.c_str(), { COLOUR_BLACK });
 
     // Invalidate screen area
     int16_t width = static_cast<int16_t>(gfx_get_string_width(buffer, FontSpriteBase::MEDIUM));
@@ -453,5 +453,5 @@ void DrawOpenRCT2(rct_drawpixelinfo* dpi, const ScreenCoordsXY& screenCoords)
     buffer.append(" (");
     buffer.append(OPENRCT2_ARCHITECTURE);
     buffer.append(")");
-    gfx_draw_string(dpi, buffer.c_str(), COLOUR_BLACK, screenCoords + ScreenCoordsXY(5, 5));
+    gfx_draw_string(dpi, screenCoords + ScreenCoordsXY(5, 5), buffer.c_str(), { COLOUR_BLACK });
 }

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -54,7 +54,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
         auto [stringId, newValue] = moneyEffect->GetStringId();
         char buffer[128];
         format_string(buffer, 128, stringId, &newValue);
-        gCurrentFontSpriteBase = FONT_SPRITE_BASE_MEDIUM;
+        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         offsetX = -(gfx_get_string_width(buffer) / 2);
     }
     moneyEffect->OffsetX = offsetX;

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -54,7 +54,6 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
         auto [stringId, newValue] = moneyEffect->GetStringId();
         char buffer[128];
         format_string(buffer, 128, stringId, &newValue);
-        gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
         offsetX = -(gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2);
     }
     moneyEffect->OffsetX = offsetX;

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -55,7 +55,7 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
         char buffer[128];
         format_string(buffer, 128, stringId, &newValue);
         gCurrentFontSpriteBase = FontSpriteBase::MEDIUM;
-        offsetX = -(gfx_get_string_width(buffer) / 2);
+        offsetX = -(gfx_get_string_width(buffer, FontSpriteBase::MEDIUM) / 2);
     }
     moneyEffect->OffsetX = offsetX;
     moneyEffect->Wiggle = 0;


### PR DESCRIPTION
This PR:
- Removes gCurrentFontSpriteBase
- Unifies several text drawing calls with more consistent syntax
- Makes calling parameters easier to follow by using enum classes