### PR TITLE
Close #13407: Allow building covered lift hill chain when cheat on

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.3.4.1+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#3868] Initial support for using TTF in OpenGL mode (still contains bugs).
+- Feature: [#13407] Allow building chain lifts on enclosed dinghy slide pieces when cheats are on.
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook.
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.
 - Feature: [#15164] Highlight elements selected by the Tile Inspector, tracks are currently not supported.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1518,10 +1518,8 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
         case WIDX_CHAIN_LIFT:
             ride_construction_invalidate_current_track();
             _currentTrackLiftHill ^= CONSTRUCTION_LIFT_HILL_SELECTED;
-            if (_currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED)
-            {
+            if ((_currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED) && !gCheatsEnableChainLiftOnAllTrack)
                 _currentTrackAlternative &= ~RIDE_TYPE_ALTERNATIVE_TRACK_PIECES;
-            }
             _currentTrackPrice = MONEY32_UNDEFINED;
             window_ride_construction_update_active_elements();
             break;
@@ -1599,7 +1597,8 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
         case WIDX_O_TRACK:
             ride_construction_invalidate_current_track();
             _currentTrackAlternative |= RIDE_TYPE_ALTERNATIVE_TRACK_PIECES;
-            _currentTrackLiftHill &= ~CONSTRUCTION_LIFT_HILL_SELECTED;
+            if (!gCheatsEnableChainLiftOnAllTrack)
+                _currentTrackLiftHill &= ~CONSTRUCTION_LIFT_HILL_SELECTED;
             _currentTrackPrice = MONEY32_UNDEFINED;
             window_ride_construction_update_active_elements();
             break;

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -311,7 +311,8 @@ bool window_ride_construction_update_state(
         if (alternativeType != TrackElemType::None && (availablePieces & (1ULL << trackType)))
         {
             trackType = alternativeType;
-            liftHillAndInvertedState &= ~CONSTRUCTION_LIFT_HILL_SELECTED;
+            if (!gCheatsEnableChainLiftOnAllTrack)
+                liftHillAndInvertedState &= ~CONSTRUCTION_LIFT_HILL_SELECTED;
         }
     }
 


### PR DESCRIPTION
This seems to work, however I'm a little concerned touching these two files, there's a lot going on here. 

In RideConstruction don't make lift hill or O_track interact when they're clicked and the cheat is enabled. I.e. if the cheat is on, and you click lift chain don't switch to U_track and if you click O_track don't turn chain off. 

In _legacy.cpp ensure that this then actually gets built: if the cheat is on and we're building the alternativeType then don't turn off lift hill.