### PR TITLE
workflow yml improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on: [push, pull_request]
+defaults:
+  run:
+    shell: bash
 env:
   OPENRCT2_BUILD_SERVER: GitHub
   OPENRCT2_ORG_TOKEN: ${{ secrets.OPENRCT2_ORG_TOKEN }}
@@ -47,10 +50,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Build OpenRCT2
-        shell: bash
         run: . scripts/setenv && build
       - name: Build artifacts
-        shell: bash
         run: |
           . scripts/setenv -q
           build-portable
@@ -62,10 +63,8 @@ jobs:
           name: "OpenRCT2-Windows-${{ matrix.platform }}"
           path: artifacts/*
       - name: Run Tests
-        shell: bash
         run: . scripts/setenv -q && run-tests
       - name: Upload artifacts (openrct2.org)
-        shell: bash
         run: |
           . scripts/setenv -q
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then
@@ -164,10 +163,8 @@ jobs:
           brew install ninja
           . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=on
       - name: Run Tests
-        shell: bash
         run: . scripts/setenv -q && run-tests
       - name: Build artifacts
-        shell: bash
         run: |
           . scripts/setenv
           mkdir -p artifacts
@@ -194,13 +191,10 @@ jobs:
         with:
           key: linux-portable
       - name: Get pre-reqs
-        shell: bash
         run: . scripts/setenv && get-discord-rpc
       - name: Build OpenRCT2
-        shell: bash
         run: . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=ON -DPORTABLE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
       - name: Build artifacts
-        shell: bash
         run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-Linux-x86_64.tar.gz bin/install/usr
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v1
@@ -208,10 +202,8 @@ jobs:
           name: "OpenRCT2-Linux-x86_64"
           path: artifacts
       - name: Run Tests
-        shell: bash
         run: . scripts/setenv -q && run-tests
       - name: Upload artifacts (openrct2.org)
-        shell: bash
         run: |
           . scripts/setenv -q
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then
@@ -233,13 +225,10 @@ jobs:
         with:
           key: linux-portable-32
       - name: Get pre-reqs
-        shell: bash
         run: . scripts/setenv && get-discord-rpc
       - name: Build OpenRCT2
-        shell: bash
-        run: . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=ON -DPORTABLE=ON -DFORCE32=ON -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -m32"
+        run: . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=ON -DPORTABLE=ON -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -gz"
       - name: Build artifacts
-        shell: bash
         run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-Linux-i686.tar.gz bin/install/usr
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v1
@@ -247,10 +236,8 @@ jobs:
           name: "OpenRCT2-Linux-i686"
           path: artifacts
       - name: Run Tests
-        shell: bash
         run: . scripts/setenv -q && run-tests
       - name: Upload artifacts (openrct2.org)
-        shell: bash
         run: |
           . scripts/setenv -q
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then
@@ -272,13 +259,10 @@ jobs:
         with:
           key: linux-appimage
       - name: Get pre-reqs
-        shell: bash
         run: . scripts/setenv -q && get-discord-rpc
       - name: Build OpenRCT2
-        shell: bash
         run: . scripts/setenv -q && build -DCMAKE_BUILD_TYPE=Release -DAPPIMAGE=ON -DOPENRCT2_USE_CCACHE=on
       - name: Build AppImage
-        shell: bash
         run: . scripts/setenv -q && build-appimage
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v1
@@ -334,7 +318,6 @@ jobs:
         with:
           key: linux-clang
       - name: Build OpenRCT2
-        shell: bash
         run: . scripts/setenv && build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DDISABLE_NETWORK=ON -DDISABLE_HTTP=ON -DDISABLE_OPENGL=ON
   android:
     name: Android
@@ -350,7 +333,6 @@ jobs:
         with:
           key: android
       - name: Build OpenRCT2
-        shell: bash
         run: |
           . scripts/setenv
           pushd src/openrct2-android
@@ -364,7 +346,6 @@ jobs:
           name: "OpenRCT2-Android"
           path: artifacts
       - name: Upload artifacts (openrct2.org)
-        shell: bash
         run: |
           . scripts/setenv -q
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,11 @@ jobs:
           build-symbols
           build-installer -i
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v2
         with:
-          name: "OpenRCT2-Windows-${{ matrix.platform }}"
-          path: artifacts/*
+          name: OpenRCT2-${{ runner.os }}-${{ matrix.platform }}
+          path: artifacts
+          if-no-files-found: error
       - name: Run Tests
         run: . scripts/setenv -q && run-tests
       - name: Upload artifacts (openrct2.org)
@@ -114,10 +115,11 @@ jobs:
           cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=MinSizeRel -DDISABLE_IPO=on -DDISABLE_HTTP=Off -DFORCE32=on -DENABLE_SCRIPTING=ON -DCMAKE_CXX_FLAGS="-Wno-error=cast-function-type -Wno-error=unused-function" -DSTATIC=on -DMINGW_TARGET_NT5_1=ON
           ninja -k0
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v2
         with:
           name: "OpenRCT2-NT5.1"
           path: bin/openrct2.exe
+          if-no-files-found: error
   macos-xcode:
     name: macOS (x64) using Xcode
     runs-on: macos-latest
@@ -135,10 +137,11 @@ jobs:
           cd artifacts
           zip -rq openrct2-macos.zip OpenRCT2.app
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v2
         with:
-          name: "OpenRCT2-macOS-xcode"
+          name: OpenRCT2-${{ runner.os }}-xcode
           path: artifacts/openrct2-macos.zip
+          if-no-files-found: error
       - name: Upload artifacts (openrct2.org)
         run: |
           . scripts/setenv
@@ -173,10 +176,11 @@ jobs:
           cd artifacts
           zip -rqy openrct2-macos.zip OpenRCT2.app
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v2
         with:
-          name: "OpenRCT2-macOS-cmake"
+          name: OpenRCT2-${{ runner.os }}-cmake
           path: artifacts/openrct2-macos.zip
+          if-no-files-found: error
   linux-portable:
     name: Linux (x64, portable)
     runs-on: ubuntu-latest
@@ -231,10 +235,11 @@ jobs:
       - name: Build artifacts
         run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-Linux-i686.tar.gz bin/install/usr
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: "OpenRCT2-Linux-i686"
           path: artifacts
+          if-no-files-found: error
       - name: Run Tests
         run: . scripts/setenv -q && run-tests
       - name: Upload artifacts (openrct2.org)
@@ -265,10 +270,11 @@ jobs:
       - name: Build AppImage
         run: . scripts/setenv -q && build-appimage
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: OpenRCT2-AppImage
           path: artifacts
+          if-no-files-found: error
   linux-flathub-beta:
     name: Linux (Flathub beta channel)
     if: github.repository == 'OpenRCT2/OpenRCT2' && github.ref == 'refs/heads/develop' && github.event_name == 'push'
@@ -341,10 +347,11 @@ jobs:
           mkdir -p artifacts
           mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2-arm.apk
       - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: "OpenRCT2-Android"
+          name: OpenRCT2-Android
           path: artifacts
+          if-no-files-found: error
       - name: Upload artifacts (openrct2.org)
         run: |
           . scripts/setenv -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       image: openrct2/openrct2-build:0.3.1-format
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run clang-format
         shell: sh
         run: scripts/check-code-formatting
@@ -48,7 +48,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Build OpenRCT2
         run: . scripts/setenv && build
       - name: Build artifacts
@@ -126,7 +126,7 @@ jobs:
     needs: [check-code-formatting]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Build OpenRCT2
         run: |
           . scripts/setenv
@@ -156,7 +156,7 @@ jobs:
     needs: [check-code-formatting]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -223,7 +223,7 @@ jobs:
       image: openrct2/openrct2-build:0.3.1-bionic32
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -258,7 +258,7 @@ jobs:
       image: openrct2/openrct2-build:0.3.1-bionic
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -293,10 +293,12 @@ jobs:
     if: github.repository == 'OpenRCT2/OpenRCT2'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout image
+        uses: actions/checkout@v2
+        with:
+          repository: OpenRCT2/openrct2-docker
       - name: Build image
-        run: |
-          git clone --depth 1 https://github.com/OpenRCT2/openrct2-docker .
-          docker build -t openrct2/openrct2-cli:develop develop/cli
+        run: docker build -t openrct2/openrct2-cli:develop develop/cli
       - name: Push image
         env:
           OPENRCT2_DOCKER_USER: ${{ secrets.OPENRCT2_DOCKER_USER }}
@@ -318,7 +320,7 @@ jobs:
       image: openrct2/openrct2-build:0.3.1-bionic
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -333,7 +335,7 @@ jobs:
       image: openrct2/openrct2-build:0.3.1-android
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,47 +77,42 @@ jobs:
               echo 'Not going to push build'
           fi
   windows-mingw:
-    name: Windows (win32) using mingw
-    runs-on: ubuntu-latest
-    needs: [check-code-formatting]
-    container:
-      image: openrct2/openrct2-build:0.3.1-mingw
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: windows-mingw
-      - name: Build OpenRCT2
-        run: |
-          sudo su
-          mkdir bin && cd bin
-          cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=MinSizeRel -DDISABLE_IPO=on -DFORCE32=on -DBUILD_SHARED_LIBS=ON -DENABLE_SCRIPTING=OFF
-          ninja -k0
-  windows-mingw-nt51:
-    name: Windows (win32, WinNT5.1) using mingw
+    name: Windows (${{ matrix.platform_name }}) using mingw
     runs-on: ubuntu-latest
     needs: check-code-formatting
     container:
       image: openrct2/openrct2-build:0.3.1-mingw
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [win32, NT5.1]
+        include:
+          - platform: win32
+            platform_name: win32
+            cache_key: windows-mingw
+            build_flags: -DBUILD_SHARED_LIBS=ON -DENABLE_SCRIPTING=OFF
+          - platform: NT5.1
+            platform_name: win32, NT5.1
+            cache_key: windows-mingw-nt51
+            build_flags: -DDISABLE_HTTP=Off -DENABLE_SCRIPTING=ON -DCMAKE_CXX_FLAGS="-Wno-error=cast-function-type -Wno-error=unused-function" -DSTATIC=on -DMINGW_TARGET_NT5_1=ON
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: windows-mingw-nt51
+          key: ${{ matrix.cache_key }}
       - name: Build OpenRCT2
         run: |
           sudo su
           mkdir bin && cd bin
-          cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=MinSizeRel -DDISABLE_IPO=on -DDISABLE_HTTP=Off -DFORCE32=on -DENABLE_SCRIPTING=ON -DCMAKE_CXX_FLAGS="-Wno-error=cast-function-type -Wno-error=unused-function" -DSTATIC=on -DMINGW_TARGET_NT5_1=ON
+          cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=../CMakeLists_mingw.txt -DCMAKE_BUILD_TYPE=Release -DDISABLE_IPO=on -DFORCE32=on ${{ matrix.build_flags }}
           ninja -k0
       - name: Upload artifacts (CI)
+        if: matrix.platform == 'NT5.1'
         uses: actions/upload-artifact@v2
         with:
-          name: "OpenRCT2-NT5.1"
+          name: OpenRCT2-${{ matrix.platform }}
           path: bin/openrct2.exe
           if-no-files-found: error
   macos-xcode:
@@ -182,62 +177,41 @@ jobs:
           path: artifacts/openrct2-macos.zip
           if-no-files-found: error
   linux-portable:
-    name: Linux (x64, portable)
+    name: Linux (${{ matrix.platform }}, portable)
     runs-on: ubuntu-latest
     needs: check-code-formatting
     container:
-      image: openrct2/openrct2-build:0.3.1-bionic
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: linux-portable
-      - name: Get pre-reqs
-        run: . scripts/setenv && get-discord-rpc
-      - name: Build OpenRCT2
-        run: . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=ON -DPORTABLE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
-      - name: Build artifacts
-        run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-Linux-x86_64.tar.gz bin/install/usr
-      - name: Upload artifacts (CI)
-        uses: actions/upload-artifact@v1
-        with:
-          name: "OpenRCT2-Linux-x86_64"
-          path: artifacts
-      - name: Run Tests
-        run: . scripts/setenv -q && run-tests
-      - name: Upload artifacts (openrct2.org)
-        run: |
-          . scripts/setenv -q
-          if [[ "$OPENRCT2_PUSH" == "true" ]]; then
-              upload-build artifacts/OpenRCT2-Linux-x86_64.tar.gz linux-x86_64 $OPENRCT2_VERSION $OPENRCT2_SHA1 $OPENRCT2_BRANCH
-          else
-              echo 'Not going to push build'
-          fi
-  linux-portable-32:
-    name: Linux (i686, portable)
-    runs-on: ubuntu-latest
-    needs: [check-code-formatting]
-    container:
-      image: openrct2/openrct2-build:0.3.1-bionic32
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x86_64, i686]
+        include:
+          - platform: x86_64
+            image: openrct2/openrct2-build:0.3.1-bionic
+            cache_key: linux-portable
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
+          - platform: i686
+            image: openrct2/openrct2-build:0.3.1-bionic32
+            cache_key: linux-portable-32
+            build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -gz"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: linux-portable-32
+          key: ${{ matrix.cache_key }}
       - name: Get pre-reqs
         run: . scripts/setenv && get-discord-rpc
       - name: Build OpenRCT2
-        run: . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=ON -DPORTABLE=ON -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -gz"
+        run: . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DPORTABLE=ON ${{ matrix.build_flags }}
       - name: Build artifacts
-        run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-Linux-i686.tar.gz bin/install/usr
+        run: . scripts/setenv -q && build-portable artifacts/OpenRCT2-${{ runner.os }}-${{ matrix.platform }}.tar.gz bin/install/usr
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v2
         with:
-          name: "OpenRCT2-Linux-i686"
+          name: OpenRCT2-${{ runner.os }}-${{ matrix.platform }}
           path: artifacts
           if-no-files-found: error
       - name: Run Tests
@@ -246,7 +220,7 @@ jobs:
         run: |
           . scripts/setenv -q
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then
-              upload-build artifacts/OpenRCT2-Linux-i686.tar.gz linux-i686 $OPENRCT2_VERSION $OPENRCT2_SHA1 $OPENRCT2_BRANCH
+              upload-build artifacts/OpenRCT2-${{ runner.os }}-${{ matrix.platform }}.tar.gz linux-${{ matrix.platform }} $OPENRCT2_VERSION $OPENRCT2_SHA1 $OPENRCT2_BRANCH
           else
               echo 'Not going to push build'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Commit Messages
-        uses: wagoid/commitlint-github-action@v1
+        uses: wagoid/commitlint-github-action@v3
         with:
           configFile: .commitlint.json
   check-code-formatting:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           key: macos
       - name: Build OpenRCT2
         run: |
-          brew install ninja
+          HOMEBREW_NO_ANALYTICS=1 brew install ninja
           . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=on
       - name: Run Tests
         run: . scripts/setenv -q && run-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     strategy:
       fail-fast: false
       matrix:
@@ -98,7 +98,7 @@ jobs:
   windows-mingw-nt51:
     name: Windows (win32, WinNT5.1) using mingw
     runs-on: ubuntu-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     container:
       image: openrct2/openrct2-build:0.3.1-mingw
     steps:
@@ -123,7 +123,7 @@ jobs:
   macos-xcode:
     name: macOS (x64) using Xcode
     runs-on: macos-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -153,7 +153,7 @@ jobs:
   macos-cmake:
     name: macOS (x64) using CMake
     runs-on: macos-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -184,7 +184,7 @@ jobs:
   linux-portable:
     name: Linux (x64, portable)
     runs-on: ubuntu-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     container:
       image: openrct2/openrct2-build:0.3.1-bionic
     steps:
@@ -253,7 +253,7 @@ jobs:
   linux-appimage:
     name: Linux (x64, AppImage)
     runs-on: ubuntu-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     container:
       image: openrct2/openrct2-build:0.3.1-bionic
     steps:
@@ -289,7 +289,7 @@ jobs:
           client-payload: '{ "commit": "${{ github.sha }}" }'
   linux-docker:
     name: Linux (docker)
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     if: github.repository == 'OpenRCT2/OpenRCT2'
     runs-on: ubuntu-latest
     steps:
@@ -315,7 +315,7 @@ jobs:
   linux-clang:
     name: Linux (Debug, [http, network, OpenGL] disabled) using clang
     runs-on: ubuntu-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     container:
       image: openrct2/openrct2-build:0.3.1-bionic
     steps:
@@ -330,7 +330,7 @@ jobs:
   android:
     name: Android
     runs-on: ubuntu-latest
-    needs: [check-code-formatting]
+    needs: check-code-formatting
     container:
       image: openrct2/openrct2-build:0.3.1-android
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Build OpenRCT2
         run: |
           brew install ninja
-          . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=on
+          . scripts/setenv -q && build -DWITH_TESTS=on -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=on
       - name: Run Tests
         run: . scripts/setenv -q && run-tests
       - name: Build artifacts

--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Clone repositories
         run: |
           echo "Cloning repositories..."
-          git clone -b master git@github.com:OpenRCT2/Localisation.git Localisation
+          git clone -b master --depth 1 git@github.com:OpenRCT2/Localisation.git Localisation
           git clone -b develop git@github.com:OpenRCT2/OpenRCT2.git OpenRCT2
       - name: Copy over language files
         run: |

--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -1,7 +1,7 @@
 name: Localisation Merge
 on:
   schedule:
-    - cron:  '0 4 * * *'
+    - cron: '0 4 * * *'
 jobs:
   merge-localisation:
     name: Merge Localisation

--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -29,8 +29,8 @@ jobs:
               cp $f "./OpenRCT2/data/language/$filename"
           done
       - name: Commit and push
+        working-directory: OpenRCT2
         run: |
-          pushd ./OpenRCT2
           if [[ $(git status -s) ]]; then
               echo "Committing and pushing..."
               git add .
@@ -42,4 +42,3 @@ jobs:
           else
               echo "No changes to merge."
           fi
-          popd


### PR DESCRIPTION
```
ci.yml:
 Use job-wide shell: bash.
 Always use checkout v2.
 Upgrade commitlint-github-action to v3.
 Remove brackets around check-code-formatting since it's only one item.
 Replace MinSizeRel with Release.
 upload-artifact:
  Always use v2.
  name:
   Remove unneeded quotation marks around name.
   Use runner.os when possible.
  if-no-files-found: error
 Make Windows mingw win32/NT5.1 into matrix.
 Add HOMEBREW_NO_ANALYTICS=1 to brew install.
 Make linux-portable(-32) into matrix.
 linux-docker:
  Use checkout action instead of git clone.
localisation.yml:
 Remove erroneous space after cron:
 Use --depth 1 to speed up cloning Localisation.
 Commit and push:
  Replace pushd with working-directory.
  Remove unneeded popd.
```