### PR TITLE
revert Xcode to v26 dependencies

### DIFF
--- a/OpenRCT2.xcodeproj/project.pbxproj
+++ b/OpenRCT2.xcodeproj/project.pbxproj
@@ -73,34 +73,9 @@
 		4CF67197206B7E720034ADDD /* object in Resources */ = {isa = PBXBuildFile; fileRef = 4CF67196206B7E720034ADDD /* object */; };
 		6341F4E12400AA0F0052902B /* Drawing.Sprite.RLE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6341F4DF2400AA0E0052902B /* Drawing.Sprite.RLE.cpp */; };
 		6341F4E22400AA0F0052902B /* Drawing.Sprite.BMP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6341F4E02400AA0F0052902B /* Drawing.Sprite.BMP.cpp */; };
-		660BA37625AAB40F00317E9A /* libbz2.1.0.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA37225AAB3F200317E9A /* libbz2.1.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA37825AAB40F00317E9A /* libcrypto.1.1.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35C25AAB3F100317E9A /* libcrypto.1.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA37A25AAB40F00317E9A /* libdiscord-rpc.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36825AAB3F200317E9A /* libdiscord-rpc.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA37C25AAB40F00317E9A /* libduktape.2.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36F25AAB3F200317E9A /* libduktape.2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA37F25AAB40F00317E9A /* libfreetype.6.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35F25AAB3F100317E9A /* libfreetype.6.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA38225AAB40F00317E9A /* libicudata.67.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35A25AAB3F100317E9A /* libicudata.67.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA38E25AAB40F00317E9A /* libicuuc.67.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35625AAB3F100317E9A /* libicuuc.67.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA39225AAB40F00317E9A /* libpng16.16.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35025AAB3F000317E9A /* libpng16.16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA39425AAB40F00317E9A /* libSDL2-2.0.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35D25AAB3F100317E9A /* libSDL2-2.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA39725AAB40F00317E9A /* libspeexdsp.1.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36325AAB3F100317E9A /* libspeexdsp.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA39925AAB40F00317E9A /* libssl.1.1.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36A25AAB3F200317E9A /* libssl.1.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA39C25AAB40F00317E9A /* libz.1.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36625AAB3F200317E9A /* libz.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA39F25AAB40F00317E9A /* libzip.5.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA34E25AAB3F000317E9A /* libzip.5.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		660BA3AC25AAB6B200317E9A /* libbz2.1.0.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36025AAB3F100317E9A /* libbz2.1.0.6.dylib */; };
-		660BA3AF25AAB6B200317E9A /* libcrypto.1.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35C25AAB3F100317E9A /* libcrypto.1.1.dylib */; };
-		660BA3B025AAB6B200317E9A /* libdiscord-rpc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36825AAB3F200317E9A /* libdiscord-rpc.dylib */; };
-		660BA3B325AAB6B200317E9A /* libduktape.2.4.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35425AAB3F000317E9A /* libduktape.2.4.0.dylib */; };
-		660BA3B525AAB6B200317E9A /* libfreetype.6.17.4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35525AAB3F000317E9A /* libfreetype.6.17.4.dylib */; };
-		660BA3B925AAB6B200317E9A /* libicudata.67.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36E25AAB3F200317E9A /* libicudata.67.1.dylib */; };
-		660BA3C525AAB6B200317E9A /* libicuuc.67.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36B25AAB3F200317E9A /* libicuuc.67.1.dylib */; };
-		660BA3C625AAB6B200317E9A /* libpng16.16.37.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36925AAB3F200317E9A /* libpng16.16.37.0.dylib */; };
-		660BA3CA25AAB6B300317E9A /* libSDL2-2.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35D25AAB3F100317E9A /* libSDL2-2.0.dylib */; };
-		660BA3CC25AAB6B300317E9A /* libspeexdsp.1.2.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36425AAB3F100317E9A /* libspeexdsp.1.2.0.dylib */; };
-		660BA3CF25AAB6B300317E9A /* libssl.1.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA36A25AAB3F200317E9A /* libssl.1.1.dylib */; };
-		660BA3D125AAB6B300317E9A /* libz.1.2.11.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA37425AAB3F200317E9A /* libz.1.2.11.dylib */; };
-		660BA3D425AAB6B300317E9A /* libzip.5.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 660BA35225AAB3F000317E9A /* libzip.5.3.dylib */; };
 		662578A625803AA90002C77E /* discord_rpc.h in Headers */ = {isa = PBXBuildFile; fileRef = 662578A525803AA90002C77E /* discord_rpc.h */; };
 		662578AD25803CE50002C77E /* libdiscord-rpc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 662578A325803A6C0002C77E /* libdiscord-rpc.a */; };
+		662578AE25803D040002C77E /* libdiscord-rpc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 662578A325803A6C0002C77E /* libdiscord-rpc.a */; settings = {ATTRIBUTES = (Required, ); }; };
 		66A10EA2257F1DE100DD651A /* BalloonPressAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66A10EA0257F1DE000DD651A /* BalloonPressAction.cpp */; };
 		66A10EA3257F1DE100DD651A /* BalloonPressAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 66A10EA1257F1DE000DD651A /* BalloonPressAction.h */; };
 		66A10EC0257F1DF800DD651A /* BannerPlaceAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66A10EA6257F1DF600DD651A /* BannerPlaceAction.cpp */; };
@@ -284,6 +259,10 @@
 		933F2CB820935653001B33FD /* LocalisationService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933F2CB620935653001B33FD /* LocalisationService.cpp */; };
 		933F2CB920935653001B33FD /* LocalisationService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933F2CB620935653001B33FD /* LocalisationService.cpp */; };
 		933F2CBB20935668001B33FD /* LocalisationService.h in Headers */ = {isa = PBXBuildFile; fileRef = 933F2CBA20935668001B33FD /* LocalisationService.h */; };
+		933F32EA24183CBB008376CE /* libicuuc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 933F32E824183CBB008376CE /* libicuuc.dylib */; };
+		933F32EB24183CBB008376CE /* libicuuc.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 933F32E824183CBB008376CE /* libicuuc.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		933F32EC24183CBB008376CE /* libicudata.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 933F32E924183CBB008376CE /* libicudata.dylib */; };
+		933F32ED24183CBB008376CE /* libicudata.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 933F32E924183CBB008376CE /* libicudata.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9344BEF920C1E6180047D165 /* Crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 9344BEF720C1E6180047D165 /* Crypt.h */; };
 		9344BEFA20C1E6180047D165 /* Crypt.OpenSSL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9344BEF820C1E6180047D165 /* Crypt.OpenSSL.cpp */; };
 		9346F9D8208A191900C77D91 /* Guest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9346F9D6208A191900C77D91 /* Guest.cpp */; };
@@ -362,6 +341,8 @@
 		93FB272124ED3601008241C9 /* Cursors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93FB272024ED3601008241C9 /* Cursors.cpp */; };
 		93FC08FF2418F3ED00CA3054 /* duktape.h in Headers */ = {isa = PBXBuildFile; fileRef = 93FC08FD2418F3ED00CA3054 /* duktape.h */; };
 		93FC09002418F3ED00CA3054 /* duk_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 93FC08FE2418F3ED00CA3054 /* duk_config.h */; };
+		93FC09022418F3F500CA3054 /* libduktape.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 93FC09012418F3F500CA3054 /* libduktape.dylib */; };
+		93FC09032418F41700CA3054 /* libduktape.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 93FC09012418F3F500CA3054 /* libduktape.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C61ADB1F1FB6A0A70024F2EF /* TopToolbar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C61ADB1E1FB6A0A60024F2EF /* TopToolbar.cpp */; };
 		C61ADB211FB7DC060024F2EF /* Scenery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C61ADB201FB7DC060024F2EF /* Scenery.cpp */; };
 		C61ADB231FBBCB8B0024F2EF /* GameBottomToolbar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C61ADB221FBBCB8A0024F2EF /* GameBottomToolbar.cpp */; };
@@ -626,19 +607,31 @@
 		C688793420289B9B0084B384 /* WaterCoaster.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C93F1A41F8B748900A9330D /* WaterCoaster.cpp */; };
 		C68879A420289C060084B384 /* Platform.macOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7B20489201E91BF0000AD7E /* Platform.macOS.mm */; };
 		C68D98BC1FC6B8AB008E8378 /* TileInspector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C68D98BB1FC6B8AB008E8378 /* TileInspector.cpp */; };
+		C6CB94F21EFFBF860065888F /* libfreetype.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B41CF3006400659A24 /* libfreetype.dylib */; };
 		C6D2BEE21F9BAA6C008B557C /* Ride.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6D2BEE11F9BAA6C008B557C /* Ride.cpp */; };
 		C6D2BEE61F9BAACE008B557C /* TrackList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6D2BEE31F9BAACC008B557C /* TrackList.cpp */; };
 		C6D2BEE71F9BAACE008B557C /* MapTooltip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6D2BEE41F9BAACD008B557C /* MapTooltip.cpp */; };
 		C6D2BEE81F9BAACE008B557C /* MazeConstruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6D2BEE51F9BAACD008B557C /* MazeConstruction.cpp */; };
 		C6D2BEEA1F9BB83C008B557C /* NetworkStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6D2BEE91F9BB83B008B557C /* NetworkStatus.cpp */; };
 		C6E415511FAFD6DC00D4A52A /* RideConstruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6E415501FAFD6DB00D4A52A /* RideConstruction.cpp */; };
+		C6E96E361E0408B40076A04F /* libzip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C6E96E351E0408B40076A04F /* libzip.dylib */; };
+		C6E96E371E040E040076A04F /* libzip.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C6E96E351E0408B40076A04F /* libzip.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C9C630B62235A22D009AD16E /* GameStateSnapshots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9C630B52235A22C009AD16E /* GameStateSnapshots.cpp */; };
 		D41B73EF1C2101890080A7B9 /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B73EE1C2101890080A7B9 /* libcurl.tbd */; };
 		D41B741D1C210A7A0080A7B9 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B741C1C210A7A0080A7B9 /* libiconv.tbd */; };
 		D41B74731C2125E50080A7B9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D41B74721C2125E50080A7B9 /* Assets.xcassets */; };
 		D43407E21D0E14CE00C2B3D4 /* shaders in Resources */ = {isa = PBXBuildFile; fileRef = D43407E11D0E14CE00C2B3D4 /* shaders */; };
