### PR TITLE
Update objects to v1.0.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 
-set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip")
-set(OBJECTS_SHA1 "151424d24b1d49a167932b58319bedaa6ec368e9")
+set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip")
+set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.31/replays.zip")
 set(REPLAYS_SHA1 "693BDD6F4B7C3B312AABEBCAEA4800FE97B33527")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -46,8 +46,8 @@
     <GtestSha1>058b9df80244c03f1633cb06e9f70471a29ebb8e</GtestSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.20/objects.zip</ObjectsUrl>
-    <ObjectsSha1>151424d24b1d49a167932b58319bedaa6ec368e9</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
+    <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.31/replays.zip</ReplaysUrl>
     <ReplaysSha1>693BDD6F4B7C3B312AABEBCAEA4800FE97B33527</ReplaysSha1>
   </PropertyGroup>

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,8 @@ let
   objects-src = pkgs.fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.0.20";
-    sha256 = "bc266ef589c60302105473499ac142dbf951847be15e65b692d165ce261aeae0";
+    rev = "v1.0.21";
+    sha256 = "b081f885311f9afebc41d9dd4a68b7db4cf736eb815c04e307e1a426f08cfa35";
   };
 
   title-sequences-src = pkgs.fetchFromGitHub {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -405,15 +405,16 @@ static void ReplaceSelectedWaterPalette(const ObjectRepositoryItem* item)
         objectManager.UnloadObjects(oldEntries);
     }
 
-    const rct_object_entry* newPaletteEntry = &item->ObjectEntry;
+    const rct_object_entry& newPaletteEntry = item->ObjectEntry;
 
-    if (objectManager.GetLoadedObject(newPaletteEntry) != nullptr || objectManager.LoadObject(newPaletteEntry) != nullptr)
+    if (objectManager.GetLoadedObject(ObjectEntryDescriptor(newPaletteEntry)) != nullptr
+        || objectManager.LoadObject(&newPaletteEntry) != nullptr)
     {
         load_palette();
     }
     else
     {
-        log_error("Failed to load selected palette %.8s", newPaletteEntry->name);
+        log_error("Failed to load selected palette %.8s", newPaletteEntry.name);
     }
 }
 

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -29,7 +29,7 @@ void BannerObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* st
     GetStringTable().Read(context, stream, ObjectStringID::NAME);
 
     rct_object_entry sgEntry = stream->ReadValue<rct_object_entry>();
-    SetPrimarySceneryGroup(&sgEntry);
+    SetPrimarySceneryGroup(ObjectEntryDescriptor(sgEntry));
 
     GetImageTable().Read(context, stream);
 
@@ -52,7 +52,7 @@ void BannerObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* st
             || sourceGame == ObjectSourceGame::Custom)
         {
             auto scgPathX = Object::GetScgPathXHeader();
-            SetPrimarySceneryGroup(&scgPathX);
+            SetPrimarySceneryGroup(scgPathX);
         }
     }
 }
@@ -97,7 +97,7 @@ void BannerObject::ReadJson(IReadObjectContext* context, json_t& root)
                 { "hasPrimaryColour", BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR },
             });
 
-        SetPrimarySceneryGroup(Json::GetString(properties["sceneryGroup"]));
+        SetPrimarySceneryGroup(ObjectEntryDescriptor(Json::GetString(properties["sceneryGroup"])));
     }
 
     PopulateTablesFromJson(context, root);

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -33,7 +33,7 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     GetStringTable().Read(context, stream, ObjectStringID::NAME);
 
     rct_object_entry sgEntry = stream->ReadValue<rct_object_entry>();
-    SetPrimarySceneryGroup(&sgEntry);
+    SetPrimarySceneryGroup(ObjectEntryDescriptor(sgEntry));
 
     GetImageTable().Read(context, stream);
 
@@ -56,7 +56,7 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
             || sourceGame == ObjectSourceGame::Custom)
         {
             auto scgPathX = Object::GetScgPathXHeader();
-            SetPrimarySceneryGroup(&scgPathX);
+            SetPrimarySceneryGroup(scgPathX);
         }
     }
 }
@@ -110,7 +110,7 @@ void FootpathItemObject::ReadJson(IReadObjectContext* context, json_t& root)
         _legacyType.path_bit.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::LamppostDown);
         _legacyType.path_bit.price = Json::GetNumber<int16_t>(properties["price"]);
 
-        SetPrimarySceneryGroup(Json::GetString(properties["sceneryGroup"]));
+        SetPrimarySceneryGroup(ObjectEntryDescriptor(Json::GetString(properties["sceneryGroup"])));
 
         // clang-format off
         _legacyType.path_bit.flags = Json::GetFlags<uint16_t>(

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -38,7 +38,7 @@ void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     GetStringTable().Read(context, stream, ObjectStringID::NAME);
 
     rct_object_entry sgEntry = stream->ReadValue<rct_object_entry>();
-    SetPrimarySceneryGroup(&sgEntry);
+    SetPrimarySceneryGroup(ObjectEntryDescriptor(sgEntry));
 
     if (_legacyType.large_scenery.flags & LARGE_SCENERY_FLAG_3D_TEXT)
     {
@@ -160,7 +160,7 @@ void LargeSceneryObject::ReadJson(IReadObjectContext* context, json_t& root)
             _legacyType.large_scenery.flags |= LARGE_SCENERY_FLAG_3D_TEXT;
         }
 
-        SetPrimarySceneryGroup(Json::GetString(properties["sceneryGroup"]));
+        SetPrimarySceneryGroup(ObjectEntryDescriptor(Json::GetString(properties["sceneryGroup"])));
     }
 
     PopulateTablesFromJson(context, root);

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -91,14 +91,14 @@ std::string Object::GetString(int32_t language, ObjectStringID index) const
     return GetStringTable().GetString(language, index);
 }
 
-rct_object_entry Object::GetScgWallsHeader()
+ObjectEntryDescriptor Object::GetScgWallsHeader()
 {
-    return Object::CreateHeader("SCGWALLS", 207140231, 3518650219);
+    return ObjectEntryDescriptor("rct2.scgwalls");
 }
 
-rct_object_entry Object::GetScgPathXHeader()
+ObjectEntryDescriptor Object::GetScgPathXHeader()
 {
-    return Object::CreateHeader("SCGPATHX", 207140231, 890227440);
+    return ObjectEntryDescriptor("rct2.scgpathx");
 }
 
 rct_object_entry Object::CreateHeader(const char name[DAT_NAME_LENGTH + 1], uint32_t flags, uint32_t checksum)

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -91,12 +91,12 @@ std::string Object::GetString(int32_t language, ObjectStringID index) const
     return GetStringTable().GetString(language, index);
 }
 
-ObjectEntryDescriptor Object::GetScgWallsHeader()
+ObjectEntryDescriptor Object::GetScgWallsHeader() const
 {
     return ObjectEntryDescriptor("rct2.scgwalls");
 }
 
-ObjectEntryDescriptor Object::GetScgPathXHeader()
+ObjectEntryDescriptor Object::GetScgPathXHeader() const
 {
     return ObjectEntryDescriptor("rct2.scgpathx");
 }

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -351,8 +351,8 @@ public:
         return _imageTable;
     }
 
-    ObjectEntryDescriptor GetScgWallsHeader();
-    ObjectEntryDescriptor GetScgPathXHeader();
+    ObjectEntryDescriptor GetScgWallsHeader() const;
+    ObjectEntryDescriptor GetScgPathXHeader() const;
     rct_object_entry CreateHeader(const char name[9], uint32_t flags, uint32_t checksum);
 
     uint32_t GetNumImages() const

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -351,8 +351,8 @@ public:
         return _imageTable;
     }
 
-    rct_object_entry GetScgWallsHeader();
-    rct_object_entry GetScgPathXHeader();
+    ObjectEntryDescriptor GetScgWallsHeader();
+    ObjectEntryDescriptor GetScgPathXHeader();
     rct_object_entry CreateHeader(const char name[9], uint32_t flags, uint32_t checksum);
 
     uint32_t GetNumImages() const

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -80,7 +80,7 @@ public:
         return GetLoadedObject(objectIndex);
     }
 
