### PR TITLE
Fix some actions for plugins

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -164,6 +164,7 @@ The following people are not part of the development team, but have been contrib
 * (evilclownattack)
 * Adam Bloom (adam-bloom)
 * Geoff B. (geoff-B)
+* Ryan D. (rctdude2)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/actions/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/ParkMarketingAction.cpp
@@ -32,7 +32,7 @@ void ParkMarketingAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit("type", _type);
     visitor.Visit("item", _item);
-    visitor.Visit("length", _numWeeks);
+    visitor.Visit("duration", _numWeeks);
 }
 
 uint16_t ParkMarketingAction::GetActionFlags() const

--- a/src/openrct2/actions/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/ParkMarketingAction.cpp
@@ -28,6 +28,13 @@ ParkMarketingAction::ParkMarketingAction(int32_t type, int32_t item, int32_t num
 {
 }
 
+void ParkMarketingAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("type", _type);
+    visitor.Visit("item", _item);
+    visitor.Visit("length", _numWeeks);
+}
+
 uint16_t ParkMarketingAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/ParkMarketingAction.h
+++ b/src/openrct2/actions/ParkMarketingAction.h
@@ -22,6 +22,8 @@ public:
     ParkMarketingAction() = default;
     ParkMarketingAction(int32_t type, int32_t item, int32_t numWeeks);
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -24,6 +24,13 @@ ParkSetDateAction::ParkSetDateAction(int32_t year, int32_t month, int32_t day)
 {
 }
 
+void ParkSetDateAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("year", _year);
+    visitor.Visit("month", _month);
+    visitor.Visit("day", _day);
+}
+
 uint16_t ParkSetDateAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/ParkSetDateAction.h
+++ b/src/openrct2/actions/ParkSetDateAction.h
@@ -22,6 +22,8 @@ public:
     ParkSetDateAction() = default;
     ParkSetDateAction(int32_t year, int32_t month, int32_t day);
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/ParkSetLoanAction.cpp
+++ b/src/openrct2/actions/ParkSetLoanAction.cpp
@@ -22,6 +22,11 @@ ParkSetLoanAction::ParkSetLoanAction(money32 value)
 {
 }
 
+void ParkSetLoanAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("loanAmount", _value);
+}
+
 uint16_t ParkSetLoanAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/ParkSetLoanAction.cpp
+++ b/src/openrct2/actions/ParkSetLoanAction.cpp
@@ -24,7 +24,7 @@ ParkSetLoanAction::ParkSetLoanAction(money32 value)
 
 void ParkSetLoanAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
-    visitor.Visit("loanAmount", _value);
+    visitor.Visit("value", _value);
 }
 
 uint16_t ParkSetLoanAction::GetActionFlags() const

--- a/src/openrct2/actions/ParkSetLoanAction.h
+++ b/src/openrct2/actions/ParkSetLoanAction.h
@@ -20,6 +20,8 @@ public:
     ParkSetLoanAction() = default;
     ParkSetLoanAction(money32 value);
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/SetParkEntranceFeeAction.cpp
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.cpp
@@ -22,7 +22,7 @@ SetParkEntranceFeeAction::SetParkEntranceFeeAction(money16 fee)
 
 void SetParkEntranceFeeAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
-    visitor.Visit("fee", _fee);
+    visitor.Visit("value", _fee);
 }
 
 uint16_t SetParkEntranceFeeAction::GetActionFlags() const

--- a/src/openrct2/actions/SetParkEntranceFeeAction.cpp
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.cpp
@@ -20,6 +20,11 @@ SetParkEntranceFeeAction::SetParkEntranceFeeAction(money16 fee)
 {
 }
 
+void SetParkEntranceFeeAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("fee", _fee);
+}
+
 uint16_t SetParkEntranceFeeAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/SetParkEntranceFeeAction.h
+++ b/src/openrct2/actions/SetParkEntranceFeeAction.h
@@ -20,6 +20,8 @@ public:
     SetParkEntranceFeeAction() = default;
     SetParkEntranceFeeAction(money16 fee);
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/actions/SignSetNameAction.cpp
+++ b/src/openrct2/actions/SignSetNameAction.cpp
@@ -28,7 +28,7 @@ SignSetNameAction::SignSetNameAction(BannerIndex bannerIndex, const std::string&
 
 void SignSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
-    visitor.Visit("banner", _bannerIndex);
+    visitor.Visit("id", _bannerIndex);
     visitor.Visit("name", _name);
 }
 

--- a/src/openrct2/actions/SignSetNameAction.cpp
+++ b/src/openrct2/actions/SignSetNameAction.cpp
@@ -26,6 +26,12 @@ SignSetNameAction::SignSetNameAction(BannerIndex bannerIndex, const std::string&
 {
 }
 
+void SignSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("banner", _bannerIndex);
+    visitor.Visit("name", _name);
+}
+
 uint16_t SignSetNameAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/SignSetNameAction.h
+++ b/src/openrct2/actions/SignSetNameAction.h
@@ -21,6 +21,8 @@ public:
     SignSetNameAction() = default;
     SignSetNameAction(BannerIndex bannerIndex, const std::string& name);
 
+    void AcceptParameters(GameActionParameterVisitor & visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser & stream) override;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 27;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 28;
 
 #    ifndef DISABLE_NETWORK
     class ScSocketBase;


### PR DESCRIPTION
If an action doesn't have an AcceptParameters method, the parameters passed in executeAction will be ignored and the action will fail.

I only fixed the ones I found that were trivial, there are still some actions that involve coordinates that don't have AcceptParameters that I didn't modify because I'm not sure how they work in plugins. Also, I'm guessing this might need a network version increment, but I didn't do that because I wanted to ask first.