### PR TITLE
Split guest and staff peep variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,9 @@ set(OBJECTS_VERSION "1.0.21")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_VERSION "0.0.38")
+set(REPLAYS_VERSION "0.0.39")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "8940FE7B3F86772214C8CF265E6CEA5A25B49FC1")
+set(REPLAYS_SHA1 "8AF797661D87394FBE1A059375D82632094290FB")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
     <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.38/replays.zip</ReplaysUrl>
-    <ReplaysSha1>8940FE7B3F86772214C8CF265E6CEA5A25B49FC1</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.39/replays.zip</ReplaysUrl>
+    <ReplaysSha1>8AF797661D87394FBE1A059375D82632094290FB</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -601,8 +601,9 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
                 return;
 
             auto clipCoords = ScreenCoordsXY{ 10, 19 };
-
-            if (peep->Is<Staff>() && peep->AssignedStaffType == StaffType::Entertainer)
+            auto* staff = peep->As<Staff>();
+            auto* guest = peep->As<Guest>();
+            if (staff != nullptr && staff->AssignedStaffType == StaffType::Entertainer)
             {
                 clipCoords.y += 3;
             }
@@ -614,17 +615,20 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
             auto image_id = ImageId(image_id_base, peep->TshirtColour, peep->TrousersColour);
             gfx_draw_sprite(&cliped_dpi, image_id, clipCoords);
 
-            if (image_id_base >= 0x2A1D && image_id_base < 0x2A3D)
+            if (guest != nullptr)
             {
-                gfx_draw_sprite(&cliped_dpi, ImageId(image_id_base + 32, peep->BalloonColour), clipCoords);
-            }
-            else if (image_id_base >= 0x2BBD && image_id_base < 0x2BDD)
-            {
-                gfx_draw_sprite(&cliped_dpi, ImageId(image_id_base + 32, peep->UmbrellaColour), clipCoords);
-            }
-            else if (image_id_base >= 0x29DD && image_id_base < 0x29FD)
-            {
-                gfx_draw_sprite(&cliped_dpi, ImageId(image_id_base + 32, peep->HatColour), clipCoords);
+                if (image_id_base >= 0x2A1D && image_id_base < 0x2A3D)
+                {
+                    gfx_draw_sprite(&cliped_dpi, ImageId(image_id_base + 32, guest->BalloonColour), clipCoords);
+                }
+                else if (image_id_base >= 0x2BBD && image_id_base < 0x2BDD)
+                {
+                    gfx_draw_sprite(&cliped_dpi, ImageId(image_id_base + 32, guest->UmbrellaColour), clipCoords);
+                }
+                else if (image_id_base >= 0x29DD && image_id_base < 0x29FD)
+                {
+                    gfx_draw_sprite(&cliped_dpi, ImageId(image_id_base + 32, guest->HatColour), clipCoords);
+                }
             }
             break;
         }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -602,7 +602,6 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
 
             auto clipCoords = ScreenCoordsXY{ 10, 19 };
             auto* staff = peep->As<Staff>();
-            auto* guest = peep->As<Guest>();
             if (staff != nullptr && staff->AssignedStaffType == StaffType::Entertainer)
             {
                 clipCoords.y += 3;
@@ -615,6 +614,7 @@ static void window_game_bottom_toolbar_draw_news_item(rct_drawpixelinfo* dpi, rc
             auto image_id = ImageId(image_id_base, peep->TshirtColour, peep->TrousersColour);
             gfx_draw_sprite(&cliped_dpi, image_id, clipCoords);
 
+            auto* guest = peep->As<Guest>();
             if (guest != nullptr)
             {
                 if (image_id_base >= 0x2A1D && image_id_base < 0x2A3D)

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -759,7 +759,6 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     }
 
     auto* staff = peep->As<Staff>();
-    auto* guest = peep->As<Guest>();
     if (staff != nullptr && staff->AssignedStaffType == StaffType::Entertainer)
         screenCoords.y++;
 
@@ -777,6 +776,7 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     auto sprite_id = ImageId(animationFrame, peep->TshirtColour, peep->TrousersColour);
     gfx_draw_sprite(&clip_dpi, sprite_id, screenCoords);
 
+    auto* guest = peep->As<Guest>();
     if (guest != nullptr)
     {
         // If holding a balloon

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -758,7 +758,9 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
         return;
     }
 
-    if (peep->Is<Staff>() && peep->AssignedStaffType == StaffType::Entertainer)
+    auto* staff = peep->As<Staff>();
+    auto* guest = peep->As<Guest>();
+    if (staff != nullptr && staff->AssignedStaffType == StaffType::Entertainer)
         screenCoords.y++;
 
     int32_t animationFrame = GetPeepAnimation(peep->SpriteType).base_image + 1;
@@ -775,22 +777,25 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     auto sprite_id = ImageId(animationFrame, peep->TshirtColour, peep->TrousersColour);
     gfx_draw_sprite(&clip_dpi, sprite_id, screenCoords);
 
-    // If holding a balloon
-    if (animationFrame >= 0x2A1D && animationFrame < 0x2A3D)
+    if (guest != nullptr)
     {
-        gfx_draw_sprite(&clip_dpi, ImageId(animationFrame + 32, peep->BalloonColour), screenCoords);
-    }
+        // If holding a balloon
+        if (animationFrame >= 0x2A1D && animationFrame < 0x2A3D)
+        {
+            gfx_draw_sprite(&clip_dpi, ImageId(animationFrame + 32, guest->BalloonColour), screenCoords);
+        }
 
-    // If holding umbrella
-    if (animationFrame >= 0x2BBD && animationFrame < 0x2BDD)
-    {
-        gfx_draw_sprite(&clip_dpi, ImageId(animationFrame + 32, peep->UmbrellaColour), screenCoords);
-    }
+        // If holding umbrella
+        if (animationFrame >= 0x2BBD && animationFrame < 0x2BDD)
+        {
+            gfx_draw_sprite(&clip_dpi, ImageId(animationFrame + 32, guest->UmbrellaColour), screenCoords);
+        }
 
-    // If wearing hat
-    if (animationFrame >= 0x29DD && animationFrame < 0x29FD)
-    {
-        gfx_draw_sprite(&clip_dpi, ImageId(animationFrame + 32, peep->HatColour), screenCoords);
+        // If wearing hat
+        if (animationFrame >= 0x29DD && animationFrame < 0x29FD)
+        {
+            gfx_draw_sprite(&clip_dpi, ImageId(animationFrame + 32, guest->HatColour), screenCoords);
+        }
     }
 }
 
@@ -1833,7 +1838,7 @@ void window_guest_inventory_update(rct_window* w)
     }
 }
 
-static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Peep* peep, ShopItem item)
+static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Guest* guest, ShopItem item)
 {
     auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
     auto parkName = park.Name.c_str();
@@ -1851,10 +1856,10 @@ static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Pe
     {
         case ShopItem::Balloon:
             ft.Rewind();
-            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->BalloonColour) | GetShopItemDescriptor(item).Image);
+            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(guest->BalloonColour) | GetShopItemDescriptor(item).Image);
             break;
         case ShopItem::Photo:
-            ride = get_ride(peep->Photo1RideRef);
+            ride = get_ride(guest->Photo1RideRef);
             if (ride != nullptr)
             {
                 ft.Rewind();
@@ -1865,10 +1870,10 @@ static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Pe
             break;
         case ShopItem::Umbrella:
             ft.Rewind();
-            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->UmbrellaColour) | GetShopItemDescriptor(item).Image);
+            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(guest->UmbrellaColour) | GetShopItemDescriptor(item).Image);
             break;
         case ShopItem::Voucher:
-            switch (peep->VoucherType)
+            switch (guest->VoucherType)
             {
                 case VOUCHER_TYPE_PARK_ENTRY_FREE:
                     ft.Rewind();
@@ -1878,7 +1883,7 @@ static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Pe
                     ft.Add<const char*>(parkName);
                     break;
                 case VOUCHER_TYPE_RIDE_FREE:
-                    ride = get_ride(peep->VoucherRideId);
+                    ride = get_ride(guest->VoucherRideId);
                     if (ride != nullptr)
                     {
                         ft.Rewind();
@@ -1898,20 +1903,20 @@ static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Pe
                     ft.Rewind();
                     ft.Increment(6);
                     ft.Add<rct_string_id>(STR_PEEP_INVENTORY_VOUCHER_FOOD_OR_DRINK_FREE);
-                    ft.Add<rct_string_id>(GetShopItemDescriptor(peep->VoucherShopItem).Naming.Singular);
+                    ft.Add<rct_string_id>(GetShopItemDescriptor(guest->VoucherShopItem).Naming.Singular);
                     break;
             }
             break;
         case ShopItem::Hat:
             ft.Rewind();
-            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->HatColour) | GetShopItemDescriptor(item).Image);
+            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(guest->HatColour) | GetShopItemDescriptor(item).Image);
             break;
         case ShopItem::TShirt:
             ft.Rewind();
-            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(peep->TshirtColour) | GetShopItemDescriptor(item).Image);
+            ft.Add<uint32_t>(SPRITE_ID_PALETTE_COLOUR_1(guest->TshirtColour) | GetShopItemDescriptor(item).Image);
             break;
         case ShopItem::Photo2:
-            ride = get_ride(peep->Photo2RideRef);
+            ride = get_ride(guest->Photo2RideRef);
             if (ride != nullptr)
             {
                 ft.Rewind();
@@ -1920,7 +1925,7 @@ static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Pe
             }
             break;
         case ShopItem::Photo3:
-            ride = get_ride(peep->Photo3RideRef);
+            ride = get_ride(guest->Photo3RideRef);
             if (ride != nullptr)
             {
                 ft.Rewind();
@@ -1929,7 +1934,7 @@ static std::pair<rct_string_id, Formatter> window_guest_inventory_format_item(Pe
             }
             break;
         case ShopItem::Photo4:
-            ride = get_ride(peep->Photo4RideRef);
+            ride = get_ride(guest->Photo4RideRef);
             if (ride != nullptr)
             {
                 ft.Rewind();

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -773,7 +773,7 @@ private:
         }
     }
 
-    bool GuestShouldBeVisible(const Peep& peep)
+    bool GuestShouldBeVisible(const Guest& peep)
     {
         if (_trackingOnly && !(peep.PeepFlags & PEEP_FLAGS_TRACKING))
             return false;
@@ -794,7 +794,7 @@ private:
         return true;
     }
 
