### PR TITLE
Plugin API: Rename 'ListView' to 'ListViewWidget' in Typescript declaration for consistency

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#14071] “Vandals stopped” statistic for security guards.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
 - Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript's Object interface.
+- Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.
 - Fix: [#13581] Opening the Options menu causes a noticeable drop in FPS.
 - Fix: [#13894] Block brakes do not animate.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2054,7 +2054,7 @@ declare global {
 
     type Widget =
         ButtonWidget | CheckboxWidget | ColourPickerWidget | CustomWidget | DropdownWidget | GroupBoxWidget |
-        LabelWidget | ListView | SpinnerWidget | TextBoxWidget | ViewportWidget;
+        LabelWidget | ListViewWidget | SpinnerWidget | TextBoxWidget | ViewportWidget;
 
     interface WidgetBase {
         readonly window?: Window;
@@ -2147,7 +2147,7 @@ declare global {
         column: number;
     }
 
-    interface ListView extends WidgetBase {
+    interface ListViewWidget extends WidgetBase {
         type: "listview";
         scrollbars?: ScrollbarType;
         isStriped?: boolean;


### PR DESCRIPTION
As previously discussed in the `#plugin` channel on the OpenRCT2 Discord, here's a pull request to rename `ListView` to `ListViewWidget` to be more consistent with other widgets.

Similar to #14496 this change has no effect on plugin users and would not require a plugin version increment. For plugin developers it is merely a Typescript name that has changed.