-    Object* GetLoadedObject(const rct_object_entry* entry) override
+    Object* GetLoadedObject(const ObjectEntryDescriptor& entry) override
     {
         Object* loadedObject = nullptr;
         const ObjectRepositoryItem* ori = _objectRepository.FindObject(entry);
@@ -534,7 +534,7 @@ private:
     ObjectEntryIndex GetPrimarySceneryGroupEntryIndex(Object* loadedObject)
     {
         auto sceneryObject = dynamic_cast<SceneryObject*>(loadedObject);
-        const rct_object_entry* primarySGEntry = sceneryObject->GetPrimarySceneryGroup();
+        const auto& primarySGEntry = sceneryObject->GetPrimarySceneryGroup();
         Object* sgObject = GetLoadedObject(primarySGEntry);
 
         auto entryIndex = OBJECT_ENTRY_INDEX_NULL;
@@ -819,7 +819,7 @@ Object* object_manager_get_loaded_object_by_index(size_t index)
 Object* object_manager_get_loaded_object(const rct_object_entry* entry)
 {
     auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
-    Object* loadedObject = objectManager.GetLoadedObject(entry);
+    Object* loadedObject = objectManager.GetLoadedObject(ObjectEntryDescriptor(*entry));
     return loadedObject;
 }
 

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -26,7 +26,7 @@ struct IObjectManager
 
     virtual Object* GetLoadedObject(size_t index) abstract;
     virtual Object* GetLoadedObject(ObjectType objectType, size_t index) abstract;
-    virtual Object* GetLoadedObject(const rct_object_entry* entry) abstract;
+    virtual Object* GetLoadedObject(const ObjectEntryDescriptor& entry) abstract;
     virtual ObjectEntryIndex GetLoadedObjectEntryIndex(const Object* object) abstract;
     virtual std::vector<rct_object_entry> GetInvalidObjects(const rct_object_entry* entries) abstract;
 

--- a/src/openrct2/object/SceneryObject.cpp
+++ b/src/openrct2/object/SceneryObject.cpp
@@ -8,12 +8,3 @@
  *****************************************************************************/
 
 #include "SceneryObject.h"
-
-void SceneryObject::SetPrimarySceneryGroup(const std::string& s)
-{
-    if (!s.empty())
-    {
-        auto sgEntry = ParseObjectEntry(s);
-        SetPrimarySceneryGroup(&sgEntry);
-    }
-}

--- a/src/openrct2/object/SceneryObject.h
+++ b/src/openrct2/object/SceneryObject.h
@@ -25,7 +25,7 @@ public:
     }
     virtual ~SceneryObject() = default;
 
-    const ObjectEntryDescriptor& GetPrimarySceneryGroup()
+    const ObjectEntryDescriptor& GetPrimarySceneryGroup() const
     {
         return _primarySceneryGroupEntry;
     }

--- a/src/openrct2/object/SceneryObject.h
+++ b/src/openrct2/object/SceneryObject.h
@@ -16,7 +16,7 @@
 class SceneryObject : public Object
 {
 private:
-    rct_object_entry _primarySceneryGroupEntry = {};
+    ObjectEntryDescriptor _primarySceneryGroupEntry = {};
 
 public:
     explicit SceneryObject(const rct_object_entry& entry)
@@ -25,15 +25,14 @@ public:
     }
     virtual ~SceneryObject() = default;
 
-    const rct_object_entry* GetPrimarySceneryGroup()
+    const ObjectEntryDescriptor& GetPrimarySceneryGroup()
     {
-        return &_primarySceneryGroupEntry;
+        return _primarySceneryGroupEntry;
     }
 
 protected:
-    void SetPrimarySceneryGroup(const rct_object_entry* entry)
+    void SetPrimarySceneryGroup(const ObjectEntryDescriptor& entry)
     {
-        _primarySceneryGroupEntry = *entry;
+        _primarySceneryGroupEntry = entry;
     }
-    void SetPrimarySceneryGroup(const std::string& s);
 };

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -40,7 +40,7 @@ void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     GetStringTable().Read(context, stream, ObjectStringID::NAME);
 
     rct_object_entry sgEntry = stream->ReadValue<rct_object_entry>();