-    bool IsPeepInFilter(const Peep& peep)
+    bool IsPeepInFilter(const Guest& peep)
     {
         auto guestViewType = _selectedFilter == GuestFilterType::Guests ? GuestViewType::Actions : GuestViewType::Thoughts;
         auto peepArgs = GetArgumentsFromPeep(peep, guestViewType);
@@ -875,7 +875,7 @@ private:
     /**
      * Calculates a hash value (arguments) for comparing peep actions/thoughts
      */
-    static FilterArguments GetArgumentsFromPeep(const Peep& peep, GuestViewType type)
+    static FilterArguments GetArgumentsFromPeep(const Guest& peep, GuestViewType type)
     {
         FilterArguments result;
         Formatter ft(result.args);

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -246,10 +246,11 @@ public:
                         // If normal peep set sprite to normal (no food)
                         // If staff set sprite to staff sprite
                         auto spriteType = PeepSpriteType::Normal;
-                        if (peep->Is<Staff>())
+                        auto* staff = peep->As<Staff>();
+                        if (staff != nullptr)
                         {
-                            spriteType = peep->SpriteType;
-                            if (peep->AssignedStaffType == StaffType::Entertainer)
+                            spriteType = staff->SpriteType;
+                            if (staff->AssignedStaffType == StaffType::Entertainer)
                             {
                                 clipCoords.y += 3;
                             }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1034,24 +1034,6 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ebx += eax;
 
     gfx_draw_sprite(&clip_dpi, ImageId(ebx, peep->TshirtColour, peep->TrousersColour), screenCoords);
-
-    // If holding a balloon
-    if (ebx >= 0x2A1D && ebx < 0x2A3D)
-    {
-        gfx_draw_sprite(&clip_dpi, ImageId(ebx + 32, peep->BalloonColour), screenCoords);
-    }
-
-    // If holding umbrella
-    if (ebx >= 0x2BBD && ebx < 0x2BDD)
-    {
-        gfx_draw_sprite(&clip_dpi, ImageId(ebx + 32, peep->UmbrellaColour), screenCoords);
-    }
-
-    // If wearing hat
-    if (ebx >= 0x29DD && ebx < 0x29FD)
-    {
-        gfx_draw_sprite(&clip_dpi, ImageId(ebx + 32, peep->HatColour), screenCoords);
-    }
 }
 
 /**

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -218,11 +218,9 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, NextLoc.y);
         COMPARE_FIELD(Peep, NextLoc.z);
         COMPARE_FIELD(Peep, NextFlags);
-        COMPARE_FIELD(Peep, OutsideOfPark);
         COMPARE_FIELD(Peep, State);
         COMPARE_FIELD(Peep, SubState);
         COMPARE_FIELD(Peep, SpriteType);
-        COMPARE_FIELD(Peep, GuestNumRides);
         COMPARE_FIELD(Peep, TshirtColour);
         COMPARE_FIELD(Peep, TrousersColour);
         COMPARE_FIELD(Peep, DestinationX);
@@ -231,27 +229,8 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, Var37);
         COMPARE_FIELD(Peep, Energy);
         COMPARE_FIELD(Peep, EnergyTarget);
-        COMPARE_FIELD(Peep, Happiness);
-        COMPARE_FIELD(Peep, HappinessTarget);
-        COMPARE_FIELD(Peep, Nausea);
-        COMPARE_FIELD(Peep, NauseaTarget);
-        COMPARE_FIELD(Peep, Hunger);
-        COMPARE_FIELD(Peep, Thirst);
-        COMPARE_FIELD(Peep, Toilet);
         COMPARE_FIELD(Peep, Mass);
-        COMPARE_FIELD(Peep, TimeToConsume);
-        COMPARE_FIELD(Peep, Intensity);
-        COMPARE_FIELD(Peep, NauseaTolerance);
         COMPARE_FIELD(Peep, WindowInvalidateFlags);
-        COMPARE_FIELD(Peep, PaidOnDrink);
-        for (int i = 0; i < 16; i++)
-        {
-            COMPARE_FIELD(Peep, RideTypesBeenOn[i]);
-        }
-        COMPARE_FIELD(Peep, ItemFlags);
-        COMPARE_FIELD(Peep, Photo2RideRef);
-        COMPARE_FIELD(Peep, Photo3RideRef);
-        COMPARE_FIELD(Peep, Photo4RideRef);
         COMPARE_FIELD(Peep, CurrentRide);
         COMPARE_FIELD(Peep, CurrentRideStation);
         COMPARE_FIELD(Peep, CurrentTrain);
@@ -263,58 +242,102 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, Action);
         COMPARE_FIELD(Peep, ActionFrame);
         COMPARE_FIELD(Peep, StepProgress);
-        COMPARE_FIELD(Peep, GuestNextInQueue);
         COMPARE_FIELD(Peep, MazeLastEdge);
         COMPARE_FIELD(Peep, InteractionRideIndex);
-        COMPARE_FIELD(Peep, TimeInQueue);
-        for (int i = 0; i < 32; i++)
-        {
-            COMPARE_FIELD(Peep, RidesBeenOn[i]);
-        }
         COMPARE_FIELD(Peep, Id);
-        COMPARE_FIELD(Peep, CashInPocket);
-        COMPARE_FIELD(Peep, CashSpent);
-        COMPARE_FIELD(Peep, ParkEntryTime);
-        COMPARE_FIELD(Peep, RejoinQueueTimeout);
-        COMPARE_FIELD(Peep, PreviousRide);
-        COMPARE_FIELD(Peep, PreviousRideTimeOut);
-        for (int i = 0; i < PEEP_MAX_THOUGHTS; i++)
-        {
-            COMPARE_FIELD(Peep, Thoughts[i]);
-        }
         COMPARE_FIELD(Peep, PathCheckOptimisation);
-        COMPARE_FIELD(Peep, GuestHeadingToRideId);
-        COMPARE_FIELD(Peep, StaffOrders);
-        COMPARE_FIELD(Peep, Photo1RideRef);
-        COMPARE_FIELD(Peep, PeepFlags);
         COMPARE_FIELD(Peep, PathfindGoal);
         for (int i = 0; i < 4; i++)
         {
             COMPARE_FIELD(Peep, PathfindHistory[i]);
         }
         COMPARE_FIELD(Peep, WalkingFrameNum);
-        COMPARE_FIELD(Peep, LitterCount);
-        COMPARE_FIELD(Peep, GuestTimeOnRide);
-        COMPARE_FIELD(Peep, DisgustingCount);
-        COMPARE_FIELD(Peep, PaidToEnter);
-        COMPARE_FIELD(Peep, PaidOnRides);
-        COMPARE_FIELD(Peep, PaidOnFood);
-        COMPARE_FIELD(Peep, PaidOnSouvenirs);
-        COMPARE_FIELD(Peep, AmountOfFood);
-        COMPARE_FIELD(Peep, AmountOfDrinks);
-        COMPARE_FIELD(Peep, AmountOfSouvenirs);
-        COMPARE_FIELD(Peep, VandalismSeen);
-        COMPARE_FIELD(Peep, VoucherType);
-        COMPARE_FIELD(Peep, VoucherRideId);
-        COMPARE_FIELD(Peep, SurroundingsThoughtTimeout);
-        COMPARE_FIELD(Peep, Angriness);
-        COMPARE_FIELD(Peep, TimeLost);
-        COMPARE_FIELD(Peep, DaysInQueue);
-        COMPARE_FIELD(Peep, BalloonColour);
-        COMPARE_FIELD(Peep, UmbrellaColour);
-        COMPARE_FIELD(Peep, HatColour);
-        COMPARE_FIELD(Peep, FavouriteRide);
-        COMPARE_FIELD(Peep, FavouriteRideRating);
+    }
+
+    void CompareSpriteDataStaff(const Staff& spriteBase, const Staff& spriteCmp, GameStateSpriteChange_t& changeData) const
+    {
+        CompareSpriteDataPeep(spriteBase, spriteCmp, changeData);
+
+        COMPARE_FIELD(Staff, AssignedStaffType);
+        COMPARE_FIELD(Staff, MechanicTimeSinceCall);
+        COMPARE_FIELD(Staff, HireDate);
+        COMPARE_FIELD(Staff, StaffId);
+        COMPARE_FIELD(Staff, StaffOrders);
+        COMPARE_FIELD(Staff, StaffMowingTimeout);
+        COMPARE_FIELD(Staff, StaffRidesFixed);
+        COMPARE_FIELD(Staff, StaffRidesInspected);
+        COMPARE_FIELD(Staff, StaffLitterSwept);
+        COMPARE_FIELD(Staff, StaffBinsEmptied);
+    }
+
+    void CompareSpriteDataGuest(const Guest& spriteBase, const Guest& spriteCmp, GameStateSpriteChange_t& changeData) const
+    {
+        CompareSpriteDataPeep(spriteBase, spriteCmp, changeData);
+
+        COMPARE_FIELD(Guest, OutsideOfPark);
+        COMPARE_FIELD(Guest, GuestNumRides);
+        COMPARE_FIELD(Guest, Happiness);
+        COMPARE_FIELD(Guest, HappinessTarget);
+        COMPARE_FIELD(Guest, Nausea);
+        COMPARE_FIELD(Guest, NauseaTarget);
+        COMPARE_FIELD(Guest, Hunger);
+        COMPARE_FIELD(Guest, Thirst);
+        COMPARE_FIELD(Guest, Toilet);
+        COMPARE_FIELD(Guest, TimeToConsume);
+        COMPARE_FIELD(Guest, Intensity);
+        COMPARE_FIELD(Guest, NauseaTolerance);
+        COMPARE_FIELD(Guest, PaidOnDrink);
+        for (int i = 0; i < 16; i++)
+        {
+            COMPARE_FIELD(Guest, RideTypesBeenOn[i]);
+        }
+        COMPARE_FIELD(Guest, ItemFlags);
+        COMPARE_FIELD(Guest, Photo2RideRef);
+        COMPARE_FIELD(Guest, Photo3RideRef);
+        COMPARE_FIELD(Guest, Photo4RideRef);
+        COMPARE_FIELD(Guest, GuestNextInQueue);
+        COMPARE_FIELD(Guest, TimeInQueue);
+        for (int i = 0; i < 32; i++)
+        {
+            COMPARE_FIELD(Guest, RidesBeenOn[i]);
+        }
+
+        COMPARE_FIELD(Guest, CashInPocket);
+        COMPARE_FIELD(Guest, CashSpent);
+        COMPARE_FIELD(Guest, ParkEntryTime);
+        COMPARE_FIELD(Guest, RejoinQueueTimeout);
+        COMPARE_FIELD(Guest, PreviousRide);
+        COMPARE_FIELD(Guest, PreviousRideTimeOut);
+        for (int i = 0; i < PEEP_MAX_THOUGHTS; i++)
+        {
+            COMPARE_FIELD(Guest, Thoughts[i]);
+        }
+        COMPARE_FIELD(Guest, GuestHeadingToRideId);
+        COMPARE_FIELD(Guest, GuestIsLostCountdown);
+        COMPARE_FIELD(Guest, Photo1RideRef);
+        COMPARE_FIELD(Guest, PeepFlags);
+        COMPARE_FIELD(Guest, LitterCount);
+        COMPARE_FIELD(Guest, GuestTimeOnRide);
+        COMPARE_FIELD(Guest, DisgustingCount);
+        COMPARE_FIELD(Guest, PaidToEnter);
+        COMPARE_FIELD(Guest, PaidOnRides);
+        COMPARE_FIELD(Guest, PaidOnFood);
+        COMPARE_FIELD(Guest, PaidOnSouvenirs);
+        COMPARE_FIELD(Guest, AmountOfFood);
+        COMPARE_FIELD(Guest, AmountOfDrinks);
+        COMPARE_FIELD(Guest, AmountOfSouvenirs);
+        COMPARE_FIELD(Guest, VandalismSeen);
+        COMPARE_FIELD(Guest, VoucherType);
+        COMPARE_FIELD(Guest, VoucherRideId);
+        COMPARE_FIELD(Guest, SurroundingsThoughtTimeout);
+        COMPARE_FIELD(Guest, Angriness);
+        COMPARE_FIELD(Guest, TimeLost);
+        COMPARE_FIELD(Guest, DaysInQueue);
+        COMPARE_FIELD(Guest, BalloonColour);
+        COMPARE_FIELD(Guest, UmbrellaColour);
+        COMPARE_FIELD(Guest, HatColour);
+        COMPARE_FIELD(Guest, FavouriteRide);
+        COMPARE_FIELD(Guest, FavouriteRideRating);
     }
 
     void CompareSpriteDataVehicle(
@@ -480,10 +503,12 @@ struct GameStateSnapshots final : public IGameStateSnapshots
             switch (spriteBase.misc.Type)
             {
                 case EntityType::Guest:
-                    CompareSpriteDataPeep(spriteBase.peep, spriteCmp.peep, changeData);
+                    CompareSpriteDataGuest(
+                        static_cast<const Guest&>(spriteBase.peep), static_cast<const Guest&>(spriteCmp.peep), changeData);
                     break;
                 case EntityType::Staff:
-                    CompareSpriteDataPeep(spriteBase.peep, spriteCmp.peep, changeData);
+                    CompareSpriteDataStaff(
+                        static_cast<const Staff&>(spriteBase.peep), static_cast<const Staff&>(spriteCmp.peep), changeData);
                     break;
                 case EntityType::Vehicle:
                     CompareSpriteDataVehicle(spriteBase.vehicle, spriteCmp.vehicle, changeData);

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -128,7 +128,7 @@ GameActions::Result::Ptr StaffHireNewAction::QueryExecute(bool execute) const
         return MakeResult(GameActions::Status::NoFreeElements, STR_TOO_MANY_STAFF_IN_GAME);
     }
 
-    Peep* newPeep = CreateEntity<Staff>();
+    Staff* newPeep = CreateEntity<Staff>();
     if (newPeep == nullptr)
     {
         // Too many peeps exist already.
@@ -149,13 +149,11 @@ GameActions::Result::Ptr StaffHireNewAction::QueryExecute(bool execute) const
         newPeep->WalkingFrameNum = 0;
         newPeep->ActionSpriteType = PeepActionSpriteType::None;
         newPeep->PathCheckOptimisation = 0;
-        newPeep->OutsideOfPark = false;
         newPeep->PeepFlags = 0;
-        newPeep->PaidToEnter = 0;
-        newPeep->PaidOnRides = 0;
-        newPeep->PaidOnFood = 0;
-        newPeep->PaidOnSouvenirs = 0;
-        newPeep->FavouriteRide = RIDE_ID_NULL;
+        newPeep->StaffLawnsMown = 0;
+        newPeep->StaffGardensWatered = 0;
+        newPeep->StaffLitterSwept = 0;
+        newPeep->StaffBinsEmptied = 0;
         newPeep->StaffOrders = _staffOrders;
 
         // We search for the first available Id for a given staff type

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -127,7 +127,7 @@ void marketing_update()
     window_invalidate_by_class(WC_FINANCES);
 }
 
-void marketing_set_guest_campaign(Peep* peep, int32_t campaignType)
+void marketing_set_guest_campaign(Guest* peep, int32_t campaignType)
 {
     auto campaign = marketing_get_campaign(campaignType);
     if (campaign == nullptr)

--- a/src/openrct2/management/Marketing.h
+++ b/src/openrct2/management/Marketing.h
@@ -63,7 +63,7 @@ extern std::vector<MarketingCampaign> gMarketingCampaigns;
 
 uint16_t marketing_get_campaign_guest_generation_probability(int32_t campaign);
 void marketing_update();
-void marketing_set_guest_campaign(Peep* peep, int32_t campaign);
+void marketing_set_guest_campaign(Guest* peep, int32_t campaign);
 bool marketing_is_campaign_type_applicable(int32_t campaignType);
 MarketingCampaign* marketing_get_campaign(int32_t campaignType);
 void marketing_new_campaign(const MarketingCampaign& campaign);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -36,7 +36,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/paint/sprite/Paint.Peep.cpp
+++ b/src/openrct2/paint/sprite/Paint.Peep.cpp
@@ -82,25 +82,28 @@ template<> void PaintEntity(paint_session* session, const Peep* peep, int32_t im
     uint32_t imageId = baseImageId | peep->TshirtColour << 19 | peep->TrousersColour << 24 | IMAGE_TYPE_REMAP
         | IMAGE_TYPE_REMAP_2_PLUS;
     PaintAddImageAsParent(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
-
-    if (baseImageId >= 10717 && baseImageId < 10749)
+    auto* guest = peep->As<Guest>();
+    if (guest != nullptr)
     {
-        imageId = (baseImageId + 32) | peep->HatColour << 19 | IMAGE_TYPE_REMAP;
-        PaintAddImageAsChild(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
-        return;
-    }
+        if (baseImageId >= 10717 && baseImageId < 10749)
+        {
+            imageId = (baseImageId + 32) | guest->HatColour << 19 | IMAGE_TYPE_REMAP;
+            PaintAddImageAsChild(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
+            return;
+        }
 
-    if (baseImageId >= 10781 && baseImageId < 10813)
-    {
-        imageId = (baseImageId + 32) | peep->BalloonColour << 19 | IMAGE_TYPE_REMAP;
-        PaintAddImageAsChild(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
-        return;
-    }
+        if (baseImageId >= 10781 && baseImageId < 10813)
+        {
+            imageId = (baseImageId + 32) | guest->BalloonColour << 19 | IMAGE_TYPE_REMAP;
+            PaintAddImageAsChild(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
+            return;
+        }
 
-    if (baseImageId >= 11197 && baseImageId < 11229)
-    {
-        imageId = (baseImageId + 32) | peep->UmbrellaColour << 19 | IMAGE_TYPE_REMAP;
-        PaintAddImageAsChild(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
-        return;
+        if (baseImageId >= 11197 && baseImageId < 11229)
+        {
+            imageId = (baseImageId + 32) | guest->UmbrellaColour << 19 | IMAGE_TYPE_REMAP;
+            PaintAddImageAsChild(session, imageId, 0, 0, 1, 1, 11, peep->z, 0, 0, peep->z + 5);
+            return;
+        }
     }
 }

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -493,15 +493,19 @@ static uint8_t peep_pathfind_get_max_number_junctions(Peep* peep)
         return 8;
     }
 
-    if (peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK && peep->GuestIsLostCountdown < 90)
+    auto* guest = peep->As<Guest>();
+    if (guest == nullptr)
+        return 8;
+
+    if (guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK && guest->GuestIsLostCountdown < 90)
     {
         return 8;
     }
 
-    if (peep->HasItem(ShopItem::Map))
+    if (guest->HasItem(ShopItem::Map))
         return 7;
 
-    if (peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK)
+    if (guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK)
         return 7;
 
     return 5;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -31,8 +31,6 @@
 #include "../ride/Station.h"
 #include "../ride/Track.h"
 #include "../scenario/Scenario.h"
-#include "../scripting/HookEngine.h"
-#include "../scripting/ScriptEngine.h"
 #include "../sprites.h"
 #include "../util/Util.h"
 #include "../windows/Intent.h"
@@ -75,197 +73,6 @@ static void* _crowdSoundChannel = nullptr;
 static void peep_128_tick_update(Peep* peep, int32_t index);
 static void peep_release_balloon(Guest* peep, int16_t spawn_height);
 // clang-format off
-
-// Flags used by PeepThoughtToActionMap
-enum PeepThoughtToActionFlag : uint8_t
-{
-    PEEP_THOUGHT_ACTION_NO_FLAGS = 0,
-    PEEP_THOUGHT_ACTION_FLAG_RIDE = (1 << 0),
-    PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_SINGULAR = (1 << 1),
-    PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_INDEFINITE = (1 << 2),
-};
-
-/** rct2: 0x00981DB0 */
-static struct
-{
-    PeepActionType action;
-    PeepThoughtToActionFlag flags;
-} PeepThoughtToActionMap[] = {
-    { PeepActionType::ShakeHead, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::EmptyPockets, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::Wow, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_SINGULAR },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_INDEFINITE },
-    { PeepActionType::ShakeHead, PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_INDEFINITE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::Wave, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::Joy, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::CheckTime, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::Wave, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::Wave, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::Disgust, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::BeingWatched, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::ShakeHead, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::Joy, PEEP_THOUGHT_ACTION_NO_FLAGS },
-    { PeepActionType::None2, PEEP_THOUGHT_ACTION_FLAG_RIDE },
-};
 
 static PeepActionSpriteType PeepSpecialSpriteToSpriteTypeMap[] = {
     PeepActionSpriteType::None,
@@ -377,11 +184,6 @@ bool Peep::CanBePickedUp() const
             return true;
     }
     return false;
-}
-
-Peep* try_get_guest(uint16_t spriteIndex)
-{
-    return TryGetEntity<Guest>(spriteIndex);
 }
 
 int32_t peep_get_staff_count()
@@ -653,20 +455,21 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
     }
     ActionSpriteImageOffset = peepAnimation[EnumValue(ActionSpriteType)].frame_offsets[ActionFrame];
 
+    auto* guest = As<Guest>();
     // If not throwing up and not at the frame where sick appears.
-    if (Action != PeepActionType::ThrowUp || ActionFrame != 15)
+    if (Action != PeepActionType::ThrowUp || ActionFrame != 15 || guest == nullptr)
     {
         return { { x, y } };
     }
 
     // We are throwing up
-    Hunger /= 2;
-    NauseaTarget /= 2;
+    guest->Hunger /= 2;
+    guest->NauseaTarget /= 2;
 
-    if (Nausea < 30)
-        Nausea = 0;
+    if (guest->Nausea < 30)
+        guest->Nausea = 0;
     else
-        Nausea -= 30;
+        guest->Nausea -= 30;
 
     WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_2;
 
@@ -811,11 +614,11 @@ std::unique_ptr<GameActions::Result> Peep::Place(const TileCoordsXYZ& location, 
         ActionSpriteType = PeepActionSpriteType::None;
         PathCheckOptimisation = 0;
         EntityTweener::Get().Reset();
-
-        if (Is<Guest>())
+        auto* guest = As<Guest>();
+        if (guest != nullptr)
         {
             ActionSpriteType = PeepActionSpriteType::Invalid;
-            HappinessTarget = std::max(HappinessTarget - 10, 0);
+            guest->HappinessTarget = std::max(guest->HappinessTarget - 10, 0);
             UpdateCurrentActionSpriteType();
         }
     }
@@ -840,18 +643,19 @@ void peep_sprite_remove(Peep* peep)
 
     window_close_by_number(WC_FIRE_PROMPT, EnumValue(peep->Type));
 
+    auto* staff = peep->As<Staff>();
     // Needed for invalidations after sprite removal
-    bool wasGuest = peep->Is<Guest>();
+    bool wasGuest = staff == nullptr;
     if (wasGuest)
     {
         News::DisableNewsItems(News::ItemType::PeepOnRide, peep->sprite_index);
     }
     else
     {
-        gStaffModes[peep->StaffId] = StaffMode::None;
+        gStaffModes[staff->StaffId] = StaffMode::None;
         staff_update_greyed_patrol_areas();
 
-        News::DisableNewsItems(News::ItemType::Peep, peep->sprite_index);
+        News::DisableNewsItems(News::ItemType::Peep, staff->sprite_index);
     }
     sprite_remove(peep);
 
