### PR TITLE
Remove near-duplicates of map_get_highest_z

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -164,6 +164,7 @@ The following people are not part of the development team, but have been contrib
 * (evilclownattack)
 * Adam Bloom (adam-bloom)
 * Geoff B. (geoff-B)
+* Michael Bugert (mbugert)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3421,7 +3421,7 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
 
     z = _trackPlaceZ;
     if (z == 0)
-        z = map_get_highest_z(*mapCoords);
+        z = map_get_highest_z(*mapCoords, true);
 
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_ARROW;
@@ -3461,14 +3461,14 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
             {
                 if (map_is_location_valid(selectedTile))
                 {
-                    z = map_get_highest_z(selectedTile);
+                    z = map_get_highest_z(selectedTile, true);
                     if (z > highestZ)
                         highestZ = z;
                 }
             }
         }
         // loc_6CC8BF:
-        // z = map_get_highest_z(x >> 5, y >> 5);
+        // z = map_get_highest_z(x >> 5, y >> 5, true);
     }
     // loc_6CC91B:
     trackBlock = TrackBlocks[trackType];
@@ -3674,7 +3674,7 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
             if (!map_is_location_valid(selectedTile))
                 continue;
 
-            z = map_get_highest_z(selectedTile);
+            z = map_get_highest_z(selectedTile, true);
             if (z > highestZ)
                 highestZ = z;
         }
@@ -3691,7 +3691,7 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 
     z = _trackPlaceZ;
     if (z == 0)
-        z = map_get_highest_z(mapCoords);
+        z = map_get_highest_z(mapCoords, true);
 
     tool_cancel();
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3421,7 +3421,7 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
 
     z = _trackPlaceZ;
     if (z == 0)
-        z = map_get_highest_z(*mapCoords, true);
+        z = map_get_highest_z_above_water_height(*mapCoords);
 
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
     gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE_ARROW;
@@ -3461,7 +3461,7 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
             {
                 if (map_is_location_valid(selectedTile))
                 {
-                    z = map_get_highest_z(selectedTile, true);
+                    z = map_get_highest_z_above_water_height(selectedTile);
                     if (z > highestZ)
                         highestZ = z;
                 }
@@ -3674,7 +3674,7 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
             if (!map_is_location_valid(selectedTile))
                 continue;
 
-            z = map_get_highest_z(selectedTile, true);
+            z = map_get_highest_z_above_water_height(selectedTile);
             if (z > highestZ)
                 highestZ = z;
         }
@@ -3691,7 +3691,7 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 
     z = _trackPlaceZ;
     if (z == 0)
-        z = map_get_highest_z(mapCoords, true);
+        z = map_get_highest_z_above_water_height(mapCoords);
 
     tool_cancel();
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -448,8 +448,8 @@ void TrackPlaceRestoreProvisional()
  */
 static int32_t window_track_place_get_base_z(const CoordsXY& loc)
 {
-    auto z = map_get_highest_z(loc, true);
-    if (z < 0)
+    auto z = map_get_highest_z_above_water_height(loc);
+    if (z == -1)
     {
         z = 0;
     }

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -448,26 +448,11 @@ void TrackPlaceRestoreProvisional()
  */
 static int32_t window_track_place_get_base_z(const CoordsXY& loc)
 {
-    auto surfaceElement = map_get_surface_element_at(loc);
-    if (surfaceElement == nullptr)
-        return 0;
-
-    auto z = surfaceElement->GetBaseZ();
-
-    // Increase Z above slope
-    if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
+    auto z = map_get_highest_z(loc, true);
+    if (z < 0)
     {
-        z += 16;
-
-        // Increase Z above double slope
-        if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT)
-            z += 16;
+        z = 0;
     }
-
-    // Increase Z above water
-    if (surfaceElement->GetWaterHeight() > 0)
-        z = std::max(z, surfaceElement->GetWaterHeight());
-
     return z + place_virtual_track(_trackDesign.get(), PTD_OPERATION_GET_PLACE_Z, true, GetOrAllocateRide(0), { loc, z });
 }
 

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -355,20 +355,10 @@ int16_t LargeSceneryPlaceAction::GetMaxSurfaceHeight(rct_large_scenery_tile* til
             continue;
         }
 
