### PR TITLE
Entity type4: Remove MiscEntityType and add FountainType

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.33/replays.zip")
-set(REPLAYS_SHA1 "6D600B756B49461CEA4F8206EA18C17AA6F2AF7B")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.34/replays.zip")
+set(REPLAYS_SHA1 "1EEC4382EB8D4CDCC3530E0F983D4412DFC77F6E")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
     <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.33/replays.zip</ReplaysUrl>
-    <ReplaysSha1>6D600B756B49461CEA4F8206EA18C17AA6F2AF7B</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.34/replays.zip</ReplaysUrl>
+    <ReplaysSha1>1EEC4382EB8D4CDCC3530E0F983D4412DFC77F6E</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -464,12 +464,12 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(JumpingFountain, TargetX);
         COMPARE_FIELD(JumpingFountain, TargetY);
         COMPARE_FIELD(JumpingFountain, Iteration);
+        COMPARE_FIELD(JumpingFountain, FountainType);
     }
 
     void CompareSpriteDataMisc(
         const MiscEntity& spriteBase, const MiscEntity& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
-        COMPARE_FIELD(MiscEntity, SubType);
         COMPARE_FIELD(MiscEntity, frame);
     }
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -36,7 +36,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -113,7 +113,7 @@ template<> void PaintEntity(paint_session* session, const JumpingFountain* jumpi
         isAntiClockwise = !isAntiClockwise;
     }
 
-    uint32_t baseImageId = (jumpingFountain->SubType == MiscEntityType::JumpingFountainSnow) ? 23037 : 22973;
+    uint32_t baseImageId = (jumpingFountain->FountainType == JumpingFountainType::Snow) ? 23037 : 22973;
     uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;
     constexpr std::array<CoordsXY, 2> antiClockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, -3 }, CoordsXY{ 0, -3 } };
     constexpr std::array<CoordsXY, 2> clockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, 3 }, CoordsXY{ 0, 3 } };

--- a/src/openrct2/paint/sprite/Paint.Misc.cpp
+++ b/src/openrct2/paint/sprite/Paint.Misc.cpp
@@ -88,6 +88,9 @@ template<> void PaintEntity(paint_session* session, const ExplosionFlare* flare,
     PaintAddImageAsParent(session, imageId, 0, 0, 1, 1, 0, flare->z);
 }
 