@@ -864,9 +668,10 @@ void peep_sprite_remove(Peep* peep)
  */
 void Peep::Remove()
 {
-    if (Is<Guest>())
+    auto* guest = As<Guest>();
+    if (guest != nullptr)
     {
-        if (!OutsideOfPark)
+        if (!guest->OutsideOfPark)
         {
             decrement_guests_in_park();
             auto intent = Intent(INTENT_ACTION_UPDATE_GUEST_COUNT);
@@ -946,9 +751,8 @@ void Peep::UpdateFalling()
                         {
                             // Drop balloon if held
                             peep_release_balloon(guest, height);
+                            guest->InsertNewThought(PeepThoughtType::Drowning, PEEP_THOUGHT_ITEM_NONE);
                         }
-
-                        InsertNewThought(PeepThoughtType::Drowning, PEEP_THOUGHT_ITEM_NONE);
 
                         Action = PeepActionType::Drowning;
                         ActionFrame = 0;
@@ -1036,14 +840,15 @@ void Peep::UpdatePicked()
     if (gCurrentTicks & 0x1F)
         return;
     SubState++;
-    if (SubState == 13)
+    auto* guest = As<Guest>();
+    if (SubState == 13 && guest != nullptr)
     {
-        InsertNewThought(PeepThoughtType::Help, PEEP_THOUGHT_ITEM_NONE);
+        guest->InsertNewThought(PeepThoughtType::Help, PEEP_THOUGHT_ITEM_NONE);
     }
 }
 
 /* From peep_update */
-static void peep_update_thoughts(Peep* peep)
+static void peep_update_thoughts(Guest* peep)
 {
     // Thoughts must always have a gap of at least
     // 220 ticks in age between them. In order to
@@ -1109,13 +914,14 @@ static void peep_update_thoughts(Peep* peep)
  */
 void Peep::Update()
 {
-    if (Is<Guest>())
+    auto* guest = As<Guest>();
+    if (guest != nullptr)
     {
-        if (PreviousRide != RIDE_ID_NULL)
-            if (++PreviousRideTimeOut >= 720)
-                PreviousRide = RIDE_ID_NULL;
+        if (guest->PreviousRide != RIDE_ID_NULL)
+            if (++guest->PreviousRideTimeOut >= 720)
+                guest->PreviousRide = RIDE_ID_NULL;
 
-        peep_update_thoughts(this);
+        peep_update_thoughts(guest);
     }
 
     // Walking speed logic
@@ -1135,7 +941,6 @@ void Peep::Update()
     StepProgress = carryCheck;
     if (carryCheck <= 255)
     {
-        auto* guest = As<Guest>();
         if (guest != nullptr)
         {
             guest->UpdateEasterEggInteractions();
@@ -1160,7 +965,6 @@ void Peep::Update()
                 break;
             default:
             {
-                auto* guest = As<Guest>();
                 if (guest != nullptr)
                 {
                     guest->UpdateGuest();
@@ -1475,319 +1279,6 @@ void peep_update_days_in_queue()
     }
 }
 
-// clang-format off
-/** rct2: 0x009823A0 */
-static constexpr const PeepNauseaTolerance nausea_tolerance_distribution[] = {
-    PeepNauseaTolerance::None,
-    PeepNauseaTolerance::Low, PeepNauseaTolerance::Low,
-    PeepNauseaTolerance::Average, PeepNauseaTolerance::Average, PeepNauseaTolerance::Average,
-    PeepNauseaTolerance::High, PeepNauseaTolerance::High, PeepNauseaTolerance::High, PeepNauseaTolerance::High, PeepNauseaTolerance::High, PeepNauseaTolerance::High,
-};
-
-/** rct2: 0x009823BC */
-static constexpr const uint8_t trouser_colours[] = {
-    COLOUR_BLACK,
-    COLOUR_GREY,
-    COLOUR_LIGHT_BROWN,
-    COLOUR_SATURATED_BROWN,
-    COLOUR_DARK_BROWN,
-    COLOUR_SALMON_PINK,
-    COLOUR_BLACK,
-    COLOUR_GREY,
-    COLOUR_LIGHT_BROWN,
-    COLOUR_SATURATED_BROWN,
-    COLOUR_DARK_BROWN,
-    COLOUR_SALMON_PINK,
-    COLOUR_BLACK,
-    COLOUR_GREY,
-    COLOUR_LIGHT_BROWN,
-    COLOUR_SATURATED_BROWN,
-    COLOUR_DARK_BROWN,
-    COLOUR_SALMON_PINK,
-    COLOUR_DARK_PURPLE,
-    COLOUR_LIGHT_PURPLE,
-    COLOUR_DARK_BLUE,
-    COLOUR_SATURATED_GREEN,
-    COLOUR_SATURATED_RED,
-    COLOUR_DARK_ORANGE,
-    COLOUR_BORDEAUX_RED,
-};
-
-/** rct2: 0x009823D5 */
-static constexpr const uint8_t tshirt_colours[] = {
-    COLOUR_BLACK,
-    COLOUR_GREY,
-    COLOUR_LIGHT_BROWN,
-    COLOUR_SATURATED_BROWN,
-    COLOUR_DARK_BROWN,
-    COLOUR_SALMON_PINK,
-    COLOUR_BLACK,
-    COLOUR_GREY,
-    COLOUR_LIGHT_BROWN,
-    COLOUR_SATURATED_BROWN,
-    COLOUR_DARK_BROWN,
-    COLOUR_SALMON_PINK,
-    COLOUR_DARK_PURPLE,
-    COLOUR_LIGHT_PURPLE,
-    COLOUR_DARK_BLUE,
-    COLOUR_SATURATED_GREEN,
-    COLOUR_SATURATED_RED,
-    COLOUR_DARK_ORANGE,
-    COLOUR_BORDEAUX_RED,
-    COLOUR_WHITE,
-    COLOUR_BRIGHT_PURPLE,
-    COLOUR_LIGHT_BLUE,
-    COLOUR_TEAL,
-    COLOUR_DARK_GREEN,
-    COLOUR_MOSS_GREEN,
-    COLOUR_BRIGHT_GREEN,
-    COLOUR_OLIVE_GREEN,
-    COLOUR_DARK_OLIVE_GREEN,
-    COLOUR_YELLOW,
-    COLOUR_LIGHT_ORANGE,
-    COLOUR_BRIGHT_RED,
-    COLOUR_DARK_PINK,
-    COLOUR_BRIGHT_PINK,
-};
-// clang-format on
-
-/**
- *
- *  rct2: 0x699F5A
- * al:thoughtType
- * ah:thoughtArguments
- * esi: peep
- */
-void Peep::InsertNewThought(PeepThoughtType thoughtType, uint8_t thoughtArguments)
-{
-    PeepActionType newAction = PeepThoughtToActionMap[EnumValue(thoughtType)].action;
-    if (newAction != PeepActionType::None2 && this->Action >= PeepActionType::None1)
-    {
-        Action = newAction;
-        ActionFrame = 0;
-        ActionSpriteImageOffset = 0;
-        UpdateCurrentActionSpriteType();
-    }
-
-    for (int32_t i = 0; i < PEEP_MAX_THOUGHTS; ++i)
-    {
-        rct_peep_thought* thought = &Thoughts[i];
-        // Remove the oldest thought by setting it to NONE.
-        if (thought->type == PeepThoughtType::None)
-            break;
-
-        if (thought->type == thoughtType && thought->item == thoughtArguments)
-        {
-            // If the thought type has not changed then we need to move
-            // it to the top of the thought list. This is done by first removing the
-            // existing thought and placing it at the top.
-            if (i < PEEP_MAX_THOUGHTS - 2)
-            {
-                memmove(thought, thought + 1, sizeof(rct_peep_thought) * (PEEP_MAX_THOUGHTS - i - 1));
-            }
-            break;
-        }
-    }
-
-    memmove(&Thoughts[1], &Thoughts[0], sizeof(rct_peep_thought) * (PEEP_MAX_THOUGHTS - 1));
-
-    Thoughts[0].type = thoughtType;
-    Thoughts[0].item = thoughtArguments;
-    Thoughts[0].freshness = 0;
-    Thoughts[0].fresh_timeout = 0;
-
-    WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_THOUGHTS;
-}
-
-/**
- *
- *  rct2: 0x0069A05D
- */
-Peep* Peep::Generate(const CoordsXYZ& coords)
-{
-    if (GetNumFreeEntities() < 400)
-        return nullptr;
-
-    Peep* peep = CreateEntity<Guest>();
-    peep->SpriteType = PeepSpriteType::Normal;
-    peep->OutsideOfPark = true;
-    peep->State = PeepState::Falling;
-    peep->Action = PeepActionType::None2;
-    peep->SpecialSprite = 0;
-    peep->ActionSpriteImageOffset = 0;
-    peep->WalkingFrameNum = 0;
-    peep->ActionSpriteType = PeepActionSpriteType::None;
-    peep->PeepFlags = 0;
-    peep->FavouriteRide = RIDE_ID_NULL;
-    peep->FavouriteRideRating = 0;
-
-    const rct_sprite_bounds* spriteBounds = &GetSpriteBounds(peep->SpriteType, peep->ActionSpriteType);
-    peep->sprite_width = spriteBounds->sprite_width;
-    peep->sprite_height_negative = spriteBounds->sprite_height_negative;
-    peep->sprite_height_positive = spriteBounds->sprite_height_positive;
-
-    peep->MoveTo(coords);
-    peep->sprite_direction = 0;
-    peep->Mass = (scenario_rand() & 0x1F) + 45;
-    peep->PathCheckOptimisation = 0;
-    peep->InteractionRideIndex = RIDE_ID_NULL;
-    peep->PreviousRide = RIDE_ID_NULL;
-    peep->Thoughts->type = PeepThoughtType::None;
-    peep->WindowInvalidateFlags = 0;
-
-    uint8_t intensityHighest = (scenario_rand() & 0x7) + 3;
-    uint8_t intensityLowest = std::min(intensityHighest, static_cast<uint8_t>(7)) - 3;
-
-    if (intensityHighest >= 7)
-        intensityHighest = 15;
-
-    /* Check which intensity boxes are enabled
-     * and apply the appropriate intensity settings. */
-    if (gParkFlags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
-    {
-        if (gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
-        {
-            intensityLowest = 0;
-            intensityHighest = 15;
-        }
-        else
-        {
-            intensityLowest = 0;
-            intensityHighest = 4;
-        }
-    }
-    else if (gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
-    {
-        intensityLowest = 9;
-        intensityHighest = 15;
-    }
-
-    peep->Intensity = IntensityRange(intensityLowest, intensityHighest);
-
-    uint8_t nauseaTolerance = scenario_rand() & 0x7;
-    if (gParkFlags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
-    {
-        nauseaTolerance += 4;
-    }
-
-    peep->NauseaTolerance = nausea_tolerance_distribution[nauseaTolerance];
-
-    /* Scenario editor limits initial guest happiness to between 37..253.
-     * To be on the safe side, assume the value could have been hacked
-     * to any value 0..255. */
-    peep->Happiness = gGuestInitialHappiness;
-    /* Assume a default initial happiness of 0 is wrong and set
-     * to 128 (50%) instead. */
-    if (gGuestInitialHappiness == 0)
-        peep->Happiness = 128;
-    /* Initial value will vary by -15..16 */
-    int8_t happinessDelta = (scenario_rand() & 0x1F) - 15;
-    /* Adjust by the delta, clamping at min=0 and max=255. */
-    peep->Happiness = std::clamp(peep->Happiness + happinessDelta, 0, PEEP_MAX_HAPPINESS);
-    peep->HappinessTarget = peep->Happiness;
-    peep->Nausea = 0;
-    peep->NauseaTarget = 0;
-
-    /* Scenario editor limits initial guest hunger to between 37..253.
-     * To be on the safe side, assume the value could have been hacked
-     * to any value 0..255. */
-    peep->Hunger = gGuestInitialHunger;
-    /* Initial value will vary by -15..16 */
-    int8_t hungerDelta = (scenario_rand() & 0x1F) - 15;
-    /* Adjust by the delta, clamping at min=0 and max=255. */
-    peep->Hunger = std::clamp(peep->Hunger + hungerDelta, 0, PEEP_MAX_HUNGER);
-
-    /* Scenario editor limits initial guest thirst to between 37..253.
-     * To be on the safe side, assume the value could have been hacked
-     * to any value 0..255. */
-    peep->Thirst = gGuestInitialThirst;
-    /* Initial value will vary by -15..16 */
-    int8_t thirstDelta = (scenario_rand() & 0x1F) - 15;
-    /* Adjust by the delta, clamping at min=0 and max=255. */
-    peep->Thirst = std::clamp(peep->Thirst + thirstDelta, 0, PEEP_MAX_THIRST);
-
-    peep->Toilet = 0;
-    peep->TimeToConsume = 0;
-    std::fill_n(peep->RidesBeenOn, 32, 0x00);
-
-    peep->GuestNumRides = 0;
-    std::fill_n(peep->RideTypesBeenOn, 16, 0x00);
-    peep->Id = gNextGuestNumber++;
-    peep->Name = nullptr;
-
-    money32 cash = (scenario_rand() & 0x3) * 100 - 100 + gGuestInitialCash;
-    if (cash < 0)
-        cash = 0;
-
-    if (gGuestInitialCash == 0)
-    {
-        cash = 500;
-    }
-
-    if (gParkFlags & PARK_FLAGS_NO_MONEY)
-    {
-        cash = 0;
-    }
-
-    if (gGuestInitialCash == MONEY16_UNDEFINED)
-    {
-        cash = 0;
-    }
-
-    peep->CashInPocket = cash;
-    peep->CashSpent = 0;
-    peep->ParkEntryTime = -1;
-    peep->ResetPathfindGoal();
-    peep->RemoveAllItems();
-    peep->GuestHeadingToRideId = RIDE_ID_NULL;
-    peep->LitterCount = 0;
-    peep->DisgustingCount = 0;
-    peep->VandalismSeen = 0;
-    peep->PaidToEnter = 0;
-    peep->PaidOnRides = 0;
-    peep->PaidOnFood = 0;
-    peep->PaidOnDrink = 0;
-    peep->PaidOnSouvenirs = 0;
-    peep->AmountOfFood = 0;
-    peep->AmountOfDrinks = 0;
-    peep->AmountOfSouvenirs = 0;
-    peep->SurroundingsThoughtTimeout = 0;
-    peep->Angriness = 0;
-    peep->TimeLost = 0;
-
-    uint8_t tshirtColour = static_cast<uint8_t>(scenario_rand() % std::size(tshirt_colours));
-    peep->TshirtColour = tshirt_colours[tshirtColour];
-
-    uint8_t trousersColour = static_cast<uint8_t>(scenario_rand() % std::size(trouser_colours));
-    peep->TrousersColour = trouser_colours[trousersColour];
-
-    /* Minimum energy is capped at 32 and maximum at 128, so this initialises
-     * a peep with approx 34%-100% energy. (65 - 32) / (128 - 32) ≈ 34% */
-    uint8_t energy = (scenario_rand() % 64) + 65;
-    peep->Energy = energy;
-    peep->EnergyTarget = energy;
-
-    increment_guests_heading_for_park();
-
-#ifdef ENABLE_SCRIPTING
-    auto& hookEngine = OpenRCT2::GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(OpenRCT2::Scripting::HOOK_TYPE::GUEST_GENERATION))
-    {
-        auto ctx = OpenRCT2::GetContext()->GetScriptEngine().GetContext();
-
-        // Create event args object
-        auto obj = OpenRCT2::Scripting::DukObject(ctx);
-        obj.Set("id", peep->sprite_index);
-
-        // Call the subscriptions
-        auto e = obj.Take();
-        hookEngine.Call(OpenRCT2::Scripting::HOOK_TYPE::GUEST_GENERATION, e, true);
-    }
-#endif
-
-    return peep;
-}
-
 void Peep::FormatActionTo(Formatter& ft) const
 {
     switch (State)
@@ -1831,20 +1322,26 @@ void Peep::FormatActionTo(Formatter& ft) const
         }
         case PeepState::Walking:
         case PeepState::UsingBin:
-            if (GuestHeadingToRideId != RIDE_ID_NULL)
+        {
+            auto* guest = As<Guest>();
+            if (guest != nullptr)
             {
-                auto ride = get_ride(GuestHeadingToRideId);
-                if (ride != nullptr)
+                if (guest->GuestHeadingToRideId != RIDE_ID_NULL)
                 {
-                    ft.Add<rct_string_id>(STR_HEADING_FOR);
-                    ride->FormatNameTo(ft);
+                    auto ride = get_ride(guest->GuestHeadingToRideId);
+                    if (ride != nullptr)
+                    {
+                        ft.Add<rct_string_id>(STR_HEADING_FOR);
+                        ride->FormatNameTo(ft);
+                    }
+                }
+                else
+                {
+                    ft.Add<rct_string_id>((PeepFlags & PEEP_FLAGS_LEAVING_PARK) ? STR_LEAVING_PARK : STR_WALKING);
                 }
             }
-            else
-            {
-                ft.Add<rct_string_id>((PeepFlags & PEEP_FLAGS_LEAVING_PARK) ? STR_LEAVING_PARK : STR_WALKING);
-            }
             break;
+        }
         case PeepState::QueuingFront:
         case PeepState::Queuing:
         {
@@ -1966,7 +1463,8 @@ void Peep::FormatNameTo(Formatter& ft) const
 {
     if (Name == nullptr)
     {
-        if (Is<Staff>())
+        auto* staff = As<Staff>();
+        if (staff != nullptr)
         {
             static constexpr const rct_string_id staffNames[] = {
                 STR_HANDYMAN_X,
@@ -1975,7 +1473,7 @@ void Peep::FormatNameTo(Formatter& ft) const
                 STR_ENTERTAINER_X,
             };
 
-            auto staffNameIndex = static_cast<uint8_t>(AssignedStaffType);
+            auto staffNameIndex = static_cast<uint8_t>(staff->AssignedStaffType);
             if (staffNameIndex > sizeof(staffNames))
             {
                 staffNameIndex = 0;
@@ -2030,152 +1528,16 @@ bool Peep::SetName(std::string_view value)
     return false;
 }
 
-/**
- * rct2: 0x00698342
- * thought.item (eax)
- * thought.type (ebx)
- * argument_1 (esi & ebx)
- * argument_2 (esi+2)
- */
-void peep_thought_set_format_args(const rct_peep_thought* thought, Formatter& ft)
-{
-    ft.Add<rct_string_id>(PeepThoughts[EnumValue(thought->type)]);
-
-    PeepThoughtToActionFlag flags = PeepThoughtToActionMap[EnumValue(thought->type)].flags;
-    if (flags & PEEP_THOUGHT_ACTION_FLAG_RIDE)
-    {
-        auto ride = get_ride(thought->item);
-        if (ride != nullptr)
-        {
-            ride->FormatNameTo(ft);
-        }
-        else
-        {
-            ft.Add<rct_string_id>(STR_NONE);
-        }
-    }
-    else if (flags & PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_SINGULAR)
-    {
-        ft.Add<rct_string_id>(GetShopItemDescriptor(ShopItem(thought->item)).Naming.Singular);
-    }
-    else if (flags & PEEP_THOUGHT_ACTION_FLAG_SHOP_ITEM_INDEFINITE)
-    {
-        ft.Add<rct_string_id>(GetShopItemDescriptor(ShopItem(thought->item)).Naming.Indefinite);
-    }
-}
-
-enum
-{
-    PEEP_FACE_OFFSET_ANGRY = 0,
-    PEEP_FACE_OFFSET_VERY_VERY_SICK,
-    PEEP_FACE_OFFSET_VERY_SICK,
-    PEEP_FACE_OFFSET_SICK,
-    PEEP_FACE_OFFSET_VERY_TIRED,
-    PEEP_FACE_OFFSET_TIRED,
-    PEEP_FACE_OFFSET_VERY_VERY_UNHAPPY,
-    PEEP_FACE_OFFSET_VERY_UNHAPPY,
-    PEEP_FACE_OFFSET_UNHAPPY,
-    PEEP_FACE_OFFSET_NORMAL,
-    PEEP_FACE_OFFSET_HAPPY,
-    PEEP_FACE_OFFSET_VERY_HAPPY,
-    PEEP_FACE_OFFSET_VERY_VERY_HAPPY,
-};
-
-static constexpr const int32_t face_sprite_small[] = {
-    SPR_PEEP_SMALL_FACE_ANGRY,
-    SPR_PEEP_SMALL_FACE_VERY_VERY_SICK,
-    SPR_PEEP_SMALL_FACE_VERY_SICK,
-    SPR_PEEP_SMALL_FACE_SICK,
-    SPR_PEEP_SMALL_FACE_VERY_TIRED,
-    SPR_PEEP_SMALL_FACE_TIRED,
-    SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY,
-    SPR_PEEP_SMALL_FACE_VERY_UNHAPPY,
-    SPR_PEEP_SMALL_FACE_UNHAPPY,
-    SPR_PEEP_SMALL_FACE_NORMAL,
-    SPR_PEEP_SMALL_FACE_HAPPY,
-    SPR_PEEP_SMALL_FACE_VERY_HAPPY,
-    SPR_PEEP_SMALL_FACE_VERY_VERY_HAPPY,
-};
-
-static constexpr const int32_t face_sprite_large[] = {
-    SPR_PEEP_LARGE_FACE_ANGRY_0,
-    SPR_PEEP_LARGE_FACE_VERY_VERY_SICK_0,
-    SPR_PEEP_LARGE_FACE_VERY_SICK_0,
-    SPR_PEEP_LARGE_FACE_SICK,
-    SPR_PEEP_LARGE_FACE_VERY_TIRED,
-    SPR_PEEP_LARGE_FACE_TIRED,
-    SPR_PEEP_LARGE_FACE_VERY_VERY_UNHAPPY,
-    SPR_PEEP_LARGE_FACE_VERY_UNHAPPY,
-    SPR_PEEP_LARGE_FACE_UNHAPPY,
-    SPR_PEEP_LARGE_FACE_NORMAL,
-    SPR_PEEP_LARGE_FACE_HAPPY,
-    SPR_PEEP_LARGE_FACE_VERY_HAPPY,
-    SPR_PEEP_LARGE_FACE_VERY_VERY_HAPPY,
-};
-
-static int32_t get_face_sprite_offset(Peep* peep)
-{
-    // ANGRY
-    if (peep->Angriness > 0)
-        return PEEP_FACE_OFFSET_ANGRY;
-
-    // VERY_VERY_SICK
-    if (peep->Nausea > 200)
-        return PEEP_FACE_OFFSET_VERY_VERY_SICK;
-
-    // VERY_SICK
-    if (peep->Nausea > 170)
-        return PEEP_FACE_OFFSET_VERY_SICK;
-
-    // SICK
-    if (peep->Nausea > 140)
-        return PEEP_FACE_OFFSET_SICK;
-
-    // VERY_TIRED
-    if (peep->Energy < 46)
-        return PEEP_FACE_OFFSET_VERY_TIRED;
-
-    // TIRED
-    if (peep->Energy < 70)
-        return PEEP_FACE_OFFSET_TIRED;
-
-    int32_t offset = PEEP_FACE_OFFSET_VERY_VERY_UNHAPPY;
-    // There are 7 different happiness based faces
-    for (int32_t i = 37; peep->Happiness >= i; i += 37)
-    {
-        offset++;
-    }
-
-    return offset;
-}
-
-/**
- * Function split into large and small sprite
- *  rct2: 0x00698721
- */
-int32_t get_peep_face_sprite_small(Peep* peep)
-{
-    return face_sprite_small[get_face_sprite_offset(peep)];
-}
-
-/**
- * Function split into large and small sprite
- *  rct2: 0x00698721
- */
-int32_t get_peep_face_sprite_large(Peep* peep)
-{
-    return face_sprite_large[get_face_sprite_offset(peep)];
-}
-
 void peep_set_map_tooltip(Peep* peep)
 {
     auto ft = Formatter();
-    if (peep->Is<Guest>())
+    auto* guest = peep->As<Guest>();
+    if (guest != nullptr)
     {
         ft.Add<rct_string_id>((peep->PeepFlags & PEEP_FLAGS_TRACKING) ? STR_TRACKED_GUEST_MAP_TIP : STR_GUEST_MAP_TIP);
-        ft.Add<uint32_t>(get_peep_face_sprite_small(peep));
-        peep->FormatNameTo(ft);
-        peep->FormatActionTo(ft);
+        ft.Add<uint32_t>(get_peep_face_sprite_small(guest));
+        guest->FormatNameTo(ft);
+        guest->FormatActionTo(ft);
     }
     else
     {
@@ -2205,80 +1567,6 @@ void Peep::SwitchNextActionSpriteType()
         sprite_height_positive = spriteBounds->sprite_height_positive;
         Invalidate();
     }
-}
-
-/**
- *
- *  rct2: 0x00693CBB
- */
-static bool peep_update_queue_position(Peep* peep, PeepActionType previous_action)
-{
-    peep->TimeInQueue++;
-
-    auto* guestNext = GetEntity<Guest>(peep->GuestNextInQueue);
-    if (guestNext == nullptr)
-    {
-        return false;
-    }
-
-    int16_t x_diff = abs(guestNext->x - peep->x);
-    int16_t y_diff = abs(guestNext->y - peep->y);
-    int16_t z_diff = abs(guestNext->z - peep->z);
-
-    if (z_diff > 10)
-        return false;
-
-    if (x_diff < y_diff)
-    {
-        int16_t temp_x = x_diff;
-        x_diff = y_diff;
-        y_diff = temp_x;
-    }
-
-    x_diff += y_diff / 2;
-    if (x_diff > 7)
-    {
-        if (x_diff > 13)
-        {
-            if ((peep->x & 0xFFE0) != (guestNext->x & 0xFFE0) || (peep->y & 0xFFE0) != (guestNext->y & 0xFFE0))
-                return false;
-        }
-
-        if (peep->sprite_direction != guestNext->sprite_direction)
-            return false;
-
-        switch (guestNext->sprite_direction / 8)
-        {
-            case 0:
-                if (peep->x >= guestNext->x)
-                    return false;
-                break;
-            case 1:
-                if (peep->y <= guestNext->y)
-                    return false;
-                break;
-            case 2:
-                if (peep->x <= guestNext->x)
-                    return false;
-                break;
-            case 3:
-                if (peep->y >= guestNext->y)
-                    return false;
-                break;
-        }
-    }
-
-    if (peep->Action < PeepActionType::None1)
-        peep->UpdateAction();
-
-    if (peep->Action != PeepActionType::None2)
-        return true;
-
-    peep->Action = PeepActionType::None1;
-    peep->NextActionSpriteType = PeepActionSpriteType::WatchRide;
-    if (previous_action != PeepActionType::None1)
-        peep->Invalidate();
-    return true;
 }
 
 /**
@@ -2350,26 +1638,26 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
             return true;
         }
 
-        if (peep->State == PeepState::Queuing)
+        if (guest->State == PeepState::Queuing)
         {
             // Guest is in the ride queue.
-            peep->RideSubState = PeepRideSubState::AtQueueFront;
-            peep->ActionSpriteImageOffset = _unk_F1AEF0;
+            guest->RideSubState = PeepRideSubState::AtQueueFront;
+            guest->ActionSpriteImageOffset = _unk_F1AEF0;
             return true;
         }
 
         // Guest is on a normal path, i.e. ride has no queue.
-        if (peep->InteractionRideIndex == rideIndex)
+        if (guest->InteractionRideIndex == rideIndex)
         {
             // Peep is retrying the ride entrance without leaving
             // the path tile and without trying any other ride
             // attached to this path tile. i.e. stick with the
             // peeps previous decision not to go on the ride.
-            peep_return_to_centre_of_tile(peep);
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
-        peep->TimeLost = 0;
+        guest->TimeLost = 0;
         auto stationNum = tile_element->AsEntrance()->GetStationIndex();
         // Guest walks up to the ride for the first time since entering
         // the path tile or since considering another ride attached to
@@ -2378,35 +1666,35 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
         {
             // Peep remembers that this is the last ride they
             // considered while on this path tile.
-            peep->InteractionRideIndex = rideIndex;
-            peep_return_to_centre_of_tile(peep);
+            guest->InteractionRideIndex = rideIndex;
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
         // Guest has decided to go on the ride.
-        peep->ActionSpriteImageOffset = _unk_F1AEF0;
-        peep->InteractionRideIndex = rideIndex;
+        guest->ActionSpriteImageOffset = _unk_F1AEF0;
+        guest->InteractionRideIndex = rideIndex;
 
         uint16_t previous_last = ride->stations[stationNum].LastPeepInQueue;
-        ride->stations[stationNum].LastPeepInQueue = peep->sprite_index;
-        peep->GuestNextInQueue = previous_last;
+        ride->stations[stationNum].LastPeepInQueue = guest->sprite_index;
+        guest->GuestNextInQueue = previous_last;
         ride->stations[stationNum].QueueLength++;
 
-        peep->CurrentRide = rideIndex;
-        peep->CurrentRideStation = stationNum;
-        peep->DaysInQueue = 0;
-        peep->SetState(PeepState::Queuing);
-        peep->RideSubState = PeepRideSubState::AtQueueFront;
-        peep->TimeInQueue = 0;
-        if (peep->PeepFlags & PEEP_FLAGS_TRACKING)
+        guest->CurrentRide = rideIndex;
+        guest->CurrentRideStation = stationNum;
+        guest->DaysInQueue = 0;
+        guest->SetState(PeepState::Queuing);
+        guest->RideSubState = PeepRideSubState::AtQueueFront;
+        guest->TimeInQueue = 0;
+        if (guest->PeepFlags & PEEP_FLAGS_TRACKING)
         {
             auto ft = Formatter();
-            peep->FormatNameTo(ft);
+            guest->FormatNameTo(ft);
             ride->FormatNameTo(ft);
             if (gConfigNotifications.guest_queuing_for_ride)
             {
                 News::AddItemToQueue(
-                    News::ItemType::PeepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, peep->sprite_index, ft);
+                    News::ItemType::PeepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, guest->sprite_index, ft);
             }
         }
     }
@@ -2424,49 +1712,49 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
         // If not the centre of the entrance arch
         if (tile_element->AsEntrance()->GetSequenceIndex() != 0)
         {
-            peep_return_to_centre_of_tile(peep);
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
         uint8_t entranceDirection = tile_element->GetDirection();
-        if (entranceDirection != peep->PeepDirection)
+        if (entranceDirection != guest->PeepDirection)
         {
-            if (direction_reverse(entranceDirection) != peep->PeepDirection)
+            if (direction_reverse(entranceDirection) != guest->PeepDirection)
             {
-                peep_return_to_centre_of_tile(peep);
+                peep_return_to_centre_of_tile(guest);
                 return true;
             }
 
             // Peep is leaving the park.
-            if (peep->State != PeepState::Walking)
+            if (guest->State != PeepState::Walking)
             {
-                peep_return_to_centre_of_tile(peep);
+                peep_return_to_centre_of_tile(guest);
                 return true;
             }
 
-            if (!(peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK))
+            if (!(guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK))
             {
                 // If the park is open and leaving flag isn't set return to centre
                 if (gParkFlags & PARK_FLAGS_PARK_OPEN)
                 {
-                    peep_return_to_centre_of_tile(peep);
+                    peep_return_to_centre_of_tile(guest);
                     return true;
                 }
             }
 
-            auto destination = peep->GetDestination() + CoordsDirectionDelta[peep->PeepDirection];
-            peep->SetDestination(destination, 9);
-            peep->MoveTo({ coords, peep->z });
-            peep->SetState(PeepState::LeavingPark);
+            auto destination = guest->GetDestination() + CoordsDirectionDelta[guest->PeepDirection];
+            guest->SetDestination(destination, 9);
+            guest->MoveTo({ coords, guest->z });
+            guest->SetState(PeepState::LeavingPark);
 
-            peep->Var37 = 0;
-            if (peep->PeepFlags & PEEP_FLAGS_TRACKING)
+            guest->Var37 = 0;
+            if (guest->PeepFlags & PEEP_FLAGS_TRACKING)
             {
                 auto ft = Formatter();
-                peep->FormatNameTo(ft);
+                guest->FormatNameTo(ft);
                 if (gConfigNotifications.guest_left_park)
                 {
-                    News::AddItemToQueue(News::ItemType::PeepOnRide, STR_PEEP_TRACKING_LEFT_PARK, peep->sprite_index, ft);
+                    News::AddItemToQueue(News::ItemType::PeepOnRide, STR_PEEP_TRACKING_LEFT_PARK, guest->sprite_index, ft);
                 }
             }
             return true;
@@ -2474,19 +1762,19 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
 
         // Peep is entering the park.
 
-        if (peep->State != PeepState::EnteringPark)
+        if (guest->State != PeepState::EnteringPark)
         {
-            peep_return_to_centre_of_tile(peep);
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
         if (!(gParkFlags & PARK_FLAGS_PARK_OPEN))
         {
-            peep->State = PeepState::LeavingPark;
-            peep->Var37 = 1;
+            guest->State = PeepState::LeavingPark;
+            guest->Var37 = 1;
             decrement_guests_heading_for_park();
-            peep_window_state_update(peep);
-            peep_return_to_centre_of_tile(peep);
+            peep_window_state_update(guest);
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
@@ -2546,55 +1834,55 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
 
         if (!found)
         {
-            peep->State = PeepState::LeavingPark;
-            peep->Var37 = 1;
+            guest->State = PeepState::LeavingPark;
+            guest->Var37 = 1;
             decrement_guests_heading_for_park();
-            peep_window_state_update(peep);
-            peep_return_to_centre_of_tile(peep);
+            peep_window_state_update(guest);
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
         money16 entranceFee = park_get_entrance_fee();
         if (entranceFee != 0)
         {
-            if (peep->HasItem(ShopItem::Voucher))
+            if (guest->HasItem(ShopItem::Voucher))
             {
-                if (peep->VoucherType == VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE)
+                if (guest->VoucherType == VOUCHER_TYPE_PARK_ENTRY_HALF_PRICE)
                 {
                     entranceFee /= 2;
-                    peep->RemoveItem(ShopItem::Voucher);
-                    peep->WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
+                    guest->RemoveItem(ShopItem::Voucher);
+                    guest->WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
                 }
-                else if (peep->VoucherType == VOUCHER_TYPE_PARK_ENTRY_FREE)
+                else if (guest->VoucherType == VOUCHER_TYPE_PARK_ENTRY_FREE)
                 {
                     entranceFee = 0;
-                    peep->RemoveItem(ShopItem::Voucher);
-                    peep->WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
+                    guest->RemoveItem(ShopItem::Voucher);
+                    guest->WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
                 }
             }
-            if (entranceFee > peep->CashInPocket)
+            if (entranceFee > guest->CashInPocket)
             {
-                peep->State = PeepState::LeavingPark;
-                peep->Var37 = 1;
+                guest->State = PeepState::LeavingPark;
+                guest->Var37 = 1;
                 decrement_guests_heading_for_park();
-                peep_window_state_update(peep);
-                peep_return_to_centre_of_tile(peep);
+                peep_window_state_update(guest);
+                peep_return_to_centre_of_tile(guest);
                 return true;
             }
 
             gTotalIncomeFromAdmissions += entranceFee;
-            guest->SpendMoney(peep->PaidToEnter, entranceFee, ExpenditureType::ParkEntranceTickets);
-            peep->PeepFlags |= PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY;
+            guest->SpendMoney(guest->PaidToEnter, entranceFee, ExpenditureType::ParkEntranceTickets);
+            guest->PeepFlags |= PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY;
         }
 
         gTotalAdmissions++;
         window_invalidate_by_number(WC_PARK_INFORMATION, 0);
 
-        peep->Var37 = 1;
-        auto destination = peep->GetDestination();
-        destination += CoordsDirectionDelta[peep->PeepDirection];
-        peep->SetDestination(destination, 7);
-        peep->MoveTo({ coords, peep->z });
+        guest->Var37 = 1;
+        auto destination = guest->GetDestination();
+        destination += CoordsDirectionDelta[guest->PeepDirection];
+        guest->SetDestination(destination, 7);
+        guest->MoveTo({ coords, guest->z });
     }
     return true;
 }
@@ -2611,15 +1899,16 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
 
     int16_t z = peep->GetZOnSlope(coords.x, coords.y);
 
-    if (peep->Is<Staff>())
+    auto* guest = peep->As<Guest>();
+    if (guest == nullptr)
     {
         peep->MoveTo({ coords, z });
         return;
     }
 
-    uint8_t vandalThoughtTimeout = (peep->VandalismSeen & 0xC0) >> 6;
+    uint8_t vandalThoughtTimeout = (guest->VandalismSeen & 0xC0) >> 6;
     // Advance the vandalised tiles by 1
-    uint8_t vandalisedTiles = (peep->VandalismSeen * 2) & 0x3F;
+    uint8_t vandalisedTiles = (guest->VandalismSeen * 2) & 0x3F;
 
     if (vandalism)
     {
@@ -2630,8 +1919,8 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
         {
             if ((scenario_rand() & 0xFFFF) <= 10922)
             {
-                peep->InsertNewThought(PeepThoughtType::Vandalism, PEEP_THOUGHT_ITEM_NONE);
-                peep->HappinessTarget = std::max(0, peep->HappinessTarget - 17);
+                guest->InsertNewThought(PeepThoughtType::Vandalism, PEEP_THOUGHT_ITEM_NONE);
+                guest->HappinessTarget = std::max(0, guest->HappinessTarget - 17);
             }
             vandalThoughtTimeout = 3;
         }
@@ -2642,7 +1931,7 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
         vandalThoughtTimeout--;
     }
 
-    peep->VandalismSeen = (vandalThoughtTimeout << 6) | vandalisedTiles;
+    guest->VandalismSeen = (vandalThoughtTimeout << 6) | vandalisedTiles;
     uint16_t crowded = 0;
     uint8_t litter_count = 0;
     uint8_t sick_count = 0;
@@ -2654,14 +1943,14 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
             if (other_peep->State != PeepState::Walking)
                 continue;
 
-            if (abs(other_peep->z - peep->NextLoc.z) > 16)
+            if (abs(other_peep->z - guest->NextLoc.z) > 16)
                 continue;
             crowded++;
             continue;
         }
         else if (auto litter = entity->As<Litter>(); litter != nullptr)
         {
-            if (abs(litter->z - peep->NextLoc.z) > 16)
+            if (abs(litter->z - guest->NextLoc.z) > 16)
                 continue;
 
             litter_count++;
@@ -2673,23 +1962,23 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
         }
     }
 
-    if (crowded >= 10 && peep->State == PeepState::Walking && (scenario_rand() & 0xFFFF) <= 21845)
+    if (crowded >= 10 && guest->State == PeepState::Walking && (scenario_rand() & 0xFFFF) <= 21845)
     {
-        peep->InsertNewThought(PeepThoughtType::Crowded, PEEP_THOUGHT_ITEM_NONE);
-        peep->HappinessTarget = std::max(0, peep->HappinessTarget - 14);
+        guest->InsertNewThought(PeepThoughtType::Crowded, PEEP_THOUGHT_ITEM_NONE);
+        guest->HappinessTarget = std::max(0, guest->HappinessTarget - 14);
     }
 
     litter_count = std::min(static_cast<uint8_t>(3), litter_count);
     sick_count = std::min(static_cast<uint8_t>(3), sick_count);
 
-    uint8_t disgusting_time = peep->DisgustingCount & 0xC0;
-    uint8_t disgusting_count = ((peep->DisgustingCount & 0xF) << 2) | sick_count;
-    peep->DisgustingCount = disgusting_count | disgusting_time;
+    uint8_t disgusting_time = guest->DisgustingCount & 0xC0;
+    uint8_t disgusting_count = ((guest->DisgustingCount & 0xF) << 2) | sick_count;
+    guest->DisgustingCount = disgusting_count | disgusting_time;
 
     if (disgusting_time & 0xC0 && (scenario_rand() & 0xFFFF) <= 4369)
     {
         // Reduce the disgusting time
-        peep->DisgustingCount -= 0x40;
+        guest->DisgustingCount -= 0x40;
     }
     else
     {
@@ -2701,21 +1990,21 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
 
         if (total_sick >= 3 && (scenario_rand() & 0xFFFF) <= 10922)
         {
-            peep->InsertNewThought(PeepThoughtType::PathDisgusting, PEEP_THOUGHT_ITEM_NONE);
-            peep->HappinessTarget = std::max(0, peep->HappinessTarget - 17);
+            guest->InsertNewThought(PeepThoughtType::PathDisgusting, PEEP_THOUGHT_ITEM_NONE);
+            guest->HappinessTarget = std::max(0, guest->HappinessTarget - 17);
             // Reset disgusting time
-            peep->DisgustingCount |= 0xC0;
+            guest->DisgustingCount |= 0xC0;
         }
     }
 
-    uint8_t litter_time = peep->LitterCount & 0xC0;
-    litter_count = ((peep->LitterCount & 0xF) << 2) | litter_count;
-    peep->LitterCount = litter_count | litter_time;
+    uint8_t litter_time = guest->LitterCount & 0xC0;
+    litter_count = ((guest->LitterCount & 0xF) << 2) | litter_count;
+    guest->LitterCount = litter_count | litter_time;
 
     if (litter_time & 0xC0 && (scenario_rand() & 0xFFFF) <= 4369)
     {
         // Reduce the litter time
-        peep->LitterCount -= 0x40;
+        guest->LitterCount -= 0x40;
     }
     else
     {
@@ -2727,14 +2016,14 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
 
         if (total_litter >= 3 && (scenario_rand() & 0xFFFF) <= 10922)
         {
-            peep->InsertNewThought(PeepThoughtType::BadLitter, PEEP_THOUGHT_ITEM_NONE);
-            peep->HappinessTarget = std::max(0, peep->HappinessTarget - 17);
+            guest->InsertNewThought(PeepThoughtType::BadLitter, PEEP_THOUGHT_ITEM_NONE);
+            guest->HappinessTarget = std::max(0, guest->HappinessTarget - 17);
             // Reset litter time
-            peep->LitterCount |= 0xC0;
+            guest->LitterCount |= 0xC0;
         }
     }
 
-    peep->MoveTo({ coords, z });
+    guest->MoveTo({ coords, z });
 }
 
 /**
@@ -2753,54 +2042,54 @@ static void peep_interact_with_path(Peep* peep, const CoordsXYE& coords)
     }
 
     int16_t z = tile_element->GetBaseZ();
+    auto* guest = peep->As<Guest>();
     if (map_is_location_owned({ coords, z }))
     {
-        if (peep->OutsideOfPark)
+        if (guest && guest->OutsideOfPark)
         {
-            peep_return_to_centre_of_tile(peep);
+            peep_return_to_centre_of_tile(guest);
             return;
         }
     }
     else
     {
-        if (!peep->OutsideOfPark)
+        if (guest == nullptr || !guest->OutsideOfPark)
         {
             peep_return_to_centre_of_tile(peep);
             return;
         }
     }
 
-    auto* guest = peep->As<Guest>();
     if (guest != nullptr && tile_element->AsPath()->IsQueue())
     {
         auto rideIndex = tile_element->AsPath()->GetRideIndex();
-        if (peep->State == PeepState::Queuing)
+        if (guest->State == PeepState::Queuing)
         {
             // Check if this queue is connected to the ride the
             // peep is queuing for, i.e. the player hasn't edited
             // the queue, rebuilt the ride, etc.
-            if (peep->CurrentRide == rideIndex)
+            if (guest->CurrentRide == rideIndex)
             {
-                peep_footpath_move_forward(peep, { coords, tile_element }, vandalism_present);
+                peep_footpath_move_forward(guest, { coords, tile_element }, vandalism_present);
             }
             else
             {
                 // Queue got disconnected from the original ride.
-                peep->InteractionRideIndex = RIDE_ID_NULL;
+                guest->InteractionRideIndex = RIDE_ID_NULL;
                 guest->RemoveFromQueue();
-                peep->SetState(PeepState::One);
-                peep_footpath_move_forward(peep, { coords, tile_element }, vandalism_present);
+                guest->SetState(PeepState::One);
+                peep_footpath_move_forward(guest, { coords, tile_element }, vandalism_present);
             }
         }
         else
         {
             // Peep is not queuing.
-            peep->TimeLost = 0;
+            guest->TimeLost = 0;
             auto stationNum = tile_element->AsPath()->GetStationIndex();
 
             if ((tile_element->AsPath()->HasQueueBanner())
                 && (tile_element->AsPath()->GetQueueBannerDirection()
-                    == direction_reverse(peep->PeepDirection)) // Ride sign is facing the direction the peep is walking
+                    == direction_reverse(guest->PeepDirection)) // Ride sign is facing the direction the peep is walking
             )
             {
                 /* Peep is approaching the entrance of a ride queue.
@@ -2809,59 +2098,59 @@ static void peep_interact_with_path(Peep* peep, const CoordsXYE& coords)
                 if (ride != nullptr && guest->ShouldGoOnRide(ride, stationNum, true, false))
                 {
                     // Peep has decided to go on the ride at the queue.
-                    peep->InteractionRideIndex = rideIndex;
+                    guest->InteractionRideIndex = rideIndex;
 
                     // Add the peep to the ride queue.
                     uint16_t old_last_peep = ride->stations[stationNum].LastPeepInQueue;
-                    ride->stations[stationNum].LastPeepInQueue = peep->sprite_index;
-                    peep->GuestNextInQueue = old_last_peep;
+                    ride->stations[stationNum].LastPeepInQueue = guest->sprite_index;
+                    guest->GuestNextInQueue = old_last_peep;
                     ride->stations[stationNum].QueueLength++;
 
-                    peep_decrement_num_riders(peep);
-                    peep->CurrentRide = rideIndex;
-                    peep->CurrentRideStation = stationNum;
-                    peep->State = PeepState::Queuing;
-                    peep->DaysInQueue = 0;
-                    peep_window_state_update(peep);
+                    peep_decrement_num_riders(guest);
+                    guest->CurrentRide = rideIndex;
+                    guest->CurrentRideStation = stationNum;
+                    guest->State = PeepState::Queuing;
+                    guest->DaysInQueue = 0;
+                    peep_window_state_update(guest);
 
-                    peep->RideSubState = PeepRideSubState::InQueue;
-                    peep->DestinationTolerance = 2;
-                    peep->TimeInQueue = 0;
-                    if (peep->PeepFlags & PEEP_FLAGS_TRACKING)
+                    guest->RideSubState = PeepRideSubState::InQueue;
+                    guest->DestinationTolerance = 2;
+                    guest->TimeInQueue = 0;
+                    if (guest->PeepFlags & PEEP_FLAGS_TRACKING)
                     {
                         auto ft = Formatter();
-                        peep->FormatNameTo(ft);
+                        guest->FormatNameTo(ft);
                         ride->FormatNameTo(ft);
                         if (gConfigNotifications.guest_queuing_for_ride)
                         {
                             News::AddItemToQueue(
-                                News::ItemType::PeepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, peep->sprite_index, ft);
+                                News::ItemType::PeepOnRide, STR_PEEP_TRACKING_PEEP_JOINED_QUEUE_FOR_X, guest->sprite_index, ft);
                         }
                     }
 
-                    peep_footpath_move_forward(peep, { coords, tile_element }, vandalism_present);
+                    peep_footpath_move_forward(guest, { coords, tile_element }, vandalism_present);
                 }
                 else
                 {
                     // Peep has decided not to go on the ride.
-                    peep_return_to_centre_of_tile(peep);
+                    peep_return_to_centre_of_tile(guest);
                 }
             }
             else
             {
                 /* Peep is approaching a queue tile without a ride
                  * sign facing the peep. */
-                peep_footpath_move_forward(peep, { coords, tile_element }, vandalism_present);
+                peep_footpath_move_forward(guest, { coords, tile_element }, vandalism_present);
             }
         }
     }
     else
     {
         peep->InteractionRideIndex = RIDE_ID_NULL;
-        if (peep->State == PeepState::Queuing)
+        if (guest != nullptr && peep->State == PeepState::Queuing)
         {
-            peep->RemoveFromQueue();
-            peep->SetState(PeepState::One);
+            guest->RemoveFromQueue();
+            guest->SetState(PeepState::One);
         }
         peep_footpath_move_forward(peep, { coords, tile_element }, vandalism_present);
     }
@@ -2887,37 +2176,37 @@ static bool peep_interact_with_shop(Peep* peep, const CoordsXYE& coords)
 
     // If we are queuing ignore the 'shop'
     // This can happen when paths clip through track
-    if (peep->State == PeepState::Queuing)
+    if (guest->State == PeepState::Queuing)
     {
         return false;
     }
 
-    peep->TimeLost = 0;
+    guest->TimeLost = 0;
 
     if (ride->status != RIDE_STATUS_OPEN)
     {
-        peep_return_to_centre_of_tile(peep);
+        peep_return_to_centre_of_tile(guest);
         return true;
     }
 
-    if (peep->InteractionRideIndex == rideIndex)
+    if (guest->InteractionRideIndex == rideIndex)
     {
-        peep_return_to_centre_of_tile(peep);
+        peep_return_to_centre_of_tile(guest);
         return true;
     }
 
-    if (peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK)
+    if (guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK)
     {
-        peep_return_to_centre_of_tile(peep);
+        peep_return_to_centre_of_tile(guest);
         return true;
     }
 
     if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_PEEP_SHOULD_GO_INSIDE_FACILITY))
     {
-        peep->TimeLost = 0;
+        guest->TimeLost = 0;
         if (!guest->ShouldGoOnRide(ride, 0, false, false))
         {
-            peep_return_to_centre_of_tile(peep);
+            peep_return_to_centre_of_tile(guest);
             return true;
         }
 
@@ -2933,35 +2222,35 @@ static bool peep_interact_with_shop(Peep* peep, const CoordsXYE& coords)
         }
 
         auto coordsCentre = coords.ToTileCentre();
-        peep->SetDestination(coordsCentre, 3);
-        peep->CurrentRide = rideIndex;
-        peep->SetState(PeepState::EnteringRide);
-        peep->RideSubState = PeepRideSubState::ApproachShop;
+        guest->SetDestination(coordsCentre, 3);
+        guest->CurrentRide = rideIndex;
+        guest->SetState(PeepState::EnteringRide);
+        guest->RideSubState = PeepRideSubState::ApproachShop;
 
-        peep->GuestTimeOnRide = 0;
+        guest->GuestTimeOnRide = 0;
         ride->cur_num_customers++;
-        if (peep->PeepFlags & PEEP_FLAGS_TRACKING)
+        if (guest->PeepFlags & PEEP_FLAGS_TRACKING)
         {
             auto ft = Formatter();
-            peep->FormatNameTo(ft);
+            guest->FormatNameTo(ft);
             ride->FormatNameTo(ft);
             rct_string_id string_id = ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_IN_RIDE)
                 ? STR_PEEP_TRACKING_PEEP_IS_IN_X
                 : STR_PEEP_TRACKING_PEEP_IS_ON_X;
             if (gConfigNotifications.guest_used_facility)
             {
-                News::AddItemToQueue(News::ItemType::PeepOnRide, string_id, peep->sprite_index, ft);
+                News::AddItemToQueue(News::ItemType::PeepOnRide, string_id, guest->sprite_index, ft);
             }
         }
     }
     else
     {
-        if (peep->GuestHeadingToRideId == rideIndex)
-            peep->GuestHeadingToRideId = RIDE_ID_NULL;
-        peep->ActionSpriteImageOffset = _unk_F1AEF0;
-        peep->SetState(PeepState::Buying);
-        peep->CurrentRide = rideIndex;
-        peep->SubState = 0;
+        if (guest->GuestHeadingToRideId == rideIndex)
+            guest->GuestHeadingToRideId = RIDE_ID_NULL;
+        guest->ActionSpriteImageOffset = _unk_F1AEF0;
+        guest->SetState(PeepState::Buying);
+        guest->CurrentRide = rideIndex;
+        guest->SubState = 0;
     }
 
     return true;
@@ -2985,9 +2274,10 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
     if (Action == PeepActionType::None1)
         Action = PeepActionType::None2;
 
-    if (State == PeepState::Queuing)
+    auto* guest = As<Guest>();
+    if (State == PeepState::Queuing && guest != nullptr)
     {
-        if (peep_update_queue_position(this, previousAction))
+        if (guest->UpdateQueuePosition(previousAction))
             return;
     }
 
@@ -2997,7 +2287,6 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         pathing_result |= PATHING_DESTINATION_REACHED;
         uint8_t result = 0;
 
-        auto* guest = As<Guest>();
         if (guest != nullptr)
         {
             result = guest_path_finding(guest);
@@ -3026,7 +2315,7 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
 
     if (map_is_edge(newLoc))
     {
-        if (OutsideOfPark)
+        if (guest != nullptr && guest->OutsideOfPark)
         {
             pathing_result |= PATHING_OUTSIDE_PARK;
         }
@@ -3079,9 +2368,9 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         if (height <= 3 || (Is<Staff>() && height <= 32))
         {
             InteractionRideIndex = RIDE_ID_NULL;
-            if (State == PeepState::Queuing)
+            if (guest != nullptr && State == PeepState::Queuing)
             {
-                RemoveFromQueue();
+                guest->RemoveFromQueue();
                 SetState(PeepState::One);
             }
 
@@ -3105,12 +2394,13 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
                 return;
             }
 
-            if (Is<Staff>() && !GetNextIsSurface())
+            auto* staff = As<Staff>();
+            if (staff != nullptr && !GetNextIsSurface())
             {
                 // Prevent staff from leaving the path on their own unless they're allowed to mow.
-                if (!((this->StaffOrders & STAFF_ORDERS_MOWING) && this->StaffMowingTimeout >= 12))
+                if (!((staff->StaffOrders & STAFF_ORDERS_MOWING) && staff->StaffMowingTimeout >= 12))
                 {
-                    peep_return_to_centre_of_tile(this);
+                    peep_return_to_centre_of_tile(staff);
                     return;
                 }
             }
@@ -3298,85 +2588,16 @@ static void peep_release_balloon(Guest* peep, int16_t spawn_height)
 
 /**
  *
- *  rct2: 0x006966A9
- */
-void Peep::RemoveFromQueue()
-{
-    auto ride = get_ride(CurrentRide);
-    if (ride == nullptr)
-        return;
-
-    auto& station = ride->stations[CurrentRideStation];
-    // Make sure we don't underflow, building while paused might reset it to 0 where peeps have
-    // not yet left the queue.
-    if (station.QueueLength > 0)
-    {
-        station.QueueLength--;
-    }
-
-    if (sprite_index == station.LastPeepInQueue)
-    {
-        station.LastPeepInQueue = GuestNextInQueue;
-        return;
-    }
-
-    auto* otherGuest = GetEntity<Guest>(station.LastPeepInQueue);
-    if (otherGuest == nullptr)
-    {
-        log_error("Invalid Guest Queue list!");
-        return;
-    }
-    for (; otherGuest != nullptr; otherGuest = GetEntity<Guest>(otherGuest->GuestNextInQueue))
-    {
-        if (sprite_index == otherGuest->GuestNextInQueue)
-        {
-            otherGuest->GuestNextInQueue = GuestNextInQueue;
-            return;
-        }
-    }
-}
-
-/**
- *
  *  rct2: 0x0069A512
  */
 void Peep::RemoveFromRide()
 {
-    if (State == PeepState::Queuing)
+    auto* guest = As<Guest>();
+    if (guest != nullptr && State == PeepState::Queuing)
     {
-        RemoveFromQueue();
+        guest->RemoveFromQueue();
     }
     StateReset();
-}
-
-uint64_t Peep::GetItemFlags() const
-{
-    return ItemFlags;
-}
-
-void Peep::SetItemFlags(uint64_t itemFlags)
-{
-    ItemFlags = itemFlags;
-}
-
-void Peep::RemoveAllItems()
-{
-    ItemFlags = 0;
-}
-
-void Peep::RemoveItem(ShopItem item)
-{
-    ItemFlags &= ~EnumToFlag(item);
-}
-
-void Peep::GiveItem(ShopItem item)
-{
-    ItemFlags |= EnumToFlag(item);
-}
-
-bool Peep::HasItem(ShopItem peepItem) const
-{
-    return GetItemFlags() & EnumToFlag(peepItem);
 }
 
 void Peep::SetDestination(const CoordsXY& coords)

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -736,10 +736,7 @@ public: // Peep
     void Pickup();
     void PickupAbort(int32_t old_x);
     std::unique_ptr<GameActions::Result> Place(const TileCoordsXYZ& location, bool apply);
-    static Peep* Generate(const CoordsXYZ& coords);
-    void RemoveFromQueue();
     void RemoveFromRide();
-    void InsertNewThought(PeepThoughtType thought_type, uint8_t thought_arguments);
     void FormatActionTo(Formatter&) const;
     void FormatNameTo(Formatter&) const;
     std::string GetName() const;
@@ -748,12 +745,6 @@ public: // Peep
     // Reset the peep's stored goal, which means they will forget any stored pathfinding history
     // on the next peep_pathfind_choose_direction call.
     void ResetPathfindGoal();
-    uint64_t GetItemFlags() const;
-    void SetItemFlags(uint64_t itemFlags);
-    void RemoveAllItems();
-    void RemoveItem(ShopItem item);
-    void GiveItem(ShopItem item);
-    bool HasItem(ShopItem peepItem) const;
 
     void SetDestination(const CoordsXY& coords);
     void SetDestination(const CoordsXY& coords, int32_t tolerance);
@@ -816,6 +807,17 @@ public:
     void HandleEasterEggName();
     int32_t GetEasterEggNameId() const;
     void UpdateEasterEggInteractions();
+    void InsertNewThought(PeepThoughtType thought_type, uint8_t thought_arguments);
+    static Guest* Generate(const CoordsXYZ& coords);
+    bool UpdateQueuePosition(PeepActionType previous_action);
+    void RemoveFromQueue();
+
+    uint64_t GetItemFlags() const;
+    void SetItemFlags(uint64_t itemFlags);
+    void RemoveAllItems();
+    void RemoveItem(ShopItem item);
+    void GiveItem(ShopItem item);
+    bool HasItem(ShopItem peepItem) const;
 
 private:
     void UpdateRide();
@@ -1006,7 +1008,6 @@ extern uint32_t gNextGuestNumber;
 
 extern uint8_t gPeepWarningThrottle[16];
 
-Peep* try_get_guest(uint16_t spriteIndex);
 int32_t peep_get_staff_count();
 void peep_update_all();
 void peep_problem_warnings_update();
@@ -1015,8 +1016,8 @@ void peep_update_crowd_noise();
 void peep_update_days_in_queue();
 void peep_applause();
 void peep_thought_set_format_args(const rct_peep_thought* thought, Formatter& ft);
-int32_t get_peep_face_sprite_small(Peep* peep);
-int32_t get_peep_face_sprite_large(Peep* peep);
+int32_t get_peep_face_sprite_small(Guest* peep);
+int32_t get_peep_face_sprite_large(Guest* peep);
 void peep_sprite_remove(Peep* peep);
 
 void peep_window_state_update(Peep* peep);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1208,157 +1208,38 @@ private:
             dst->SetName(GetUserString(src->name_string_idx));
         }
 
-        dst->OutsideOfPark = static_cast<bool>(src->outside_of_park);
-
         dst->State = static_cast<PeepState>(src->state);
         dst->SubState = src->sub_state;
         dst->NextLoc = { src->next_x, src->next_y, src->next_z * RCT1_COORDS_Z_STEP };
         dst->NextFlags = src->next_flags;
         dst->Var37 = src->var_37;
-        dst->TimeToConsume = src->time_to_consume;
         dst->StepProgress = src->step_progress;
-        dst->VandalismSeen = src->vandalism_seen;
-
         dst->TshirtColour = RCT1::GetColour(src->tshirt_colour);
         dst->TrousersColour = RCT1::GetColour(src->trousers_colour);
-        dst->UmbrellaColour = RCT1::GetColour(src->umbrella_colour);
-        dst->HatColour = RCT1::GetColour(src->hat_colour);
-
-        // Balloons were always blue in RCT1 without AA/LL
-        if (_gameVersion == FILE_VERSION_RCT1)
-        {
-            dst->BalloonColour = COLOUR_LIGHT_BLUE;
-        }
-        else
-        {
-            dst->BalloonColour = RCT1::GetColour(src->balloon_colour);
-        }
-
         dst->DestinationX = src->destination_x;
         dst->DestinationY = src->destination_y;
         dst->DestinationTolerance = src->destination_tolerance;
         dst->PeepDirection = src->direction;
-
         dst->Energy = src->energy;
         dst->EnergyTarget = src->energy_target;
-        dst->Happiness = src->happiness;
-        dst->HappinessTarget = src->happiness_target;
-        dst->Nausea = src->nausea;
-        dst->NauseaTarget = src->nausea_target;
-        dst->Hunger = src->hunger;
-        dst->Thirst = src->thirst;
-        dst->Toilet = src->toilet;
         dst->Mass = src->mass;
-
-        dst->LitterCount = src->litter_count;
-        dst->DisgustingCount = src->disgusting_count;
-
-        dst->Intensity = static_cast<IntensityRange>(src->intensity);
-        dst->NauseaTolerance = static_cast<PeepNauseaTolerance>(src->nausea_tolerance);
         dst->WindowInvalidateFlags = 0;
-
         dst->CurrentRide = RCT12RideIdToOpenRCT2RideId(src->current_ride);
         dst->CurrentRideStation = src->current_ride_station;
         dst->CurrentTrain = src->current_train;
         dst->CurrentCar = src->current_car;
         dst->CurrentSeat = src->current_seat;
-        dst->GuestTimeOnRide = src->time_on_ride;
-        dst->DaysInQueue = src->days_in_queue;
-
         dst->InteractionRideIndex = RCT12RideIdToOpenRCT2RideId(src->interaction_ride_index);
-
         dst->Id = src->id;
-        dst->CashInPocket = src->cash_in_pocket;
-        dst->CashSpent = src->cash_spent;
-        // This doubles as staff hire date
-        dst->ParkEntryTime = src->park_entry_time;
-
-        // This doubles as staff type
-        dst->GuestNumRides = src->no_of_rides;
-
-        dst->AmountOfDrinks = src->no_of_drinks;
-        dst->AmountOfFood = src->no_of_food;
-        dst->AmountOfSouvenirs = src->no_of_souvenirs;
-
-        dst->PaidToEnter = src->paid_to_enter;
-        dst->PaidOnRides = src->paid_on_rides;
-        dst->PaidOnDrink = src->paid_on_drink;
-        dst->PaidOnFood = src->paid_on_food;
-        dst->PaidOnSouvenirs = src->paid_on_souvenirs;
-
-        dst->VoucherRideId = RCT12RideIdToOpenRCT2RideId(src->voucher_arguments);
-        dst->VoucherType = src->voucher_type;
-
-        dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
-        dst->Angriness = src->angriness;
-        dst->TimeLost = src->time_lost;
-
-        for (size_t i = 0; i < 32; i++)
-        {
-            dst->RidesBeenOn[i] = src->rides_been_on[i];
-        }
-        for (size_t i = 0; i < 16; i++)
-        {
-            dst->RideTypesBeenOn[i] = src->ride_types_been_on[i];
-        }
-
-        dst->Photo1RideRef = RCT12RideIdToOpenRCT2RideId(src->photo1_ride_ref);
-
-        for (size_t i = 0; i < std::size(src->thoughts); i++)
-        {
-            auto srcThought = &src->thoughts[i];
-            auto dstThought = &dst->Thoughts[i];
-            dstThought->type = static_cast<PeepThoughtType>(srcThought->type);
-            dstThought->item = srcThought->item;
-            dstThought->freshness = srcThought->freshness;
-            dstThought->fresh_timeout = srcThought->fresh_timeout;
-        }
-
-        dst->PreviousRide = RCT12RideIdToOpenRCT2RideId(src->previous_ride);
-        dst->PreviousRideTimeOut = src->previous_ride_time_out;
-
         dst->PathCheckOptimisation = 0;
-        dst->GuestHeadingToRideId = RCT12RideIdToOpenRCT2RideId(src->guest_heading_to_ride_id);
-        // Doubles as staff orders
-        dst->GuestIsLostCountdown = src->peep_is_lost_countdown;
-        // The ID is fixed later
-        dst->GuestNextInQueue = src->next_in_queue;
-
         dst->PeepFlags = 0;
         dst->PathfindGoal.x = 0xFF;
         dst->PathfindGoal.y = 0xFF;
         dst->PathfindGoal.z = 0xFF;
         dst->PathfindGoal.direction = INVALID_DIRECTION;
-
-        // Guests' favourite ride was only saved in LL.
-        // Set it to N/A if the save comes from the original or AA.
-        if (_gameVersion == FILE_VERSION_RCT1_LL)
-        {
-            dst->FavouriteRide = RCT12RideIdToOpenRCT2RideId(src->favourite_ride);
-            dst->FavouriteRideRating = src->favourite_ride_rating;
-        }
-        else
-        {
-            dst->FavouriteRide = RIDE_ID_NULL;
-            dst->FavouriteRideRating = 0;
-        }
-
-        dst->SetItemFlags(src->GetItemFlags());
-
-        if (dst->Is<Guest>())
-        {
-            if (dst->OutsideOfPark && dst->State != PeepState::LeavingPark)
-            {
-                increment_guests_heading_for_park();
-            }
-            else
-            {
-                increment_guests_in_park();
-            }
-        }
     }
 
-    void ImportStaffPatrolArea(Peep* staffmember)
+    void ImportStaffPatrolArea(Staff* staffmember)
     {
         // The patrol areas in RCT1 are encoded as follows, for coordinates x and y, separately for every staff member:
         // - Chop off the 7 lowest bits of the x and y coordinates, which leaves 5 bits per coordinate.
@@ -2884,6 +2765,102 @@ template<> void S4Importer::ImportEntity<Guest>(const RCT12SpriteBase& srcBase)
     auto* dst = CreateEntityAt<Guest>(srcBase.sprite_index);
     auto* src = static_cast<const rct1_peep*>(&srcBase);
     ImportPeep(dst, src);
+
+    dst->OutsideOfPark = static_cast<bool>(src->outside_of_park);
+    dst->TimeToConsume = src->time_to_consume;
+    dst->VandalismSeen = src->vandalism_seen;
+    dst->UmbrellaColour = RCT1::GetColour(src->umbrella_colour);
+    dst->HatColour = RCT1::GetColour(src->hat_colour);
+
+    // Balloons were always blue in RCT1 without AA/LL
+    if (_gameVersion == FILE_VERSION_RCT1)
+    {
+        dst->BalloonColour = COLOUR_LIGHT_BLUE;
+    }
+    else
+    {
+        dst->BalloonColour = RCT1::GetColour(src->balloon_colour);
+    }
+    dst->Happiness = src->happiness;
+    dst->HappinessTarget = src->happiness_target;
+    dst->Nausea = src->nausea;
+    dst->NauseaTarget = src->nausea_target;
+    dst->Hunger = src->hunger;
+    dst->Thirst = src->thirst;
+    dst->Toilet = src->toilet;
+    dst->LitterCount = src->litter_count;
+    dst->DisgustingCount = src->disgusting_count;
+    dst->Intensity = static_cast<IntensityRange>(src->intensity);
+    dst->NauseaTolerance = static_cast<PeepNauseaTolerance>(src->nausea_tolerance);
+    dst->GuestTimeOnRide = src->time_on_ride;
+    dst->DaysInQueue = src->days_in_queue;
+    dst->CashInPocket = src->cash_in_pocket;
+    dst->CashSpent = src->cash_spent;
+    dst->ParkEntryTime = src->park_entry_time;
+    dst->GuestNumRides = src->no_of_rides;
+    dst->AmountOfDrinks = src->no_of_drinks;
+    dst->AmountOfFood = src->no_of_food;
+    dst->AmountOfSouvenirs = src->no_of_souvenirs;
+    dst->PaidToEnter = src->paid_to_enter;
+    dst->PaidOnRides = src->paid_on_rides;
+    dst->PaidOnDrink = src->paid_on_drink;
+    dst->PaidOnFood = src->paid_on_food;
+    dst->PaidOnSouvenirs = src->paid_on_souvenirs;
+    dst->VoucherRideId = RCT12RideIdToOpenRCT2RideId(src->voucher_arguments);
+    dst->VoucherType = src->voucher_type;
+    dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
+    dst->Angriness = src->angriness;
+    dst->TimeLost = src->time_lost;
+
+    for (size_t i = 0; i < 32; i++)
+    {
+        dst->RidesBeenOn[i] = src->rides_been_on[i];
+    }
+    for (size_t i = 0; i < 16; i++)
+    {
+        dst->RideTypesBeenOn[i] = src->ride_types_been_on[i];
+    }
+
+    dst->Photo1RideRef = RCT12RideIdToOpenRCT2RideId(src->photo1_ride_ref);
+
+    for (size_t i = 0; i < std::size(src->thoughts); i++)
+    {
+        auto srcThought = &src->thoughts[i];
+        auto dstThought = &dst->Thoughts[i];
+        dstThought->type = static_cast<PeepThoughtType>(srcThought->type);
+        dstThought->item = srcThought->item;
+        dstThought->freshness = srcThought->freshness;
+        dstThought->fresh_timeout = srcThought->fresh_timeout;
+    }
+
+    dst->PreviousRide = RCT12RideIdToOpenRCT2RideId(src->previous_ride);
+    dst->PreviousRideTimeOut = src->previous_ride_time_out;
+    dst->GuestHeadingToRideId = RCT12RideIdToOpenRCT2RideId(src->guest_heading_to_ride_id);
+    dst->GuestIsLostCountdown = src->peep_is_lost_countdown;
+    dst->GuestNextInQueue = src->next_in_queue;
+    // Guests' favourite ride was only saved in LL.
+    // Set it to N/A if the save comes from the original or AA.
+    if (_gameVersion == FILE_VERSION_RCT1_LL)
+    {
+        dst->FavouriteRide = RCT12RideIdToOpenRCT2RideId(src->favourite_ride);
+        dst->FavouriteRideRating = src->favourite_ride_rating;
+    }
+    else
+    {
+        dst->FavouriteRide = RIDE_ID_NULL;
+        dst->FavouriteRideRating = 0;
+    }
+
+    dst->SetItemFlags(src->GetItemFlags());
+
+    if (dst->OutsideOfPark && dst->State != PeepState::LeavingPark)
+    {
+        increment_guests_heading_for_park();
+    }
+    else
+    {
+        increment_guests_in_park();
+    }
 }
 
 template<> void S4Importer::ImportEntity<Staff>(const RCT12SpriteBase& srcBase)
@@ -2891,6 +2868,16 @@ template<> void S4Importer::ImportEntity<Staff>(const RCT12SpriteBase& srcBase)
     auto* dst = CreateEntityAt<Staff>(srcBase.sprite_index);
     auto* src = static_cast<const rct1_peep*>(&srcBase);
     ImportPeep(dst, src);
+    dst->AssignedStaffType = StaffType(src->staff_type);
+    dst->MechanicTimeSinceCall = src->mechanic_time_since_call;
+    dst->HireDate = src->park_entry_time;
+    dst->StaffId = src->staff_id;
+    dst->StaffOrders = src->staff_orders;
+    dst->StaffMowingTimeout = src->staff_mowing_timeout;
+    dst->StaffLawnsMown = src->paid_to_enter;
+    dst->StaffGardensWatered = src->paid_on_rides;
+    dst->StaffLitterSwept = src->paid_on_food;
+    dst->StaffBinsEmptied = src->paid_on_souvenirs;
 }
 
 template<> void S4Importer::ImportEntity<Litter>(const RCT12SpriteBase& srcBase)

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1173,10 +1173,88 @@ template<> void S6Exporter::ExportEntity(RCT2SpriteVehicle* dst, const Vehicle* 
 template<> void S6Exporter::ExportEntity(RCT2SpritePeep* dst, const Guest* src)
 {
     ExportEntityPeep(dst, src);
+    dst->outside_of_park = static_cast<uint8_t>(src->OutsideOfPark);
+    dst->no_of_rides = src->GuestNumRides;
+    dst->happiness = src->Happiness;
+    dst->happiness_target = src->HappinessTarget;
+    dst->nausea = src->Nausea;
+    dst->nausea_target = src->NauseaTarget;
+    dst->hunger = src->Hunger;
+    dst->thirst = src->Thirst;
+    dst->toilet = src->Toilet;
+    dst->time_to_consume = src->TimeToConsume;
+    dst->intensity = static_cast<uint8_t>(src->Intensity);
+    dst->nausea_tolerance = EnumValue(src->NauseaTolerance);
+    dst->paid_on_drink = src->PaidOnDrink;
+    for (size_t i = 0; i < std::size(src->RideTypesBeenOn); i++)
+    {
+        dst->ride_types_been_on[i] = src->RideTypesBeenOn[i];
+    }
+    dst->item_extra_flags = static_cast<uint32_t>(src->GetItemFlags() >> 32);
+    dst->photo1_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo1RideRef);
+    dst->photo2_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo2RideRef);
+    dst->photo3_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo3RideRef);
+    dst->photo4_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo4RideRef);
+    dst->next_in_queue = src->GuestNextInQueue;
+    dst->time_in_queue = src->TimeInQueue;
+    for (size_t i = 0; i < std::size(src->RidesBeenOn); i++)
+    {
+        dst->rides_been_on[i] = src->RidesBeenOn[i];
+    }
+    dst->cash_in_pocket = src->CashInPocket;
+    dst->cash_spent = src->CashSpent;
+    dst->park_entry_time = src->ParkEntryTime;
+    dst->rejoin_queue_timeout = src->RejoinQueueTimeout;
+    dst->previous_ride = OpenRCT2RideIdToRCT12RideId(src->PreviousRide);
+    dst->previous_ride_time_out = src->PreviousRideTimeOut;
+    for (size_t i = 0; i < std::size(src->Thoughts); i++)
+    {
+        auto srcThought = &src->Thoughts[i];
+        auto dstThought = &dst->thoughts[i];
+        dstThought->type = static_cast<uint8_t>(srcThought->type);
+        dstThought->item = srcThought->item;
+        dstThought->freshness = srcThought->freshness;
+        dstThought->fresh_timeout = srcThought->fresh_timeout;
+    }
+    dst->guest_heading_to_ride_id = OpenRCT2RideIdToRCT12RideId(src->GuestHeadingToRideId);
+    dst->peep_is_lost_countdown = src->GuestIsLostCountdown;
+    dst->litter_count = src->LitterCount;
+    dst->time_on_ride = src->GuestTimeOnRide;
+    dst->disgusting_count = src->DisgustingCount;
+    dst->paid_to_enter = src->PaidToEnter;
+    dst->paid_on_rides = src->PaidOnRides;
+    dst->paid_on_food = src->PaidOnFood;
+    dst->paid_on_souvenirs = src->PaidOnSouvenirs;
+    dst->no_of_food = src->AmountOfFood;
+    dst->no_of_drinks = src->AmountOfDrinks;
+    dst->no_of_souvenirs = src->AmountOfSouvenirs;
+    dst->vandalism_seen = src->VandalismSeen;
+    dst->voucher_type = src->VoucherType;
+    dst->voucher_arguments = OpenRCT2RideIdToRCT12RideId(src->VoucherRideId);
+    dst->surroundings_thought_timeout = src->SurroundingsThoughtTimeout;
+    dst->angriness = src->Angriness;
+    dst->time_lost = src->TimeLost;
+    dst->days_in_queue = src->DaysInQueue;
+    dst->balloon_colour = src->BalloonColour;
+    dst->umbrella_colour = src->UmbrellaColour;
+    dst->hat_colour = src->HatColour;
+    dst->favourite_ride = OpenRCT2RideIdToRCT12RideId(src->FavouriteRide);
+    dst->favourite_ride_rating = src->FavouriteRideRating;
+    dst->item_standard_flags = static_cast<uint32_t>(src->GetItemFlags());
 }
 template<> void S6Exporter::ExportEntity(RCT2SpritePeep* dst, const Staff* src)
 {
     ExportEntityPeep(dst, src);
+    dst->staff_type = static_cast<uint8_t>(src->AssignedStaffType);
+    dst->mechanic_time_since_call = src->MechanicTimeSinceCall;
+    dst->park_entry_time = src->HireDate;
+    dst->staff_id = src->StaffId;
+    dst->staff_orders = src->StaffOrders;
+    dst->staff_mowing_timeout = src->StaffMowingTimeout;
+    dst->paid_to_enter = src->StaffLawnsMown;
+    dst->paid_on_rides = src->StaffGardensWatered;
+    dst->paid_on_food = src->StaffLitterSwept;
+    dst->paid_on_souvenirs = src->StaffBinsEmptied;
 }
 
 void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
@@ -1201,7 +1279,8 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
     }
     if (generateName)
     {
-        if (src->Is<Staff>())
+        auto* staff = src->As<Staff>();
+        if (staff != nullptr)
         {
             static constexpr const rct_string_id staffNames[] = {
                 STR_HANDYMAN_X,
@@ -1209,7 +1288,7 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
                 STR_SECURITY_GUARD_X,
                 STR_ENTERTAINER_X,
             };
-            dst->name_string_idx = staffNames[static_cast<uint8_t>(src->AssignedStaffType) % sizeof(staffNames)];
+            dst->name_string_idx = staffNames[static_cast<uint8_t>(staff->AssignedStaffType) % sizeof(staffNames)];
         }
         else if (gParkFlags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
         {
@@ -1225,12 +1304,10 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
     dst->next_y = src->NextLoc.y;
     dst->next_z = src->NextLoc.z / COORDS_Z_STEP;
     dst->next_flags = src->NextFlags;
-    dst->outside_of_park = static_cast<uint8_t>(src->OutsideOfPark);
     dst->state = static_cast<uint8_t>(src->State);
     dst->sub_state = src->SubState;
     dst->sprite_type = static_cast<uint8_t>(src->SpriteType);
     dst->peep_type = static_cast<uint8_t>(src->Type == EntityType::Staff ? RCT12PeepType::Staff : RCT12PeepType::Guest);
-    dst->no_of_rides = src->GuestNumRides;
     dst->tshirt_colour = src->TshirtColour;
     dst->trousers_colour = src->TrousersColour;
     dst->destination_x = src->DestinationX;
@@ -1239,27 +1316,8 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
     dst->var_37 = src->Var37;
     dst->energy = src->Energy;
     dst->energy_target = src->EnergyTarget;
-    dst->happiness = src->Happiness;
-    dst->happiness_target = src->HappinessTarget;
-    dst->nausea = src->Nausea;
-    dst->nausea_target = src->NauseaTarget;
-    dst->hunger = src->Hunger;
-    dst->thirst = src->Thirst;
-    dst->toilet = src->Toilet;
     dst->mass = src->Mass;
-    dst->time_to_consume = src->TimeToConsume;
-    dst->intensity = static_cast<uint8_t>(src->Intensity);
-    dst->nausea_tolerance = EnumValue(src->NauseaTolerance);
     dst->window_invalidate_flags = src->WindowInvalidateFlags;
-    dst->paid_on_drink = src->PaidOnDrink;
-    for (size_t i = 0; i < std::size(src->RideTypesBeenOn); i++)
-    {
-        dst->ride_types_been_on[i] = src->RideTypesBeenOn[i];
-    }
-    dst->item_extra_flags = static_cast<uint32_t>(src->GetItemFlags() >> 32);
-    dst->photo2_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo2RideRef);
-    dst->photo3_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo3RideRef);
-    dst->photo4_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo4RideRef);
     dst->current_ride = OpenRCT2RideIdToRCT12RideId(src->CurrentRide);
     dst->current_ride_station = src->CurrentRideStation;
     dst->current_train = src->CurrentTrain;
@@ -1271,34 +1329,10 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
     dst->action = static_cast<uint8_t>(src->Action);
     dst->action_frame = src->ActionFrame;
     dst->step_progress = src->StepProgress;
-    dst->next_in_queue = src->GuestNextInQueue;
     dst->direction = src->PeepDirection;
     dst->interaction_ride_index = OpenRCT2RideIdToRCT12RideId(src->InteractionRideIndex);
-    dst->time_in_queue = src->TimeInQueue;
-    for (size_t i = 0; i < std::size(src->RidesBeenOn); i++)
-    {
-        dst->rides_been_on[i] = src->RidesBeenOn[i];
-    }
     dst->id = src->Id;
-    dst->cash_in_pocket = src->CashInPocket;
-    dst->cash_spent = src->CashSpent;
-    dst->park_entry_time = src->ParkEntryTime;
-    dst->rejoin_queue_timeout = src->RejoinQueueTimeout;
-    dst->previous_ride = OpenRCT2RideIdToRCT12RideId(src->PreviousRide);
-    dst->previous_ride_time_out = src->PreviousRideTimeOut;
-    for (size_t i = 0; i < std::size(src->Thoughts); i++)
-    {
-        auto srcThought = &src->Thoughts[i];
-        auto dstThought = &dst->thoughts[i];
-        dstThought->type = static_cast<uint8_t>(srcThought->type);
-        dstThought->item = srcThought->item;
-        dstThought->freshness = srcThought->freshness;
-        dstThought->fresh_timeout = srcThought->fresh_timeout;
-    }
     dst->path_check_optimisation = src->PathCheckOptimisation;
-    dst->guest_heading_to_ride_id = OpenRCT2RideIdToRCT12RideId(src->GuestHeadingToRideId);
-    dst->peep_is_lost_countdown = src->GuestIsLostCountdown;
-    dst->photo1_ride_ref = OpenRCT2RideIdToRCT12RideId(src->Photo1RideRef);
     dst->peep_flags = src->PeepFlags;
     dst->pathfind_goal = src->PathfindGoal;
     for (size_t i = 0; i < std::size(src->PathfindHistory); i++)
@@ -1306,29 +1340,6 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
         dst->pathfind_history[i] = src->PathfindHistory[i];
     }
     dst->no_action_frame_num = src->WalkingFrameNum;
-    dst->litter_count = src->LitterCount;
-    dst->time_on_ride = src->GuestTimeOnRide;
-    dst->disgusting_count = src->DisgustingCount;
-    dst->paid_to_enter = src->PaidToEnter;
-    dst->paid_on_rides = src->PaidOnRides;
-    dst->paid_on_food = src->PaidOnFood;
-    dst->paid_on_souvenirs = src->PaidOnSouvenirs;
-    dst->no_of_food = src->AmountOfFood;
-    dst->no_of_drinks = src->AmountOfDrinks;
-    dst->no_of_souvenirs = src->AmountOfSouvenirs;
-    dst->vandalism_seen = src->VandalismSeen;
-    dst->voucher_type = src->VoucherType;
-    dst->voucher_arguments = OpenRCT2RideIdToRCT12RideId(src->VoucherRideId);
-    dst->surroundings_thought_timeout = src->SurroundingsThoughtTimeout;
-    dst->angriness = src->Angriness;
-    dst->time_lost = src->TimeLost;
-    dst->days_in_queue = src->DaysInQueue;
-    dst->balloon_colour = src->BalloonColour;
-    dst->umbrella_colour = src->UmbrellaColour;
-    dst->hat_colour = src->HatColour;
-    dst->favourite_ride = OpenRCT2RideIdToRCT12RideId(src->FavouriteRide);
-    dst->favourite_ride_rating = src->FavouriteRideRating;
-    dst->item_standard_flags = static_cast<uint32_t>(src->GetItemFlags());
 }
 
 template<> void S6Exporter::ExportEntity(RCT12SpriteSteamParticle* dst, const SteamParticle* src)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1340,11 +1340,9 @@ public:
         }
         dst->NextLoc = { src->next_x, src->next_y, src->next_z * COORDS_Z_STEP };
         dst->NextFlags = src->next_flags;