-        auto* surfaceElement = map_get_surface_element_at(curTile);
-        if (surfaceElement == nullptr)
-            continue;
-
-        int32_t baseZ = surfaceElement->GetBaseZ();
-        int32_t slope = surfaceElement->GetSlope();
-
-        if ((slope & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP) != TILE_ELEMENT_SLOPE_FLAT)
+        auto baseZ = map_get_highest_z(curTile, false);
+        if (baseZ < 0)
         {
-            baseZ += LAND_HEIGHT_STEP;
-            if (slope & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT)
-            {
-                baseZ += LAND_HEIGHT_STEP;
-            }
+            continue;
         }
 
         if (baseZ > maxHeight)

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -355,8 +355,8 @@ int16_t LargeSceneryPlaceAction::GetMaxSurfaceHeight(rct_large_scenery_tile* til
             continue;
         }
 
-        auto baseZ = map_get_highest_z(curTile, false);
-        if (baseZ < 0)
+        auto baseZ = map_get_highest_z(curTile);
+        if (baseZ == -1)
         {
             continue;
         }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1466,23 +1466,10 @@ static int32_t track_design_place_maze(TrackDesign* td6, const CoordsXYZ& coords
                 continue;
             }
 
-            auto surfaceElement = map_get_surface_element_at(mapCoord);
-            if (surfaceElement == nullptr)
+            auto surfaceZ = map_get_highest_z(mapCoord, true);
+            if (surfaceZ < 0)
+            {
                 continue;
-            int16_t surfaceZ = surfaceElement->GetBaseZ();
-            if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
-            {
-                surfaceZ += LAND_HEIGHT_STEP;
-                if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT)
-                {
-                    surfaceZ += LAND_HEIGHT_STEP;
-                }
-            }
-
-            int16_t waterZ = surfaceElement->GetWaterHeight();
-            if (waterZ > 0 && waterZ > surfaceZ)
-            {
-                surfaceZ = waterZ;
             }
 
             int16_t temp_z = coords.z + _trackDesignPlaceZ - surfaceZ;
@@ -1621,27 +1608,12 @@ static bool track_design_place_ride(TrackDesign* td6, const CoordsXYZ& origin, R
                         continue;
                     }
 
-                    auto surfaceElement = map_get_surface_element_at(tile);
-                    if (surfaceElement == nullptr)
+                    auto surfaceZ = map_get_highest_z(tile, true);
+                    if (surfaceZ < 0)
                     {
                         return false;
                     }
 
-                    int32_t surfaceZ = surfaceElement->GetBaseZ();
-                    if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
-                    {
-                        surfaceZ += LAND_HEIGHT_STEP;
-                        if (surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT)
-                        {
-                            surfaceZ += LAND_HEIGHT_STEP;
-                        }
-                    }
-
-                    auto waterZ = surfaceElement->GetWaterHeight();
-                    if (waterZ > 0 && waterZ > surfaceZ)
-                    {
-                        surfaceZ = waterZ;
-                    }
                     int32_t heightDifference = tempZ + _trackDesignPlaceZ + trackBlock->z - surfaceZ;
                     if (heightDifference < 0)
                     {

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1466,8 +1466,8 @@ static int32_t track_design_place_maze(TrackDesign* td6, const CoordsXYZ& coords
                 continue;
             }
 
-            auto surfaceZ = map_get_highest_z(mapCoord, true);
-            if (surfaceZ < 0)
+            auto surfaceZ = map_get_highest_z_above_water_height(mapCoord);
+            if (surfaceZ == -1)
             {
                 continue;
             }
@@ -1608,8 +1608,8 @@ static bool track_design_place_ride(TrackDesign* td6, const CoordsXYZ& origin, R
                         continue;
                     }
 
-                    auto surfaceZ = map_get_highest_z(tile, true);
-                    if (surfaceZ < 0)
+                    auto surfaceZ = map_get_highest_z_above_water_height(tile);
+                    if (surfaceZ == -1)
                     {
                         return false;
                     }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1778,7 +1778,7 @@ static void clear_elements_at(const CoordsXY& loc)
     clear_element_at(loc, &tileElement);
 }
 
