### PR TITLE
Fix #14587: Send queued packets before disconnecting the client

### DIFF
--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -155,6 +155,16 @@ void NetworkConnection::QueuePacket(NetworkPacket&& packet, bool front)
     }
 }
 
+void NetworkConnection::Disconnect()
+{
+    ShouldDisconnect = true;
+}
+
+bool NetworkConnection::IsValid() const
+{
+    return !ShouldDisconnect && Socket->GetStatus() == SocketStatus::Connected;
+}
+
 void NetworkConnection::SendQueuedPackets()
 {
     while (!_outboundPackets.empty() && SendPacket(_outboundPackets.front()))

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -35,7 +35,7 @@ public:
     NetworkKey Key;
     std::vector<uint8_t> Challenge;
     std::vector<const ObjectRepositoryItem*> RequestedObjects;
-    bool IsDisconnected = false;
+    bool ShouldDisconnect = false;
 
     NetworkConnection();
     ~NetworkConnection();
@@ -48,6 +48,11 @@ public:
         return QueuePacket(std::move(copy), front);
     }
 
+    // This will not immediately disconnect the client. The disconnect
+    // will happen post-tick.
+    void Disconnect();
+
+    bool IsValid() const;
     void SendQueuedPackets();
     void ResetLastPacketTime();
     bool ReceivedPacketRecently();

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -541,6 +541,7 @@ public:
         {
             shutdown(_socket, SHUT_RDWR);
         }
+        _status = SocketStatus::Closed;
     }
 
     size_t SendData(const void* buffer, size_t size) override


### PR DESCRIPTION
Users never got to see this:
![openrct2_2021-05-08_23-28-18bc7075ec70d8b530e](https://user-images.githubusercontent.com/5415177/117552707-c3e1dc80-b055-11eb-8796-00d301b4b1ed.png)

or this:
![openrct2_2021-05-08_23-29-32975c1ba29ba42e41b](https://user-images.githubusercontent.com/5415177/117552711-c7756380-b055-11eb-9c41-cdd0c3b4b7bc.png)

This happened because the socket was closed before it had the chance to send the packet with the auth status in it, this PR does the disconnect post-tick and ensures the packets are sent.