### PR TITLE
Fix ui.showTextInput performance issue

### DIFF
--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -222,14 +222,15 @@ namespace OpenRCT2::Scripting
         {
             try
             {
+                constexpr int32_t MaxLengthAllowed = 4096;
                 auto plugin = _scriptEngine.GetExecInfo().GetCurrentPlugin();
                 auto title = desc["title"].as_string();
                 auto description = desc["description"].as_string();
                 auto initialValue = AsOrDefault(desc["initialValue"], "");
-                auto maxLength = AsOrDefault(desc["maxLength"], std::numeric_limits<int32_t>::max());
+                auto maxLength = AsOrDefault(desc["maxLength"], MaxLengthAllowed);
                 auto callback = desc["callback"];
                 window_text_input_open(
-                    title, description, initialValue, std::max(0, maxLength),
+                    title, description, initialValue, std::clamp(maxLength, 0, MaxLengthAllowed),
                     [this, plugin, callback](std::string_view value) {
                         auto dukValue = ToDuk(_scriptEngine.GetContext(), value);
                         _scriptEngine.ExecutePluginCall(plugin, callback, { dukValue }, false);


### PR DESCRIPTION
Over 2 GiB of memory was being allocated when calling ui.showTextInput. Restrict max length to 4 KiB.