+		D45A38BC1CF3006400659A24 /* libcrypto.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B31CF3006400659A24 /* libcrypto.dylib */; };
+		D45A38C11CF3006400659A24 /* libSDL2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B81CF3006400659A24 /* libSDL2.dylib */; };
+		D45A38C21CF3006400659A24 /* libspeexdsp.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B91CF3006400659A24 /* libspeexdsp.dylib */; };
+		D45A39591CF300AF00659A24 /* libcrypto.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B31CF3006400659A24 /* libcrypto.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D45A395A1CF300AF00659A24 /* libfreetype.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B41CF3006400659A24 /* libfreetype.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D45A395E1CF300AF00659A24 /* libSDL2.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B81CF3006400659A24 /* libSDL2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		D45A395F1CF300AF00659A24 /* libspeexdsp.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B91CF3006400659A24 /* libspeexdsp.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D47304D51C4FF8250015C0EA /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D47304D41C4FF8250015C0EA /* libz.tbd */; };
 		D48AFDB71EF78DBF0081C644 /* BenchGfxCommmands.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D48AFDB61EF78DBF0081C644 /* BenchGfxCommmands.cpp */; };
+		D4A8B4B41DB41873007A2F29 /* libpng16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D4A8B4B31DB41873007A2F29 /* libpng16.dylib */; };
+		D4A8B4B51DB4188D007A2F29 /* libpng16.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4A8B4B31DB41873007A2F29 /* libpng16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D4EC48E61C2637710024B507 /* g2.dat in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E31C2637710024B507 /* g2.dat */; };
 		D4EC48E71C2637710024B507 /* language in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E41C2637710024B507 /* language */; };
 		D4EC48E81C2637710024B507 /* sequence in Resources */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* sequence */; };
@@ -740,7 +733,18 @@
 		F7D7748E1EC66FA000BE6EBC /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B741C1C210A7A0080A7B9 /* libiconv.tbd */; };
 		F7D7748F1EC66FA900BE6EBC /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D41B73EE1C2101890080A7B9 /* libcurl.tbd */; };
 		F7D774901EC66FB000BE6EBC /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D47304D41C4FF8250015C0EA /* libz.tbd */; };
+		F7D774911EC66FBA00BE6EBC /* libcrypto.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B31CF3006400659A24 /* libcrypto.dylib */; };
+		F7D774921EC66FBA00BE6EBC /* libfreetype.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B41CF3006400659A24 /* libfreetype.dylib */; };
+		F7D774941EC66FBA00BE6EBC /* libpng16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D4A8B4B31DB41873007A2F29 /* libpng16.dylib */; };
+		F7D774951EC66FBA00BE6EBC /* libspeexdsp.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B91CF3006400659A24 /* libspeexdsp.dylib */; };
+		F7D774961EC66FBA00BE6EBC /* libzip.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C6E96E351E0408B40076A04F /* libzip.dylib */; };
+		F7D774971EC6705F00BE6EBC /* libcrypto.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B31CF3006400659A24 /* libcrypto.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F7D774981EC6705F00BE6EBC /* libfreetype.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B41CF3006400659A24 /* libfreetype.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F7D7749A1EC6705F00BE6EBC /* libpng16.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4A8B4B31DB41873007A2F29 /* libpng16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F7D7749B1EC6705F00BE6EBC /* libspeexdsp.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B91CF3006400659A24 /* libspeexdsp.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F7D7749C1EC6705F00BE6EBC /* libzip.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C6E96E351E0408B40076A04F /* libzip.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F7D7749E1EC6713200BE6EBC /* Cli.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F76C857D1EC4E80E00FA49E2 /* Cli.cpp */; };
+		F7D774A21EC6715C00BE6EBC /* libSDL2.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D45A38B81CF3006400659A24 /* libSDL2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F7D774AC1EC6741D00BE6EBC /* language in CopyFiles */ = {isa = PBXBuildFile; fileRef = D4EC48E41C2637710024B507 /* language */; };
 		F7D774AD1EC6741D00BE6EBC /* shaders in CopyFiles */ = {isa = PBXBuildFile; fileRef = D43407E11D0E14CE00C2B3D4 /* shaders */; };
 		F7D774AE1EC6741D00BE6EBC /* sequence in CopyFiles */ = {isa = PBXBuildFile; fileRef = D4EC48E51C2637710024B507 /* sequence */; };
