### PR TITLE
Add ARM SIMD routines in SW renderer on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,10 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
     set(X86_64 1)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*|amd64.*|AMD64.*")
     set(X86 1)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
+  set(ARM 1)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
+  set(AARCH64 1)
 endif()
 
 # Check if a flag exists and add it to the list of compiler (so, not linker) options

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -250,6 +250,10 @@ if((X86 OR X86_64) AND NOT MSVC)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/AVX2Drawing.cpp PROPERTIES COMPILE_FLAGS -mavx2)
 endif()
 
+if((ARM OR AARCH64) AND NOT MSVC)
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/NEONDrawing.cpp PROPERTIES COMPILE_FLAGS -mfpu=neon)
+endif()
+
 # Add headers check to verify all headers carry their dependencies.
 # Only valid for Clang for now:
 # - GCC 8 does not support -Wno-pragma-once-outside-header

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -179,11 +179,24 @@ constexpr uint16_t SPRITE_INDEX_NULL = 0xFFFF;
 #    define PLATFORM_X86
 #endif
 
+#if defined(__GNUC__) && defined(__arm__)
+#   define OPENRCT2_ARM
+#elif defined(_MSC_VER) && (defined(_M_ARM))
+#   define OPENRCT2_ARM
+#endif
+
+#if defined(__GNUC__) && defined(__aarch64__)
+#   define OPENRCT2_AARCH64
+#elif defined(_MSC_VER) && (defined(_M_ARM64))
+#   define OPENRCT2_AARCH64
+#endif
+
 #if defined(__LP64__) || defined(_WIN64)
 #    define PLATFORM_64BIT
 #else
 #    define PLATFORM_32BIT
 #endif
+
 
 // C99's restrict keywords guarantees the pointer in question, for the whole of its lifetime,
 // will be the only way to access a given memory region. In other words: there is no other pointer

--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -180,15 +180,15 @@ constexpr uint16_t SPRITE_INDEX_NULL = 0xFFFF;
 #endif
 
 #if defined(__GNUC__) && defined(__arm__)
-#   define OPENRCT2_ARM
+#    define OPENRCT2_ARM
 #elif defined(_MSC_VER) && (defined(_M_ARM))
-#   define OPENRCT2_ARM
+#    define OPENRCT2_ARM
 #endif
 
 #if defined(__GNUC__) && defined(__aarch64__)
-#   define OPENRCT2_AARCH64
+#    define OPENRCT2_AARCH64
 #elif defined(_MSC_VER) && (defined(_M_ARM64))
-#   define OPENRCT2_AARCH64
+#    define OPENRCT2_AARCH64
 #endif
 
 #if defined(__LP64__) || defined(_WIN64)
@@ -196,7 +196,6 @@ constexpr uint16_t SPRITE_INDEX_NULL = 0xFFFF;
 #else
 #    define PLATFORM_32BIT
 #endif
-
 
 // C99's restrict keywords guarantees the pointer in question, for the whole of its lifetime,
 // will be the only way to access a given memory region. In other words: there is no other pointer

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -568,6 +568,11 @@ void mask_init()
         log_verbose("registering SSE4.1 mask function");
         mask_fn = mask_sse4_1;
     }