+constexpr uint32_t JumpingFountainSnowBaseImage = 23037;
+constexpr uint32_t JumpingFountainWaterBaseImage = 22973;
+
 template<> void PaintEntity(paint_session* session, const JumpingFountain* jumpingFountain, int32_t imageDirection)
 {
     rct_drawpixelinfo* dpi = &session->DPI;
@@ -113,7 +116,8 @@ template<> void PaintEntity(paint_session* session, const JumpingFountain* jumpi
         isAntiClockwise = !isAntiClockwise;
     }
 
-    uint32_t baseImageId = (jumpingFountain->FountainType == JumpingFountainType::Snow) ? 23037 : 22973;
+    uint32_t baseImageId = (jumpingFountain->FountainType == JumpingFountainType::Snow) ? JumpingFountainSnowBaseImage
+                                                                                        : JumpingFountainWaterBaseImage;
     uint32_t imageId = baseImageId + ebx * 16 + jumpingFountain->frame;
     constexpr std::array<CoordsXY, 2> antiClockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, -3 }, CoordsXY{ 0, -3 } };
     constexpr std::array<CoordsXY, 2> clockWiseBoundingBoxes = { CoordsXY{ -COORDS_XY_STEP, 3 }, CoordsXY{ 0, 3 } };

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1132,7 +1132,7 @@ private:
         for (int i = 0; i < RCT1_MAX_SPRITES; i++)
         {
             spriteIndexMap[i] = SPRITE_INDEX_NULL;
-            if (_s4.sprites[i].unknown.sprite_identifier == SpriteIdentifier::Vehicle)
+            if (_s4.sprites[i].unknown.sprite_identifier == RCT12SpriteIdentifier::Vehicle)
             {
                 rct1_vehicle* srcVehicle = &_s4.sprites[i].vehicle;
                 if (srcVehicle->x != LOCATION_NULL)
@@ -1343,7 +1343,7 @@ private:
         for (size_t i = 0; i < RCT1_MAX_SPRITES; i++)
         {
             spriteIndexMap[i] = SPRITE_INDEX_NULL;
-            if (_s4.sprites[i].unknown.sprite_identifier == SpriteIdentifier::Peep)
+            if (_s4.sprites[i].unknown.sprite_identifier == RCT12SpriteIdentifier::Peep)
             {
                 rct1_peep* srcPeep = &_s4.sprites[i].peep;
                 Peep* peep = nullptr;
@@ -1651,7 +1651,7 @@ private:
     {
         for (auto& sprite : _s4.sprites)
         {
-            if (sprite.unknown.sprite_identifier == SpriteIdentifier::Litter)
+            if (sprite.unknown.sprite_identifier == RCT12SpriteIdentifier::Litter)
             {
                 const auto* srcLitter = &sprite.litter;
 
@@ -1671,37 +1671,37 @@ private:
         }
     }
 
-    MiscEntity* CreateMiscFromType(MiscEntityType type)
+    MiscEntity* CreateMiscFromType(RCT12MiscEntityType type)
     {
         MiscEntity* misc = nullptr;
         switch (type)
         {
-            case MiscEntityType::SteamParticle:
+            case RCT12MiscEntityType::SteamParticle:
                 misc = CreateEntity<SteamParticle>();
                 break;
-            case MiscEntityType::MoneyEffect:
+            case RCT12MiscEntityType::MoneyEffect:
                 misc = CreateEntity<MoneyEffect>();
                 break;
-            case MiscEntityType::CrashedVehicleParticle:
+            case RCT12MiscEntityType::CrashedVehicleParticle:
                 misc = CreateEntity<VehicleCrashParticle>();
                 break;
-            case MiscEntityType::ExplosionCloud:
+            case RCT12MiscEntityType::ExplosionCloud:
                 misc = CreateEntity<ExplosionCloud>();
                 break;
-            case MiscEntityType::CrashSplash:
+            case RCT12MiscEntityType::CrashSplash:
                 misc = CreateEntity<CrashSplashParticle>();
                 break;
-            case MiscEntityType::ExplosionFlare:
+            case RCT12MiscEntityType::ExplosionFlare:
                 misc = CreateEntity<ExplosionFlare>();
                 break;
-            case MiscEntityType::JumpingFountainWater:
-            case MiscEntityType::JumpingFountainSnow:
+            case RCT12MiscEntityType::JumpingFountainWater:
+            case RCT12MiscEntityType::JumpingFountainSnow:
                 misc = CreateEntity<JumpingFountain>();
                 break;
-            case MiscEntityType::Balloon:
+            case RCT12MiscEntityType::Balloon:
                 misc = CreateEntity<Balloon>();
                 break;
-            case MiscEntityType::Duck:
+            case RCT12MiscEntityType::Duck:
                 misc = CreateEntity<Duck>();
                 break;
             default:
@@ -1714,10 +1714,10 @@ private:
     {
         for (auto& sprite : _s4.sprites)
         {
-            if (sprite.unknown.sprite_identifier == SpriteIdentifier::Misc)
+            if (sprite.unknown.sprite_identifier == RCT12SpriteIdentifier::Misc)
             {
                 rct1_unk_sprite* src = &sprite.unknown;
-                MiscEntity* dst = CreateMiscFromType(MiscEntityType(src->type));
+                MiscEntity* dst = CreateMiscFromType(RCT12MiscEntityType(src->type));
                 if (dst == nullptr)
                 {
                     log_warning("SV4 has too many misc entities. No more misc entities will be imported!");
@@ -1731,30 +1731,30 @@ private:
 
                 dst->MoveTo({ src->x, src->y, src->z });
 
-                switch (static_cast<MiscEntityType>(src->type))
+                switch (static_cast<RCT12MiscEntityType>(src->type))
                 {
-                    case MiscEntityType::SteamParticle:
+                    case RCT12MiscEntityType::SteamParticle:
                         ImportSteamParticle(dst->As<SteamParticle>(), reinterpret_cast<RCT12SpriteSteamParticle*>(src));
                         break;
-                    case MiscEntityType::MoneyEffect:
+                    case RCT12MiscEntityType::MoneyEffect:
                         ImportMoneyEffect(dst->As<MoneyEffect>(), reinterpret_cast<RCT12SpriteMoneyEffect*>(src));
                         break;
-                    case MiscEntityType::CrashedVehicleParticle:
+                    case RCT12MiscEntityType::CrashedVehicleParticle:
                         break;
-                    case MiscEntityType::ExplosionCloud:
+                    case RCT12MiscEntityType::ExplosionCloud:
                         break;
-                    case MiscEntityType::CrashSplash:
+                    case RCT12MiscEntityType::CrashSplash:
                         break;
-                    case MiscEntityType::ExplosionFlare:
+                    case RCT12MiscEntityType::ExplosionFlare:
                         break;
-                    case MiscEntityType::JumpingFountainWater:
+                    case RCT12MiscEntityType::JumpingFountainWater:
                         ImportJumpingFountainWater(
                             dst->As<JumpingFountain>(), reinterpret_cast<RCT12SpriteJumpingFountain*>(src));
                         break;
-                    case MiscEntityType::Balloon:
+                    case RCT12MiscEntityType::Balloon:
                         ImportBalloon(dst->As<Balloon>(), reinterpret_cast<RCT12SpriteBalloon*>(src));
                         break;
-                    case MiscEntityType::Duck:
+                    case RCT12MiscEntityType::Duck:
                         ImportDuck(dst->As<Duck>(), reinterpret_cast<RCT12SpriteDuck*>(src));
                         break;
                     default:

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1793,6 +1793,7 @@ private:
         dst->Iteration = src->iteration;
         dst->NumTicksAlive = src->num_ticks_alive;
         dst->frame = src->frame;
+        dst->FountainType = JumpingFountainType::Water;
     }
 
     void ImportBalloon(Balloon* dst, RCT12SpriteBalloon* src)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1723,7 +1723,6 @@ private:
                     log_warning("SV4 has too many misc entities. No more misc entities will be imported!");
                     break;
                 }
-                dst->SubType = MiscEntityType(src->type);
                 dst->flags = src->flags;
                 dst->sprite_direction = src->sprite_direction;
                 dst->sprite_width = src->sprite_width;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -85,8 +85,6 @@ constexpr const uint16_t RCT12_PEEP_SPAWN_UNDEFINED = 0xFFFF;
 constexpr const uint16_t RCT12VehicleTrackDirectionMask = 0b0000000000000011;
 constexpr const uint16_t RCT12VehicleTrackTypeMask = 0b1111111111111100;
 
-enum class SpriteIdentifier : uint8_t;
-
 enum class RCT12TrackDesignVersion : uint8_t
 {
     TD4,
@@ -692,9 +690,32 @@ enum class RCT12EntityLinkListOffset : uint8_t
     Vehicle = 5 * sizeof(uint16_t),
 };
 
+enum class RCT12SpriteIdentifier : uint8_t
+{
+    Vehicle = 0,
+    Peep = 1,
+    Misc = 2,
+    Litter = 3,
+    Null = 255
+};
+
+enum class RCT12MiscEntityType : uint8_t
+{
+    SteamParticle,
+    MoneyEffect,
+    CrashedVehicleParticle,
+    ExplosionCloud,
+    CrashSplash,
+    ExplosionFlare,
+    JumpingFountainWater,
+    Balloon,
+    Duck,
+    JumpingFountainSnow
+};
+
 struct RCT12SpriteBase
 {
-    SpriteIdentifier sprite_identifier;                // 0x00
+    RCT12SpriteIdentifier sprite_identifier;           // 0x00
     uint8_t type;                                      // 0x01
     uint16_t next_in_quadrant;                         // 0x02
     uint16_t next;                                     // 0x04

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1333,14 +1333,14 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
 template<> void S6Exporter::ExportEntity(RCT12SpriteSteamParticle* dst, const SteamParticle* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::SteamParticle);
     dst->time_to_move = src->time_to_move;
     dst->frame = src->frame;
 }
 template<> void S6Exporter::ExportEntity(RCT12SpriteMoneyEffect* dst, const MoneyEffect* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::MoneyEffect);
     dst->move_delay = src->MoveDelay;
     dst->num_movements = src->NumMovements;
     dst->vertical = src->Vertical;
@@ -1351,7 +1351,7 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteMoneyEffect* dst, const Mone
 template<> void S6Exporter::ExportEntity(RCT12SpriteCrashedVehicleParticle* dst, const VehicleCrashParticle* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::CrashedVehicleParticle);
     dst->frame = src->frame;
     dst->time_to_live = src->time_to_live;
     dst->frame = src->frame;
@@ -1368,7 +1368,9 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteCrashedVehicleParticle* dst,
 template<> void S6Exporter::ExportEntity(RCT12SpriteJumpingFountain* dst, const JumpingFountain* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(
+        src->FountainType == JumpingFountainType::Snow ? MiscEntityType::JumpingFountainSnow
+                                                       : MiscEntityType::JumpingFountainWater);
     dst->num_ticks_alive = src->NumTicksAlive;
     dst->frame = src->frame;
     dst->fountain_flags = src->FountainFlags;
@@ -1380,7 +1382,7 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteJumpingFountain* dst, const 
 template<> void S6Exporter::ExportEntity(RCT12SpriteBalloon* dst, const Balloon* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::Balloon);
     dst->popped = src->popped;
     dst->time_to_move = src->time_to_move;
     dst->frame = src->frame;
@@ -1389,7 +1391,7 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteBalloon* dst, const Balloon*
 template<> void S6Exporter::ExportEntity(RCT12SpriteDuck* dst, const Duck* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::Duck);
     dst->frame = src->frame;
     dst->target_x = src->target_x;
     dst->target_y = src->target_y;
@@ -1398,19 +1400,19 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteDuck* dst, const Duck* src)
 template<> void S6Exporter::ExportEntity(RCT12SpriteParticle* dst, const ExplosionCloud* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::ExplosionCloud);
     dst->frame = src->frame;
 }
 template<> void S6Exporter::ExportEntity(RCT12SpriteParticle* dst, const ExplosionFlare* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::ExplosionFlare);
     dst->frame = src->frame;
 }
 template<> void S6Exporter::ExportEntity(RCT12SpriteParticle* dst, const CrashSplashParticle* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(src->SubType);
+    dst->type = EnumValue(MiscEntityType::CrashSplash);
     dst->frame = src->frame;
 }
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1029,17 +1029,17 @@ constexpr RCT12EntityLinkListOffset GetRCT2LinkListOffset(const SpriteBase* src)
     return output;
 }
 
-constexpr SpriteIdentifier GetRCT2SpriteIdentifier(const SpriteBase* src)
+constexpr RCT12SpriteIdentifier GetRCT2SpriteIdentifier(const SpriteBase* src)
 {
-    SpriteIdentifier output = SpriteIdentifier::Null;
+    RCT12SpriteIdentifier output = RCT12SpriteIdentifier::Null;
     switch (src->Type)
     {
         case EntityType::Vehicle:
-            output = SpriteIdentifier::Vehicle;
+            output = RCT12SpriteIdentifier::Vehicle;
             break;
         case EntityType::Guest:
         case EntityType::Staff:
-            output = SpriteIdentifier::Peep;
+            output = RCT12SpriteIdentifier::Peep;
             break;
         case EntityType::SteamParticle:
         case EntityType::MoneyEffect:
@@ -1050,10 +1050,10 @@ constexpr SpriteIdentifier GetRCT2SpriteIdentifier(const SpriteBase* src)
         case EntityType::JumpingFountain:
         case EntityType::Balloon:
         case EntityType::Duck:
-            output = SpriteIdentifier::Misc;
+            output = RCT12SpriteIdentifier::Misc;
             break;
         case EntityType::Litter:
-            output = SpriteIdentifier::Litter;
+            output = RCT12SpriteIdentifier::Litter;
             break;
         default:
             break;
@@ -1333,14 +1333,14 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
 template<> void S6Exporter::ExportEntity(RCT12SpriteSteamParticle* dst, const SteamParticle* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::SteamParticle);
+    dst->type = EnumValue(RCT12MiscEntityType::SteamParticle);
     dst->time_to_move = src->time_to_move;
     dst->frame = src->frame;
 }
 template<> void S6Exporter::ExportEntity(RCT12SpriteMoneyEffect* dst, const MoneyEffect* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::MoneyEffect);
+    dst->type = EnumValue(RCT12MiscEntityType::MoneyEffect);
     dst->move_delay = src->MoveDelay;
     dst->num_movements = src->NumMovements;
     dst->vertical = src->Vertical;
@@ -1351,7 +1351,7 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteMoneyEffect* dst, const Mone
 template<> void S6Exporter::ExportEntity(RCT12SpriteCrashedVehicleParticle* dst, const VehicleCrashParticle* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::CrashedVehicleParticle);
+    dst->type = EnumValue(RCT12MiscEntityType::CrashedVehicleParticle);
     dst->frame = src->frame;
     dst->time_to_live = src->time_to_live;
     dst->frame = src->frame;
@@ -1369,8 +1369,8 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteJumpingFountain* dst, const 
 {
     ExportEntityCommonProperties(dst, src);
     dst->type = EnumValue(
-        src->FountainType == JumpingFountainType::Snow ? MiscEntityType::JumpingFountainSnow
-                                                       : MiscEntityType::JumpingFountainWater);
+        src->FountainType == JumpingFountainType::Snow ? RCT12MiscEntityType::JumpingFountainSnow
+                                                       : RCT12MiscEntityType::JumpingFountainWater);
     dst->num_ticks_alive = src->NumTicksAlive;
     dst->frame = src->frame;
     dst->fountain_flags = src->FountainFlags;
@@ -1382,7 +1382,7 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteJumpingFountain* dst, const 
 template<> void S6Exporter::ExportEntity(RCT12SpriteBalloon* dst, const Balloon* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::Balloon);
+    dst->type = EnumValue(RCT12MiscEntityType::Balloon);
     dst->popped = src->popped;
     dst->time_to_move = src->time_to_move;
     dst->frame = src->frame;
@@ -1391,7 +1391,7 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteBalloon* dst, const Balloon*
 template<> void S6Exporter::ExportEntity(RCT12SpriteDuck* dst, const Duck* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::Duck);
+    dst->type = EnumValue(RCT12MiscEntityType::Duck);
     dst->frame = src->frame;
     dst->target_x = src->target_x;
     dst->target_y = src->target_y;
@@ -1400,19 +1400,19 @@ template<> void S6Exporter::ExportEntity(RCT12SpriteDuck* dst, const Duck* src)
 template<> void S6Exporter::ExportEntity(RCT12SpriteParticle* dst, const ExplosionCloud* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::ExplosionCloud);
+    dst->type = EnumValue(RCT12MiscEntityType::ExplosionCloud);
     dst->frame = src->frame;
 }
 template<> void S6Exporter::ExportEntity(RCT12SpriteParticle* dst, const ExplosionFlare* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::ExplosionFlare);
+    dst->type = EnumValue(RCT12MiscEntityType::ExplosionFlare);
     dst->frame = src->frame;
 }
 template<> void S6Exporter::ExportEntity(RCT12SpriteParticle* dst, const CrashSplashParticle* src)
 {
     ExportEntityCommonProperties(dst, src);
-    dst->type = EnumValue(MiscEntityType::CrashSplash);
+    dst->type = EnumValue(RCT12MiscEntityType::CrashSplash);
     dst->frame = src->frame;
 }
 
@@ -1430,7 +1430,7 @@ void S6Exporter::ExportEntities()
     {
         auto& entity = _s6.sprites[i];
         std::memset(&entity, 0, sizeof(entity));
-        entity.unknown.sprite_identifier = SpriteIdentifier::Null;
+        entity.unknown.sprite_identifier = RCT12SpriteIdentifier::Null;
         entity.unknown.sprite_index = i;
         entity.unknown.linked_list_type_offset = RCT12EntityLinkListOffset::Free;
     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1582,8 +1582,7 @@ public:
     void ImportSpriteMisc(MiscEntity* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        cdst->SubType = MiscEntityType(csrc->type);
-        switch (cdst->SubType)
+        switch (MiscEntityType(csrc->type))
         {
             case MiscEntityType::SteamParticle:
             {
@@ -1669,7 +1668,7 @@ public:
                 break;
             }
             default:
-                log_warning("Misc. sprite type %d can not be imported.", cdst->SubType);
+                log_warning("Misc. sprite type %d can not be imported.", csrc->type);
                 break;
         }
     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1012,7 +1012,7 @@ public:
         uint16_t numRiders = 0;
         for (const auto& sprite : _s6.sprites)
         {
-            if (sprite.unknown.sprite_identifier == SpriteIdentifier::Peep)
+            if (sprite.unknown.sprite_identifier == RCT12SpriteIdentifier::Peep)
             {
                 if (sprite.peep.current_ride == rideIndex
                     && (static_cast<PeepState>(sprite.peep.state) == PeepState::OnRide
@@ -1337,19 +1337,19 @@ public:
         std::memset(&dst->pad_00, 0, sizeof(rct_sprite));
         switch (src->unknown.sprite_identifier)
         {
-            case SpriteIdentifier::Null:
+            case RCT12SpriteIdentifier::Null:
                 ImportSpriteCommonProperties(reinterpret_cast<SpriteBase*>(dst), &src->unknown);
                 break;
-            case SpriteIdentifier::Vehicle:
+            case RCT12SpriteIdentifier::Vehicle:
                 ImportSpriteVehicle(&dst->vehicle, &src->vehicle);
                 break;
-            case SpriteIdentifier::Peep:
+            case RCT12SpriteIdentifier::Peep:
                 ImportSpritePeep(&dst->peep, &src->peep);
                 break;
-            case SpriteIdentifier::Misc:
+            case RCT12SpriteIdentifier::Misc:
                 ImportSpriteMisc(&dst->misc, &src->unknown);
                 break;
-            case SpriteIdentifier::Litter:
+            case RCT12SpriteIdentifier::Litter:
                 ImportSpriteLitter(&dst->litter, &src->litter);
                 break;
             default:
@@ -1582,9 +1582,9 @@ public:
     void ImportSpriteMisc(MiscEntity* cdst, const RCT12SpriteBase* csrc)
     {
         ImportSpriteCommonProperties(cdst, csrc);
-        switch (MiscEntityType(csrc->type))
+        switch (RCT12MiscEntityType(csrc->type))
         {
-            case MiscEntityType::SteamParticle:
+            case RCT12MiscEntityType::SteamParticle:
             {
                 auto src = static_cast<const RCT12SpriteSteamParticle*>(csrc);
                 auto dst = static_cast<SteamParticle*>(cdst);
@@ -1592,7 +1592,7 @@ public:
                 dst->frame = src->frame;
                 break;
             }
-            case MiscEntityType::MoneyEffect:
+            case RCT12MiscEntityType::MoneyEffect:
             {
                 auto src = static_cast<const RCT12SpriteMoneyEffect*>(csrc);
                 auto dst = static_cast<MoneyEffect*>(cdst);
@@ -1604,7 +1604,7 @@ public:
                 dst->Wiggle = src->wiggle;
                 break;
             }
-            case MiscEntityType::CrashedVehicleParticle:
+            case RCT12MiscEntityType::CrashedVehicleParticle:
             {
                 auto src = static_cast<const RCT12SpriteCrashedVehicleParticle*>(csrc);
                 auto dst = static_cast<VehicleCrashParticle*>(cdst);
@@ -1622,17 +1622,17 @@ public:
                 dst->acceleration_z = src->acceleration_z;
                 break;
             }
-            case MiscEntityType::ExplosionCloud:
-            case MiscEntityType::ExplosionFlare:
-            case MiscEntityType::CrashSplash:
+            case RCT12MiscEntityType::ExplosionCloud:
+            case RCT12MiscEntityType::ExplosionFlare:
+            case RCT12MiscEntityType::CrashSplash:
             {
                 auto src = static_cast<const RCT12SpriteParticle*>(csrc);
                 auto dst = static_cast<MiscEntity*>(cdst);
                 dst->frame = src->frame;
                 break;
             }
-            case MiscEntityType::JumpingFountainWater:
-            case MiscEntityType::JumpingFountainSnow:
+            case RCT12MiscEntityType::JumpingFountainWater:
+            case RCT12MiscEntityType::JumpingFountainSnow:
             {
                 auto* src = static_cast<const RCT12SpriteJumpingFountain*>(csrc);
                 auto* dst = static_cast<JumpingFountain*>(cdst);
@@ -1642,12 +1642,12 @@ public:
                 dst->TargetX = src->target_x;
                 dst->TargetY = src->target_y;
                 dst->Iteration = src->iteration;
-                dst->FountainType = MiscEntityType(src->type) == MiscEntityType::JumpingFountainSnow
+                dst->FountainType = RCT12MiscEntityType(src->type) == RCT12MiscEntityType::JumpingFountainSnow
                     ? JumpingFountainType::Snow
                     : JumpingFountainType::Water;
                 break;
             }
-            case MiscEntityType::Balloon:
+            case RCT12MiscEntityType::Balloon:
             {
                 auto src = static_cast<const RCT12SpriteBalloon*>(csrc);
                 auto dst = static_cast<Balloon*>(cdst);
@@ -1657,7 +1657,7 @@ public:
                 dst->colour = src->colour;
                 break;
             }
-            case MiscEntityType::Duck:
+            case RCT12MiscEntityType::Duck:
             {
                 auto src = static_cast<const RCT12SpriteDuck*>(csrc);
                 auto dst = static_cast<Duck*>(cdst);
@@ -1685,10 +1685,10 @@ public:
         EntityType output = EntityType::Null;
         switch (src->sprite_identifier)
         {
-            case SpriteIdentifier::Vehicle:
+            case RCT12SpriteIdentifier::Vehicle:
                 output = EntityType::Vehicle;
                 break;
-            case SpriteIdentifier::Peep:
+            case RCT12SpriteIdentifier::Peep:
                 if (PeepType(static_cast<const RCT2SpritePeep*>(src)->peep_type) == PeepType::Guest)
                 {
                     output = EntityType::Guest;
@@ -1698,43 +1698,43 @@ public:
                     output = EntityType::Staff;
                 }
                 break;
-            case SpriteIdentifier::Misc:
+            case RCT12SpriteIdentifier::Misc:
 
-                switch (MiscEntityType(src->type))
+                switch (RCT12MiscEntityType(src->type))
                 {
-                    case MiscEntityType::SteamParticle:
+                    case RCT12MiscEntityType::SteamParticle:
                         output = EntityType::SteamParticle;
                         break;
-                    case MiscEntityType::MoneyEffect:
+                    case RCT12MiscEntityType::MoneyEffect:
                         output = EntityType::MoneyEffect;
                         break;
-                    case MiscEntityType::CrashedVehicleParticle:
+                    case RCT12MiscEntityType::CrashedVehicleParticle:
                         output = EntityType::CrashedVehicleParticle;
                         break;
-                    case MiscEntityType::ExplosionCloud:
+                    case RCT12MiscEntityType::ExplosionCloud:
                         output = EntityType::ExplosionCloud;
                         break;
-                    case MiscEntityType::CrashSplash:
+                    case RCT12MiscEntityType::CrashSplash:
                         output = EntityType::CrashSplash;
                         break;
-                    case MiscEntityType::ExplosionFlare:
+                    case RCT12MiscEntityType::ExplosionFlare:
                         output = EntityType::ExplosionFlare;
                         break;
-                    case MiscEntityType::JumpingFountainWater:
-                    case MiscEntityType::JumpingFountainSnow:
+                    case RCT12MiscEntityType::JumpingFountainWater:
+                    case RCT12MiscEntityType::JumpingFountainSnow:
                         output = EntityType::JumpingFountain;
                         break;
-                    case MiscEntityType::Balloon:
+                    case RCT12MiscEntityType::Balloon:
                         output = EntityType::Balloon;
                         break;
-                    case MiscEntityType::Duck:
+                    case RCT12MiscEntityType::Duck:
                         output = EntityType::Duck;
                         break;
                     default:
                         break;
                 }
                 break;
-            case SpriteIdentifier::Litter:
+            case RCT12SpriteIdentifier::Litter:
                 output = EntityType::Litter;
                 break;
             default:

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1643,6 +1643,9 @@ public:
                 dst->TargetX = src->target_x;
                 dst->TargetY = src->target_y;
                 dst->Iteration = src->iteration;
+                dst->FountainType = MiscEntityType(src->type) == MiscEntityType::JumpingFountainSnow
+                    ? JumpingFountainType::Snow
+                    : JumpingFountainType::Water;
                 break;
             }
             case MiscEntityType::Balloon:

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7244,7 +7244,6 @@ static void steam_particle_create(const CoordsXYZ& coords)
         steam->sprite_width = 20;
         steam->sprite_height_negative = 18;
         steam->sprite_height_positive = 16;
-        steam->SubType = MiscEntityType::SteamParticle;
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -83,7 +83,7 @@ void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
 {
     auto* balloon = CreateEntity<Balloon>();
     if (balloon == nullptr)
-        return; // can never happen
+        return;
 
     balloon->sprite_width = 13;
     balloon->sprite_height_negative = 22;

--- a/src/openrct2/world/Balloon.cpp
+++ b/src/openrct2/world/Balloon.cpp
@@ -81,11 +81,7 @@ void Balloon::Pop()
 
 void create_balloon(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
 {
-    auto* sprite = CreateEntity<Balloon>();
-    if (sprite == nullptr)
-        return;
-    sprite->SubType = MiscEntityType::Balloon;
-    auto balloon = sprite->As<Balloon>();
+    auto* balloon = CreateEntity<Balloon>();
     if (balloon == nullptr)
         return; // can never happen
 

--- a/src/openrct2/world/Duck.cpp
+++ b/src/openrct2/world/Duck.cpp
@@ -280,8 +280,8 @@ uint32_t Duck::GetFrameImage(int32_t direction) const
 
 void create_duck(const CoordsXY& pos)
 {
-    auto* sprite = CreateEntity<Duck>();
-    if (sprite == nullptr)
+    auto* duck = CreateEntity<Duck>();
+    if (duck == nullptr)
         return;
 
     CoordsXY targetPos = pos;
@@ -290,10 +290,6 @@ void create_duck(const CoordsXY& pos)
     targetPos.x += offsetXY;
     targetPos.y += offsetXY;
 
-    sprite->SubType = MiscEntityType::Duck;
-    auto duck = sprite->As<Duck>();
-    if (duck == nullptr)
-        return; // can never happen
     duck->sprite_width = 9;
     duck->sprite_height_negative = 12;
     duck->sprite_height_positive = 9;

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -139,8 +139,6 @@ void JumpingFountain::Create(
         jumpingFountain->sprite_height_positive = 12;
         jumpingFountain->MoveTo(newLoc);
         jumpingFountain->FountainType = newType;
-        jumpingFountain->SubType = newType == JumpingFountainType::Snow ? MiscEntityType::JumpingFountainSnow
-                                                                        : MiscEntityType::JumpingFountainWater;
         jumpingFountain->NumTicksAlive = 0;
         jumpingFountain->frame = 0;
     }
@@ -161,9 +159,9 @@ void JumpingFountain::Update()
     Invalidate();
     frame++;
 
-    switch (SubType)
+    switch (FountainType)
     {
-        case MiscEntityType::JumpingFountainWater:
+        case JumpingFountainType::Water:
             if (frame == 11 && (FountainFlags & FOUNTAIN_FLAG::FAST))
             {
                 AdvanceAnimation();
@@ -173,7 +171,7 @@ void JumpingFountain::Update()
                 AdvanceAnimation();
             }
             break;
-        case MiscEntityType::JumpingFountainSnow:
+        case JumpingFountainType::Snow:
             if (frame == 16)
             {
                 AdvanceAnimation();

--- a/src/openrct2/world/Fountain.h
+++ b/src/openrct2/world/Fountain.h
@@ -13,35 +13,36 @@
 #include "Map.h"
 #include "SpriteBase.h"
 
+enum class JumpingFountainType : uint8_t
+{
+    Water,
+    Snow
+};
+
 struct JumpingFountain : MiscEntity
 {
     static constexpr auto cEntityType = EntityType::JumpingFountain;
 
+    JumpingFountainType FountainType;
     uint8_t NumTicksAlive;
     uint8_t FountainFlags;
     int16_t TargetX;
     int16_t TargetY;
     uint16_t Iteration;
-
     void Update();
-    static void StartAnimation(int32_t newType, const CoordsXY& newLoc, const TileElement* tileElement);
+    static void StartAnimation(JumpingFountainType newType, const CoordsXY& newLoc, const TileElement* tileElement);
 
 private:
-    int32_t GetType() const;
+    JumpingFountainType GetType() const;
     void AdvanceAnimation();
     void GoToEdge(const CoordsXYZ& newLoc, int32_t availableDirections) const;
     void Bounce(const CoordsXYZ& newLoc, int32_t availableDirections);
     void Split(const CoordsXYZ& newLoc, int32_t availableDirections) const;
     void Random(const CoordsXYZ& newLoc, int32_t availableDirections) const;
     void CreateNext(const CoordsXYZ& newLoc, int32_t direction) const;
-    static void Create(int32_t newType, const CoordsXYZ& newLoc, int32_t direction, int32_t newFlags, int32_t iteration);
-    static bool IsJumpingFountain(int32_t newType, const CoordsXYZ& newLoc);
-};
-
-enum
-{
-    JUMPING_FOUNTAIN_TYPE_WATER,
-    JUMPING_FOUNTAIN_TYPE_SNOW
+    static void Create(
+        JumpingFountainType newType, const CoordsXYZ& newLoc, int32_t direction, int32_t newFlags, int32_t iteration);
+    static bool IsJumpingFountain(JumpingFountainType newType, const CoordsXYZ& newLoc);
 };
 
 namespace FOUNTAIN_FLAG

--- a/src/openrct2/world/MoneyEffect.cpp
+++ b/src/openrct2/world/MoneyEffect.cpp
@@ -42,7 +42,6 @@ void MoneyEffect::CreateAt(money32 value, const CoordsXYZ& effectPos, bool verti
     moneyEffect->sprite_height_negative = 20;
     moneyEffect->sprite_height_positive = 30;
     moneyEffect->MoveTo(effectPos);
-    moneyEffect->SubType = MiscEntityType::MoneyEffect;
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;
 

--- a/src/openrct2/world/Particle.cpp
+++ b/src/openrct2/world/Particle.cpp
@@ -38,7 +38,6 @@ void crashed_vehicle_particle_create(rct_vehicle_colour colours, const CoordsXYZ
         sprite->sprite_height_negative = 8;
         sprite->sprite_height_positive = 8;
         sprite->MoveTo(vehiclePos);
-        sprite->SubType = MiscEntityType::CrashedVehicleParticle;
 
         sprite->frame = (scenario_rand() & 0xFF) * 12;
         sprite->time_to_live = (scenario_rand() & 0x7F) + 140;
@@ -126,7 +125,6 @@ void crash_splash_create(const CoordsXYZ& splashPos)
         sprite->sprite_height_negative = 51;
         sprite->sprite_height_positive = 16;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
-        sprite->SubType = MiscEntityType::CrashSplash;
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -85,11 +85,11 @@ void scenery_update_tile(const CoordsXY& sceneryPos)
                 {
                     if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER)
                     {
-                        JumpingFountain::StartAnimation(JUMPING_FOUNTAIN_TYPE_WATER, sceneryPos, tileElement);
+                        JumpingFountain::StartAnimation(JumpingFountainType::Water, sceneryPos, tileElement);
                     }
                     else if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW)
                     {
-                        JumpingFountain::StartAnimation(JUMPING_FOUNTAIN_TYPE_SNOW, sceneryPos, tileElement);
+                        JumpingFountain::StartAnimation(JumpingFountainType::Snow, sceneryPos, tileElement);
                     }
                 }
             }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -519,7 +519,6 @@ void sprite_misc_explosion_cloud_create(const CoordsXYZ& cloudPos)
         sprite->sprite_height_negative = 32;
         sprite->sprite_height_positive = 34;
         sprite->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
-        sprite->SubType = MiscEntityType::ExplosionCloud;
         sprite->frame = 0;
     }
 }
@@ -551,7 +550,6 @@ void sprite_misc_explosion_flare_create(const CoordsXYZ& flarePos)
         sprite->sprite_height_negative = 85;
         sprite->sprite_height_positive = 8;
         sprite->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
-        sprite->SubType = MiscEntityType::ExplosionFlare;
         sprite->frame = 0;
     }
 }

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -78,9 +78,9 @@ template<> bool SpriteBase::Is<Litter>() const
     return Type == EntityType::Litter;
 }
 
-template<> bool SpriteBase::Is<MiscEntity>() const
+constexpr bool EntityTypeIsMiscEntity(const EntityType type)
 {
-    switch (Type)
+    switch (type)
     {
         case EntityType::SteamParticle:
         case EntityType::MoneyEffect:
@@ -95,6 +95,11 @@ template<> bool SpriteBase::Is<MiscEntity>() const
         default:
             return false;
     }
+}
+
+template<> bool SpriteBase::Is<MiscEntity>() const
+{
+    return EntityTypeIsMiscEntity(Type);
 }
 
 template<> bool SpriteBase::Is<SteamParticle>() const
@@ -193,35 +198,6 @@ void SpriteBase::Invalidate()
     }
 
     viewports_invalidate(sprite_left, sprite_top, sprite_right, sprite_bottom, maxZoom);
-}
-
-constexpr SpriteIdentifier EntityTypeToSpriteIdentifier(const EntityType type)
-{
-    switch (type)
-    {
-        case EntityType::Vehicle:
-            return SpriteIdentifier::Vehicle;
-        case EntityType::Guest:
-            return SpriteIdentifier::Peep;
-        case EntityType::Staff:
-            return SpriteIdentifier::Peep;
-        case EntityType::Litter:
-            return SpriteIdentifier::Litter;
-        case EntityType::SteamParticle:
-        case EntityType::MoneyEffect:
-        case EntityType::CrashedVehicleParticle:
-        case EntityType::ExplosionCloud:
-        case EntityType::CrashSplash:
-        case EntityType::ExplosionFlare:
-        case EntityType::JumpingFountain:
-        case EntityType::Balloon:
-        case EntityType::Duck:
-            return SpriteIdentifier::Misc;
-        case EntityType::Null:
-        case EntityType::Count:
-            return SpriteIdentifier::Null;
-    }
-    return SpriteIdentifier::Null;
 }
 
 void RebuildEntityLists()
@@ -444,8 +420,7 @@ rct_sprite* create_sprite(EntityType type)
         return nullptr;
     }
 
-    auto spriteIdentifier = EntityTypeToSpriteIdentifier(type);
-    if (spriteIdentifier == SpriteIdentifier::Misc)
+    if (EntityTypeIsMiscEntity(type))
     {
         // Misc sprites are commonly used for effects, if there are less than MAX_MISC_SPRITES
         // free it will fail to keep slots for more relevant sprites.

--- a/src/openrct2/world/Sprite.h
+++ b/src/openrct2/world/Sprite.h
@@ -17,15 +17,6 @@
 #include "Fountain.h"
 #include "SpriteBase.h"
 
-enum class SpriteIdentifier : uint8_t
-{
-    Vehicle = 0,
-    Peep = 1,
-    Misc = 2,
-    Litter = 3,
-    Null = 255
-};
-
 enum LitterType : uint8_t;
 
 struct Litter : SpriteBase
@@ -169,20 +160,6 @@ struct rct_sprite_checksum
 };
 
 #pragma pack(pop)
-
-enum class MiscEntityType : uint8_t
-{
-    SteamParticle,
-    MoneyEffect,
-    CrashedVehicleParticle,
-    ExplosionCloud,
-    CrashSplash,
-    ExplosionFlare,
-    JumpingFountainWater,
-    Balloon,
-    Duck,
-    JumpingFountainSnow
-};
 
 enum
 {

--- a/src/openrct2/world/SpriteBase.h
+++ b/src/openrct2/world/SpriteBase.h
@@ -75,9 +75,7 @@ struct SpriteBase
     }
 };
 
-enum class MiscEntityType : uint8_t;
 struct MiscEntity : SpriteBase
 {
-    MiscEntityType SubType;
     uint16_t frame;
 };

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -347,13 +347,13 @@ static void CompareSpriteDataLitter(const Litter& left, const Litter& right)
 
 static void CompareSpriteDataSteamParticle(const SteamParticle& left, const SteamParticle& right)
 {
-    COMPARE_FIELD(SubType);
+    COMPARE_FIELD(frame);
     COMPARE_FIELD(time_to_move);
 }
 
 static void CompareSpriteDataMoneyEffect(const MoneyEffect& left, const MoneyEffect& right)
 {
-    COMPARE_FIELD(SubType);
+    COMPARE_FIELD(frame);
     COMPARE_FIELD(MoveDelay);
     COMPARE_FIELD(NumMovements);
     COMPARE_FIELD(Vertical);
@@ -364,7 +364,7 @@ static void CompareSpriteDataMoneyEffect(const MoneyEffect& left, const MoneyEff
 
 static void CompareSpriteDataCrashedVehicleParticle(const VehicleCrashParticle& left, const VehicleCrashParticle& right)
 {
-    COMPARE_FIELD(SubType);
+    COMPARE_FIELD(frame);
     COMPARE_FIELD(time_to_live);
     for (size_t i = 0; i < std::size(left.colour); i++)
     {
@@ -381,17 +381,18 @@ static void CompareSpriteDataCrashedVehicleParticle(const VehicleCrashParticle& 
 
 static void CompareSpriteDataJumpingFountain(const JumpingFountain& left, const JumpingFountain& right)
 {
-    COMPARE_FIELD(SubType);
+    COMPARE_FIELD(frame);
     COMPARE_FIELD(NumTicksAlive);
     COMPARE_FIELD(FountainFlags);
     COMPARE_FIELD(TargetX);
     COMPARE_FIELD(TargetY);
     COMPARE_FIELD(Iteration);
+    COMPARE_FIELD(FountainType);
 }
 
 static void CompareSpriteDataBalloon(const Balloon& left, const Balloon& right)
 {
-    COMPARE_FIELD(SubType);
+    COMPARE_FIELD(frame);
     COMPARE_FIELD(popped);
     COMPARE_FIELD(time_to_move);
     COMPARE_FIELD(colour);
@@ -399,7 +400,7 @@ static void CompareSpriteDataBalloon(const Balloon& left, const Balloon& right)
 
 static void CompareSpriteDataDuck(const Duck& left, const Duck& right)
 {
-    COMPARE_FIELD(SubType);
+    COMPARE_FIELD(frame);
     COMPARE_FIELD(target_x);
     COMPARE_FIELD(target_y);
     COMPARE_FIELD(state);
@@ -443,7 +444,7 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
             case EntityType::ExplosionCloud:
             case EntityType::CrashSplash:
             case EntityType::ExplosionFlare:
-                COMPARE_FIELD(misc.SubType);
+                COMPARE_FIELD(misc.frame);
                 break;
             case EntityType::Null:
                 break;


### PR DESCRIPTION
Final few bits of reorg of the fundamental setup of entities. Removal of SubType as we can just use Type but for jumping fountains we needed a way to distinguish between snow and water so had to add a field for that.