@@ -784,19 +788,15 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				660BA37625AAB40F00317E9A /* libbz2.1.0.dylib in Embed Frameworks */,
-				660BA37825AAB40F00317E9A /* libcrypto.1.1.dylib in Embed Frameworks */,
-				660BA37A25AAB40F00317E9A /* libdiscord-rpc.dylib in Embed Frameworks */,
-				660BA37C25AAB40F00317E9A /* libduktape.2.dylib in Embed Frameworks */,
-				660BA37F25AAB40F00317E9A /* libfreetype.6.dylib in Embed Frameworks */,
-				660BA38225AAB40F00317E9A /* libicudata.67.dylib in Embed Frameworks */,
-				660BA38E25AAB40F00317E9A /* libicuuc.67.dylib in Embed Frameworks */,
-				660BA39225AAB40F00317E9A /* libpng16.16.dylib in Embed Frameworks */,
-				660BA39425AAB40F00317E9A /* libSDL2-2.0.dylib in Embed Frameworks */,
-				660BA39725AAB40F00317E9A /* libspeexdsp.1.dylib in Embed Frameworks */,
-				660BA39925AAB40F00317E9A /* libssl.1.1.dylib in Embed Frameworks */,
-				660BA39C25AAB40F00317E9A /* libz.1.dylib in Embed Frameworks */,
-				660BA39F25AAB40F00317E9A /* libzip.5.dylib in Embed Frameworks */,
+				933F32EB24183CBB008376CE /* libicuuc.dylib in Embed Frameworks */,
+				C6E96E371E040E040076A04F /* libzip.dylib in Embed Frameworks */,
+				D45A39591CF300AF00659A24 /* libcrypto.dylib in Embed Frameworks */,
+				93FC09032418F41700CA3054 /* libduktape.dylib in Embed Frameworks */,
+				D45A395A1CF300AF00659A24 /* libfreetype.dylib in Embed Frameworks */,
+				D4A8B4B51DB4188D007A2F29 /* libpng16.dylib in Embed Frameworks */,
+				D45A395E1CF300AF00659A24 /* libSDL2.dylib in Embed Frameworks */,
+				933F32ED24183CBB008376CE /* libicudata.dylib in Embed Frameworks */,
+				D45A395F1CF300AF00659A24 /* libspeexdsp.dylib in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -807,6 +807,12 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				F7D774A21EC6715C00BE6EBC /* libSDL2.dylib in Embed Frameworks */,
+				F7D774971EC6705F00BE6EBC /* libcrypto.dylib in Embed Frameworks */,
+				F7D774981EC6705F00BE6EBC /* libfreetype.dylib in Embed Frameworks */,
+				F7D7749A1EC6705F00BE6EBC /* libpng16.dylib in Embed Frameworks */,
+				F7D7749B1EC6705F00BE6EBC /* libspeexdsp.dylib in Embed Frameworks */,
+				F7D7749C1EC6705F00BE6EBC /* libzip.dylib in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1167,50 +1173,6 @@
 		51160A24250C7A15002029F6 /* GuestPathfinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuestPathfinding.h; sourceTree = "<group>"; };
 		6341F4DF2400AA0E0052902B /* Drawing.Sprite.RLE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Drawing.Sprite.RLE.cpp; sourceTree = "<group>"; };
 		6341F4E02400AA0F0052902B /* Drawing.Sprite.BMP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Drawing.Sprite.BMP.cpp; sourceTree = "<group>"; };
-		660BA34925AAB3F000317E9A /* libzip.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libzip.dylib; sourceTree = "<group>"; };
-		660BA34A25AAB3F000317E9A /* libicuio.67.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuio.67.1.dylib; sourceTree = "<group>"; };
-		660BA34B25AAB3F000317E9A /* libcrypto.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libcrypto.dylib; sourceTree = "<group>"; };
-		660BA34C25AAB3F000317E9A /* libduktape.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libduktape.dylib; sourceTree = "<group>"; };
-		660BA34D25AAB3F000317E9A /* libicudata.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicudata.dylib; sourceTree = "<group>"; };
-		660BA34E25AAB3F000317E9A /* libzip.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libzip.5.dylib; sourceTree = "<group>"; };
-		660BA34F25AAB3F000317E9A /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libbz2.dylib; sourceTree = "<group>"; };
-		660BA35025AAB3F000317E9A /* libpng16.16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpng16.16.dylib; sourceTree = "<group>"; };
-		660BA35125AAB3F000317E9A /* libicuio.67.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuio.67.dylib; sourceTree = "<group>"; };
-		660BA35225AAB3F000317E9A /* libzip.5.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libzip.5.3.dylib; sourceTree = "<group>"; };
-		660BA35325AAB3F000317E9A /* libicutu.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicutu.dylib; sourceTree = "<group>"; };
-		660BA35425AAB3F000317E9A /* libduktape.2.4.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libduktape.2.4.0.dylib; sourceTree = "<group>"; };
-		660BA35525AAB3F000317E9A /* libfreetype.6.17.4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfreetype.6.17.4.dylib; sourceTree = "<group>"; };
-		660BA35625AAB3F100317E9A /* libicuuc.67.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuuc.67.dylib; sourceTree = "<group>"; };
-		660BA35725AAB3F100317E9A /* libicui18n.67.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicui18n.67.dylib; sourceTree = "<group>"; };
-		660BA35825AAB3F100317E9A /* libfreetype.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfreetype.dylib; sourceTree = "<group>"; };
-		660BA35925AAB3F100317E9A /* libicui18n.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicui18n.dylib; sourceTree = "<group>"; };
-		660BA35A25AAB3F100317E9A /* libicudata.67.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicudata.67.dylib; sourceTree = "<group>"; };
-		660BA35B25AAB3F100317E9A /* libicutu.67.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicutu.67.1.dylib; sourceTree = "<group>"; };
-		660BA35C25AAB3F100317E9A /* libcrypto.1.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libcrypto.1.1.dylib; sourceTree = "<group>"; };
-		660BA35D25AAB3F100317E9A /* libSDL2-2.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "libSDL2-2.0.dylib"; sourceTree = "<group>"; };
-		660BA35E25AAB3F100317E9A /* libSDL2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libSDL2.dylib; sourceTree = "<group>"; };
-		660BA35F25AAB3F100317E9A /* libfreetype.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfreetype.6.dylib; sourceTree = "<group>"; };
-		660BA36025AAB3F100317E9A /* libbz2.1.0.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libbz2.1.0.6.dylib; sourceTree = "<group>"; };
-		660BA36125AAB3F100317E9A /* libicuuc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuuc.dylib; sourceTree = "<group>"; };
-		660BA36225AAB3F100317E9A /* libicuio.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuio.dylib; sourceTree = "<group>"; };
-		660BA36325AAB3F100317E9A /* libspeexdsp.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libspeexdsp.1.dylib; sourceTree = "<group>"; };
-		660BA36425AAB3F100317E9A /* libspeexdsp.1.2.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libspeexdsp.1.2.0.dylib; sourceTree = "<group>"; };
-		660BA36525AAB3F100317E9A /* libpng.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpng.dylib; sourceTree = "<group>"; };
-		660BA36625AAB3F200317E9A /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libz.1.dylib; sourceTree = "<group>"; };
-		660BA36725AAB3F200317E9A /* libspeexdsp.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libspeexdsp.dylib; sourceTree = "<group>"; };
-		660BA36825AAB3F200317E9A /* libdiscord-rpc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "libdiscord-rpc.dylib"; sourceTree = "<group>"; };
-		660BA36925AAB3F200317E9A /* libpng16.16.37.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpng16.16.37.0.dylib; sourceTree = "<group>"; };
-		660BA36A25AAB3F200317E9A /* libssl.1.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libssl.1.1.dylib; sourceTree = "<group>"; };
-		660BA36B25AAB3F200317E9A /* libicuuc.67.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuuc.67.1.dylib; sourceTree = "<group>"; };
-		660BA36C25AAB3F200317E9A /* libicui18n.67.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicui18n.67.1.dylib; sourceTree = "<group>"; };
-		660BA36D25AAB3F200317E9A /* libssl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libssl.dylib; sourceTree = "<group>"; };
-		660BA36E25AAB3F200317E9A /* libicudata.67.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicudata.67.1.dylib; sourceTree = "<group>"; };
-		660BA36F25AAB3F200317E9A /* libduktape.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libduktape.2.dylib; sourceTree = "<group>"; };
-		660BA37025AAB3F200317E9A /* libicutu.67.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicutu.67.dylib; sourceTree = "<group>"; };
-		660BA37125AAB3F200317E9A /* libpng16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpng16.dylib; sourceTree = "<group>"; };
-		660BA37225AAB3F200317E9A /* libbz2.1.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libbz2.1.0.dylib; sourceTree = "<group>"; };
-		660BA37325AAB3F200317E9A /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libz.dylib; sourceTree = "<group>"; };
-		660BA37425AAB3F200317E9A /* libz.1.2.11.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libz.1.2.11.dylib; sourceTree = "<group>"; };
 		662578A325803A6C0002C77E /* libdiscord-rpc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libdiscord-rpc.a"; path = "discord-rpc/build/src/libdiscord-rpc.a"; sourceTree = "<group>"; };
 		662578A525803AA90002C77E /* discord_rpc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = discord_rpc.h; path = "discord-rpc/include/discord_rpc.h"; sourceTree = "<group>"; };
 		66A10EA0257F1DE000DD651A /* BalloonPressAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BalloonPressAction.cpp; sourceTree = "<group>"; };
@@ -1393,6 +1355,8 @@
 		933CBDBE20CB1BCA00134678 /* Window.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Window.cpp; sourceTree = "<group>"; };
 		933F2CB620935653001B33FD /* LocalisationService.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LocalisationService.cpp; sourceTree = "<group>"; };
 		933F2CBA20935668001B33FD /* LocalisationService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocalisationService.h; sourceTree = "<group>"; };
+		933F32E824183CBB008376CE /* libicuuc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicuuc.dylib; sourceTree = "<group>"; };
+		933F32E924183CBB008376CE /* libicudata.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libicudata.dylib; sourceTree = "<group>"; };
 		9344BEF720C1E6180047D165 /* Crypt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Crypt.h; sourceTree = "<group>"; };
 		9344BEF820C1E6180047D165 /* Crypt.OpenSSL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Crypt.OpenSSL.cpp; sourceTree = "<group>"; };
 		9346F9D6208A191900C77D91 /* Guest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Guest.cpp; sourceTree = "<group>"; };
@@ -1692,6 +1656,7 @@
 		93FB272024ED3601008241C9 /* Cursors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Cursors.cpp; sourceTree = "<group>"; };
 		93FC08FD2418F3ED00CA3054 /* duktape.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = duktape.h; sourceTree = "<group>"; };
 		93FC08FE2418F3ED00CA3054 /* duk_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = duk_config.h; sourceTree = "<group>"; };
+		93FC09012418F3F500CA3054 /* libduktape.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libduktape.dylib; sourceTree = "<group>"; };
 		C61ADB1E1FB6A0A60024F2EF /* TopToolbar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TopToolbar.cpp; sourceTree = "<group>"; };
 		C61ADB201FB7DC060024F2EF /* Scenery.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Scenery.cpp; sourceTree = "<group>"; };
 		C61ADB221FBBCB8A0024F2EF /* GameBottomToolbar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameBottomToolbar.cpp; sourceTree = "<group>"; };
@@ -1788,6 +1753,7 @@
 		C6E415501FAFD6DB00D4A52A /* RideConstruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RideConstruction.cpp; sourceTree = "<group>"; };
 		C6E96E331E0408A80076A04F /* zip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = zip.h; sourceTree = "<group>"; };
 		C6E96E341E0408A80076A04F /* zipconf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = zipconf.h; sourceTree = "<group>"; };
+		C6E96E351E0408B40076A04F /* libzip.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libzip.dylib; sourceTree = "<group>"; };
 		C9C630B42235A22C009AD16E /* GameStateSnapshots.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameStateSnapshots.h; sourceTree = "<group>"; };
 		C9C630B52235A22C009AD16E /* GameStateSnapshots.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameStateSnapshots.cpp; sourceTree = "<group>"; };
 		D41B73EE1C2101890080A7B9 /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
@@ -1795,6 +1761,10 @@
 		D41B74721C2125E50080A7B9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = distribution/macos/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		D43407E11D0E14CE00C2B3D4 /* shaders */ = {isa = PBXFileReference; lastKnownFileType = folder; name = shaders; path = data/shaders; sourceTree = SOURCE_ROOT; };
 		D43BAB921F8C2B2B00A9E362 /* OpenGLAPIProc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenGLAPIProc.h; sourceTree = "<group>"; };
+		D45A38B31CF3006400659A24 /* libcrypto.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libcrypto.dylib; sourceTree = "<group>"; };
+		D45A38B41CF3006400659A24 /* libfreetype.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libfreetype.dylib; sourceTree = "<group>"; };
+		D45A38B81CF3006400659A24 /* libSDL2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libSDL2.dylib; sourceTree = "<group>"; };
+		D45A38B91CF3006400659A24 /* libspeexdsp.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libspeexdsp.dylib; sourceTree = "<group>"; };
 		D45A38C71CF3007A00659A24 /* png.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = png.h; sourceTree = "<group>"; };
 		D45A38C81CF3007A00659A24 /* pngconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pngconf.h; sourceTree = "<group>"; };
 		D45A38C91CF3007A00659A24 /* pnglibconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pnglibconf.h; sourceTree = "<group>"; };
@@ -1945,6 +1915,7 @@
 		D4974F1A1FA04A1900F7FD7F /* TransparencyDepth.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TransparencyDepth.cpp; sourceTree = "<group>"; };
 		D4974F1B1FA04A1900F7FD7F /* TransparencyDepth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TransparencyDepth.h; sourceTree = "<group>"; };
 		D497D0781C20FD52002BF46A /* OpenRCT2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenRCT2.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D4A8B4B31DB41873007A2F29 /* libpng16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpng16.dylib; sourceTree = "<group>"; };
 		D4EC48E31C2637710024B507 /* g2.dat */ = {isa = PBXFileReference; lastKnownFileType = file; name = g2.dat; path = data/g2.dat; sourceTree = SOURCE_ROOT; };
 		D4EC48E41C2637710024B507 /* language */ = {isa = PBXFileReference; lastKnownFileType = folder; name = language; path = data/language; sourceTree = SOURCE_ROOT; };
 		D4EC48E51C2637710024B507 /* sequence */ = {isa = PBXFileReference; lastKnownFileType = folder; name = sequence; path = data/sequence; sourceTree = SOURCE_ROOT; };
