### PR TITLE
Fix #14493: isHidden broken for elements with baseheight > 32

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#13894] Block brakes do not animate.
 - Fix: [#14315] Crash when trying to rename Air Powered Vertical Coaster in Korean.
 - Fix: [#14330] join_server uses default_port from config.
+- Fix: [#14493] [Plugin] isHidden only works for tile elements up to the first element with a base height of over 32.
 
 0.3.3 (2021-03-13)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/ScTile.hpp
+++ b/src/openrct2/scripting/ScTile.hpp
@@ -836,7 +836,7 @@ namespace OpenRCT2::Scripting
                 // Insert corrupt element at the end of the list for this tile
                 // Note: Z = MAX_ELEMENT_HEIGHT to guarantee this
                 TileElement* insertedElement = tile_element_insert(
-                    { _coords, MAX_ELEMENT_HEIGHT }, 0, TileElementType::Corrupt);
+                    { _coords, MAX_ELEMENT_HEIGHT * COORDS_Z_STEP }, 0, TileElementType::Corrupt);
                 if (insertedElement == nullptr)
                 {
                     // TODO: Show error


### PR DESCRIPTION
When setting `isHidden` to true, the game inserts a corrupt element below the element to hide. The inserted element gets placed at the end of the list - this is done by supplying the maximum base height an element can have - and then swaps it with the previous element until it reaches the one it should hide.

The provided maximum base height was not changed when the Coordinate system was changed, this was overlooked, meaning the inserted corrupt element could be placed anywhere in the list.