### PR TITLE
cmake macOS .app bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           mv bin/OpenRCT2.app artifacts
           echo -e "\033[0;36mCompressing OpenRCT2.app...\033[0m"
           cd artifacts
-          zip -rq openrct2-macos-cmake-app.zip OpenRCT2.app
+          zip -rqy openrct2-macos-cmake-app.zip OpenRCT2.app
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v2-preview
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v2-preview
         with:
-          name: "OpenRCT2-macOS"
+          name: "OpenRCT2-macOS-xcode"
           path: artifacts/openrct2-macos.zip
       - name: Upload artifacts (openrct2.org)
         run: |
@@ -168,42 +168,18 @@ jobs:
         run: . scripts/setenv -q && run-tests
       - name: Build artifacts
         shell: bash
-        run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-MacOS-x64-cmake.tar.gz bin/install/usr
-      - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v2-preview
-        with:
-          name: "OpenRCT2-macOS-cmake"
-          path: artifacts/OpenRCT2-MacOS-x64-cmake.tar.gz
-  macos-cmake-portable:
-    name: macOS (x64, portable) using CMake
-    runs-on: macos-latest
-    needs: [check-code-formatting]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: macos-app
-      - name: Build OpenRCT2
         run: |
-          brew install ninja
-          . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=on -DMACOS_BUNDLE=on
-      - name: Build artifacts
-        shell: bash
-        run:  |
           . scripts/setenv
           mkdir -p artifacts
           mv bin/OpenRCT2.app artifacts
           echo -e "\033[0;36mCompressing OpenRCT2.app...\033[0m"
           cd artifacts
-          zip -rqy openrct2-macos-cmake-app.zip OpenRCT2.app
+          zip -rqy openrct2-macos.zip OpenRCT2.app
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v2-preview
         with:
-          name: "OpenRCT2-macOS-cmake-app"
-          path: artifacts/openrct2-macos-cmake-app.zip 
-
+          name: "OpenRCT2-macOS-cmake"
+          path: artifacts/openrct2-macos.zip
   linux-portable:
     name: Linux (x64, portable)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,36 @@ jobs:
         uses: actions/upload-artifact@v2-preview
         with:
           name: "OpenRCT2-macOS-cmake"
-          path: artifacts
+          path: artifacts/OpenRCT2-MacOS-x64-cmake.tar.gz
+  macos-cmake-portable:
+    name: macOS (x64, portable) using CMake
+    runs-on: macos-latest
+    needs: [check-code-formatting]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: macos
+      - name: Build OpenRCT2
+        run: |
+          brew install ninja
+          . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=on -DMACOS_BUNDLE=on
+      - name: Build artifacts
+        shell: bash
+        run:  |
+          . scripts/setenv
+          mkdir -p artifacts
+          mv bin/OpenRCT2.app artifacts
+          echo -e "\033[0;36mCompressing OpenRCT2.app...\033[0m"
+          cd artifacts
+          zip -rq openrct2-macos-cmake-app.zip OpenRCT2.app
+      - name: Upload artifacts (CI)
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: "OpenRCT2-macOS-cmake-app"
+          path: artifacts/openrct2-macos-cmake-app.zip 
 
   linux-portable:
     name: Linux (x64, portable)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: macos
+          key: macos-app
       - name: Build OpenRCT2
         run: |
           brew install ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ set(OBJECTS_VERSION "1.0.21")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.37/replays.zip")
+set(REPLAYS_VERSION "0.0.37")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
 set(REPLAYS_SHA1 "C31C299539EB86DA013AEE47C9B2B2F4609F52C4")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
@@ -399,36 +400,37 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
     # targets, like `install`, so we have to trick it and execute dependency ourselves.
     install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
     if (DOWNLOAD_TITLE_SEQUENCES)