-        dst->OutsideOfPark = static_cast<bool>(src->outside_of_park);
         dst->State = static_cast<PeepState>(src->state);
         dst->SubState = src->sub_state;
         dst->SpriteType = static_cast<PeepSpriteType>(src->sprite_type);
-        dst->GuestNumRides = src->no_of_rides;
         dst->TshirtColour = src->tshirt_colour;
         dst->TrousersColour = src->trousers_colour;
         dst->DestinationX = src->destination_x;
@@ -1353,27 +1351,8 @@ public:
         dst->Var37 = src->var_37;
         dst->Energy = src->energy;
         dst->EnergyTarget = src->energy_target;
-        dst->Happiness = src->happiness;
-        dst->HappinessTarget = src->happiness_target;
-        dst->Nausea = src->nausea;
-        dst->NauseaTarget = src->nausea_target;
-        dst->Hunger = src->hunger;
-        dst->Thirst = src->thirst;
-        dst->Toilet = src->toilet;
         dst->Mass = src->mass;
-        dst->TimeToConsume = src->time_to_consume;
-        dst->Intensity = static_cast<IntensityRange>(src->intensity);
-        dst->NauseaTolerance = static_cast<PeepNauseaTolerance>(src->nausea_tolerance);
         dst->WindowInvalidateFlags = src->window_invalidate_flags;
