### PR TITLE
Dynamically allocate paint structs and remove 4000 per column limit

### DIFF
--- a/src/openrct2/cmdline/BenchSpriteSort.cpp
+++ b/src/openrct2/cmdline/BenchSpriteSort.cpp
@@ -34,47 +34,50 @@
 #    include <iterator>
 #    include <vector>
 
-static void fixup_pointers(paint_session* s, size_t paint_session_entries, size_t paint_struct_entries, size_t quadrant_entries)
+static void fixup_pointers(std::vector<RecordedPaintSession>& s)
 {
-    for (size_t i = 0; i < paint_session_entries; i++)
+    for (size_t i = 0; i < s.size(); i++)
     {
-        for (size_t j = 0; j < paint_struct_entries; j++)
+        auto& entries = s[i].Entries;
+        auto& quadrants = s[i].Session.Quadrants;
+        for (size_t j = 0; j < entries.size(); j++)
         {
-            if (s[i].PaintStructs[j].basic.next_quadrant_ps == reinterpret_cast<paint_struct*>(paint_struct_entries))
+            if (entries[j].basic.next_quadrant_ps == reinterpret_cast<paint_struct*>(-1))
             {
-                s[i].PaintStructs[j].basic.next_quadrant_ps = nullptr;
+                entries[j].basic.next_quadrant_ps = nullptr;
             }
             else
             {
-                auto nextQuadrantPs = reinterpret_cast<uintptr_t>(s[i].PaintStructs[j].basic.next_quadrant_ps);
-                s[i].PaintStructs[j].basic.next_quadrant_ps = &s[i].PaintStructs[nextQuadrantPs].basic;
+                auto nextQuadrantPs = reinterpret_cast<size_t>(entries[j].basic.next_quadrant_ps) / sizeof(paint_entry);
+                entries[j].basic.next_quadrant_ps = &s[i].Entries[nextQuadrantPs].basic;
             }
         }
-        for (size_t j = 0; j < quadrant_entries; j++)
+        for (size_t j = 0; j < std::size(quadrants); j++)
         {
-            if (s[i].Quadrants[j] == reinterpret_cast<paint_struct*>(quadrant_entries))
+            if (quadrants[j] == reinterpret_cast<paint_struct*>(-1))
             {
-                s[i].Quadrants[j] = nullptr;
+                quadrants[j] = nullptr;
             }
             else
             {
-                s[i].Quadrants[j] = &s[i].PaintStructs[reinterpret_cast<size_t>(s[i].Quadrants[j])].basic;
+                auto ps = reinterpret_cast<size_t>(quadrants[j]) / sizeof(paint_entry);
+                quadrants[j] = &entries[ps].basic;
             }
         }
     }
 }
 