-    SetPrimarySceneryGroup(&sgEntry);
+    SetPrimarySceneryGroup(ObjectEntryDescriptor(sgEntry));
 
     if (scenery_small_entry_has_flag(&_legacyType, SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS))
     {
@@ -156,14 +156,14 @@ std::vector<uint8_t> SmallSceneryObject::ReadFrameOffsets(OpenRCT2::IStream* str
 void SmallSceneryObject::PerformFixes()
 {
     auto identifier = GetLegacyIdentifier();
-    static const rct_object_entry scgWalls = Object::GetScgWallsHeader();
+    static const auto& scgWalls = Object::GetScgWallsHeader();
 
     // ToonTowner's base blocks. Make them allow supports on top and put them in the Walls and Roofs group.
     if (identifier == "XXBBCL01" ||
         identifier == "XXBBMD01" ||
         identifier == "ARBASE2 ")
     {
-        SetPrimarySceneryGroup(&scgWalls);
+        SetPrimarySceneryGroup(scgWalls);
 
         _legacyType.small_scenery.flags |= SMALL_SCENERY_FLAG_BUILD_DIRECTLY_ONTOP;
     }
@@ -179,8 +179,8 @@ void SmallSceneryObject::PerformFixes()
         identifier == "TTPRF10 " ||
         identifier == "TTPRF11 ")
     {
-        static const rct_object_entry scgPirat = GetScgPiratHeader();
-        SetPrimarySceneryGroup(&scgPirat);
+        static const auto& scgPirat = GetScgPiratHeader();
+        SetPrimarySceneryGroup(scgPirat);
     }
 
     // ToonTowner's wooden roofs. Make them show up in the Mine Theming.
@@ -193,8 +193,8 @@ void SmallSceneryObject::PerformFixes()
         identifier == "TTRFWD07" ||
         identifier == "TTRFWD08")
     {
-        static const rct_object_entry scgMine = GetScgMineHeader();
-        SetPrimarySceneryGroup(&scgMine);
+        static const auto& scgMine = GetScgMineHeader();
+        SetPrimarySceneryGroup(scgMine);
     }
 
     // ToonTowner's glass roofs. Make them show up in the Abstract Theming.
@@ -202,25 +202,25 @@ void SmallSceneryObject::PerformFixes()
         identifier == "TTRFGL02" ||
         identifier == "TTRFGL03")
     {
-        static const rct_object_entry scgAbstr = GetScgAbstrHeader();
-        SetPrimarySceneryGroup(&scgAbstr);
+        static const auto& scgAbstr = GetScgAbstrHeader();
+        SetPrimarySceneryGroup(scgAbstr);
     }
 }
 // clang-format on
 
-rct_object_entry SmallSceneryObject::GetScgPiratHeader()
+ObjectEntryDescriptor SmallSceneryObject::GetScgPiratHeader()
 {
-    return Object::CreateHeader("SCGPIRAT", 169381767, 132382977);
+    return ObjectEntryDescriptor("rct2.scgpirat");
 }
 
-rct_object_entry SmallSceneryObject::GetScgMineHeader()
+ObjectEntryDescriptor SmallSceneryObject::GetScgMineHeader()
 {
-    return Object::CreateHeader("SCGMINE ", 207140231, 3638141733);
+    return ObjectEntryDescriptor("rct2.scgpirat");
 }
 
-rct_object_entry SmallSceneryObject::GetScgAbstrHeader()
+ObjectEntryDescriptor SmallSceneryObject::GetScgAbstrHeader()
 {
-    return Object::CreateHeader("SCGABSTR", 207140231, 932253451);
+    return ObjectEntryDescriptor("rct2.scgabstr");
 }
 
 void SmallSceneryObject::ReadJson(IReadObjectContext* context, json_t& root)
@@ -301,7 +301,7 @@ void SmallSceneryObject::ReadJson(IReadObjectContext* context, json_t& root)
             _legacyType.small_scenery.flags |= SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS;
         }
 