-        dst->PaidOnDrink = src->paid_on_drink;
-        for (size_t i = 0; i < std::size(src->ride_types_been_on); i++)
-        {
-            dst->RideTypesBeenOn[i] = src->ride_types_been_on[i];
-        }
-        dst->SetItemFlags(src->GetItemFlags());
-        dst->Photo2RideRef = RCT12RideIdToOpenRCT2RideId(src->photo2_ride_ref);
-        dst->Photo3RideRef = RCT12RideIdToOpenRCT2RideId(src->photo3_ride_ref);
-        dst->Photo4RideRef = RCT12RideIdToOpenRCT2RideId(src->photo4_ride_ref);
         dst->CurrentRide = RCT12RideIdToOpenRCT2RideId(src->current_ride);
         dst->CurrentRideStation = src->current_ride_station;
         dst->CurrentTrain = src->current_train;
@@ -1385,34 +1364,10 @@ public:
         dst->Action = static_cast<PeepActionType>(src->action);
         dst->ActionFrame = src->action_frame;
         dst->StepProgress = src->step_progress;
-        dst->GuestNextInQueue = src->next_in_queue;
         dst->PeepDirection = src->direction;
         dst->InteractionRideIndex = RCT12RideIdToOpenRCT2RideId(src->interaction_ride_index);
