### PR TITLE
Fix #14523: suppress downloads if a directory exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,22 +401,28 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
     install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_CURRENT_BINARY_DIR}\" --target g2)")
     if (DOWNLOAD_TITLE_SEQUENCES)
         # Checks if this version of the title sequences are already installed, updates if necessary
+        # if /data/sequence exists, it will overwrite this anyways (see `install(DIRECTORY "data/" ...)` below)
+        # therefore, the existence of that directory will skip this download
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
                 ZIP_VERSION ${TITLE_SEQUENCE_VERSION}
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/sequence/
+                SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/sequence/
                 ZIP_URL ${TITLE_SEQUENCE_URL}
                 SHA1 ${TITLE_SEQUENCE_SHA1}
             )")
     endif ()
     if (DOWNLOAD_OBJECTS)
         # Checks if this version of the objects are already installed, updates if necessary
+        # if /data/object exists, it will overwrite this anyways (see `install(DIRECTORY "data/" ...)` below)
+        # therefore, the existence of that directory will skip this download
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
                 ZIP_VERSION ${OBJECTS_VERSION}
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/object/
+                SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/object/
                 ZIP_URL ${OBJECTS_URL}
                 SHA1 ${OBJECTS_SHA1}
             )")

--- a/cmake/download.cmake
+++ b/cmake/download.cmake
@@ -1,5 +1,6 @@
 function(download_openrct2_zip)
     set(oneValueArgs ZIP_VERSION DOWNLOAD_DIR ZIP_URL SHA1)
+    set(multiValueArgs SKIP_IF_EXISTS)
     cmake_parse_arguments(DOWNLOAD_OPENRCT2 "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN} )
 
@@ -15,9 +16,18 @@ function(download_openrct2_zip)
                 set(DOWNLOAD_ZIP 1)
             endif ()
         else ()
-        set(DOWNLOAD_ZIP 1)
+            set(DOWNLOAD_ZIP 1)
         endif ()
     endif ()
+
+    foreach(check_exist_dir ${DOWNLOAD_OPENRCT2_SKIP_IF_EXISTS})
+        if (EXISTS ${check_exist_dir})
+            message("${check_exist_dir} exists, skipping download")
+            set(DOWNLOAD_ZIP 0)
+            break()
+        endif ()
+    endforeach(check_exist_dir)
+
     if (DOWNLOAD_ZIP)
         message("Downloading ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}")
         file(DOWNLOAD


### PR DESCRIPTION
This adds a new argument to the download function to include a list of directories that would cause the download to be skipped, if populated.

This should allow the nightly PPA builds to function again, since the objects and sequence directories are prepopulated by that build.