### PR TITLE
Fix compile error when DEBUG_LEVEL=1

### DIFF
--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -34,9 +34,9 @@ ride_id_t gPeepPathFindQueueRideIndex;
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 // Use to guard calls to log messages
-bool gPathFindDebug = false;
+static bool gPathFindDebug = false;
 // Use to put the peep name in the log message
-utf8 gPathFindDebugPeepName[256];
+static utf8 gPathFindDebugPeepName[256];
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 static int32_t guest_surface_path_finding(Peep* peep);

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -34,9 +34,9 @@ ride_id_t gPeepPathFindQueueRideIndex;
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 // Use to guard calls to log messages
-static bool gPathFindDebug = false;
+static bool _pathFindDebug = false;
 // Use to put the peep name in the log message
-static utf8 gPathFindDebugPeepName[256];
+static utf8 _pathFindDebugPeepName[256];
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
 static int32_t guest_surface_path_finding(Peep* peep);
@@ -1269,10 +1269,10 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
     TileCoordsXYZ goal = gPeepPathFindGoalPosition;
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-    if (gPathFindDebug)
+    if (_pathFindDebug)
     {
         log_verbose(
-            "Choose direction for %s for goal %d,%d,%d from %d,%d,%d", gPathFindDebugPeepName, goal.x, goal.y, goal.z, loc.x,
+            "Choose direction for %s for goal %d,%d,%d from %d,%d,%d", _pathFindDebugPeepName, goal.x, goal.y, goal.z, loc.x,
             loc.y, loc.z);
     }
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -1362,7 +1362,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
                 edges = pathfindHistory.direction;
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-                if (gPathFindDebug)
+                if (_pathFindDebug)
                 {
                     log_verbose(
                         "Getting untried edges from pf_history for %d,%d,%d:  %s,%s,%s,%s", loc.x, loc.y, loc.z,
@@ -1384,7 +1384,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
                     edges = pathfindHistory.direction;
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-                    if (gPathFindDebug)
+                    if (_pathFindDebug)
                     {
                         log_verbose("All edges tried for %d,%d,%d - resetting to all untried", loc.x, loc.y, loc.z);
                     }
@@ -1408,7 +1408,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
         // Clear pathfinding history
         std::fill_n(reinterpret_cast<uint8_t*>(peep->PathfindHistory), sizeof(peep->PathfindHistory), 0xFF);
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
             log_verbose("New goal; clearing pf_history.");
         }
@@ -1433,7 +1433,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
         uint8_t bestDirectionList[16];
         TileCoordsXYZ bestXYZ;
 
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
             log_verbose("Pathfind start for goal %d,%d,%d from %d,%d,%d", goal.x, goal.y, goal.z, loc.x, loc.y, loc.z);
         }