-        dst->TimeInQueue = src->time_in_queue;
-        for (size_t i = 0; i < std::size(src->rides_been_on); i++)
-        {
-            dst->RidesBeenOn[i] = src->rides_been_on[i];
-        }
         dst->Id = src->id;
-        dst->CashInPocket = src->cash_in_pocket;
-        dst->CashSpent = src->cash_spent;
-        dst->ParkEntryTime = src->park_entry_time;
-        dst->RejoinQueueTimeout = src->rejoin_queue_timeout;
-        dst->PreviousRide = RCT12RideIdToOpenRCT2RideId(src->previous_ride);
-        dst->PreviousRideTimeOut = src->previous_ride_time_out;
-        for (size_t i = 0; i < std::size(src->thoughts); i++)
-        {
-            auto srcThought = &src->thoughts[i];
-            auto dstThought = &dst->Thoughts[i];
-            dstThought->type = static_cast<PeepThoughtType>(srcThought->type);
-            dstThought->item = srcThought->item;
-            dstThought->freshness = srcThought->freshness;
-            dstThought->fresh_timeout = srcThought->fresh_timeout;
-        }
         dst->PathCheckOptimisation = src->path_check_optimisation;
-        dst->GuestHeadingToRideId = RCT12RideIdToOpenRCT2RideId(src->guest_heading_to_ride_id);
-        dst->GuestIsLostCountdown = src->peep_is_lost_countdown;
-        dst->Photo1RideRef = RCT12RideIdToOpenRCT2RideId(src->photo1_ride_ref);
         dst->PeepFlags = src->peep_flags;
         dst->PathfindGoal = src->pathfind_goal;
         for (size_t i = 0; i < std::size(src->pathfind_history); i++)
@@ -1420,28 +1375,6 @@ public:
             dst->PathfindHistory[i] = src->pathfind_history[i];
         }
         dst->WalkingFrameNum = src->no_action_frame_num;
-        dst->LitterCount = src->litter_count;
-        dst->GuestTimeOnRide = src->time_on_ride;
-        dst->DisgustingCount = src->disgusting_count;
-        dst->PaidToEnter = src->paid_to_enter;
-        dst->PaidOnRides = src->paid_on_rides;
-        dst->PaidOnFood = src->paid_on_food;
-        dst->PaidOnSouvenirs = src->paid_on_souvenirs;
-        dst->AmountOfFood = src->no_of_food;
-        dst->AmountOfDrinks = src->no_of_drinks;
-        dst->AmountOfSouvenirs = src->no_of_souvenirs;
-        dst->VandalismSeen = src->vandalism_seen;
-        dst->VoucherType = src->voucher_type;
-        dst->VoucherRideId = RCT12RideIdToOpenRCT2RideId(src->voucher_arguments);
-        dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
-        dst->Angriness = src->angriness;
-        dst->TimeLost = src->time_lost;
-        dst->DaysInQueue = src->days_in_queue;
-        dst->BalloonColour = src->balloon_colour;
-        dst->UmbrellaColour = src->umbrella_colour;
-        dst->HatColour = src->hat_colour;
-        dst->FavouriteRide = RCT12RideIdToOpenRCT2RideId(src->favourite_ride);
-        dst->FavouriteRideRating = src->favourite_ride_rating;
     }
 
     constexpr EntityType GetEntityTypeFromRCT2Sprite(const RCT12SpriteBase* src)
@@ -1673,6 +1606,74 @@ template<> void S6Importer::ImportEntity<Guest>(const RCT12SpriteBase& baseSrc)
     auto dst = CreateEntityAt<Guest>(baseSrc.sprite_index);
     auto src = static_cast<const RCT2SpritePeep*>(&baseSrc);
     ImportEntityPeep(dst, src);
+
+    dst->OutsideOfPark = static_cast<bool>(src->outside_of_park);
+    dst->GuestNumRides = src->no_of_rides;
+    dst->Happiness = src->happiness;
+    dst->HappinessTarget = src->happiness_target;
+    dst->Nausea = src->nausea;
+    dst->NauseaTarget = src->nausea_target;
+    dst->Hunger = src->hunger;
+    dst->Thirst = src->thirst;
+    dst->Toilet = src->toilet;
+    dst->TimeToConsume = src->time_to_consume;
+    dst->Intensity = static_cast<IntensityRange>(src->intensity);
+    dst->NauseaTolerance = static_cast<PeepNauseaTolerance>(src->nausea_tolerance);
+    dst->PaidOnDrink = src->paid_on_drink;
+    for (size_t i = 0; i < std::size(src->ride_types_been_on); i++)
+    {
+        dst->RideTypesBeenOn[i] = src->ride_types_been_on[i];
+    }
+    dst->SetItemFlags(src->GetItemFlags());
+    dst->Photo1RideRef = RCT12RideIdToOpenRCT2RideId(src->photo1_ride_ref);
+    dst->Photo2RideRef = RCT12RideIdToOpenRCT2RideId(src->photo2_ride_ref);
+    dst->Photo3RideRef = RCT12RideIdToOpenRCT2RideId(src->photo3_ride_ref);
+    dst->Photo4RideRef = RCT12RideIdToOpenRCT2RideId(src->photo4_ride_ref);
+    dst->GuestNextInQueue = src->next_in_queue;
+    dst->TimeInQueue = src->time_in_queue;
+    for (size_t i = 0; i < std::size(src->rides_been_on); i++)
+    {
+        dst->RidesBeenOn[i] = src->rides_been_on[i];
+    }
+    dst->CashInPocket = src->cash_in_pocket;
+    dst->CashSpent = src->cash_spent;
+    dst->ParkEntryTime = src->park_entry_time;
+    dst->RejoinQueueTimeout = src->rejoin_queue_timeout;
+    dst->PreviousRide = RCT12RideIdToOpenRCT2RideId(src->previous_ride);
+    dst->PreviousRideTimeOut = src->previous_ride_time_out;
+    for (size_t i = 0; i < std::size(src->thoughts); i++)
+    {
+        auto srcThought = &src->thoughts[i];
+        auto dstThought = &dst->Thoughts[i];
+        dstThought->type = static_cast<PeepThoughtType>(srcThought->type);
+        dstThought->item = srcThought->item;
+        dstThought->freshness = srcThought->freshness;
+        dstThought->fresh_timeout = srcThought->fresh_timeout;
+    }
+    dst->GuestHeadingToRideId = RCT12RideIdToOpenRCT2RideId(src->guest_heading_to_ride_id);
+    dst->GuestIsLostCountdown = src->peep_is_lost_countdown;
+    dst->LitterCount = src->litter_count;
+    dst->GuestTimeOnRide = src->time_on_ride;
+    dst->DisgustingCount = src->disgusting_count;
+    dst->PaidToEnter = src->paid_to_enter;
+    dst->PaidOnRides = src->paid_on_rides;
+    dst->PaidOnFood = src->paid_on_food;
+    dst->PaidOnSouvenirs = src->paid_on_souvenirs;
+    dst->AmountOfFood = src->no_of_food;
+    dst->AmountOfDrinks = src->no_of_drinks;
+    dst->AmountOfSouvenirs = src->no_of_souvenirs;
+    dst->VandalismSeen = src->vandalism_seen;
+    dst->VoucherType = src->voucher_type;
+    dst->VoucherRideId = RCT12RideIdToOpenRCT2RideId(src->voucher_arguments);
+    dst->SurroundingsThoughtTimeout = src->surroundings_thought_timeout;
+    dst->Angriness = src->angriness;
+    dst->TimeLost = src->time_lost;
+    dst->DaysInQueue = src->days_in_queue;
+    dst->BalloonColour = src->balloon_colour;
+    dst->UmbrellaColour = src->umbrella_colour;
+    dst->HatColour = src->hat_colour;
+    dst->FavouriteRide = RCT12RideIdToOpenRCT2RideId(src->favourite_ride);
+    dst->FavouriteRideRating = src->favourite_ride_rating;
 }
 
 template<> void S6Importer::ImportEntity<Staff>(const RCT12SpriteBase& baseSrc)
