### PR TITLE
Re-enable 32bit replay tests

### DIFF
--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -71,10 +71,6 @@ protected:
 
 TEST_P(ReplayTests, RunReplay)
 {
-#ifdef PLATFORM_32BIT
-    log_warning("Replay Tests have not been performed. OpenRCT2/OpenRCT2#11279.");
-    return;
-#else
     gOpenRCT2Headless = true;
     gOpenRCT2NoGraphics = true;
     core_init();
@@ -103,7 +99,6 @@ TEST_P(ReplayTests, RunReplay)
     }
     ASSERT_FALSE(replayManager->IsReplaying());
     ASSERT_FALSE(replayManager->IsPlaybackStateMismatching());
-#endif
 }
 
 static void PrintTo(const ReplayTestData& testData, std::ostream* os)


### PR DESCRIPTION
After the changes made to the serialise functions the 32bit replay tests can now be re-enabled

Fixes #11279