### PR TITLE
Use entity list size rather than distance

### DIFF
--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -263,10 +263,8 @@ static bool award_is_deserved_best_staff(int32_t activeAwardTypes)
     if (activeAwardTypes & EnumToFlag(ParkAward::MostUntidy))
         return false;
 
-    auto staff = EntityList<Staff>();
-    auto staffCount = std::distance(staff.begin(), staff.end());
-    auto guests = EntityList<Guest>();
-    auto peepCount = std::distance(guests.begin(), guests.end());
+    auto staffCount = GetEntityListCount(EntityType::Staff);
+    auto peepCount = GetEntityListCount(EntityType::Guest);
 
     return ((staffCount != 0) && staffCount >= 20 && staffCount >= peepCount / 32);
 }

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -384,10 +384,7 @@ Peep* try_get_guest(uint16_t spriteIndex)
 
 int32_t peep_get_staff_count()
 {
-    auto list = EntityList<Staff>();
-    auto count = std::distance(list.begin(), list.end());
-
-    return count;
+    return GetEntityListCount(EntityType::Staff);
 }
 
 /**


### PR DESCRIPTION
After the refactors with the entity lists we no longer require to walk the whole entity list to get the number of entries.