-        SetPrimarySceneryGroup(Json::GetString(properties["sceneryGroup"]));
+        SetPrimarySceneryGroup(ObjectEntryDescriptor(Json::GetString(properties["sceneryGroup"])));
     }
 
     PopulateTablesFromJson(context, root);

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -208,17 +208,17 @@ void SmallSceneryObject::PerformFixes()
 }
 // clang-format on
 
-ObjectEntryDescriptor SmallSceneryObject::GetScgPiratHeader()
+ObjectEntryDescriptor SmallSceneryObject::GetScgPiratHeader() const
 {
     return ObjectEntryDescriptor("rct2.scgpirat");
 }
 
-ObjectEntryDescriptor SmallSceneryObject::GetScgMineHeader()
+ObjectEntryDescriptor SmallSceneryObject::GetScgMineHeader() const
 {
     return ObjectEntryDescriptor("rct2.scgpirat");
 }
 
-ObjectEntryDescriptor SmallSceneryObject::GetScgAbstrHeader()
+ObjectEntryDescriptor SmallSceneryObject::GetScgAbstrHeader() const
 {
     return ObjectEntryDescriptor("rct2.scgabstr");
 }

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -42,7 +42,7 @@ private:
     static std::vector<uint8_t> ReadFrameOffsets(OpenRCT2::IStream* stream);
     static std::vector<uint8_t> ReadJsonFrameOffsets(json_t& jFrameOffsets);
     void PerformFixes();
-    rct_object_entry GetScgPiratHeader();
-    rct_object_entry GetScgMineHeader();
-    rct_object_entry GetScgAbstrHeader();
+    ObjectEntryDescriptor GetScgPiratHeader();
+    ObjectEntryDescriptor GetScgMineHeader();
+    ObjectEntryDescriptor GetScgAbstrHeader();
 };

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -42,7 +42,7 @@ private:
     static std::vector<uint8_t> ReadFrameOffsets(OpenRCT2::IStream* stream);
     static std::vector<uint8_t> ReadJsonFrameOffsets(json_t& jFrameOffsets);
     void PerformFixes();
-    ObjectEntryDescriptor GetScgPiratHeader();
-    ObjectEntryDescriptor GetScgMineHeader();
-    ObjectEntryDescriptor GetScgAbstrHeader();
+    ObjectEntryDescriptor GetScgPiratHeader() const;
+    ObjectEntryDescriptor GetScgMineHeader() const;
+    ObjectEntryDescriptor GetScgAbstrHeader() const;
 };

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -32,7 +32,7 @@ void WallObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stre
     GetStringTable().Read(context, stream, ObjectStringID::NAME);
 
     rct_object_entry sgEntry = stream->ReadValue<rct_object_entry>();
-    SetPrimarySceneryGroup(&sgEntry);
+    SetPrimarySceneryGroup(ObjectEntryDescriptor(sgEntry));
 
     GetImageTable().Read(context, stream);
 
@@ -108,7 +108,7 @@ void WallObject::ReadJson(IReadObjectContext* context, json_t& root)
 
         _legacyType.wall.scrolling_mode = Json::GetNumber<uint8_t>(properties["scrollingMode"], SCROLLING_MODE_NONE);
 
-        SetPrimarySceneryGroup(Json::GetString(properties["sceneryGroup"]));
+        SetPrimarySceneryGroup(ObjectEntryDescriptor(Json::GetString(properties["sceneryGroup"])));
 
         // clang-format off
         _legacyType.wall.flags = Json::GetFlags<uint8_t>(


### PR DESCRIPTION
This update mostly concerns two things: translations, and using the new JSON ids for scenery group instead of the legacy ones (so `rct2.scgwalls` instead of `SCGWALLS`). This had to be accompanied by some changes in the code to be able to handle both types.

@tellovishous @rzhao271 It looks like Esperanto is updated correctly: 
![afbeelding](https://user-images.githubusercontent.com/1478678/110374148-9c1fc980-8050-11eb-99cc-f94625ec08cc.png)
