### PR TITLE
Compute checksum by entity type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.35/replays.zip")
-set(REPLAYS_SHA1 "5875A182E2828B8E0234F496B5D5E84CFE25EFCB")
+set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v0.0.36/replays.zip")
+set(REPLAYS_SHA1 "F539E5BD4F5062C2972C6E0DA974318DB01A0308")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
     <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.35/replays.zip</ReplaysUrl>
-    <ReplaysSha1>5875A182E2828B8E0234F496B5D5E84CFE25EFCB</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.36/replays.zip</ReplaysUrl>
+    <ReplaysSha1>F539E5BD4F5062C2972C6E0DA974318DB01A0308</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -36,7 +36,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -279,22 +279,21 @@ template<typename T> void ComputeChecksumForEntityType(Crypt::HashAlgorithm<20>*
 {
     for (auto* ent : EntityList<T>())
     {
-        // Upconvert it to rct_sprite so that the full size is copied.
-        auto copy = *reinterpret_cast<rct_sprite*>(ent);
+        T copy = *ent;
 
         // Only required for rendering/invalidation, has no meaning to the game state.
-        copy.misc.sprite_left = copy.misc.sprite_right = copy.misc.sprite_top = copy.misc.sprite_bottom = 0;
-        copy.misc.sprite_width = copy.misc.sprite_height_negative = copy.misc.sprite_height_positive = 0;
+        copy.sprite_left = copy.sprite_right = copy.sprite_top = copy.sprite_bottom = 0;
+        copy.sprite_width = copy.sprite_height_negative = copy.sprite_height_positive = 0;
 
         if constexpr (std::is_base_of_v<Peep, T>)
         {
             // Name is pointer and will not be the same across clients
-            copy.peep.Name = {};
+            copy.Name = {};
 
             // We set this to 0 because as soon the client selects a guest the window will remove the
             // invalidation flags causing the sprite checksum to be different than on server, the flag does not
             // affect game state.
-            copy.peep.WindowInvalidateFlags = 0;
+            copy.WindowInvalidateFlags = 0;
         }
 
         _entityHashAlg->Update(&copy, sizeof(copy));

--- a/src/openrct2/world/Sprite.cpp
+++ b/src/openrct2/world/Sprite.cpp
@@ -275,6 +275,37 @@ void reset_sprite_spatial_index()
 
 #ifndef DISABLE_NETWORK
 
+template<typename T> void ComputeChecksumForEntityType(Crypt::HashAlgorithm<20>* _entityHashAlg)
+{
+    for (auto* ent : EntityList<T>())
+    {
+        // Upconvert it to rct_sprite so that the full size is copied.
+        auto copy = *reinterpret_cast<rct_sprite*>(ent);
+
+        // Only required for rendering/invalidation, has no meaning to the game state.
+        copy.misc.sprite_left = copy.misc.sprite_right = copy.misc.sprite_top = copy.misc.sprite_bottom = 0;
+        copy.misc.sprite_width = copy.misc.sprite_height_negative = copy.misc.sprite_height_positive = 0;
+
+        if constexpr (std::is_base_of_v<Peep, T>)
+        {
+            // Name is pointer and will not be the same across clients
+            copy.peep.Name = {};
+
+            // We set this to 0 because as soon the client selects a guest the window will remove the
+            // invalidation flags causing the sprite checksum to be different than on server, the flag does not
+            // affect game state.
+            copy.peep.WindowInvalidateFlags = 0;
+        }
+
+        _entityHashAlg->Update(&copy, sizeof(copy));
+    }
+}
+
+template<typename... T> void ComputeChecksumForEntityTypes(Crypt::HashAlgorithm<20>* _entityHashAlg)
+{
+    (ComputeChecksumForEntityType<T>(_entityHashAlg), ...);
+}
+
 rct_sprite_checksum sprite_checksum()
 {
     using namespace Crypt;
@@ -293,33 +324,8 @@ rct_sprite_checksum sprite_checksum()
         }
 
         _spriteHashAlg->Clear();
-        for (size_t i = 0; i < MAX_ENTITIES; i++)
-        {
-            // TODO create a way to copy only the specific type
-            auto sprite = GetEntity(i);
-            if (sprite != nullptr && sprite->Type != EntityType::Null && !sprite->Is<MiscEntity>())
-            {
-                // Upconvert it to rct_sprite so that the full size is copied.
-                auto copy = *reinterpret_cast<rct_sprite*>(sprite);
 
-                // Only required for rendering/invalidation, has no meaning to the game state.
-                copy.misc.sprite_left = copy.misc.sprite_right = copy.misc.sprite_top = copy.misc.sprite_bottom = 0;
-                copy.misc.sprite_width = copy.misc.sprite_height_negative = copy.misc.sprite_height_positive = 0;
-
-                if (copy.misc.Is<Peep>())
-                {
-                    // Name is pointer and will not be the same across clients
-                    copy.peep.Name = {};
-
-                    // We set this to 0 because as soon the client selects a guest the window will remove the
-                    // invalidation flags causing the sprite checksum to be different than on server, the flag does not
-                    // affect game state.
-                    copy.peep.WindowInvalidateFlags = 0;
-                }
-
-                _spriteHashAlg->Update(&copy, sizeof(copy));
-            }
-        }
+        ComputeChecksumForEntityTypes<Guest, Staff, Vehicle, Litter>(_spriteHashAlg.get());
 
         checksum.raw = _spriteHashAlg->Finish();
     }


### PR DESCRIPTION
This removes a user of the raw sprite list and replaces it with an entity list user. Do you think I should just make it compute the checksum based on the actual size rather than rct_sprite size? You can see this in the second commit.

Will fail all replays as the checksum will be different.