@@ -1515,7 +1515,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
                 endJunctionList, endDirectionList, &endXYZ, &endSteps);
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-            if (gPathFindDebug)
+            if (_pathFindDebug)
             {
                 log_verbose(
                     "Pathfind test edge: %d score: %d steps: %d end: %d,%d,%d junctions: %d", test_edge, score, endSteps,
@@ -1556,7 +1556,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
         if (best_score == 0xFFFF)
         {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-            if (gPathFindDebug)
+            if (_pathFindDebug)
             {
                 log_verbose("Pathfind heuristic search failed.");
             }
@@ -1564,7 +1564,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
             return INVALID_DIRECTION;
         }
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
             log_verbose("Pathfind best edge %d with score %d steps %d", chosen_edge, best_score, best_sub);
             for (uint8_t listIdx = 0; listIdx < bestJunctions; listIdx++)
@@ -1592,7 +1592,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
                  * entered the junction from those left to try. */
                 peep->PathfindHistory[i].direction &= ~(1 << direction_reverse(peep->PeepDirection));
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-                if (gPathFindDebug)
+                if (_pathFindDebug)
                 {
                     log_verbose(
                         "Updating existing pf_history (in index: %d) for %d,%d,%d without entry edge %d & exit edge %d.", i,
@@ -1617,7 +1617,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
          * entered the junction from those left to try. */
         peep->PathfindHistory[i].direction &= ~(1 << direction_reverse(peep->PeepDirection));
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
             log_verbose(
                 "Storing new pf_history (in index: %d) for %d,%d,%d without entry edge %d & exit edge %d.", i, loc.x, loc.y,
@@ -1980,9 +1980,9 @@ int32_t guest_path_finding(Guest* peep)
 {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
     PathfindLoggingEnable(peep);
-    if (gPathFindDebug)
+    if (_pathFindDebug)
     {
-        log_info("Starting guest_path_finding for %s", gPathFindDebugPeepName);
+        log_info("Starting guest_path_finding for %s", _pathFindDebugPeepName);
     }
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
@@ -2050,10 +2050,10 @@ int32_t guest_path_finding(Guest* peep)
     if ((edges & ~(1 << direction)) == 0)
     {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
             log_info(
-                "Completed guest_path_finding for %s - taking only direction available: %d.", gPathFindDebugPeepName,
+                "Completed guest_path_finding for %s - taking only direction available: %d.", _pathFindDebugPeepName,
                 direction);
         }
         PathfindLoggingDisable();
@@ -2068,9 +2068,9 @@ int32_t guest_path_finding(Guest* peep)
     if (peep->OutsideOfPark)
     {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
-            log_info("Completed guest_path_finding for %s - peep is outside the park.", gPathFindDebugPeepName);
+            log_info("Completed guest_path_finding for %s - peep is outside the park.", _pathFindDebugPeepName);
         }
         PathfindLoggingDisable();
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -2138,9 +2138,9 @@ int32_t guest_path_finding(Guest* peep)
     if (peep->PeepFlags & PEEP_FLAGS_LEAVING_PARK)
     {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
-            log_info("Completed guest_path_finding for %s - peep is leaving the park.", gPathFindDebugPeepName);
+            log_info("Completed guest_path_finding for %s - peep is leaving the park.", _pathFindDebugPeepName);
         }
         PathfindLoggingDisable();
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -2150,9 +2150,9 @@ int32_t guest_path_finding(Guest* peep)
     if (peep->GuestHeadingToRideId == RIDE_ID_NULL)
     {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
-            log_info("Completed guest_path_finding for %s - peep is aimless.", gPathFindDebugPeepName);
+            log_info("Completed guest_path_finding for %s - peep is aimless.", _pathFindDebugPeepName);
         }
         PathfindLoggingDisable();
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -2165,10 +2165,10 @@ int32_t guest_path_finding(Guest* peep)
     if (ride == nullptr || ride->status != RIDE_STATUS_OPEN)
     {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
             log_info(
-                "Completed guest_path_finding for %s - peep is heading to closed ride == aimless.", gPathFindDebugPeepName);
+                "Completed guest_path_finding for %s - peep is heading to closed ride == aimless.", _pathFindDebugPeepName);
         }
         PathfindLoggingDisable();
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -2249,9 +2249,9 @@ int32_t guest_path_finding(Guest* peep)
         peep->ResetPathfindGoal();
 
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-        if (gPathFindDebug)
+        if (_pathFindDebug)
         {
-            log_info("Completed guest_path_finding for %s - failed to choose a direction == aimless.", gPathFindDebugPeepName);
+            log_info("Completed guest_path_finding for %s - failed to choose a direction == aimless.", _pathFindDebugPeepName);
         }
         PathfindLoggingDisable();
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -2259,9 +2259,9 @@ int32_t guest_path_finding(Guest* peep)
         return guest_path_find_aimless(peep, edges);
     }
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-    if (gPathFindDebug)
+    if (_pathFindDebug)
     {
-        log_info("Completed guest_path_finding for %s - direction chosen: %d.", gPathFindDebugPeepName, direction);
+        log_info("Completed guest_path_finding for %s - direction chosen: %d.", _pathFindDebugPeepName, direction);
     }
     PathfindLoggingDisable();
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
@@ -2302,9 +2302,9 @@ bool IsValidPathZAndDirection(TileElement* tileElement, int32_t currentZ, int32_
 void Peep::ResetPathfindGoal()
 {
 #if defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
-    if (gPathFindDebug)
+    if (_pathFindDebug)
     {
-        log_info("Resetting PathfindGoal for %s", gPathFindDebugPeepName);
+        log_info("Resetting PathfindGoal for %s", _pathFindDebugPeepName);
     }
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 


### PR DESCRIPTION
This fixes the following compile errors:
```
/home/ceeac/Projects/code/OpenRCT2/src/openrct2/peep/GuestPathfinding.cpp:37:6: error: no previous extern declaration for non-static variable 'gPathFindDebug' [-Werror,-Wmissing-variable-declarations]
bool gPathFindDebug = false;
     ^
/home/ceeac/Projects/code/OpenRCT2/src/openrct2/peep/GuestPathfinding.cpp:37:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
bool gPathFindDebug = false;
^
/home/ceeac/Projects/code/OpenRCT2/src/openrct2/peep/GuestPathfinding.cpp:39:6: error: no previous extern declaration for non-static variable 'gPathFindDebugPeepName' [-Werror,-Wmissing-variable-declarations]
utf8 gPathFindDebugPeepName[256];
     ^
/home/ceeac/Projects/code/OpenRCT2/src/openrct2/peep/GuestPathfinding.cpp:39:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
utf8 gPathFindDebugPeepName[256];
^
```