### PR TITLE
Fix #14415: Entrances/exits are removed when built on top of each other

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#13986] OpenGL: Track preview window, flip/rotate button do not update the thumbnail.
 - Fix: [#14315] Crash when trying to rename Air Powered Vertical Coaster in Korean.
 - Fix: [#14330] join_server uses default_port from config.
+- Fix: [#14415] Entrances/exits are removed when built on top of each other.
 - Fix: [#14449] Surface smoothing at extra zoom levels not working.
 - Fix: [#14468] Cannot close Options window on Android.
 - Fix: [#14493] [Plugin] isHidden only works for tile elements up to the first element with a base height of over 32.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -36,7 +36,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "14"
+#define NETWORK_STREAM_VERSION "15"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -6671,6 +6671,8 @@ void sub_6CB945(Ride* ride)
         {
             if (tileElement->GetType() != TILE_ELEMENT_TYPE_ENTRANCE)
                 continue;
+            if (tileElement->base_height != locationCoords.z)
+                continue;
             if (tileElement->AsEntrance()->GetRideIndex() != ride->id)
                 continue;
             if (tileElement->AsEntrance()->GetEntranceType() > ENTRANCE_TYPE_RIDE_EXIT)


### PR DESCRIPTION
Note that #14415 says Elevator/lift, but this bug applied to all ride types. There just probably isn't a use case to build a station for any other ride type on top of another station, but this can be seen with a simple roller coaster with two stations as well.

This loop was originally iterating over unique (x,y,z), casting each location to (x,y), and then handling each element on the tile. When the duplicate (x,y) iteration occurred (different z), the rest of this function logic deletes both the original entrance/exit and the one now being iterated over. Since all elements on the tile are iterated through, iterating over unique (x,y) elements instead resolves the issue. I validated with both the silly coaster and a lift - two entrances/exits can now be on the same tile.