### PR TITLE
Update rating skipping unused ride ids

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Fix: [#14312] Research ride type message incorrect.
+- Fix: [#14425] Ride ratings do not skip unallocated ride ids.
 - Fix: [#15969] Guests heading for ride use vanilla behaviour
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17657] When switching from buying land rights to buying construction rights, grid disables and won't re-enable afterwards.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -145,6 +145,11 @@ RideManager::Iterator RideManager::end()
     return RideManager::Iterator(*this, endIndex, endIndex);
 }
 
+RideManager::Iterator RideManager::get(RideId rideId)
+{
+    return RideManager::Iterator(*this, rideId.ToUnderlying(), _rides.size());
+}
+
 RideId GetNextFreeRideId()
 {
     auto result = static_cast<RideId::UnderlyingType>(_rides.size());

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -979,6 +979,7 @@ struct RideManager
     size_t size() const;
     Iterator begin();
     Iterator end();
+    Iterator get(RideId rideId);
     Iterator begin() const
     {
         return (const_cast<RideManager*>(this))->begin();

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -178,8 +178,8 @@ static RideId GetNextRideToUpdate(RideId currentRide)
 static void ride_ratings_update_state_0(RideRatingUpdateState& state)
 {
     // It is possible that the current ride being calculated has
-    // been removed or due to import is invalid. For both reset
-    // ratings check at the start
+    // been removed or due to import invalid. For both, reset
+    // ratings and start check at the start
     if (get_ride(state.CurrentRide) == nullptr)
     {
         state.CurrentRide = {};

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -185,13 +185,14 @@ static void ride_ratings_update_state_0(RideRatingUpdateState& state)
         state.CurrentRide = {};
     }
 
-    auto nextRide = get_ride(GetNextRideToUpdate(state.CurrentRide));
+    auto nextRideId = GetNextRideToUpdate(state.CurrentRide);
+    auto nextRide = get_ride(nextRideId);
     if (nextRide != nullptr && nextRide->status != RideStatus::Closed
         && !(nextRide->lifecycle_flags & RIDE_LIFECYCLE_FIXED_RATINGS))
     {
         state.State = RIDE_RATINGS_STATE_INITIALISE;
     }
-    state.CurrentRide = nextRide->id;
+    state.CurrentRide = nextRideId;
 }
 
 /**

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -154,24 +154,44 @@ static void ride_ratings_update_state(RideRatingUpdateState& state)
     }
 }
 
+static RideId GetNextRideToUpdate(RideId currentRide)
+{
+    auto rm = GetRideManager();
+    if (rm.size() == 0)
+    {
+        return RideId::GetNull();
+    }
+    // Skip all empty ride ids
+    auto nextRide = std::next(rm.get(currentRide));
+    // If at end, loop around
+    if (nextRide == rm.end())
+    {
+        nextRide = rm.begin();
+    }
+    return (*nextRide).id;
+}
+
 /**
  *
  *  rct2: 0x006B5A5C
  */
 static void ride_ratings_update_state_0(RideRatingUpdateState& state)
 {
-    auto nextRide = RideId::FromUnderlying(state.CurrentRide.ToUnderlying() + 1);
-    if (nextRide.ToUnderlying() >= OpenRCT2::Limits::MaxRidesInPark)
+    // It is possible that the current ride being calculated has
+    // been removed or due to import is invalid. For both reset
+    // ratings check at the start
+    if (get_ride(state.CurrentRide) == nullptr)
     {
-        nextRide = {};
+        state.CurrentRide = {};
     }
 
-    auto ride = get_ride(nextRide);
-    if (ride != nullptr && ride->status != RideStatus::Closed && !(ride->lifecycle_flags & RIDE_LIFECYCLE_FIXED_RATINGS))
+    auto nextRide = get_ride(GetNextRideToUpdate(state.CurrentRide));
+    if (nextRide != nullptr && nextRide->status != RideStatus::Closed
+        && !(nextRide->lifecycle_flags & RIDE_LIFECYCLE_FIXED_RATINGS))
     {
         state.State = RIDE_RATINGS_STATE_INITIALISE;
     }
-    state.CurrentRide = nextRide;
+    state.CurrentRide = nextRide->id;
 }
 
 /**


### PR DESCRIPTION
After the change to the ride null value we know iterate from 0 -> 65535 when updating ratings. This is slightly wasteful when we only have 0-254 ride id's in use. I've changed the code so that gRideRatingsCalcData.CurrentRide isn't actually the current ride but the distance from ridemanager.begin. I don't quite know what to do about names and this all looks super hacky but it does resolve the issue.