### PR TITLE
Fix #14198: Crash when creating new folder

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -455,7 +455,7 @@ static void window_loadsave_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             break;
 
         case WIDX_NEW_FOLDER:
-            window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, nullptr, 64);
+            window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, "", 64);
             break;
 
         case WIDX_BROWSE:


### PR DESCRIPTION
It's our old friend, the null pointer exception!