-        # If openrct2.parkseq or data/sequence/ exists, assume all the title sequences are already present
-        install(CODE
-            "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/openrct2.parkseq\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/sequence/)\n\
-                message(\"Using cached title sequences\")\n\
-            else () \n\
-                file(DOWNLOAD ${TITLE_SEQUENCE_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/title-sequences.zip EXPECTED_HASH SHA1=${TITLE_SEQUENCE_SHA1} SHOW_PROGRESS)\n\
-                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/ \"${CMAKE_COMMAND}\" -E tar xf title-sequences.zip)\n\
-                file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/title-sequences.zip)\n\
-            endif ()")
+        # Checks if this version of the title sequences are already installed, updates if necessary
+        install(CODE "
+            include(${ROOT_DIR}/cmake/download.cmake)
+            download_openrct2_zip(
+                ZIP_VERSION ${TITLE_SEQUENCE_VERSION}
+                DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/
+                ZIP_URL ${TITLE_SEQUENCE_URL}
+                SHA1 ${TITLE_SEQUENCE_SHA1}
+            )")
     endif ()
     if (DOWNLOAD_OBJECTS)
-        # If rct2.wtrcyan.json or data/object/ exists, assume all the objects are already present
-        install(CODE
-            "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/rct2/water/rct2.wtrcyan.json\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/object/)\n\
-                message(\"Using cached objects\")\n\
-            else () \n\
-                file(DOWNLOAD ${OBJECTS_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/objects.zip EXPECTED_HASH SHA1=${OBJECTS_SHA1} SHOW_PROGRESS)\n\
-                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/ \"${CMAKE_COMMAND}\" -E tar xf objects.zip)\n\
-                file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/objects.zip)\n\
-            endif ()")
+        # Checks if this version of the objects are already installed, updates if necessary
+        install(CODE "
+            include(${ROOT_DIR}/cmake/download.cmake)
+            download_openrct2_zip(
+                ZIP_VERSION ${OBJECTS_VERSION}
+                DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/
+                ZIP_URL ${OBJECTS_URL}
+                SHA1 ${OBJECTS_SHA1}
+            )")
     endif ()
     if (DOWNLOAD_REPLAYS)
-        install(CODE
-            "if (EXISTS \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/)\n\
-                message(\"Using cached replays\")\n\
-            else () \n\
-            file(DOWNLOAD ${REPLAYS_URL} \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/replays.zip EXPECTED_HASH SHA1=${REPLAYS_SHA1} SHOW_PROGRESS)\n\
-                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/ \"${CMAKE_COMMAND}\" -E tar xf replays.zip)\n\
-                file(REMOVE \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/replays.zip)\n\
-            endif ()")
+        # Checks if this version of the replays are already installed, updates if necessary
+        install(CODE "
+            include(${ROOT_DIR}/cmake/download.cmake)
+            download_openrct2_zip(
+                ZIP_VERSION ${REPLAYS_VERSION}
+                DOWNLOAD_DIR \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/
+                ZIP_URL ${REPLAYS_URL}
+                SHA1 ${REPLAYS_SHA1}
+            )")
     endif ()
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
     install(DIRECTORY "data/" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ option(DOWNLOAD_OBJECTS "Download objects during installation." ON)
 CMAKE_DEPENDENT_OPTION(DOWNLOAD_REPLAYS "Download replays during installation." ON
     "WITH_TESTS" OFF)
 option(MACOS_USE_DEPENDENCIES "Use OpenRCT2 dependencies instead of system libraries" ON)
+CMAKE_DEPENDENT_OPTION(MACOS_BUNDLE "Build macOS application bundle (OpenRCT2.app)" OFF
+     "MACOS_USE_DEPENDENCIES; NOT DISABLE_GUI" OFF)
 
 # Options
 option(STATIC "Create a static build.")
@@ -435,7 +437,7 @@ if (DOWNLOAD_REPLAYS)
 endif ()
 install(TARGETS "libopenrct2" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
                               ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-if(NOT DISABLE_GUI)
+if(NOT DISABLE_GUI AND NOT MACOS_BUNDLE)
     install(TARGETS "openrct2" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 install(TARGETS "openrct2-cli" OPTIONAL RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,9 @@ option(DOWNLOAD_TITLE_SEQUENCES "Download title sequences during installation." 
 option(DOWNLOAD_OBJECTS "Download objects during installation." ON)
 CMAKE_DEPENDENT_OPTION(DOWNLOAD_REPLAYS "Download replays during installation." ON
     "WITH_TESTS" OFF)
-option(MACOS_USE_DEPENDENCIES "Use OpenRCT2 dependencies instead of system libraries" ON)
-CMAKE_DEPENDENT_OPTION(MACOS_BUNDLE "Build macOS application bundle (OpenRCT2.app)" OFF
+CMAKE_DEPENDENT_OPTION(MACOS_USE_DEPENDENCIES "Use OpenRCT2 dependencies instead of system libraries" ON
+    "APPLE" OFF)
+CMAKE_DEPENDENT_OPTION(MACOS_BUNDLE "Build macOS application bundle (OpenRCT2.app)" ON
      "MACOS_USE_DEPENDENCIES; NOT DISABLE_GUI" OFF)
 
 # Options
@@ -104,9 +105,8 @@ if (APPIMAGE)
     set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 endif ()
 
-if (APPLE AND MACOS_USE_DEPENDENCIES)
+if (MACOS_USE_DEPENDENCIES)
     # if we're building on macOS, then we need the dependencies
-    # update dylibs
     include(cmake/download.cmake)
     
     set(MACOS_DYLIBS_VERSION "28")
@@ -125,17 +125,21 @@ if (APPLE AND MACOS_USE_DEPENDENCIES)
     set(CMAKE_MACOSX_RPATH 1)
     list(APPEND CMAKE_PREFIX_PATH "${MACOS_DYLIBS_DIR}")
 
-    # the RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-    if("${isSystemDir}" STREQUAL "-1")
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-    endif("${isSystemDir}" STREQUAL "-1")
+    # if we're making the OpenRCT2.app bundle, rpath will be handled by fixup_bundle
+    # if we're building the CLI executable, we need to do it ourselves
+    if (NOT MACOS_BUNDLE)
+        # the RPATH to be used when installing, but only if it's not a system directory
+        list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+        if("${isSystemDir}" STREQUAL "-1")
+            set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+        endif("${isSystemDir}" STREQUAL "-1")
 
-    # if the DESTDIR env var is defined, use it in the install RPATH
-    if(DEFINED ENV{DESTDIR})
-        get_filename_component(destdirRealPath "$ENV{DESTDIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
-        set(CMAKE_INSTALL_RPATH "${destdirRealPath}${CMAKE_INSTALL_PREFIX}/lib")
-    endif()
+        # if the DESTDIR env var is defined, use it in the install RPATH
+        if(DEFINED ENV{DESTDIR})
+            get_filename_component(destdirRealPath "$ENV{DESTDIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+            set(CMAKE_INSTALL_RPATH "${destdirRealPath}${CMAKE_INSTALL_PREFIX}/lib")
+        endif()
+    endif ()
 endif ()
 
 # LIST of supported flags, use SET_CHECK_CXX_FLAGS() to apply to target.
@@ -203,7 +207,7 @@ if (NOT DISABLE_DISCORD_RPC)
             add_definitions(-D__ENABLE_DISCORD__)
             include_directories(DISCORDRPC_PROCESS_INCLUDES)
         endif()
-    elseif (APPLE AND MACOS_USE_DEPENDENCIES)
+    elseif (MACOS_USE_DEPENDENCIES)
         find_package(discordrpc CONFIG REQUIRED)
         if(${DISCORDRPC_FOUND})
             add_definitions(-D__ENABLE_DISCORD__)
@@ -380,80 +384,88 @@ if (WITH_TESTS)
     include("${ROOT_DIR}/test/tests/CMakeLists.txt" NO_POLICY_SCOPE)
 endif ()
 
-# Install
-# Don't recurse, grab all *.txt and *.md files
-file(GLOB DOC_FILES "${ROOT_DIR}/distribution/*.txt")
-list(APPEND DOC_FILES "${ROOT_DIR}/contributors.md"
-                      "${ROOT_DIR}/licence.txt"
-                      "${ROOT_DIR}/distribution/scripting.md"
-                      "${ROOT_DIR}/distribution/openrct2.d.ts")
+# macOS bundle "install" is handled in src/openrct2-ui/CMakeLists.txt
+# This is because the openrct2 target is modified (and that is where that target is defined)
+if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
+    # Install
+    # Don't recurse, grab all *.txt and *.md files
+    file(GLOB DOC_FILES "${ROOT_DIR}/distribution/*.txt")
+    list(APPEND DOC_FILES "${ROOT_DIR}/contributors.md"
+                        "${ROOT_DIR}/licence.txt"
+                        "${ROOT_DIR}/distribution/scripting.md"
+                        "${ROOT_DIR}/distribution/openrct2.d.ts")
 
-# CMake does not allow specifying a dependency chain which includes built-in
-# targets, like `install`, so we have to trick it and execute dependency ourselves.
-install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
-if (DOWNLOAD_TITLE_SEQUENCES)
-    # If openrct2.parkseq or data/sequence/ exists, assume all the title sequences are already present
-    install(CODE
-        "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/openrct2.parkseq\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/sequence/)\n\
-            message(\"Using cached title sequences\")\n\
-        else () \n\
-            file(DOWNLOAD ${TITLE_SEQUENCE_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/title-sequences.zip EXPECTED_HASH SHA1=${TITLE_SEQUENCE_SHA1} SHOW_PROGRESS)\n\
-            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/ \"${CMAKE_COMMAND}\" -E tar xf title-sequences.zip)\n\
-            file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/title-sequences.zip)\n\
-        endif ()")
-endif ()
-if (DOWNLOAD_OBJECTS)
-    # If rct2.wtrcyan.json or data/object/ exists, assume all the objects are already present
-    install(CODE
-        "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/rct2/water/rct2.wtrcyan.json\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/object/)\n\
-            message(\"Using cached objects\")\n\
-        else () \n\
-            file(DOWNLOAD ${OBJECTS_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/objects.zip EXPECTED_HASH SHA1=${OBJECTS_SHA1} SHOW_PROGRESS)\n\
-            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/ \"${CMAKE_COMMAND}\" -E tar xf objects.zip)\n\
-            file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/objects.zip)\n\
-        endif ()")
-endif ()
-if (DOWNLOAD_REPLAYS)
-    install(CODE
-        "if (EXISTS \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/)\n\
-            message(\"Using cached replays\")\n\
-        else () \n\
-	    file(DOWNLOAD ${REPLAYS_URL} \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/replays.zip EXPECTED_HASH SHA1=${REPLAYS_SHA1} SHOW_PROGRESS)\n\
-            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/ \"${CMAKE_COMMAND}\" -E tar xf replays.zip)\n\
-            file(REMOVE \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/replays.zip)\n\
-        endif ()")
-endif ()
-install(TARGETS "libopenrct2" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-                              ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-if(NOT DISABLE_GUI AND NOT MACOS_BUNDLE)
-    install(TARGETS "openrct2" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-endif()
-install(TARGETS "openrct2-cli" OPTIONAL RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
-install(DIRECTORY "data/" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
-install(FILES ${DOC_FILES} DESTINATION "${CMAKE_INSTALL_DOCDIR}")
-install(FILES "distribution/linux/openrct2.appdata.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
-if (NOT DISABLE_GUI)
-	install(FILES "resources/logo/icon_x16.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x24.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x32.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x48.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x64.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x96.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/96x96/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x128.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_x256.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps" RENAME "openrct2.png")
-	install(FILES "resources/logo/icon_flag.svg" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps" RENAME "openrct2.svg")
-	install(FILES "distribution/linux/openrct2.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
-	install(FILES "distribution/linux/openrct2-savegame.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
-	install(FILES "distribution/linux/openrct2-scenario.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
-	install(FILES "distribution/linux/openrct2-uri.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
-endif()
-install(FILES "distribution/linux/openrct2-mimeinfo.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages/" RENAME "openrct2.xml")
-install(DIRECTORY "distribution/man/" DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" FILES_MATCHING PATTERN "*.6")
+    # CMake does not allow specifying a dependency chain which includes built-in
+    # targets, like `install`, so we have to trick it and execute dependency ourselves.
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
+    if (DOWNLOAD_TITLE_SEQUENCES)
+        # If openrct2.parkseq or data/sequence/ exists, assume all the title sequences are already present
+        install(CODE
+            "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/openrct2.parkseq\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/sequence/)\n\
+                message(\"Using cached title sequences\")\n\
+            else () \n\
+                file(DOWNLOAD ${TITLE_SEQUENCE_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/title-sequences.zip EXPECTED_HASH SHA1=${TITLE_SEQUENCE_SHA1} SHOW_PROGRESS)\n\
+                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/ \"${CMAKE_COMMAND}\" -E tar xf title-sequences.zip)\n\
+                file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/title-sequences.zip)\n\
+            endif ()")
+    endif ()
+    if (DOWNLOAD_OBJECTS)
+        # If rct2.wtrcyan.json or data/object/ exists, assume all the objects are already present
+        install(CODE
+            "if (EXISTS \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/rct2/water/rct2.wtrcyan.json\" OR EXISTS ${CMAKE_SOURCE_DIR}/data/object/)\n\
+                message(\"Using cached objects\")\n\
+            else () \n\
+                file(DOWNLOAD ${OBJECTS_URL} \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/objects.zip EXPECTED_HASH SHA1=${OBJECTS_SHA1} SHOW_PROGRESS)\n\
+                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/ \"${CMAKE_COMMAND}\" -E tar xf objects.zip)\n\
+                file(REMOVE \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/objects.zip)\n\
+            endif ()")
+    endif ()
+    if (DOWNLOAD_REPLAYS)
+        install(CODE
+            "if (EXISTS \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/)\n\
+                message(\"Using cached replays\")\n\
+            else () \n\
+            file(DOWNLOAD ${REPLAYS_URL} \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/replays.zip EXPECTED_HASH SHA1=${REPLAYS_SHA1} SHOW_PROGRESS)\n\
+                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E chdir \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/ \"${CMAKE_COMMAND}\" -E tar xf replays.zip)\n\
+                file(REMOVE \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/replays.zip)\n\
+            endif ()")
+    endif ()
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+    install(DIRECTORY "data/" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
 
-if (APPLE AND MACOS_USE_DEPENDENCIES)
-    # Note: dependencies may have the same names as system installed libraries
-    # (via homebrew). A local CMAKE_INSTALL_PREFIX is recommended to avoid issues
-    file(GLOB DYLIB_FILES "${MACOS_DYLIBS_DIR}/lib/*.dylib")
-    install(FILES ${DYLIB_FILES} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    # even when building WITH_TESTS, none of the below install steps are required for OpenRCT2.app
+    if (NOT MACOS_BUNDLE)
+        install(TARGETS "libopenrct2" LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+                                    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+        if(NOT DISABLE_GUI)
+            install(TARGETS "openrct2" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+        endif()
+        install(TARGETS "openrct2-cli" OPTIONAL RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+        install(FILES ${DOC_FILES} DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+        install(FILES "distribution/linux/openrct2.appdata.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
+        if (NOT DISABLE_GUI)
+            install(FILES "resources/logo/icon_x16.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x24.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x32.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x48.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x64.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x96.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/96x96/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x128.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_x256.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps" RENAME "openrct2.png")
+            install(FILES "resources/logo/icon_flag.svg" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps" RENAME "openrct2.svg")
+            install(FILES "distribution/linux/openrct2.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+            install(FILES "distribution/linux/openrct2-savegame.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+            install(FILES "distribution/linux/openrct2-scenario.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+            install(FILES "distribution/linux/openrct2-uri.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+        endif()
+        install(FILES "distribution/linux/openrct2-mimeinfo.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages/" RENAME "openrct2.xml")
+        install(DIRECTORY "distribution/man/" DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" FILES_MATCHING PATTERN "*.6")
+
+        if (MACOS_USE_DEPENDENCIES)
+            # Note: dependencies may have the same names as system installed libraries
+            # (via homebrew). A local CMAKE_INSTALL_PREFIX is recommended to avoid issues
+            file(GLOB DYLIB_FILES "${MACOS_DYLIBS_DIR}/lib/*.dylib")
+            install(FILES ${DYLIB_FILES} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+        endif()
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip")
+set(TITLE_SEQUENCE_VERSION "0.1.2c")
+set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 
-set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip")
+set(OBJECTS_VERSION "1.0.21")
+set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.37/replays.zip")
@@ -105,34 +107,20 @@ endif ()
 if (APPLE AND MACOS_USE_DEPENDENCIES)
     # if we're building on macOS, then we need the dependencies
     # update dylibs
+    include(cmake/download.cmake)
+    
     set(MACOS_DYLIBS_VERSION "28")
     set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v${MACOS_DYLIBS_VERSION}-x64-macos-dylibs.zip")
+    set(MACOS_DYLIBS_SHA1 "29e5480376cf4ac5943f114387e32685204c8b78")
     set(MACOS_DYLIBS_DIR "${ROOT_DIR}/lib/macos")
     set(MACOS_DYLIBS_URL "https://github.com/OpenRCT2/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
 
-    if (NOT EXISTS ${MACOS_DYLIBS_DIR})
-        set(DOWNLOAD_DYLIBS 1)
-    else ()
-        file(READ "${MACOS_DYLIBS_DIR}/libversion" MACOS_DYLIBS_CACHED_VERSION)
-        if (NOT ${MACOS_DYLIBS_CACHED_VERSION} STREQUAL ${MACOS_DYLIBS_VERSION})
-        message("Cached macOS dylibs out of date")
-        set(DOWNLOAD_DYLIBS 1)
-        endif ()
-    endif ()
-    if (DOWNLOAD_DYLIBS)
-        message("Downloading macOS dylibs")
-        file(DOWNLOAD "${MACOS_DYLIBS_URL}" "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
-        file(ARCHIVE_EXTRACT
-            INPUT "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}"
-            DESTINATION "${MACOS_DYLIBS_DIR}"
-        )
-        file(WRITE
-            "${MACOS_DYLIBS_DIR}/libversion"
-            "${MACOS_DYLIBS_VERSION}"
-        )
-        file(REMOVE "${MACOS_DYLIBS_DIR}/${MACOS_DYLIBS_ZIPFILE}")
-    endif ()
-    # TODO: make the above routine a function, use it for objects, title sequences, and languages
+    download_openrct2_zip(
+        ZIP_VERSION ${MACOS_DYLIBS_VERSION}
+        DOWNLOAD_DIR ${MACOS_DYLIBS_DIR}
+        ZIP_URL ${MACOS_DYLIBS_URL}
+        SHA1 ${MACOS_DYLIBS_SHA1}
+    )
 
     set(CMAKE_MACOSX_RPATH 1)
     list(APPEND CMAKE_PREFIX_PATH "${MACOS_DYLIBS_DIR}")

--- a/cmake/download.cmake
+++ b/cmake/download.cmake
@@ -1,0 +1,37 @@
+function(download_openrct2_zip)
+    set(oneValueArgs ZIP_VERSION DOWNLOAD_DIR ZIP_URL SHA1)
+    cmake_parse_arguments(DOWNLOAD_OPENRCT2 "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN} )
+
+    get_filename_component(ZIP_FILE_NAME ${DOWNLOAD_OPENRCT2_ZIP_URL} NAME)
+
+    if (NOT EXISTS ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR})
+        set(DOWNLOAD_ZIP 1)
+    else ()
+        if (EXISTS "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/zipversion")
+            file(READ "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/zipversion" DOWNLOAD_OPENRCT2_CACHED_VERSION)
+            if (NOT ${DOWNLOAD_OPENRCT2_CACHED_VERSION} STREQUAL ${DOWNLOAD_OPENRCT2_ZIP_VERSION})
+                message("Cache ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR} not up to date")
+                set(DOWNLOAD_ZIP 1)
+            endif ()
+        else ()
+        set(DOWNLOAD_ZIP 1)
+        endif ()
+    endif ()
+    if (DOWNLOAD_ZIP)
+        message("Downloading ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}")
+        file(DOWNLOAD
+            "${DOWNLOAD_OPENRCT2_ZIP_URL}" "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}"
+            EXPECTED_HASH SHA1=${DOWNLOAD_OPENRCT2_SHA1} SHOW_PROGRESS)
+        file(ARCHIVE_EXTRACT
+            INPUT "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}"
+            DESTINATION "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}"
+        )
+        file(WRITE
+            "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/zipversion"
+            "${DOWNLOAD_OPENRCT2_ZIP_VERSION}"
+        )
+        file(REMOVE "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}")
+    endif ()
+
+endfunction ()

--- a/cmake/download.cmake
+++ b/cmake/download.cmake
@@ -23,10 +23,14 @@ function(download_openrct2_zip)
         file(DOWNLOAD
             "${DOWNLOAD_OPENRCT2_ZIP_URL}" "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}"
             EXPECTED_HASH SHA1=${DOWNLOAD_OPENRCT2_SHA1} SHOW_PROGRESS)
-        file(ARCHIVE_EXTRACT
-            INPUT "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}"
-            DESTINATION "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}"
-        )
+        if(${CMAKE_VERSION} VERSION_LESS "3.18.0") 
+            execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR} ${CMAKE_COMMAND} -E tar xf ${ZIP_FILE_NAME})
+        else()
+            file(ARCHIVE_EXTRACT
+                INPUT "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}"
+                DESTINATION "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}"
+            )
+        endif()
         file(WRITE
             "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/zipversion"
             "${DOWNLOAD_OPENRCT2_ZIP_VERSION}"

--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleSignature</key>
 	<string>ORCT</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>OpenRCT2 is licensed under the GNU General Public License version 3</string>
 	<key>CFBundleAllowMixedLocalizations</key>

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -11,11 +11,7 @@ cd $basedir/bin
 
 # Scan objects first so that does not happen within a test
 echo -e "\033[0;36mBuilding OpenRCT2 repository indexes...\033[0m"
-if [[ $(uname) == "Darwin" ]]; then
-    ./openrct2-cli scan-objects
-else
-    ./openrct2 scan-objects
-fi
+./openrct2-cli scan-objects
 
 if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     # Now run all the tests

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -11,7 +11,11 @@ cd $basedir/bin
 
 # Scan objects first so that does not happen within a test
 echo -e "\033[0;36mBuilding OpenRCT2 repository indexes...\033[0m"
-./openrct2 scan-objects
+if [[ $(uname) == "Darwin" ]]; then
+    ./openrct2-cli scan-objects
+else
+    ./openrct2 scan-objects
+fi
 
 if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     # Now run all the tests

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -201,7 +201,6 @@ if(MACOS_BUNDLE)
     install(CODE "
         include(BundleUtilities)
         fixup_bundle(${CMAKE_BINARY_DIR}/${MACOS_APP_NAME} \"\" \"\")
-        verify_app(${CMAKE_BINARY_DIR}/${MACOS_APP_NAME})
         "  BUNDLE DESTINATION ${CMAKE_BINARY_DIR}
     )
 endif ()

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -168,6 +168,7 @@ if(MACOS_BUNDLE)
 
     # copy data
     file(COPY ${SOURCE_DATA_DIR}/language DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/shaders DESTINATION "${BUNDLE_RESOURCE_DIR}")
 
     # download objects and sequences
     set(OBJECTS_DIR ${CMAKE_BINARY_DIR}/object)

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -127,3 +127,69 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     get_target_property(OPENRCT2_INCLUDE_DIRS ${PROJECT_NAME} INCLUDE_DIRECTORIES)
     set_target_properties(${PROJECT_NAME}-headers-check PROPERTIES INCLUDE_DIRECTORIES "${OPENRCT2_INCLUDE_DIRS}")
 endif ()
+
+
+if(MACOS_BUNDLE)
+    add_dependencies(${PROJECT_NAME} openrct2-cli)
+    set(OUTPUT_NAME "OpenRCT2")
+    set(MACOS_APP_NAME "${OUTPUT_NAME}.app")
+    set(BUNDLE_FRAMEWORK_DIR "${MACOS_APP_NAME}/Contents/Frameworks")
+    set(BUNDLE_RESOURCE_DIR "${MACOS_APP_NAME}/Contents/Resources")
+    set(SOURCE_DATA_DIR "${ROOT_DIR}/data")
+
+    # Add distribution sources
+    target_sources(${PROJECT_NAME}
+        PUBLIC distribution/readme.txt
+        PUBLIC distribution/changelog.txt
+        PUBLIC g2.dat
+        PUBLIC resources/mac/openrct2.icns
+        PUBLIC ${SOURCE_DATA_DIR}/language
+        PUBLIC ${SOURCE_DATA_DIR}/object
+        PUBLIC ${SOURCE_DATA_DIR}/sequence
+        )
+
+    # Specify the resources to move to the bundle
+    set(BUNDLE_RESOURCES
+        distribution/readme.txt
+        distribution/changelog.txt
+        g2.dat
+        resources/mac/openrct2.icns
+        ${SOURCE_DATA_DIR}/language
+        ${SOURCE_DATA_DIR}/object
+        ${SOURCE_DATA_DIR}/sequence
+        )
+
+
+    if(${OPENRCT2_BRANCH} EQUAL master)
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG}")
+    else()
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENRCT2_VERSION_TAG} ${OPENRCT2_BRANCH}")
+    endif()
+
+    set(PRODUCT_BUNDLE_IDENTIFIER "io.openrct2.OpenRCT2")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${OPENRCT2_COMMIT_SHA1_SHORT}")
+    set(EXECUTABLE_NAME "${OUTPUT_NAME}")
+    set(MACOSX_DEPLOYMENT_TARGET "${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    set(PRODUCT_NAME "${OUTPUT_NAME}")
+
+    # copy data
+    file(COPY ${SOURCE_DATA_DIR}/language DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/object DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${SOURCE_DATA_DIR}/sequence DESTINATION "${BUNDLE_RESOURCE_DIR}")
+
+    # Create as a bundle
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE ON
+        OUTPUT_NAME ${OUTPUT_NAME}
+        MACOSX_BUNDLE_BUNDLE_NAME ${OUTPUT_NAME}
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/Info.plist
+        RESOURCE "${BUNDLE_RESOURCES}")
+
+    install(CODE "
+        include(BundleUtilities)
+        fixup_bundle(${CMAKE_BINARY_DIR}/${MACOS_APP_NAME} \"\" \"\")
+        verify_app(${CMAKE_BINARY_DIR}/${MACOS_APP_NAME})
+        "  BUNDLE DESTINATION ${CMAKE_BINARY_DIR}
+    )
+    
+endif ()

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -139,24 +139,18 @@ if(MACOS_BUNDLE)
 
     # Add distribution sources
     target_sources(${PROJECT_NAME}
-        PUBLIC distribution/readme.txt
-        PUBLIC distribution/changelog.txt
-        PUBLIC g2.dat
-        PUBLIC resources/mac/openrct2.icns
-        PUBLIC ${SOURCE_DATA_DIR}/language
-        PUBLIC ${SOURCE_DATA_DIR}/object
-        PUBLIC ${SOURCE_DATA_DIR}/sequence
+        PUBLIC ${ROOT_DIR}/distribution/readme.txt
+        PUBLIC ${ROOT_DIR}/distribution/changelog.txt
+        PUBLIC ${CMAKE_BINARY_DIR}/g2.dat
+        PUBLIC ${ROOT_DIR}/resources/mac/openrct2.icns
         )
 
     # Specify the resources to move to the bundle
     set(BUNDLE_RESOURCES
-        distribution/readme.txt
-        distribution/changelog.txt
-        g2.dat
-        resources/mac/openrct2.icns
-        ${SOURCE_DATA_DIR}/language
-        ${SOURCE_DATA_DIR}/object
-        ${SOURCE_DATA_DIR}/sequence
+        ${ROOT_DIR}/distribution/readme.txt
+        ${ROOT_DIR}/distribution/changelog.txt
+        ${CMAKE_BINARY_DIR}/g2.dat
+        ${ROOT_DIR}/resources/mac/openrct2.icns
         )
 
 
@@ -174,8 +168,26 @@ if(MACOS_BUNDLE)
 
     # copy data
     file(COPY ${SOURCE_DATA_DIR}/language DESTINATION "${BUNDLE_RESOURCE_DIR}")
-    file(COPY ${SOURCE_DATA_DIR}/object DESTINATION "${BUNDLE_RESOURCE_DIR}")
-    file(COPY ${SOURCE_DATA_DIR}/sequence DESTINATION "${BUNDLE_RESOURCE_DIR}")
+
+    # download objects and sequences
+    set(OBJECTS_DIR ${CMAKE_BINARY_DIR}/object)
+    set(TITLE_SEQUENCE_DIR ${CMAKE_BINARY_DIR}/sequence)
+    download_openrct2_zip(
+        ZIP_VERSION ${OBJECTS_VERSION}
+        DOWNLOAD_DIR ${OBJECTS_DIR}
+        ZIP_URL ${OBJECTS_URL}
+        SHA1 ${OBJECTS_SHA1}
+    )
+
+    download_openrct2_zip(
+        ZIP_VERSION ${TITLE_SEQUENCE_VERSION}
+        DOWNLOAD_DIR ${TITLE_SEQUENCE_DIR}
+        ZIP_URL ${TITLE_SEQUENCE_URL}
+        SHA1 ${TITLE_SEQUENCE_SHA1}
+    )
+    
+    file(COPY ${OBJECTS_DIR} DESTINATION "${BUNDLE_RESOURCE_DIR}")
+    file(COPY ${TITLE_SEQUENCE_DIR} DESTINATION "${BUNDLE_RESOURCE_DIR}")
 
     # Create as a bundle
     set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -191,5 +203,4 @@ if(MACOS_BUNDLE)
         verify_app(${CMAKE_BINARY_DIR}/${MACOS_APP_NAME})
         "  BUNDLE DESTINATION ${CMAKE_BINARY_DIR}
     )
-    
 endif ()


### PR DESCRIPTION
Note: This is branched off of #14307 - so I'll need to give it a rebase after that is merged. Sorry for the lack of a clean branch, but I wanted to be sure all of these changes still worked together. Of course, one could argue that this PR makes Xcode irrelevant anyways ;)

This is another part of #13569: the actual OpenRCT2.app bundle built in cmake. This PR does **not** remove the Xcode build, nor does it switch the "official" macOS build from Xcode to cmake. I'll let a member of the core OpenRCT2 team make that decision.

For now, I've added this as a new CI job and left the `./openrct2` (non-portable) CI job alone. Since that job already ran tests, this job does not build nor run the tests. I think there's a strong argument to be made for merging these CI jobs into one (add tests to this new one, remove the CLI executable build from CI), but I at least wanted to make sure that others saw these separately first. I've left the CLI executables as the default macOS build in cmake - the option to make the app bundle instead defaults to OFF. Discussion on that point is certainly welcomed.

As best I can tell, the cmake-built OpenRCT2.app bundle is very closely matching with the Xcode produced one, and I think entirely matching from a functionality perspective. I've downloaded both artifacts from a CI run, and I'm able to open both of them (after acknowledging that they're from an unknown developer, as usual).

@janisozaur - looks like ccache is working great for the .app bundle too....one of the runs earlier took 2.5 minutes. Xcode has never been close to that fast!

Random aside - the CI runs are still showing 0.3.2-### on the launch screen when opened....is that being cached somewhere? When I build locally, I get 0.3.3-###, as expected.