### PR TITLE
Apply changed strings from the new-save-format branch

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3680,6 +3680,10 @@ STR_6432    :Mouse {INT32}
 STR_6433    :Remove
 STR_6434    :Remove all bindings for this shortcut.
 STR_6435    :{WINDOW_COLOUR_2}Vandals stopped: {BLACK}{COMMA16}
+STR_6436    :Toggle invisibility
+STR_6437    :Invisible
+STR_6438    :I
+STR_6439    :Tile Inspector: Toggle invisibility
 
 #############
 # Scenarios #

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3938,6 +3938,11 @@ enum
 
     STR_STAFF_STAT_VANDALS_STOPPED = 6435,
 
+    STR_TILE_INSPECTOR_TOGGLE_INVISIBILITY_TIP = 6436,
+    STR_TILE_INSPECTOR_FLAG_INVISIBLE = 6437,
+    STR_TILE_INSPECTOR_INVISIBLE_SHORT = 6438,
+    STR_SHORTCUT_TOGGLE_INVISIBILITY = 6439,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
Discussed in the new-save-format meeting today. Avoids having to rebase the new-save-format branch too often.