### PR TITLE
Plugin API: Add property for getting current plugin api version

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#13967] Track List window now displays the path to the design when debugging tools are on.
 - Feature: [#14071] “Vandals stopped” statistic for security guards.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
+- Feature: [#14538] [Plugin] Add property for getting current plugin api version.
 - Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript's Object interface.
 - Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -160,6 +160,12 @@ declare global {
      */
     interface Context {
         /**
+         * Gets the current version of the plugin api. This is an integer that increments
+         * by 1 every time a change to the plugin api is made.
+         */
+        readonly apiVersion: number;
+
+        /**
          * The user's current configuration.
          */
         configuration: Configuration;

--- a/src/openrct2/scripting/ScContext.hpp
+++ b/src/openrct2/scripting/ScContext.hpp
@@ -42,6 +42,11 @@ namespace OpenRCT2::Scripting
         }
 
     private:
+        int32_t apiVersion_get()
+        {
+            return OPENRCT2_PLUGIN_API_VERSION;
+        }
+
         std::shared_ptr<ScConfiguration> configuration_get()
         {
             return std::make_shared<ScConfiguration>();
@@ -373,6 +378,7 @@ namespace OpenRCT2::Scripting
     public:
         static void Register(duk_context* ctx)
         {
+            dukglue_register_property(ctx, &ScContext::apiVersion_get, nullptr, "apiVersion");
             dukglue_register_property(ctx, &ScContext::configuration_get, nullptr, "configuration");
             dukglue_register_property(ctx, &ScContext::sharedStorage_get, nullptr, "sharedStorage");
             dukglue_register_method(ctx, &ScContext::captureImage, "captureImage");

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -44,8 +44,6 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;
 
-static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 26;
-
 struct ExpressionStringifier final
 {
 private:

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,6 +46,8 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 27;
+
 #    ifndef DISABLE_NETWORK
     class ScSocketBase;
 #    endif


### PR DESCRIPTION
Small change to allow plugins to read the version of the plugin API they are loaded into. This can be used to check if the version of OpenRCT2 that the user has installed supports potentially newly added functionalities that the plugin would like to use. 

**Notes on network/game version**
I have also considered adding endpoints for other versions, like the network version and OpenRCT2 major, minor, patch versions. Ultimately I decided not to do it (yet) because currently both of them are strings instead of integers and they both are concatenated together with other string characters. (See [Version.h](https://github.com/OpenRCT2/OpenRCT2/blob/ec7088364efb46429b7d603e58f6c5491bf4e801/src/openrct2/Version.h#L17), [NetworkBase.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/ec7088364efb46429b7d603e58f6c5491bf4e801/src/openrct2/network/NetworkBase.cpp#L39-L40))

Adding them would require breaking them up, and I'm not sure if that is preferred and I'm not sure whether we would really need this information in the plugin api. Please let me know if it is preferred to have them, then I'll add them as to the plugin api as well. Also if there are any other suggestions, please let me know as well. :)

**Additional note**
I moved `OPENRCT2_PLUGIN_API_VERSION` from `ScriptEngine.cpp` to `ScriptEngine.h` so I could access it from `ScContext.hpp`. I also incremented it by 1. I hope this is not a problem.