-int32_t map_get_highest_z(const CoordsXY& loc, bool strictlyAboveWater)
+int32_t map_get_highest_z(const CoordsXY& loc)
 {
     auto surfaceElement = map_get_surface_element_at(loc);
     if (surfaceElement == nullptr)
@@ -1786,17 +1786,25 @@ int32_t map_get_highest_z(const CoordsXY& loc, bool strictlyAboveWater)
 
     auto z = surfaceElement->GetBaseZ();
 
-    // Raise z so that is above highest point of land and water on tile
+    // Raise z so that is above highest point of land
     if ((surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP) != TILE_ELEMENT_SLOPE_FLAT)
         z += LAND_HEIGHT_STEP;
     if ((surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT) != 0)
         z += LAND_HEIGHT_STEP;
 
-    if (strictlyAboveWater)
-    {
-        z = std::max(z, surfaceElement->GetWaterHeight());
-    }
     return z;
+}
+
+int32_t map_get_highest_z_above_water_height(const CoordsXY& loc)
+{
+    auto highest_z = map_get_highest_z(loc);
+    if (highest_z != -1)
+    {
+        auto surfaceElement = map_get_surface_element_at(loc);
+        assert(surfaceElement != nullptr);
+        highest_z = std::max(highest_z, surfaceElement->GetWaterHeight());
+    }
+    return highest_z;
 }
 
 LargeSceneryElement* map_get_large_scenery_segment(const CoordsXYZD& sceneryPos, int32_t sequence)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1778,7 +1778,7 @@ static void clear_elements_at(const CoordsXY& loc)
     clear_element_at(loc, &tileElement);
 }
 
-int32_t map_get_highest_z(const CoordsXY& loc)
+int32_t map_get_highest_z(const CoordsXY& loc, bool strictlyAboveWater)
 {
     auto surfaceElement = map_get_surface_element_at(loc);
     if (surfaceElement == nullptr)
@@ -1792,7 +1792,10 @@ int32_t map_get_highest_z(const CoordsXY& loc)
     if ((surfaceElement->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT) != 0)
         z += LAND_HEIGHT_STEP;
 
-    z = std::max(z, surfaceElement->GetWaterHeight());
+    if (strictlyAboveWater)
+    {
+        z = std::max(z, surfaceElement->GetWaterHeight());
+    }
     return z;
 }
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -256,13 +256,19 @@ void tile_element_iterator_restart_for_tile(tile_element_iterator* it);
 void map_update_tiles();
 
 /**
- * Determine z height which is just above the highest point of land for a given tile, taking slopes and (optionally) water level
- * into account.
+ * Determine z height which is just above the highest point of land for a given tile, ignoring the water height (resulting z
+ * value can be underwater on this tile).
  * @param loc A XY map location.
- * @param strictlyAboveWater If true, the resulting z height cannot be lower than the water level at this location.
  * @return The z height, or -1 if no surface element is found at this location.
  */
-int32_t map_get_highest_z(const CoordsXY& loc, bool strictlyAboveWater);
+int32_t map_get_highest_z(const CoordsXY& loc);
+
+/**
+ * Determine z height which is just above the highest point of land and above the water height for a given tile.
+ * @param loc A XY map location.
+ * @return The z height, or -1 if no surface element is found at this location.
+ */
+int32_t map_get_highest_z_above_water_height(const CoordsXY& loc);
 
 bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved);
 

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -254,7 +254,15 @@ int32_t tile_element_iterator_next(tile_element_iterator* it);
 void tile_element_iterator_restart_for_tile(tile_element_iterator* it);
 
 void map_update_tiles();
-int32_t map_get_highest_z(const CoordsXY& loc);
+
+/**
+ * Determine z height which is just above the highest point of land for a given tile, taking slopes and (optionally) water level
+ * into account.
+ * @param loc A XY map location.
+ * @param strictlyAboveWater If true, the resulting z height cannot be lower than the water level at this location.
+ * @return The z height, or -1 if no surface element is found at this location.
+ */
+int32_t map_get_highest_z(const CoordsXY& loc, bool strictlyAboveWater);
 
 bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved);
 


### PR DESCRIPTION
There were several near-duplicates of `map_get_highest_z` (finding the lowest z height on a given tile above slopes/water). This PR replaces those duplicates with calls to `map_get_highest_z`.

Large scenery can be placed underwater with cheats, so I added a boolean flag to `map_get_highest_z` to cover this use case.