### PR TITLE
Fix Duplicate Entries in Free Food Ad Campaign

### DIFF
--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -94,7 +94,6 @@ private:
     void GetShopItems()
     {
         std::bitset<EnumValue(ShopItem::Count)> items = {};
-        ShopItems.clear();
         for (auto& curRide : GetRideManager())
         {
             auto rideEntry = curRide.GetRideEntry();
@@ -110,6 +109,7 @@ private:
             }
         }
 
+        ShopItems.clear();
         for (auto i = 0; i < EnumValue(ShopItem::Count); i++)
         {
             if (items[i])

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -94,6 +94,7 @@ private:
     void GetShopItems()
     {
         std::bitset<EnumValue(ShopItem::Count)> items = {};
+        ShopItems.clear();
         for (auto& curRide : GetRideManager())
         {
             auto rideEntry = curRide.GetRideEntry();


### PR DESCRIPTION
When opening and closing the drop down box to select a food or drink multiple times while attempting to create an ad campaign for free food vouchers, the game would duplicate the available food items in the list each time.

I discovered that it was because the vector used to populate this list wasn't being cleared each time the game went to gather the available shop items, so an easy fix is to clear it before continuing.