@@ -2177,25 +2148,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				660BA3AC25AAB6B200317E9A /* libbz2.1.0.6.dylib in Frameworks */,
-				660BA3AF25AAB6B200317E9A /* libcrypto.1.1.dylib in Frameworks */,
-				660BA3B025AAB6B200317E9A /* libdiscord-rpc.dylib in Frameworks */,
-				660BA3B325AAB6B200317E9A /* libduktape.2.4.0.dylib in Frameworks */,
-				660BA3B525AAB6B200317E9A /* libfreetype.6.17.4.dylib in Frameworks */,
-				660BA3B925AAB6B200317E9A /* libicudata.67.1.dylib in Frameworks */,
-				660BA3C525AAB6B200317E9A /* libicuuc.67.1.dylib in Frameworks */,
-				660BA3C625AAB6B200317E9A /* libpng16.16.37.0.dylib in Frameworks */,
-				660BA3CA25AAB6B300317E9A /* libSDL2-2.0.dylib in Frameworks */,
-				660BA3CC25AAB6B300317E9A /* libspeexdsp.1.2.0.dylib in Frameworks */,
-				660BA3CF25AAB6B300317E9A /* libssl.1.1.dylib in Frameworks */,
-				660BA3D125AAB6B300317E9A /* libz.1.2.11.dylib in Frameworks */,
-				660BA3D425AAB6B300317E9A /* libzip.5.3.dylib in Frameworks */,
 				C6887847202897B70084B384 /* Cocoa.framework in Frameworks */,
 				C6887846202897B30084B384 /* Foundation.framework in Frameworks */,
 				F76C88921EC539A300FA49E2 /* libopenrct2.a in Frameworks */,
 				D47304D51C4FF8250015C0EA /* libz.tbd in Frameworks */,
 				D41B73EF1C2101890080A7B9 /* libcurl.tbd in Frameworks */,
 				D41B741D1C210A7A0080A7B9 /* libiconv.tbd in Frameworks */,