-static std::vector<paint_session> extract_paint_session(const std::string parkFileName)
+static std::vector<RecordedPaintSession> extract_paint_session(std::string_view parkFileName)
 {
     core_init();
     gOpenRCT2Headless = true;
     auto context = OpenRCT2::CreateContext();
-    std::vector<paint_session> sessions;
+    std::vector<RecordedPaintSession> sessions;
     log_info("Starting...");
     if (context->Initialise())
     {
         drawing_engine_init();
-        if (!context->LoadParkFromFile(parkFileName))
+        if (!context->LoadParkFromFile(std::string(parkFileName)))
         {
             log_error("Failed to load park!");
             return {};
@@ -133,21 +136,21 @@ static std::vector<paint_session> extract_paint_session(const std::string parkFi
 }
 
 // This function is based on benchgfx_render_screenshots
-static void BM_paint_session_arrange(benchmark::State& state, const std::vector<paint_session> inputSessions)
+static void BM_paint_session_arrange(benchmark::State& state, const std::vector<RecordedPaintSession> inputSessions)
 {
-    std::vector<paint_session> sessions = inputSessions;
+    auto sessions = inputSessions;
     // Fixing up the pointers continuously is wasteful. Fix it up once for `sessions` and store a copy.
     // Keep in mind we need bit-exact copy, as the lists use pointers.
     // Once sorted, just restore the copy with the original fixed-up version.
-    paint_session* local_s = new paint_session[std::size(sessions)];
-    fixup_pointers(&sessions[0], std::size(sessions), std::size(local_s->PaintStructs), std::size(local_s->Quadrants));
+    RecordedPaintSession* local_s = new RecordedPaintSession[std::size(sessions)];
+    fixup_pointers(sessions);
     std::copy_n(sessions.cbegin(), std::size(sessions), local_s);
     for (auto _ : state)
     {
         state.PauseTiming();
         std::copy_n(local_s, std::size(sessions), sessions.begin());
         state.ResumeTiming();
-        PaintSessionArrange(&sessions[0]);
+        PaintSessionArrange(&sessions[0].Session);
         benchmark::DoNotOptimize(sessions);
     }
     state.SetItemsProcessed(state.iterations() * std::size(sessions));
@@ -158,14 +161,14 @@ static int cmdline_for_bench_sprite_sort(int argc, const char** argv)
 {
     {
         // Register some basic "baseline" benchmark
-        std::vector<paint_session> sessions(1);
-        for (auto& ps : sessions[0].PaintStructs)
+        std::vector<RecordedPaintSession> sessions(1);
+        for (auto& ps : sessions[0].Entries)
         {
-            ps.basic.next_quadrant_ps = reinterpret_cast<paint_struct*>((std::size(sessions[0].PaintStructs)));
+            ps.basic.next_quadrant_ps = reinterpret_cast<paint_struct*>(-1);
         }
-        for (auto& quad : sessions[0].Quadrants)
+        for (auto& quad : sessions[0].Session.Quadrants)
         {
-            quad = reinterpret_cast<paint_struct*>((std::size(sessions[0].Quadrants)));
+            quad = reinterpret_cast<paint_struct*>(-1);
         }
         benchmark::RegisterBenchmark("baseline", BM_paint_session_arrange, sessions);
     }
@@ -183,7 +186,7 @@ static int cmdline_for_bench_sprite_sort(int argc, const char** argv)
         if (Platform::FileExists(argv[i]))
         {
             // Register benchmark for sv6 if valid
-            std::vector<paint_session> sessions = extract_paint_session(argv[i]);
+            std::vector<RecordedPaintSession> sessions = extract_paint_session(argv[i]);
             if (!sessions.empty())
                 benchmark::RegisterBenchmark(argv[i], BM_paint_session_arrange, sessions);
         }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <cstring>
 #include <list>
+#include <unordered_map>
 
 using namespace OpenRCT2;
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -852,6 +852,7 @@ static void record_session(const paint_session* session, std::vector<paint_sessi
     // This is done to extract the session for benchmark.
     // Place the copied session at provided record_index, so the caller can decide which columns/paint sessions to copy;
     // there is no column information embedded in the session itself.
+    /*
     (*recorded_sessions)[record_index] = (*session);
     paint_session* session_copy = &recorded_sessions->at(record_index);
 
@@ -867,6 +868,7 @@ static void record_session(const paint_session* session, std::vector<paint_sessi
         quad = reinterpret_cast<paint_struct*>(
             quad ? int(quad - &session->PaintStructs[0].basic) : std::size(session->Quadrants));
     }
+    */
 }
 
 static void viewport_fill_column(paint_session* session, std::vector<paint_session>* recorded_sessions, size_t record_index)

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 struct paint_session;
+struct RecordedPaintSession;
 struct paint_struct;
 struct rct_drawpixelinfo;
 struct Peep;
@@ -116,10 +117,10 @@ void viewport_update_smart_staff_follow(rct_window* window, Peep* peep);
 void viewport_update_smart_vehicle_follow(rct_window* window);
 void viewport_render(
     rct_drawpixelinfo* dpi, const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom,
-    std::vector<paint_session>* sessions = nullptr);
+    std::vector<RecordedPaintSession>* sessions = nullptr);
 void viewport_paint(
     const rct_viewport* viewport, rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t right, int16_t bottom,
-    std::vector<paint_session>* sessions = nullptr);
+    std::vector<RecordedPaintSession>* sessions = nullptr);
 
 CoordsXYZ viewport_adjust_for_map_height(const ScreenCoordsXY& startCoords);
 

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -385,7 +385,7 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
     }
 }
 
-template<int TRotation> static void PaintSessionArrange(paint_session* session, bool)
+template<int TRotation> static void PaintSessionArrange(PaintSessionCore* session, bool)
 {
     paint_struct* psHead = &session->PaintHead;
 
@@ -425,7 +425,7 @@ template<int TRotation> static void PaintSessionArrange(paint_session* session, 
  *
  *  rct2: 0x00688217
  */
-void PaintSessionArrange(paint_session* session)
+void PaintSessionArrange(PaintSessionCore* session)
 {
     switch (session->CurrentRotation)
     {

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -1041,6 +1041,18 @@ void PaintEntryPool::Chain::Clear()
     assert(Current == nullptr);
 }
 
+size_t PaintEntryPool::Chain::GetCount() const
+{
+    size_t count = 0;
+    auto current = Head;
+    while (current != nullptr)
+    {
+        count += current->Count;
+        current = current->Next;
+    }
+    return count;
+}
+
 PaintEntryPool::~PaintEntryPool()
 {
     for (auto node : _available)

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -333,7 +333,7 @@ void PaintFloatingMoneyEffect(
 paint_session* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags);
 void PaintSessionFree(paint_session* session);
 void PaintSessionGenerate(paint_session* session);
-void PaintSessionArrange(paint_session* session);
+void PaintSessionArrange(PaintSessionCore* session);
 void PaintDrawStructs(paint_session* session);
 void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, paint_string_struct* ps);
 

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -172,6 +172,7 @@ public:
 
         paint_entry* Allocate();
         void Clear();
+        size_t GetCount() const;
     };
 
 private:
@@ -187,10 +188,8 @@ public:
     void FreeNodes(Node* head);
 };
 
-struct paint_session
+struct PaintSessionCore
 {
-    rct_drawpixelinfo DPI;
-    PaintEntryPool::Chain PaintEntryChain;
     paint_struct* Quadrants[MAX_PAINT_QUADRANTS];
     paint_struct* LastPS;
     paint_string_struct* PSStringHead;
@@ -220,6 +219,12 @@ struct paint_session
     uint8_t Unk141E9DB;
     uint16_t WaterHeight;
     uint32_t TrackColours[4];
+};
+
+struct paint_session : public PaintSessionCore
+{
+    rct_drawpixelinfo DPI;
+    PaintEntryPool::Chain PaintEntryChain;
 
     paint_struct* AllocateNormalPaintEntry() noexcept
     {
@@ -262,6 +267,12 @@ struct paint_session
         }
         return nullptr;
     }
+};
+
+struct RecordedPaintSession
+{
+    PaintSessionCore Session;
+    std::vector<paint_entry> Entries;
 };
 
 extern paint_session gPaintSession;

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -37,8 +37,6 @@ Painter::Painter(const std::shared_ptr<IUiContext>& uiContext)
 
 void Painter::Paint(IDrawingEngine& de)
 {
-    _paintStructPool.Clear();
-
     auto dpi = de.GetDrawingPixelInfo();
     if (gIntroState != IntroState::None)
     {
@@ -153,7 +151,7 @@ paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags
     session->ViewFlags = viewFlags;
     session->QuadrantBackIndex = std::numeric_limits<uint32_t>::max();
     session->QuadrantFrontIndex = 0;
-    session->SharedPaintStructPool = &_paintStructPool;
+    session->PaintEntryChain = _paintStructPool.Create();
 
     std::fill(std::begin(session->Quadrants), std::end(session->Quadrants), nullptr);
     session->LastPS = nullptr;
@@ -169,5 +167,6 @@ paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags
 
 void Painter::ReleaseSession(paint_session* session)
 {
+    session->PaintEntryChain.Clear();
     _freePaintSessions.push_back(session);
 }

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -37,6 +37,8 @@ Painter::Painter(const std::shared_ptr<IUiContext>& uiContext)
 
 void Painter::Paint(IDrawingEngine& de)
 {
+    _paintStructPool.Clear();
+
     auto dpi = de.GetDrawingPixelInfo();
     if (gIntroState != IntroState::None)
     {
@@ -151,7 +153,7 @@ paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags
     session->ViewFlags = viewFlags;
     session->QuadrantBackIndex = std::numeric_limits<uint32_t>::max();
     session->QuadrantFrontIndex = 0;
-    session->PaintStructs.clear();
+    session->SharedPaintStructPool = &_paintStructPool;
 
     std::fill(std::begin(session->Quadrants), std::end(session->Quadrants), nullptr);
     session->LastPS = nullptr;

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -38,7 +38,7 @@ namespace OpenRCT2
             std::shared_ptr<Ui::IUiContext> const _uiContext;
             std::vector<std::unique_ptr<paint_session>> _paintSessionPool;
             std::vector<paint_session*> _freePaintSessions;
-            PaintStructPool _paintStructPool;
+            PaintEntryPool _paintStructPool;
             time_t _lastSecond = 0;
             int32_t _currentFPS = 0;
             int32_t _frames = 0;

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -38,6 +38,7 @@ namespace OpenRCT2
             std::shared_ptr<Ui::IUiContext> const _uiContext;
             std::vector<std::unique_ptr<paint_session>> _paintSessionPool;
             std::vector<paint_session*> _freePaintSessions;
+            PaintStructPool _paintStructPool;
             time_t _lastSecond = 0;
             int32_t _currentFPS = 0;
             int32_t _frames = 0;


### PR DESCRIPTION
Some parks have so many tile elements on a single tile, and vertical screen column of tiles, that it exceeds the number of available paint structs for that paint session. This results in large areas of the screen undrawn.

All paint sessions now share a common pool of paint structs. I have used an unrolled linked list which allows each session to grab 512 paint structs at a time and only grab another set of 512 when they have been used up. This reduces the amount of thread locking involved when multithreaded drawing is enabled.

The amount of memory used will now be based on the complexity of the scene being drawn. Less memory in some cases, more in the cases that would have exceeded the original limit.