### PR TITLE
Add pre-processor directives to avoid warnings

### DIFF
--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -745,6 +745,7 @@ static void ttf_process_format_code(rct_drawpixelinfo* dpi, const FmtString::tok
     }
 }
 
+#ifndef NO_TTF
 static bool ShouldUseSpriteForCodepoint(char32_t codepoint)
 {
     switch (codepoint)
@@ -769,6 +770,7 @@ static bool ShouldUseSpriteForCodepoint(char32_t codepoint)
             return false;
     }
 }
+#endif // NO_TTF
 
 static void ttf_process_string_literal(rct_drawpixelinfo* dpi, std::string_view text, text_draw_info* info)
 {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,11 +42,11 @@
 static Peep* _pickup_peep = nullptr;
 static int32_t _pickup_peep_old_x = LOCATION_NULL;
 
+#ifndef DISABLE_NETWORK
+
 // General chunk size is 63 KiB, this can not be any larger because the packet size is encoded
 // with uint16_t and needs some spare room for other data in the packet.
 static constexpr uint32_t CHUNK_SIZE = 1024 * 63;
-
-#ifndef DISABLE_NETWORK
 
 #    include "../Cheats.h"
 #    include "../ParkImporter.h"


### PR DESCRIPTION
add pre-processor directives to avoid variable not used/function not used when building with DISABLE_NETWORK or DISABLE_TTF.