### PR TITLE
Fix #14190: Game crash likely related to plug-in hotkeys

### DIFF
--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -288,13 +288,16 @@ void InputManager::ProcessHoldEvents()
     _viewScroll.x = 0;
     _viewScroll.y = 0;
 
-    auto& shortcutManager = GetShortcutManager();
-    if (!shortcutManager.IsPendingShortcutChange())
+    if (!HasTextInputFocus())
     {
-        ProcessViewScrollEvent(ShortcutId::ViewScrollUp, { 0, -1 });
-        ProcessViewScrollEvent(ShortcutId::ViewScrollDown, { 0, 1 });
-        ProcessViewScrollEvent(ShortcutId::ViewScrollLeft, { -1, 0 });
-        ProcessViewScrollEvent(ShortcutId::ViewScrollRight, { 1, 0 });
+        auto& shortcutManager = GetShortcutManager();
+        if (!shortcutManager.IsPendingShortcutChange())
+        {
+            ProcessViewScrollEvent(ShortcutId::ViewScrollUp, { 0, -1 });
+            ProcessViewScrollEvent(ShortcutId::ViewScrollDown, { 0, 1 });
+            ProcessViewScrollEvent(ShortcutId::ViewScrollLeft, { -1, 0 });
+            ProcessViewScrollEvent(ShortcutId::ViewScrollRight, { 1, 0 });
+        }
     }
 }
 
@@ -375,5 +378,21 @@ bool InputManager::GetState(const ShortcutInput& shortcut) const
             }
         }
     }
