### PR TITLE
Plugin API: Rename 'Object' to 'LoadedObject'

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#13967] Track List window now displays the path to the design when debugging tools are on.
 - Feature: [#14071] “Vandals stopped” statistic for security guards.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
+- Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript's Object interface.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.
 - Fix: [#13581] Opening the Options menu causes a noticeable drop in FPS.
 - Fix: [#13894] Block brakes do not animate.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -186,11 +186,11 @@ declare global {
          * @param type The object type.
          * @param index The index.
          */
-        getObject(type: ObjectType, index: number): Object;
+        getObject(type: ObjectType, index: number): LoadedObject;
         getObject(type: "ride", index: number): RideObject;
         getObject(type: "small_scenery", index: number): SmallSceneryObject;
 
-        getAllObjects(type: ObjectType): Object[];
+        getAllObjects(type: ObjectType): LoadedObject[];
         getAllObjects(type: "ride"): RideObject[];
 
         /**
@@ -724,7 +724,7 @@ declare global {
     /**
      * Represents the definition of a loaded object (.DAT or .json) such a ride type or scenery item.
      */
-    interface Object {
+    interface LoadedObject {
         /**
          * The object type.
          */
@@ -757,7 +757,7 @@ declare global {
     /**
      * Represents the object definition of a ride or stall.
      */
-    interface RideObject extends Object {
+    interface RideObject extends LoadedObject {
         /**
          * The description of the ride / stall in the player's current language.
          */
@@ -840,7 +840,7 @@ declare global {
     /**
      * Represents the object definition of a small scenery item such a tree.
      */
-    interface SmallSceneryObject extends Object {
+    interface SmallSceneryObject extends LoadedObject {
         /**
          * Raw bit flags that describe characteristics of the scenery item.
          */


### PR DESCRIPTION
## Problem

As discussed on Discord in the Plugin channel, the interface `Object` is problematic when it comes to type checking with Typescript. The 'Object' interface will merge with Typescripts own definition of `Object` (defining the Javascript base object). Typescript also seems to have some special rules built in on how to treat this Object, which conflict with the expected rules for all other interfaces.

### [Example 1](https://www.typescriptlang.org/play?ts=4.2.3#code/GYVwdgxgLglg9mABFApgZygfTgIwFYrQAUueAXIgPL6FQCUFAbnDACYCwAUAN5cCQEBGjgAbFADoRcAOYl8dANxcAvly6hIsBMnRYATmxTUCxUhQBKh47QaJmbLr04ChoiVNmlFKtZwD0fogAcnCIAA56cGEoerDoiACGeiiIyQCOIDDJrIgAFjEpROAoAB7R0CisDFyoGNg0xE4q3py+AYgAgiIi4ZHRsTDxSSnpmdl5BYhECWiIpeWoVWRc7ZRgIgCeiABElqxGDVDbvVExcbPDc2DAcHoQlQA0iGBwUDvW0McRpwPxRWDzWiVOg1XSYAz7D5QIhOPjNJStREwMCoPTABL3KiHRBORB41IoBKsBCbRDI-YlChgEAAWxwMQR+IJRJJW0MKJgwEGegoGAMYGkjPxyRZ6y2YmkGI2AEl9hyuTFeVB+YKuEyRcSxc8EjSUEqVQjVEiUTF0Zi9gcTG9SqgwKxZlCcWrhYTNaT9mgIAYwlowPrkarOOrXazUoYACobaJU2n0vQAbQAukK8RrQzTkQBhJJoaVgcN6BLImN0hnO1MhrU0hIlbN6XP5wvF56xsucZRAA)
Here Typescript doesn't enforce any required properties on the `Object` interface, while it does on the `RideObject` interface. Also note that on the `RideObject` interface, it only requires its own properties assigned and not any inherited properties from `Object`. 

Expected behaviour would be that all properties are required on both objects.

### [Example 2](https://www.typescriptlang.org/play?ts=4.2.3#code/C4TwDgpgBAkgdsCAnAzhAxsAKuCAeLAPigF4osoAyAWACgBvOgSAEsFk1MB9MJAe0hJQALigpgSNgHMA3HQC+c2nVCQoAVTgs+cHGrIAiAIYGoAHygGARgaV02iJADMj6aAGU+AWwh6IdRlooYLFvCB5+QRExCWklEKhVCFFNbV1cGSgAeiyoPABaRIALFhQodAAbIxQiiDKAdxZgIqgAeSsAKwxgADokhTo6HKgAdSaivgBXYCgBCDgkTAAmHoATPpRRAHIkOsmK4C2xCfqyybAoasTcUlh2VG6-PE8fP0Ih3LHm2cgF5bWNqIQjs9gcjjU+KcoOdLmUkrc4BAAG7IOjoHTiKC7FD7GZkeihHwROZCECiAwAL1M8lhd0cnGwuGeYTedmUtCyACoPlAAGL8Lw-eaLYArdbAFAAGmhcHRXh8CGKpUSfHKVRqUEa314yO0kzK6NWyRUN3aXUwfluBkkRtMFgMXn1LHQtjoCQS9nuLjcbU63SgATdIV2RlWOgqIGukFEZseGSDwRDYbgEagcCMPlE4kkcFkA1onKyQA)
In this example you can look at the type of the constant `result`. Its type will change whether the (seemingly unrelated) snippet at the bottom is commented or not. 

- With the OpenRCT2 snippet commented, `result` resolves to `IntersectType<SomeType>`. 
- With the OpenRCT2 uncommented, `result` resolves to `never`. 

This happens because `SomeType` implicitly implements the `Object`, which results in both Typescripts `Object` and also OpenRCT2's `Object` being implemented. Since Openrct2's `Object` has a union property called `type`, it clashes with `SomeType` its union property called `type`, creating an impossible type (= `never`). 

This is very unexpected behaviour and can cause seemingly random `never`'s to popup whenever you start doing some more complex typing.

## Proposed solution
Rename OpenRCT2's `Object`-interface to `LoadedObject` in the TS declaration file.

### Effect on plugin users
Plugin users are not affected by this change, because typing (like this interface) are completely stripped during the transpiling to Javascript.

### Effect on plugin developers
Plugin developers are required to change all uses of OpenRCT2's `Object` to `LoadedObject` next time they update their `openrct2.d.ts` file in an already existing Typescript project. Developers who do not update their `openrct2.d.ts` are not affected since the underlying Duktape API did not change. 

If there are any more questions, please let me know. :blush: