### PR TITLE
Sort cache

### DIFF
--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -12,6 +12,7 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/localisation/StringIds.h>
+#include <openrct2/paint/Paint.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Sprite.h>
 
@@ -59,6 +60,11 @@ void window_main_update(rct_window* w)
 {
     if (!w->viewport)
         return;
+
+    for (auto* session : w->viewport->sessions)
+    {
+        PaintSessionFree(session);
+    }
 
     w->viewport->sessions.clear();
 }

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -21,10 +21,12 @@ static rct_widget window_main_widgets[] = {
     { WIDGETS_END },
 };
 
-void window_main_paint(rct_window *w, rct_drawpixelinfo *dpi);
+static void window_main_update(rct_window* w);
+static void window_main_paint(rct_window *w, rct_drawpixelinfo *dpi);
 
 static rct_window_event_list window_main_events([](auto& events)
 {
+    events.update = &window_main_update;
     events.paint = &window_main_paint;
 });
 // clang-format on
@@ -51,6 +53,14 @@ rct_window* window_main_open()
     window_footpath_reset_selected_path();
 
     return window;
+}
+
+void window_main_update(rct_window* w)
+{
+    if (!w->viewport)
+        return;
+
+    w->viewport->sessions.clear();
 }
 
 /**

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -363,7 +363,7 @@ static rct_viewport GetGiantViewport(int32_t mapSize, int32_t rotation, ZoomLeve
     return viewport;
 }
 
-static void RenderViewport(IDrawingEngine* drawingEngine, const rct_viewport& viewport, rct_drawpixelinfo& dpi)
+static void RenderViewport(IDrawingEngine* drawingEngine, rct_viewport& viewport, rct_drawpixelinfo& dpi)
 {
     // Ensure sprites appear regardless of rotation
     reset_all_sprite_quadrant_placements();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -944,8 +944,6 @@ static void viewport_paint_column(paint_session* session)
     {
         PaintDrawMoneyStructs(&session->DPI, session->PSStringHead);
     }
-
-    PaintSessionFree(session);
 }
 
 static void viewport_build_renderables(

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -1,4 +1,4 @@
-/*****************************************************************************
+﻿/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -116,10 +116,10 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, Peep* peep
 void viewport_update_smart_staff_follow(rct_window* window, Peep* peep);
 void viewport_update_smart_vehicle_follow(rct_window* window);
 void viewport_render(
-    rct_drawpixelinfo* dpi, const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom,
+    rct_drawpixelinfo* dpi, rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom,
     std::vector<RecordedPaintSession>* sessions = nullptr);
 void viewport_paint(
-    const rct_viewport* viewport, rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t right, int16_t bottom,
+    rct_viewport* viewport, rct_drawpixelinfo* dpi, int16_t left, int16_t top, int16_t right, int16_t bottom,
     std::vector<RecordedPaintSession>* sessions = nullptr);
 
 CoordsXYZ viewport_adjust_for_map_height(const ScreenCoordsXY& startCoords);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -156,6 +156,7 @@ struct rct_viewport
     ZoomLevel zoom;
     uint8_t var_11;
     VisibilityCache visibility;
+    std::vector<paint_session*> sessions;
 
     // Use this function on coordinates that are relative to the viewport zoom i.e. a peeps x, y position after transforming
     // from its x, y, z


### PR DESCRIPTION
This is a proof of concept currently and more for testing purposes. This currently renders tweening useless as it builds the render list per tick rather per frame now. The tweener needs to be changed to update the render list instead and not the entities. The way this is currently implemented is also not very practical.

It has however some promising results.
```
---- bpb.sv6 @ 1080p, zoom/position from save, avg. FPS ----
develop: 130 (mt off)
sort-cache: 270 (mt off)

develop: 260 (mt on)
sort-cache: 330 (mt on)
```