@@ -1680,6 +1681,17 @@ template<> void S6Importer::ImportEntity<Staff>(const RCT12SpriteBase& baseSrc)
     auto dst = CreateEntityAt<Staff>(baseSrc.sprite_index);
     auto src = static_cast<const RCT2SpritePeep*>(&baseSrc);
     ImportEntityPeep(dst, src);
+
+    dst->AssignedStaffType = StaffType(src->staff_type);
+    dst->MechanicTimeSinceCall = src->mechanic_time_since_call;
+    dst->HireDate = src->park_entry_time;
+    dst->StaffId = src->staff_id;
+    dst->StaffOrders = src->staff_orders;
+    dst->StaffMowingTimeout = src->staff_mowing_timeout;
+    dst->StaffLawnsMown = src->paid_to_enter;
+    dst->StaffGardensWatered = src->paid_on_rides;
+    dst->StaffLitterSwept = src->paid_on_food;
+    dst->StaffBinsEmptied = src->paid_on_souvenirs;
 }
 
 template<> void S6Importer::ImportEntity<SteamParticle>(const RCT12SpriteBase& baseSrc)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -131,7 +131,7 @@ Direction gRideEntranceExitPlaceDirection;
 uint8_t gLastEntranceStyle;
 
 // Static function declarations
-Peep* find_closest_mechanic(const CoordsXY& entrancePosition, int32_t forInspection);
+Staff* find_closest_mechanic(const CoordsXY& entrancePosition, int32_t forInspection);
 static void ride_breakdown_status_update(Ride* ride);
 static void ride_breakdown_update(Ride* ride);
 static void ride_call_closest_mechanic(Ride* ride);
@@ -309,12 +309,12 @@ int32_t Ride::GetMaxQueueTime() const
     return static_cast<int32_t>(queueTime);
 }
 
-Peep* Ride::GetQueueHeadGuest(StationIndex stationIndex) const
+Guest* Ride::GetQueueHeadGuest(StationIndex stationIndex) const
 {
-    Peep* peep;
-    Peep* result = nullptr;
+    Guest* peep;
+    Guest* result = nullptr;
     uint16_t spriteIndex = stations[stationIndex].LastPeepInQueue;
-    while ((peep = try_get_guest(spriteIndex)) != nullptr)
+    while ((peep = TryGetEntity<Guest>(spriteIndex)) != nullptr)
     {
         spriteIndex = peep->GuestNextInQueue;
         result = peep;
@@ -325,9 +325,9 @@ Peep* Ride::GetQueueHeadGuest(StationIndex stationIndex) const
 void Ride::UpdateQueueLength(StationIndex stationIndex)
 {
     uint16_t count = 0;
-    Peep* peep;
+    Guest* peep;
     uint16_t spriteIndex = stations[stationIndex].LastPeepInQueue;
-    while ((peep = try_get_guest(spriteIndex)) != nullptr)
+    while ((peep = TryGetEntity<Guest>(spriteIndex)) != nullptr)
     {
         spriteIndex = peep->GuestNextInQueue;
         count++;
@@ -335,13 +335,13 @@ void Ride::UpdateQueueLength(StationIndex stationIndex)
     stations[stationIndex].QueueLength = count;
 }
 
-void Ride::QueueInsertGuestAtFront(StationIndex stationIndex, Peep* peep)
+void Ride::QueueInsertGuestAtFront(StationIndex stationIndex, Guest* peep)
 {
     assert(stationIndex < MAX_STATIONS);
     assert(peep != nullptr);
 
     peep->GuestNextInQueue = SPRITE_INDEX_NULL;
-    Peep* queueHeadGuest = GetQueueHeadGuest(peep->CurrentRideStation);
+    auto* queueHeadGuest = GetQueueHeadGuest(peep->CurrentRideStation);
     if (queueHeadGuest == nullptr)
     {
         stations[peep->CurrentRideStation].LastPeepInQueue = peep->sprite_index;
@@ -2698,7 +2698,7 @@ static void ride_call_closest_mechanic(Ride* ride)
         ride_call_mechanic(ride, mechanic, forInspection);
 }
 
-Peep* ride_find_closest_mechanic(Ride* ride, int32_t forInspection)
+Staff* ride_find_closest_mechanic(Ride* ride, int32_t forInspection)
 {
     // Get either exit position or entrance position if there is no exit
     auto stationIndex = ride->inspection_station;
@@ -2727,9 +2727,9 @@ Peep* ride_find_closest_mechanic(Ride* ride, int32_t forInspection)
  *  rct2: 0x006B774B (forInspection = 0)
  *  rct2: 0x006B78C3 (forInspection = 1)
  */
-Peep* find_closest_mechanic(const CoordsXY& entrancePosition, int32_t forInspection)
+Staff* find_closest_mechanic(const CoordsXY& entrancePosition, int32_t forInspection)
 {
-    Peep* closestMechanic = nullptr;
+    Staff* closestMechanic = nullptr;
     uint32_t closestDistance = std::numeric_limits<uint32_t>::max();
 
     for (auto peep : EntityList<Staff>())

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -26,9 +26,9 @@
 struct IObjectManager;
 class Formatter;
 class StationObject;
-struct Peep;
 struct Ride;
 struct RideTypeDescriptor;
+struct Guest;
 struct Staff;
 struct Vehicle;
 
@@ -437,8 +437,8 @@ public:
     int32_t GetTotalQueueLength() const;
     int32_t GetMaxQueueTime() const;
 
-    void QueueInsertGuestAtFront(StationIndex stationIndex, Peep* peep);
-    Peep* GetQueueHeadGuest(StationIndex stationIndex) const;
+    void QueueInsertGuestAtFront(StationIndex stationIndex, Guest* peep);
+    Guest* GetQueueHeadGuest(StationIndex stationIndex) const;
 
     void SetNameToDefault();
     std::string GetName() const;
@@ -1140,7 +1140,7 @@ int32_t ride_get_unused_preset_vehicle_colour(ObjectEntryIndex subType);
 void ride_set_vehicle_colours_to_random_preset(Ride* ride, uint8_t preset_index);
 void ride_measurements_update();
 void ride_breakdown_add_news_item(Ride* ride);
-Peep* ride_find_closest_mechanic(Ride* ride, int32_t forInspection);
+Staff* ride_find_closest_mechanic(Ride* ride, int32_t forInspection);
 int32_t ride_initialise_construction_window(Ride* ride);
 void ride_construction_invalidate_current_track();
 std::optional<CoordsXYZ> sub_6C683D(

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -699,7 +699,7 @@ void Park::GenerateGuests()
     }
 }
 
-Peep* Park::GenerateGuestFromCampaign(int32_t campaign)
+Guest* Park::GenerateGuestFromCampaign(int32_t campaign)
 {
     auto peep = GenerateGuest();
     if (peep != nullptr)
@@ -709,14 +709,14 @@ Peep* Park::GenerateGuestFromCampaign(int32_t campaign)
     return peep;
 }
 
-Peep* Park::GenerateGuest()
+Guest* Park::GenerateGuest()
 {
-    Peep* peep = nullptr;
+    Guest* peep = nullptr;
     const auto spawn = get_random_peep_spawn();
     if (spawn != nullptr)
     {
         auto direction = direction_reverse(spawn->direction);
-        peep = Peep::Generate({ spawn->x, spawn->y, spawn->z });
+        peep = Guest::Generate({ spawn->x, spawn->y, spawn->z });
         if (peep != nullptr)
         {
             peep->sprite_direction = direction << 3;

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -18,8 +18,6 @@
 
 #define MAX_ENTRANCE_FEE MONEY(200, 00)
 
-struct Peep;
-
 enum : uint32_t
 {
     PARK_FLAGS_PARK_OPEN = (1 << 0),
@@ -43,7 +41,7 @@ enum : uint32_t
     PARK_FLAGS_UNLOCK_ALL_PRICES = (1u << 31),   // OpenRCT2 only!
 };
 
-struct Peep;
+struct Guest;
 struct rct_ride;
 
 namespace OpenRCT2
@@ -73,7 +71,7 @@ namespace OpenRCT2
         money32 CalculateCompanyValue() const;
         static uint8_t CalculateGuestInitialHappiness(uint8_t percentage);
 
-        Peep* GenerateGuest();
+        Guest* GenerateGuest();
 
         void ResetHistories();
         void UpdateHistories();
@@ -85,7 +83,7 @@ namespace OpenRCT2
         uint32_t CalculateGuestGenerationProbability() const;
 
         void GenerateGuests();
-        Peep* GenerateGuestFromCampaign(int32_t campaign);
+        Guest* GenerateGuestFromCampaign(int32_t campaign);
     };
 } // namespace OpenRCT2
 

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -69,7 +69,7 @@ protected:
         // Our start position is in tile coordinates, but we need to give the peep spawn
         // position in actual world coords (32 units per tile X/Y, 8 per Z level).
         // Add 16 so the peep spawns in the center of the tile.
-        Peep* peep = Peep::Generate(pos->ToCoordsXYZ().ToTileCentre());
+        auto* peep = Guest::Generate(pos->ToCoordsXYZ().ToTileCentre());
 
         // Peeps that are outside of the park use specialized pathfinding which we don't want to
         // use here

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -154,11 +154,9 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(NextLoc.y);
     COMPARE_FIELD(NextLoc.z);
     COMPARE_FIELD(NextFlags);
-    COMPARE_FIELD(OutsideOfPark);
     COMPARE_FIELD(State);
     COMPARE_FIELD(SubState);
     COMPARE_FIELD(SpriteType);
-    COMPARE_FIELD(GuestNumRides);
     COMPARE_FIELD(TshirtColour);
     COMPARE_FIELD(TrousersColour);
     COMPARE_FIELD(DestinationX);
@@ -167,27 +165,8 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(Var37);
     COMPARE_FIELD(Energy);
     COMPARE_FIELD(EnergyTarget);
-    COMPARE_FIELD(Happiness);
-    COMPARE_FIELD(HappinessTarget);
-    COMPARE_FIELD(Nausea);
-    COMPARE_FIELD(NauseaTarget);
-    COMPARE_FIELD(Hunger);
-    COMPARE_FIELD(Thirst);
-    COMPARE_FIELD(Toilet);
     COMPARE_FIELD(Mass);
-    COMPARE_FIELD(TimeToConsume);
-    COMPARE_FIELD(Intensity);
-    COMPARE_FIELD(NauseaTolerance);
     COMPARE_FIELD(WindowInvalidateFlags);
-    COMPARE_FIELD(PaidOnDrink);
-    for (int i = 0; i < PEEP_MAX_THOUGHTS; i++)
-    {
-        COMPARE_FIELD(RideTypesBeenOn[i]);
-    }
-    COMPARE_FIELD(ItemFlags);
-    COMPARE_FIELD(Photo2RideRef);
-    COMPARE_FIELD(Photo3RideRef);
-    COMPARE_FIELD(Photo4RideRef);
     COMPARE_FIELD(CurrentRide);
     COMPARE_FIELD(CurrentRideStation);
     COMPARE_FIELD(CurrentTrain);
@@ -199,32 +178,10 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(Action);
     COMPARE_FIELD(ActionFrame);
     COMPARE_FIELD(StepProgress);
-    COMPARE_FIELD(GuestNextInQueue);
     COMPARE_FIELD(MazeLastEdge);
     COMPARE_FIELD(InteractionRideIndex);
-    COMPARE_FIELD(TimeInQueue);
-    for (int i = 0; i < 32; i++)
-    {
-        COMPARE_FIELD(RidesBeenOn[i]);
-    }
     COMPARE_FIELD(Id);
-    COMPARE_FIELD(CashInPocket);
-    COMPARE_FIELD(CashSpent);
-    COMPARE_FIELD(ParkEntryTime);
-    COMPARE_FIELD(RejoinQueueTimeout);
-    COMPARE_FIELD(PreviousRide);
-    COMPARE_FIELD(PreviousRideTimeOut);
-    for (int i = 0; i < PEEP_MAX_THOUGHTS; i++)
-    {
-        COMPARE_FIELD(Thoughts[i].type);
-        COMPARE_FIELD(Thoughts[i].item);
-        COMPARE_FIELD(Thoughts[i].freshness);
-        COMPARE_FIELD(Thoughts[i].fresh_timeout);
-    }
     COMPARE_FIELD(PathCheckOptimisation);
-    COMPARE_FIELD(GuestHeadingToRideId);
-    COMPARE_FIELD(StaffOrders);
-    COMPARE_FIELD(Photo1RideRef);
     COMPARE_FIELD(PeepFlags);
     COMPARE_FIELD(PathfindGoal.x);
     COMPARE_FIELD(PathfindGoal.y);
@@ -238,6 +195,54 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
         COMPARE_FIELD(PathfindHistory[i].direction);
     }
     COMPARE_FIELD(WalkingFrameNum);
+}
+
+static void CompareSpriteDataGuest(const Guest& left, const Guest& right)
+{
+    CompareSpriteDataPeep(left, right);
+    COMPARE_FIELD(OutsideOfPark);
+    COMPARE_FIELD(GuestNumRides);
+    COMPARE_FIELD(Happiness);
+    COMPARE_FIELD(HappinessTarget);
+    COMPARE_FIELD(Nausea);
+    COMPARE_FIELD(NauseaTarget);
+    COMPARE_FIELD(Hunger);
+    COMPARE_FIELD(Thirst);
+    COMPARE_FIELD(Toilet);
+    COMPARE_FIELD(TimeToConsume);
+    COMPARE_FIELD(Intensity);
+    COMPARE_FIELD(NauseaTolerance);
+    COMPARE_FIELD(PaidOnDrink);
+    for (int i = 0; i < PEEP_MAX_THOUGHTS; i++)
+    {
+        COMPARE_FIELD(RideTypesBeenOn[i]);
+    }
+    COMPARE_FIELD(ItemFlags);
+    COMPARE_FIELD(Photo2RideRef);
+    COMPARE_FIELD(Photo3RideRef);
+    COMPARE_FIELD(Photo4RideRef);
+    COMPARE_FIELD(GuestNextInQueue);
+    COMPARE_FIELD(TimeInQueue);
+    for (int i = 0; i < 32; i++)
+    {
+        COMPARE_FIELD(RidesBeenOn[i]);
+    }
+    COMPARE_FIELD(CashInPocket);
+    COMPARE_FIELD(CashSpent);
+    COMPARE_FIELD(ParkEntryTime);
+    COMPARE_FIELD(RejoinQueueTimeout);
+    COMPARE_FIELD(PreviousRide);
+    COMPARE_FIELD(PreviousRideTimeOut);
+    for (int i = 0; i < PEEP_MAX_THOUGHTS; i++)
+    {
+        COMPARE_FIELD(Thoughts[i].type);
+        COMPARE_FIELD(Thoughts[i].item);
+        COMPARE_FIELD(Thoughts[i].freshness);
+        COMPARE_FIELD(Thoughts[i].fresh_timeout);
+    }
+    COMPARE_FIELD(GuestHeadingToRideId);
+    COMPARE_FIELD(GuestIsLostCountdown);
+    COMPARE_FIELD(Photo1RideRef);
     COMPARE_FIELD(LitterCount);
     COMPARE_FIELD(GuestTimeOnRide);
     COMPARE_FIELD(DisgustingCount);
@@ -260,6 +265,22 @@ static void CompareSpriteDataPeep(const Peep& left, const Peep& right)
     COMPARE_FIELD(HatColour);
     COMPARE_FIELD(FavouriteRide);
     COMPARE_FIELD(FavouriteRideRating);
+}
+
+static void CompareSpriteDataStaff(const Staff& left, const Staff& right)
+{
+    CompareSpriteDataPeep(left, right);
+
+    COMPARE_FIELD(AssignedStaffType);
+    COMPARE_FIELD(MechanicTimeSinceCall);
+    COMPARE_FIELD(HireDate);
+    COMPARE_FIELD(StaffId);
+    COMPARE_FIELD(StaffOrders);
+    COMPARE_FIELD(StaffMowingTimeout);
+    COMPARE_FIELD(StaffRidesFixed);
+    COMPARE_FIELD(StaffRidesInspected);
+    COMPARE_FIELD(StaffLitterSwept);
+    COMPARE_FIELD(StaffBinsEmptied);
 }
 
 static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)
@@ -413,8 +434,10 @@ static void CompareSpriteData(const rct_sprite& left, const rct_sprite& right)
         switch (left.misc.Type)
         {
             case EntityType::Guest:
+                CompareSpriteDataGuest(static_cast<const Guest&>(left.peep), static_cast<const Guest&>(right.peep));
+                break;
             case EntityType::Staff:
-                CompareSpriteDataPeep(left.peep, right.peep);
+                CompareSpriteDataStaff(static_cast<const Staff&>(left.peep), static_cast<const Staff&>(right.peep));
                 break;
             case EntityType::Vehicle:
                 CompareSpriteDataVehicle(left.vehicle, right.vehicle);


### PR DESCRIPTION
This splits a huge amount of code so that it uses either Guest or Staff for the variables that are tied to guest or staff. (I've a follow on branch https://github.com/duncanspumpkin/OpenRCT2/commit/ddbc994769bb4c01234f15be60c890ce762fc731 that does the actual field moving so thats how I know I've caught all the instances)
Replays are expected to pass on this and the follow on will fail them.