### PR TITLE
Feature #14373 [Plugin] ui.activateTool returns Tool object

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#14071] “Vandals stopped” statistic for security guards.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
+- Feature: [#14373] [Plugin] ui.activateTool returns a Tool object instead of void.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.
 - Fix: [#13581] Opening the Options menu causes a noticeable drop in FPS.
 - Fix: [#13894] Block brakes do not animate.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1846,7 +1846,7 @@ declare global {
          * given tool descriptor and cursor events will be provided.
          * @param tool The properties and event handlers for the tool.
          */
-        activateTool(tool: ToolDesc): void;
+        activateTool(tool: ToolDesc): Tool;
 
         registerMenuItem(text: string, callback: () => void): void;
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -44,7 +44,7 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 25;
+static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 26;
 
 struct ExpressionStringifier final
 {


### PR DESCRIPTION
``ui.activateTool(...)`` now returns a ``Tool`` object
calling ``Tool.cancel()`` only cancels the tool itself, but not any other tool
``ui.tool`` still behaves as before