### PR TITLE
Fix #14201: Assert in research_finish_item for invalid ride type

### DIFF
--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -200,7 +200,7 @@ void research_finish_item(ResearchItem* researchItem)
 
         if (rideEntry != nullptr && base_ride_type != RIDE_TYPE_NULL)
         {
-            if (RideTypeIsValid(base_ride_type))
+            if (!RideTypeIsValid(base_ride_type))
             {
                 log_warning("Invalid ride type: %d", base_ride_type);
                 base_ride_type = ride_entry_get_first_non_null_ride_type(rideEntry);

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -200,8 +200,11 @@ void research_finish_item(ResearchItem* researchItem)
 
         if (rideEntry != nullptr && base_ride_type != RIDE_TYPE_NULL)
         {
-            if (base_ride_type >= RIDE_TYPE_COUNT)
+            if (RideTypeIsValid(base_ride_type))
+            {
                 log_warning("Invalid ride type: %d", base_ride_type);
+                base_ride_type = ride_entry_get_first_non_null_ride_type(rideEntry);
+            }
 
             rct_string_id availabilityString;
             ride_type_set_invented(base_ride_type);
@@ -528,8 +531,7 @@ bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool resea
 
 bool ride_type_is_invented(uint32_t rideType)
 {
-    Guard::Assert(rideType < std::size(_researchedRideTypes), GUARD_LINE);
-    return _researchedRideTypes[rideType];
+    return RideTypeIsValid(rideType) ? _researchedRideTypes[rideType] : false;
 }
 
 bool ride_entry_is_invented(int32_t rideEntryIndex)
@@ -539,7 +541,7 @@ bool ride_entry_is_invented(int32_t rideEntryIndex)
 
 void ride_type_set_invented(uint32_t rideType)
 {
-    if (rideType < std::size(_researchedRideTypes))
+    if (RideTypeIsValid(rideType))
     {
         _researchedRideTypes[rideType] = true;
     }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -200,11 +200,11 @@ void research_finish_item(ResearchItem* researchItem)
 
         if (rideEntry != nullptr && base_ride_type != RIDE_TYPE_NULL)
         {
+            if (base_ride_type >= RIDE_TYPE_COUNT)
+                log_warning("Invalid ride type: %d", base_ride_type);
+
             rct_string_id availabilityString;
-
             ride_type_set_invented(base_ride_type);
-            openrct2_assert(base_ride_type < RIDE_TYPE_COUNT, "Invalid base_ride_type = %d", base_ride_type);
-
             ride_entry_set_invented(rideEntryIndex);
 
             bool seenRideEntry[MAX_RIDE_OBJECTS]{};
@@ -539,8 +539,10 @@ bool ride_entry_is_invented(int32_t rideEntryIndex)
 
 void ride_type_set_invented(uint32_t rideType)
 {
-    Guard::Assert(rideType < std::size(_researchedRideTypes), GUARD_LINE);
-    _researchedRideTypes[rideType] = true;
+    if (rideType < std::size(_researchedRideTypes))
+    {
+        _researchedRideTypes[rideType] = true;
+    }
 }
 
 void ride_entry_set_invented(int32_t rideEntryIndex)


### PR DESCRIPTION
Prevent crash and assert. Instead just log a warning and continue as normal.
All functions that take ride type should now handle invalid ride types.