+    else if (neon_available())
+    {
+        log_verbose("registering NEON mask function");
+        mask_fn = mask_neon;
+    }
     else
     {
         log_verbose("registering scalar mask function");

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -780,6 +780,9 @@ void mask_sse4_1(
 void mask_avx2(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
     int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+void mask_neon(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
 void mask_init();
 
 extern void (*mask_fn)(

--- a/src/openrct2/drawing/NEONDrawing.cpp
+++ b/src/openrct2/drawing/NEONDrawing.cpp
@@ -1,0 +1,77 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "../common.h"
+#include "../core/Guard.hpp"
+#include "Drawing.h"
+
+#ifdef __NEON__
+
+#    include <arm_neon.h>
+
+void mask_neon(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    if (width == 32)
+    {
+        const int8x16_t zero128 = {};
+        for (int32_t yy = 0; yy < height; yy++)
+        {
+            int32_t colourStep = yy * (colourWrap + 32);
+            int32_t maskStep = yy * (maskWrap + 32);
+            int32_t dstStep = yy * (dstWrap + 32);
+
+            // first half
+            const int8x16_t colour1 = _mm_lddqu_si128(reinterpret_cast<const int8x16_t*>(colourSrc + colourStep));
+            const int8x16_t mask1 = _mm_lddqu_si128(reinterpret_cast<const int8x16_t*>(maskSrc + maskStep));
+            const int8x16_t dest1 = _mm_lddqu_si128(reinterpret_cast<const int8x16_t*>(dst + dstStep));
+            const int8x16_t mc1 = vandq_s8(colour1, mask1);
+            const int8x16_t saturate1 = vceqq_s8(mc1, zero128);
+            // blended = (for each bit) if mc1 then satureate1 else dest1
+            const int8x16_t blended1_tmp1 = vandq_s8(mc1, saturate1);          // tmp1     = mc1 & saturate1
+            const int8x16_t blended1_tmp2 = vandq_s8(mc1, dest1);              // tmp2     = mc1 & dest1
+            const int8x16_t blended1 = vornq_s8(blended1_tmp1, blended1_tmp2); // blended1 = tmp1 | !tmp2
+
+            // second half
+            const int8x16_t colour2 = _mm_lddqu_si128(reinterpret_cast<const int8x16_t*>(colourSrc + 16 + colourStep));
+            const int8x16_t mask2 = _mm_lddqu_si128(reinterpret_cast<const int8x16_t*>(maskSrc + 16 + maskStep));
+            const int8x16_t dest2 = _mm_lddqu_si128(reinterpret_cast<const int8x16_t*>(dst + 16 + dstStep));
+            const int8x16_t mc2 = vandq_s8(colour2, mask2);
+            const int8x16_t saturate2 = vceqq_s8(mc2, zero128);
+            // blended = (for each bit) if mc1 then satureate1 else dest1
+            const int8x16_t blended2_tmp1 = vandq_s8(mc2, saturate2);          // tmp1     = mc1 & saturate1
+            const int8x16_t blended2_tmp2 = vandq_s8(mc2, des21);              // tmp2     = mc1 & dest1
+            const int8x16_t blended2 = vornq_s8(blended2_tmp1, blended2_tmp2); // blended2 = tmp1 | !tmp2
+
+            _mm_storeu_si128(reinterpret_cast<int8x16_t*>(dst + dstStep), blended1);
+            _mm_storeu_si128(reinterpret_cast<int8x16_t*>(dst + 16 + dstStep), blended2);
+        }
+    }
+    else
+    {
+        mask_scalar(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
+    }
+}
+
+#else
+
+#    if defined(OPENRCT2_ARM) || defined(OPENRCT2_AARCH64)
+#        error You have to compile this file with NEON enabled, when targeting ARM!
+#    endif
+
+void mask_neon(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    openrct2_assert(false, "ARM NEON function called on a CPU that doesn't support NEON");
+}
+
+#endif // __NEON__
+

--- a/src/openrct2/drawing/NEONDrawing.cpp
+++ b/src/openrct2/drawing/NEONDrawing.cpp
@@ -34,10 +34,8 @@ void mask_neon(
             const uint8x16_t dest1 = vld1q_u8(reinterpret_cast<const uint8_t*>(dst + dstStep));
             const uint8x16_t mc1 = vandq_u8(colour1, mask1);
             const uint8x16_t saturate1 = vceqq_u8(mc1, zero128);
-            // blended = (for each bit) if mc1 then satureate1 else dest1
-            const uint8x16_t blended1_tmp1 = vandq_u8(mc1, saturate1);          // tmp1     = mc1 & saturate1
-            const uint8x16_t blended1_tmp2 = vandq_u8(mc1, dest1);              // tmp2     = mc1 & dest1
-            const uint8x16_t blended1 = vornq_u8(blended1_tmp1, blended1_tmp2); // blended1 = tmp1 | !tmp2
+            // blended = (for each bit) if saturate1 then dest1 else mc1
+            const uint8x16_t blended1 = vbslq_u8(saturate1, dest1, mc1);
 
             // second half
             const uint8x16_t colour2 = vld1q_u8(reinterpret_cast<const uint8_t*>(colourSrc + 16 + colourStep));
@@ -45,10 +43,8 @@ void mask_neon(
             const uint8x16_t dest2 = vld1q_u8(reinterpret_cast<const uint8_t*>(dst + 16 + dstStep));
             const uint8x16_t mc2 = vandq_u8(colour2, mask2);
             const uint8x16_t saturate2 = vceqq_u8(mc2, zero128);
-            // blended = (for each bit) if mc1 then satureate1 else dest1
-            const uint8x16_t blended2_tmp1 = vandq_u8(mc2, saturate2);          // tmp1     = mc1 & saturate1
-            const uint8x16_t blended2_tmp2 = vandq_u8(mc2, dest2);              // tmp2     = mc1 & dest1
-            const uint8x16_t blended2 = vornq_u8(blended2_tmp1, blended2_tmp2); // blended2 = tmp1 | !tmp2
+            // blended = (for each bit) if saturate1 then dest1 else mc1
+            const uint8x16_t blended2 = vbslq_u8(saturate2, dest2, mc2);
 
             vst1q_u8(reinterpret_cast<uint8_t*>(dst + dstStep), blended1);
             vst1q_u8(reinterpret_cast<uint8_t*>(dst + 16 + dstStep), blended2);

--- a/src/openrct2/drawing/NEONDrawing.cpp
+++ b/src/openrct2/drawing/NEONDrawing.cpp
@@ -73,5 +73,4 @@ void mask_neon(
     openrct2_assert(false, "ARM NEON function called on a CPU that doesn't support NEON");
 }
 
-#endif // __NEON__
-
+#endif // defined(__ARM_NEON__) || defined(__ARM_NEON)

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -23,6 +23,11 @@
 #include <ctime>
 #include <random>
 
+#if defined(__linux__) && (defined(OPENRCT2_ARM) || defined(OPENRCT2_AARCH64))
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#endif
+
 int32_t squaredmetres_to_squaredfeet(int32_t squaredMetres)
 {
     // 1 metre squared = 10.7639104 feet squared
@@ -271,6 +276,17 @@ bool avx2_available()
 #endif
     return false;
 }
+
+bool neon_available()
+{
+#   if defined(__linux__) && defined(OPENRCT2_ARM)
+    return getauxval(AT_HWCAP) & HWCAP_NEON;
+#   elif defined(__linux__) && defined(OPENRCT2_AARCH64)
+    return getauxval(AT_HWCAP) & HWCAP_ASIMD;
+#   endif
+    return false;
+}
+
 
 static bool bitcount_popcnt_available()
 {

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -24,8 +24,8 @@
 #include <random>
 
 #if defined(__linux__) && (defined(OPENRCT2_ARM) || defined(OPENRCT2_AARCH64))
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
+#    include <asm/hwcap.h>
+#    include <sys/auxv.h>
 #endif
 
 int32_t squaredmetres_to_squaredfeet(int32_t squaredMetres)
@@ -279,14 +279,13 @@ bool avx2_available()
 
 bool neon_available()
 {
-#   if defined(__linux__) && defined(OPENRCT2_ARM)
+#if defined(__linux__) && defined(OPENRCT2_ARM)
     return getauxval(AT_HWCAP) & HWCAP_NEON;
-#   elif defined(__linux__) && defined(OPENRCT2_AARCH64)
+#elif defined(__linux__) && defined(OPENRCT2_AARCH64)
     return getauxval(AT_HWCAP) & HWCAP_ASIMD;
-#   endif
+#endif
     return false;
 }
-
 
 static bool bitcount_popcnt_available()
 {

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -36,6 +36,7 @@ bool writeentirefile(const utf8* path, const void* buffer, size_t length);
 
 bool sse41_available();
 bool avx2_available();
+bool neon_available();
 
 int32_t bitscanforward(int32_t source);
 int32_t bitscanforward(int64_t source);


### PR DESCRIPTION
This commit introduces an mask_neon function, which renders draws the
mask using the ARM NEON SIMD instruction set. This is based on the AVX
mask drawing function.

I do not know how to test for NEON support in non-Linux OSs, therefore
this commit only enables it on arm devices running Linux.

This commit has only been tested on an ARM 32-bit processor running
Linux, compiled with GCC. On my Sony Xperia X running SailfishOS
(32-bit ARM-based Linux distro) this boosts the performance on the title
screen from 8-12 FPS to 20-40 FPS (depending on how complex the scene
displayed screen actually is).