### PR TITLE
Fix #13986: OpenGL: Track preview, flip/rotate does not update thumbnail

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.
 - Fix: [#13581] Opening the Options menu causes a noticeable drop in FPS.
 - Fix: [#13894] Block brakes do not animate.
+- Fix: [#13986] OpenGL: Track preview window, flip/rotate button do not update the thumbnail.
 - Fix: [#14315] Crash when trying to rename Air Powered Vertical Coaster in Korean.
 - Fix: [#14330] join_server uses default_port from config.
 - Fix: [#14493] [Plugin] isHidden only works for tile elements up to the first element with a base height of over 32.

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -490,6 +490,7 @@ static void window_track_place_paint(rct_window* w, rct_drawpixelinfo* dpi)
         g1temp.width = TRACK_MINI_PREVIEW_WIDTH;
         g1temp.height = TRACK_MINI_PREVIEW_HEIGHT;
         gfx_set_g1_element(SPR_TEMP, &g1temp);
+        drawing_engine_invalidate_image(SPR_TEMP);
         gfx_draw_sprite(&clippedDpi, ImageId(SPR_TEMP, NOT_TRANSLUCENT(w->colours[0])), { 0, 0 });
     }
 


### PR DESCRIPTION
Invalidate SPR_TEMP so that it is not cached in the OpenGL drawing engine.