+				D45A38BC1CF3006400659A24 /* libcrypto.dylib in Frameworks */,
+				93FC09022418F3F500CA3054 /* libduktape.dylib in Frameworks */,
+				933F32EC24183CBB008376CE /* libicudata.dylib in Frameworks */,
+				933F32EA24183CBB008376CE /* libicuuc.dylib in Frameworks */,
+				D4A8B4B41DB41873007A2F29 /* libpng16.dylib in Frameworks */,
+				D45A38C11CF3006400659A24 /* libSDL2.dylib in Frameworks */,
+				C6CB94F21EFFBF860065888F /* libfreetype.dylib in Frameworks */,
+				D45A38C21CF3006400659A24 /* libspeexdsp.dylib in Frameworks */,
+				C6E96E361E0408B40076A04F /* libzip.dylib in Frameworks */,
+				662578AE25803D040002C77E /* libdiscord-rpc.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2210,6 +2178,11 @@
 				F7D774901EC66FB000BE6EBC /* libz.tbd in Frameworks */,
 				F7D7748F1EC66FA900BE6EBC /* libcurl.tbd in Frameworks */,
 				F7D7748E1EC66FA000BE6EBC /* libiconv.tbd in Frameworks */,
+				F7D774911EC66FBA00BE6EBC /* libcrypto.dylib in Frameworks */,
+				F7D774921EC66FBA00BE6EBC /* libfreetype.dylib in Frameworks */,
+				F7D774941EC66FBA00BE6EBC /* libpng16.dylib in Frameworks */,
+				F7D774951EC66FBA00BE6EBC /* libspeexdsp.dylib in Frameworks */,
+				F7D774961EC66FBA00BE6EBC /* libzip.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3039,50 +3012,15 @@
 		D4EC48C31C2634870024B507 /* lib */ = {
 			isa = PBXGroup;
 			children = (
-				660BA36025AAB3F100317E9A /* libbz2.1.0.6.dylib */,
-				660BA37225AAB3F200317E9A /* libbz2.1.0.dylib */,
-				660BA34F25AAB3F000317E9A /* libbz2.dylib */,
-				660BA35C25AAB3F100317E9A /* libcrypto.1.1.dylib */,
-				660BA34B25AAB3F000317E9A /* libcrypto.dylib */,
-				660BA36825AAB3F200317E9A /* libdiscord-rpc.dylib */,
-				660BA35425AAB3F000317E9A /* libduktape.2.4.0.dylib */,
-				660BA36F25AAB3F200317E9A /* libduktape.2.dylib */,
-				660BA34C25AAB3F000317E9A /* libduktape.dylib */,
-				660BA35525AAB3F000317E9A /* libfreetype.6.17.4.dylib */,
-				660BA35F25AAB3F100317E9A /* libfreetype.6.dylib */,
-				660BA35825AAB3F100317E9A /* libfreetype.dylib */,
-				660BA36E25AAB3F200317E9A /* libicudata.67.1.dylib */,
-				660BA35A25AAB3F100317E9A /* libicudata.67.dylib */,
-				660BA34D25AAB3F000317E9A /* libicudata.dylib */,
-				660BA36C25AAB3F200317E9A /* libicui18n.67.1.dylib */,
-				660BA35725AAB3F100317E9A /* libicui18n.67.dylib */,
-				660BA35925AAB3F100317E9A /* libicui18n.dylib */,
-				660BA34A25AAB3F000317E9A /* libicuio.67.1.dylib */,
-				660BA35125AAB3F000317E9A /* libicuio.67.dylib */,
-				660BA36225AAB3F100317E9A /* libicuio.dylib */,
-				660BA35B25AAB3F100317E9A /* libicutu.67.1.dylib */,
-				660BA37025AAB3F200317E9A /* libicutu.67.dylib */,
-				660BA35325AAB3F000317E9A /* libicutu.dylib */,
-				660BA36B25AAB3F200317E9A /* libicuuc.67.1.dylib */,
-				660BA35625AAB3F100317E9A /* libicuuc.67.dylib */,
-				660BA36125AAB3F100317E9A /* libicuuc.dylib */,
-				660BA36525AAB3F100317E9A /* libpng.dylib */,
-				660BA36925AAB3F200317E9A /* libpng16.16.37.0.dylib */,
-				660BA35025AAB3F000317E9A /* libpng16.16.dylib */,
-				660BA37125AAB3F200317E9A /* libpng16.dylib */,
-				660BA35D25AAB3F100317E9A /* libSDL2-2.0.dylib */,
-				660BA35E25AAB3F100317E9A /* libSDL2.dylib */,
-				660BA36425AAB3F100317E9A /* libspeexdsp.1.2.0.dylib */,
-				660BA36325AAB3F100317E9A /* libspeexdsp.1.dylib */,
-				660BA36725AAB3F200317E9A /* libspeexdsp.dylib */,
-				660BA36A25AAB3F200317E9A /* libssl.1.1.dylib */,
-				660BA36D25AAB3F200317E9A /* libssl.dylib */,
-				660BA37425AAB3F200317E9A /* libz.1.2.11.dylib */,
-				660BA36625AAB3F200317E9A /* libz.1.dylib */,
-				660BA37325AAB3F200317E9A /* libz.dylib */,
-				660BA35225AAB3F000317E9A /* libzip.5.3.dylib */,
-				660BA34E25AAB3F000317E9A /* libzip.5.dylib */,
-				660BA34925AAB3F000317E9A /* libzip.dylib */,
+				D45A38B31CF3006400659A24 /* libcrypto.dylib */,
+				93FC09012418F3F500CA3054 /* libduktape.dylib */,
+				D45A38B41CF3006400659A24 /* libfreetype.dylib */,
+				933F32E924183CBB008376CE /* libicudata.dylib */,
+				933F32E824183CBB008376CE /* libicuuc.dylib */,
+				D4A8B4B31DB41873007A2F29 /* libpng16.dylib */,
+				D45A38B81CF3006400659A24 /* libSDL2.dylib */,
+				D45A38B91CF3006400659A24 /* libspeexdsp.dylib */,
+				C6E96E351E0408B40076A04F /* libzip.dylib */,
 			);
 			path = lib;
 			sourceTree = "<group>";
@@ -4273,6 +4211,7 @@
 			buildConfigurationList = F76C809D1EC4D9FA00FA49E2 /* Build configuration list for PBXNativeTarget "libopenrct2" */;
 			buildPhases = (
 				F76C809F1EC4DB0300FA49E2 /* Get Git Variables */,
+				66257898258032500002C77E /* Get discord-rpc */,
 				F76C80961EC4D9FA00FA49E2 /* Sources */,
 				F76C88381EC4EB5900FA49E2 /* Resources */,
 				F76C80981EC4D9FA00FA49E2 /* Headers */,
@@ -4399,6 +4338,24 @@
 			shellPath = /bin/sh;
 			shellScript = "version=\"1.0.20\"\nzipname=\"objects.zip\"\nliburl=\"https://github.com/OpenRCT2/objects/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/data/object\" || ! -e \"${SRCROOT}/objectsversion\" || $(head -n 1 \"${SRCROOT}/objectsversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/data/object\" ]]; then rm -r \"${SRCROOT}/data/object\"; fi\nmkdir -p \"${SRCROOT}/data/object\"\n\ncurl -L -o \"${SRCROOT}/data/object/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/data/object\" \"${SRCROOT}/data/object/$zipname\"\nrm \"${SRCROOT}/data/object/$zipname\"\n\necho $version > \"${SRCROOT}/objectsversion\"\nfi\n";
 		};
+		66257898258032500002C77E /* Get discord-rpc */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Get discord-rpc";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ ! -d \"${SRCROOT}/discord-rpc\" ]]; then\n    . ${SRCROOT}/scripts/get-discord-rpc\nfi\n\nif [[ -d \"${SRCROOT}/discord-rpc\" ]]; then\n    cd ${SRCROOT}/discord-rpc\n    mkdir build\n    cd build\n    cmake ..\n    cmake --build . --config Release\nfi\n";
+		};
 		C68B2D471EC790710020651C /* Download Libraries */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -4411,7 +4368,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "version=\"28\"\nzipname=\"openrct2-libs-v28-x64-macos-dylibs.zip\"\nliburl=\"https://github.com/OpenRCT2/Dependencies/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/libxc\" || ! -e \"${SRCROOT}/libversion\" || $(head -n 1 \"${SRCROOT}/libversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/libxc\" ]]; then rm -r \"${SRCROOT}/libxc\"; fi\nmkdir \"${SRCROOT}/libxc\"\n\ncurl -L -o \"${SRCROOT}/libxc/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/libxc\" \"${SRCROOT}/libxc/$zipname\"\nrm \"${SRCROOT}/libxc/$zipname\"\n\necho $version > \"${SRCROOT}/libversion\"\nfi\n";
+			shellScript = "version=\"26\"\nzipname=\"openrct2-libs-v26-x64-macos-dylibs.zip\"\nliburl=\"https://github.com/OpenRCT2/Dependencies/releases/download/v$version/$zipname\"\n\n[[ ! -d \"${SRCROOT}/libxc\" || ! -e \"${SRCROOT}/libversion\" || $(head -n 1 \"${SRCROOT}/libversion\") != $version ]]\noutdated=$?\n\nif [[ $outdated -eq 0 ]]; then\nif [[ -d \"${SRCROOT}/libxc\" ]]; then rm -r \"${SRCROOT}/libxc\"; fi\nmkdir \"${SRCROOT}/libxc\"\n\ncurl -L -o \"${SRCROOT}/libxc/$zipname\" \"$liburl\"\nunzip -uaq -d \"${SRCROOT}/libxc\" \"${SRCROOT}/libxc/$zipname\"\nrm \"${SRCROOT}/libxc/$zipname\"\n\necho $version > \"${SRCROOT}/libversion\"\nfi\n";
 		};
 		D42C09D21C254F4E00309751 /* Build g2.dat */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Reverts the Xcode project file to its state at f3ed018

In Dependencies v28, we allowed freetype to use brotli. brotli does not appear to fully support rpath at this time, so we'll likely need to revert the inclusion of brotli. I'll investigate when I have some more time. We'll then need a new dependencies release, and can update both Xcode and cmake. FYI @LRFLEW.

The macos-cmake build is not yet "released" anywhere, so I'll leave that pointed at v28.