+    return false;
+}
+
+bool InputManager::HasTextInputFocus() const
+{
+    if (gUsingWidgetTextBox || gChatOpen)
+        return true;
+
+    auto w = window_find_by_class(WC_TEXTINPUT);
+    if (w != nullptr)
+        return true;
+
+    auto& console = GetInGameConsole();
+    if (console.IsOpen())
+        return true;
+
     return false;
 }

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -253,7 +253,7 @@ void InputManager::ProcessInGameConsole(const InputEvent& e)
 
 void InputManager::ProcessChat(const InputEvent& e)
 {
-    if (e.DeviceKind == InputDeviceKind::Keyboard && e.State == InputEventState::Release)
+    if (e.DeviceKind == InputDeviceKind::Keyboard && e.State == InputEventState::Down)
     {
         auto input = ChatInput::None;
         switch (e.Button)

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -291,21 +291,17 @@ void InputManager::ProcessHoldEvents()
     auto& shortcutManager = GetShortcutManager();
     if (!shortcutManager.IsPendingShortcutChange())
     {
-        ProcessViewScrollEvent(ShortcutId::ViewScrollUp, _scrollUpShortcut, { 0, -1 });
-        ProcessViewScrollEvent(ShortcutId::ViewScrollDown, _scrollDownShortcut, { 0, 1 });
-        ProcessViewScrollEvent(ShortcutId::ViewScrollLeft, _scrollLeftShortcut, { -1, 0 });
-        ProcessViewScrollEvent(ShortcutId::ViewScrollRight, _scrollRightShortcut, { 1, 0 });
+        ProcessViewScrollEvent(ShortcutId::ViewScrollUp, { 0, -1 });
+        ProcessViewScrollEvent(ShortcutId::ViewScrollDown, { 0, 1 });
+        ProcessViewScrollEvent(ShortcutId::ViewScrollLeft, { -1, 0 });
+        ProcessViewScrollEvent(ShortcutId::ViewScrollRight, { 1, 0 });
     }
 }
 
-void InputManager::ProcessViewScrollEvent(
-    std::string_view shortcutId, RegisteredShortcut*& shortcut, const ScreenCoordsXY& delta)
+void InputManager::ProcessViewScrollEvent(std::string_view shortcutId, const ScreenCoordsXY& delta)
 {
-    if (shortcut == nullptr)
-    {
-        auto& shortcutManager = GetShortcutManager();
-        shortcut = shortcutManager.GetShortcut(shortcutId);
-    }
+    auto& shortcutManager = GetShortcutManager();
+    auto shortcut = shortcutManager.GetShortcut(shortcutId);
     if (shortcut != nullptr && GetState(*shortcut))
     {
         _viewScroll.x += delta.x;

--- a/src/openrct2-ui/input/InputManager.h
+++ b/src/openrct2-ui/input/InputManager.h
@@ -53,11 +53,6 @@ namespace OpenRCT2::Ui
         uint32_t _mouseState;
         std::vector<uint8_t> _keyboardState;
 
-        RegisteredShortcut* _scrollLeftShortcut{};
-        RegisteredShortcut* _scrollUpShortcut{};
-        RegisteredShortcut* _scrollRightShortcut{};
-        RegisteredShortcut* _scrollDownShortcut{};
-
         void CheckJoysticks();
 
         void HandleViewScrolling();
@@ -67,7 +62,7 @@ namespace OpenRCT2::Ui
         void ProcessInGameConsole(const InputEvent& e);
         void ProcessChat(const InputEvent& e);
         void ProcessHoldEvents();
-        void ProcessViewScrollEvent(std::string_view shortcutId, RegisteredShortcut*& shortcut, const ScreenCoordsXY& delta);
+        void ProcessViewScrollEvent(std::string_view shortcutId, const ScreenCoordsXY& delta);
 
         bool GetState(const RegisteredShortcut& shortcut) const;
         bool GetState(const ShortcutInput& shortcut) const;

--- a/src/openrct2-ui/input/InputManager.h
+++ b/src/openrct2-ui/input/InputManager.h
@@ -67,6 +67,8 @@ namespace OpenRCT2::Ui
         bool GetState(const RegisteredShortcut& shortcut) const;
         bool GetState(const ShortcutInput& shortcut) const;
 
+        bool HasTextInputFocus() const;
+
     public:
         void QueueInputEvent(const SDL_Event& e);
         void QueueInputEvent(InputEvent&& e);

--- a/src/openrct2-ui/input/ShortcutManager.h
+++ b/src/openrct2-ui/input/ShortcutManager.h
@@ -18,6 +18,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -118,8 +119,11 @@ namespace OpenRCT2::Ui
         void LoadUserBindings(const fs::path& path);
         void SaveUserBindings(const fs::path& path);
 
+        // We store the IDs separately so that we can safely use them for string_view in the map
+        std::vector<std::unique_ptr<std::string>> _ids;
+
     public:
-        std::vector<RegisteredShortcut> Shortcuts;
+        std::unordered_map<std::string_view, RegisteredShortcut> Shortcuts;
 
         ShortcutManager(const std::shared_ptr<IPlatformEnvironment>& env);
         ShortcutManager(const ShortcutManager&) = delete;

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -403,9 +403,9 @@ private:
         auto& shortcutManager = GetShortcutManager();
         for (const auto& shortcut : shortcutManager.Shortcuts)
         {
-            if (IsInCurrentTab(shortcut))
+            if (IsInCurrentTab(shortcut.second))
             {
-                result.push_back(&shortcut);
+                result.push_back(&shortcut.second);
             }
         }
         return result;


### PR DESCRIPTION
* Do not cache references to RegisteredShortcut as they can be invalidated when new shortcuts are registered / removed.
* Use a map to improve query performance of shortcut by ID.
* Store a separate list of strings for the map to use as a key.

@ZehMatt I tried using `std::list<std::string>` for `_ids`, but for some reason the string data for elements after the removed element were getting invalidated / shuffled. I am surprised by this as I thought `std::list` was supposed to ensure the data and address for each element is unchanged when the list is modified. I had to resort to `std::vector<std::unique_ptr<std::string>>` in the end which is a big ugly. The whole reason for the separate list of IDs is so I can use `std::string_view` for the map. That way you don't need to create `std::string` when calling `GetShortcut`.