### PR TITLE
Change Vehicle Rotation namings in accordance with OpenRCT2 Codestyle

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -344,7 +344,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
     void CompareSpriteDataVehicle(
         const Vehicle& spriteBase, const Vehicle& spriteCmp, GameStateSpriteChange_t& changeData) const
     {
-        COMPARE_FIELD(Vehicle, vehicle_sprite_type);
+        COMPARE_FIELD(Vehicle, Pitch);
         COMPARE_FIELD(Vehicle, bank_rotation);
         COMPARE_FIELD(Vehicle, remaining_distance);
         COMPARE_FIELD(Vehicle, velocity);

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2432,7 +2432,7 @@ static void peep_choose_seat_from_car(Peep* peep, Ride* ride, Vehicle* vehicle)
 
     if (ride->mode == RideMode::ForwardRotation || ride->mode == RideMode::BackwardRotation)
     {
-        chosen_seat = (((~vehicle->vehicle_sprite_type + 1) >> 3) & 0xF) * 2;
+        chosen_seat = (((~vehicle->Pitch + 1) >> 3) & 0xF) * 2;
         if (vehicle->next_free_seat & 1)
         {
             chosen_seat++;
@@ -2547,7 +2547,7 @@ bool Guest::FindVehicleToEnter(Ride* ride, std::vector<uint8_t>& car_array)
 
         if (ride->mode == RideMode::ForwardRotation || ride->mode == RideMode::BackwardRotation)
         {
-            uint8_t position = (((~vehicle->vehicle_sprite_type + 1) >> 3) & 0xF) * 2;
+            uint8_t position = (((~vehicle->Pitch + 1) >> 3) & 0xF) * 2;
             if (vehicle->peep[position] != SPRITE_INDEX_NULL)
                 continue;
         }

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -224,8 +224,8 @@ struct rct1_unk_sprite : RCT12SpriteBase
 
 struct rct1_vehicle : RCT12SpriteBase
 {
-    uint8_t Pitch; // 0x1F
-    uint8_t bank_rotation;       // 0x20
+    uint8_t Pitch;         // 0x1F
+    uint8_t bank_rotation; // 0x20
     uint8_t pad_21[3];
     int32_t remaining_distance; // 0x24
     int32_t velocity;           // 0x28

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -224,7 +224,7 @@ struct rct1_unk_sprite : RCT12SpriteBase
 
 struct rct1_vehicle : RCT12SpriteBase
 {
-    uint8_t vehicle_sprite_type; // 0x1F
+    uint8_t Pitch; // 0x1F
     uint8_t bank_rotation;       // 0x20
     uint8_t pad_21[3];
     int32_t remaining_distance; // 0x24

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2699,7 +2699,7 @@ template<> void S4Importer::ImportEntity<Vehicle>(const RCT12SpriteBase& srcBase
     dst->var_CE = src->var_CE;
     dst->var_D3 = src->var_D3;
     dst->scream_sound_id = OpenRCT2::Audio::SoundId::Null;
-    dst->vehicle_sprite_type = src->vehicle_sprite_type;
+    dst->Pitch = src->Pitch;
     dst->bank_rotation = src->bank_rotation;
 
     // Seat rotation was not in RCT1

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -453,7 +453,7 @@ assert_struct_size(rct_scores_entry, 0x02B0);
 
 struct RCT2SpriteVehicle : RCT12SpriteBase
 {
-    uint8_t vehicle_sprite_type; // 0x1F
+    uint8_t Pitch; // 0x1F
     uint8_t bank_rotation;       // 0x20
     uint8_t pad_21[3];
     int32_t remaining_distance; // 0x24

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -453,8 +453,8 @@ assert_struct_size(rct_scores_entry, 0x02B0);
 
 struct RCT2SpriteVehicle : RCT12SpriteBase
 {
-    uint8_t Pitch; // 0x1F
-    uint8_t bank_rotation;       // 0x20
+    uint8_t Pitch;         // 0x1F
+    uint8_t bank_rotation; // 0x20
     uint8_t pad_21[3];
     int32_t remaining_distance; // 0x24
     int32_t velocity;           // 0x28

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1087,7 +1087,7 @@ template<> void S6Exporter::ExportEntity(RCT2SpriteVehicle* dst, const Vehicle* 
 
     ExportEntityCommonProperties(dst, src);
     dst->type = EnumValue(src->SubType);
-    dst->vehicle_sprite_type = src->vehicle_sprite_type;
+    dst->Pitch = src->Pitch;
     dst->bank_rotation = src->bank_rotation;
     dst->remaining_distance = src->remaining_distance;
     dst->velocity = src->velocity;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1500,7 +1500,7 @@ template<> void S6Importer::ImportEntity<Vehicle>(const RCT12SpriteBase& baseSrc
 
     ImportEntityCommonProperties(dst, src);
     dst->SubType = Vehicle::Type(src->type);
-    dst->vehicle_sprite_type = src->vehicle_sprite_type;
+    dst->Pitch = src->Pitch;
     dst->bank_rotation = src->bank_rotation;
     dst->remaining_distance = src->remaining_distance;
     dst->velocity = src->velocity;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -57,7 +57,7 @@ Vehicle* cable_lift_segment_create(
     current->var_C8 = 0;
     current->var_CA = 0;
     current->scream_sound_id = OpenRCT2::Audio::SoundId::Null;
-    current->vehicle_sprite_type = 0;
+    current->Pitch = 0;
     current->bank_rotation = 0;
     for (auto& peep : current->peep)
     {
@@ -285,11 +285,11 @@ bool Vehicle::CableLiftUpdateTrackMotionForwards()
 
         sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
-        vehicle_sprite_type = moveInfo->vehicle_sprite_type;
+        Pitch = moveInfo->Pitch;
 
         if (remaining_distance >= 13962)
         {
-            acceleration += dword_9A2970[vehicle_sprite_type];
+            acceleration += dword_9A2970[Pitch];
         }
     }
     return true;
@@ -351,11 +351,11 @@ bool Vehicle::CableLiftUpdateTrackMotionBackwards()
 
         sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
-        vehicle_sprite_type = moveInfo->vehicle_sprite_type;
+        Pitch = moveInfo->Pitch;
 
         if (remaining_distance < 0)
         {
-            acceleration += dword_9A2970[vehicle_sprite_type];
+            acceleration += dword_9A2970[Pitch];
         }
     }
     return true;
@@ -386,7 +386,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
 
     for (Vehicle* vehicle = frontVehicle; vehicle != nullptr;)
     {
-        vehicle->acceleration = dword_9A2970[vehicle->vehicle_sprite_type];
+        vehicle->acceleration = dword_9A2970[vehicle->Pitch];
         _vehicleUnkF64E10 = 1;
         vehicle->remaining_distance += _vehicleVelocityF64E0C;
 
@@ -410,7 +410,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
                         _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                         _vehicleVelocityF64E0C -= vehicle->remaining_distance - 13962;
                         vehicle->remaining_distance = 13962;
-                        vehicle->acceleration += dword_9A2970[vehicle->vehicle_sprite_type];
+                        vehicle->acceleration += dword_9A2970[vehicle->Pitch];
                         _vehicleUnkF64E10++;
                         continue;
                     }
@@ -426,7 +426,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
                         _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                         _vehicleVelocityF64E0C -= vehicle->remaining_distance + 1;
                         vehicle->remaining_distance = -1;
-                        vehicle->acceleration += dword_9A2970[vehicle->vehicle_sprite_type];
+                        vehicle->acceleration += dword_9A2970[vehicle->Pitch];
                         _vehicleUnkF64E10++;
                     }
                 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4138,7 +4138,7 @@ static Vehicle* vehicle_create_car(
     vehicle->animation_frame = 0;
     vehicle->var_C8 = 0;
     vehicle->scream_sound_id = OpenRCT2::Audio::SoundId::Null;
-    vehicle->vehicle_sprite_type = 0;
+    vehicle->Pitch = 0;
     vehicle->bank_rotation = 0;
     vehicle->target_seat_rotation = 4;
     vehicle->seat_rotation = 4;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1911,7 +1911,7 @@ void Vehicle::UpdateMeasurements()
 
         curRide->IncreaseNumShelteredSections();
 
-        if (vehicle_sprite_type != 0)
+        if (Pitch != 0)
         {
             curRide->num_sheltered_sections |= ShelteredSectionsBits::RotatingWhileSheltered;
         }
@@ -2008,7 +2008,7 @@ void Vehicle::Update()
         auto vehicleEntry = &rideEntry->vehicles[vehicle_type];
         if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED) && curRide->breakdown_reason_pending == BREAKDOWN_SAFETY_CUT_OUT)
         {
-            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WATER_RIDE) || (vehicle_sprite_type == 2 && velocity <= 0x20000))
+            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WATER_RIDE) || (Pitch == 2 && velocity <= 0x20000))
             {
                 SetUpdateFlag(VEHICLE_UPDATE_FLAG_ZERO_VELOCITY);
             }
@@ -2234,7 +2234,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
 
     if (curRide->mode == RideMode::ForwardRotation || curRide->mode == RideMode::BackwardRotation)
     {
-        uint8_t seat = ((-vehicle_sprite_type) / 8) & 0xF;
+        uint8_t seat = ((-Pitch) / 8) & 0xF;
         if (peep[seat] != SPRITE_INDEX_NULL)
         {
             curRide->stations[current_station].TrainAtStation = RideStation::NO_TRAIN;
@@ -2521,7 +2521,7 @@ void Vehicle::UpdateWaitingToDepart()
     {
         if (curRide->mode == RideMode::ForwardRotation || curRide->mode == RideMode::BackwardRotation)
         {
-            uint8_t seat = ((-vehicle_sprite_type) >> 3) & 0xF;
+            uint8_t seat = ((-Pitch) >> 3) & 0xF;
             if (peep[seat * 2] == SPRITE_INDEX_NULL)
             {
                 if (num_peeps == 0)
@@ -2647,13 +2647,13 @@ void Vehicle::UpdateWaitingToDepart()
                 }
             }
             current_time = -1;
-            vehicle_sprite_type = 0;
+            Pitch = 0;
             bank_rotation = 0;
             UpdateTopSpinOperating();
             break;
         case RideMode::ForwardRotation:
         case RideMode::BackwardRotation:
-            SetState(Vehicle::Status::FerrisWheelRotating, vehicle_sprite_type);
+            SetState(Vehicle::Status::FerrisWheelRotating, Pitch);
             var_CE = 0;
             ferris_wheel_var_0 = 8;
             ferris_wheel_var_1 = 8;
@@ -2690,19 +2690,19 @@ void Vehicle::UpdateWaitingToDepart()
             break;
         case RideMode::SpaceRings:
             SetState(Vehicle::Status::SpaceRingsOperating);
-            vehicle_sprite_type = 0;
+            Pitch = 0;
             current_time = -1;
             UpdateSpaceRingsOperating();
             break;
         case RideMode::HauntedHouse:
             SetState(Vehicle::Status::HauntedHouseOperating);
-            vehicle_sprite_type = 0;
+            Pitch = 0;
             current_time = -1;
             UpdateHauntedHouseOperating();
             break;
         case RideMode::CrookedHouse:
             SetState(Vehicle::Status::CrookedHouseOperating);
-            vehicle_sprite_type = 0;
+            Pitch = 0;
             current_time = -1;
             UpdateCrookedHouseOperating();
             break;
@@ -3677,9 +3677,9 @@ void Vehicle::UpdateCrashSetup()
         trainVehicle->sub_state = 0;
         int32_t trainX = stru_9A3AC4[trainVehicle->sprite_direction / 2].x;
         int32_t trainY = stru_9A3AC4[trainVehicle->sprite_direction / 2].y;
-        auto trainZ = Unk9A38D4[trainVehicle->vehicle_sprite_type] >> 23;
+        auto trainZ = Unk9A38D4[trainVehicle->Pitch] >> 23;
 
-        int32_t ecx = Unk9A37E4[trainVehicle->vehicle_sprite_type] >> 15;
+        int32_t ecx = Unk9A37E4[trainVehicle->Pitch] >> 15;
         trainX *= ecx;
         trainY *= ecx;
         trainX >>= 16;
@@ -4129,7 +4129,7 @@ void Vehicle::UpdateUnloadingPassengers()
 
     if (curRide->mode == RideMode::ForwardRotation || curRide->mode == RideMode::BackwardRotation)
     {
-        uint8_t seat = ((-vehicle_sprite_type) >> 3) & 0xF;
+        uint8_t seat = ((-Pitch) >> 3) & 0xF;
         if (restraints_position == 255 && (peep[seat * 2] != SPRITE_INDEX_NULL))
         {
             next_free_seat -= 2;
@@ -4775,10 +4775,10 @@ void Vehicle::UpdateSwinging()
     if (spriteType != -128)
     {
         current_time++;
-        if (static_cast<uint8_t>(spriteType) != vehicle_sprite_type)
+        if (static_cast<uint8_t>(spriteType) != Pitch)
         {
             // Used to know which sprite to draw
-            vehicle_sprite_type = static_cast<uint8_t>(spriteType);
+            Pitch = static_cast<uint8_t>(spriteType);
             Invalidate();
         }
         return;
@@ -4853,14 +4853,14 @@ void Vehicle::UpdateFerrisWheelRotating()
         ferris_wheel_var_1 = curFerrisWheelVar0;
     }
 
-    uint8_t rotation = vehicle_sprite_type;
+    uint8_t rotation = Pitch;
     if (curRide->mode == RideMode::ForwardRotation)
         rotation++;
     else
         rotation--;
 
     rotation &= 0x7F;
-    vehicle_sprite_type = rotation;
+    Pitch = rotation;
 
     if (rotation == sub_state)
         var_CE++;
@@ -4874,7 +4874,7 @@ void Vehicle::UpdateFerrisWheelRotating()
         subState--;
     subState &= 0x7F;
 
-    if (subState == vehicle_sprite_type)
+    if (subState == Pitch)
     {
         bool shouldStop = true;
         if (curRide->status != RIDE_STATUS_CLOSED)
@@ -4901,7 +4901,7 @@ void Vehicle::UpdateFerrisWheelRotating()
         subState -= 8;
     subState &= 0x7F;
 
-    if (subState != vehicle_sprite_type)
+    if (subState != Pitch)
         return;
 
     SetState(Vehicle::Status::Arriving);
@@ -4923,9 +4923,9 @@ void Vehicle::UpdateSimulatorOperating()
     if (al != 0xFF)
     {
         current_time++;
-        if (al == vehicle_sprite_type)
+        if (al == Pitch)
             return;
-        vehicle_sprite_type = al;
+        Pitch = al;
         Invalidate();
         return;
     }
@@ -4978,9 +4978,9 @@ void Vehicle::UpdateRotating()
     if (sprite != 0xFF)
     {
         current_time = static_cast<uint16_t>(time);
-        if (sprite == vehicle_sprite_type)
+        if (sprite == Pitch)
             return;
-        vehicle_sprite_type = sprite;
+        Pitch = sprite;
         Invalidate();
         return;
     }
@@ -5038,9 +5038,9 @@ void Vehicle::UpdateSpaceRingsOperating()
     if (spriteType != 255)
     {
         current_time++;
-        if (spriteType != vehicle_sprite_type)
+        if (spriteType != Pitch)
         {
-            vehicle_sprite_type = spriteType;
+            Pitch = spriteType;
             Invalidate();
         }
     }
@@ -5060,15 +5060,15 @@ void Vehicle::UpdateHauntedHouseOperating()
     if (_vehicleBreakdown == 0)
         return;
 
-    if (vehicle_sprite_type != 0)
+    if (Pitch != 0)
     {
         if (gCurrentTicks & 1)
         {
-            vehicle_sprite_type++;
+            Pitch++;
             Invalidate();
 
-            if (vehicle_sprite_type == 19)
-                vehicle_sprite_type = 0;
+            if (Pitch == 19)
+                Pitch = 0;
         }
     }
 
@@ -5086,7 +5086,7 @@ void Vehicle::UpdateHauntedHouseOperating()
             OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::HauntedHouseScare, { x, y, z });
             break;
         case 75:
-            vehicle_sprite_type = 1;
+            Pitch = 1;
             Invalidate();
             break;
         case 400:
@@ -5096,7 +5096,7 @@ void Vehicle::UpdateHauntedHouseOperating()
             OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::HauntedHouseScare, { x, y, z });
             break;
         case 775:
-            vehicle_sprite_type = 1;
+            Pitch = 1;
             Invalidate();
             break;
         case 1100:
@@ -5139,9 +5139,9 @@ void Vehicle::UpdateTopSpinOperating()
     if (rotation != 0xFF)
     {
         current_time = current_time + 1;
-        if (rotation != vehicle_sprite_type)
+        if (rotation != Pitch)
         {
-            vehicle_sprite_type = rotation;
+            Pitch = rotation;
             Invalidate();
         }
         rotation = sprite_map[current_time].bank_rotation;
@@ -5654,13 +5654,13 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
         for (Vehicle* vehicle2 = GetEntity<Vehicle>(sprite_index); vehicle2 != nullptr;
              vehicle2 = GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
         {
-            if (vehicle2->vehicle_sprite_type < 1)
+            if (vehicle2->Pitch < 1)
                 continue;
-            if (vehicle2->vehicle_sprite_type <= 4)
+            if (vehicle2->Pitch <= 4)
                 return ProduceScreamSound(totalNumPeeps);
-            if (vehicle2->vehicle_sprite_type < 9)
+            if (vehicle2->Pitch < 9)
                 continue;
-            if (vehicle2->vehicle_sprite_type <= 15)
+            if (vehicle2->Pitch <= 15)
                 return ProduceScreamSound(totalNumPeeps);
         }
         return OpenRCT2::Audio::SoundId::Null;
@@ -5672,13 +5672,13 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
     for (Vehicle* vehicle2 = GetEntity<Vehicle>(sprite_index); vehicle2 != nullptr;
          vehicle2 = GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
     {
-        if (vehicle2->vehicle_sprite_type < 5)
+        if (vehicle2->Pitch < 5)
             continue;
-        if (vehicle2->vehicle_sprite_type <= 8)
+        if (vehicle2->Pitch <= 8)
             return ProduceScreamSound(totalNumPeeps);
-        if (vehicle2->vehicle_sprite_type < 17)
+        if (vehicle2->Pitch < 17)
             continue;
-        if (vehicle2->vehicle_sprite_type <= 23)
+        if (vehicle2->Pitch <= 23)
             return ProduceScreamSound(totalNumPeeps);
     }
     return OpenRCT2::Audio::SoundId::Null;
@@ -5728,7 +5728,7 @@ OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps
  */
 GForces Vehicle::GetGForces() const
 {
-    int32_t gForceVert = ((static_cast<int64_t>(0x280000)) * Unk9A37E4[vehicle_sprite_type]) >> 32;
+    int32_t gForceVert = ((static_cast<int64_t>(0x280000)) * Unk9A37E4[Pitch]) >> 32;
     gForceVert = ((static_cast<int64_t>(gForceVert)) * Unk9A39C4[bank_rotation]) >> 32;
     int32_t lateralFactor = 0, vertFactor = 0;
 
@@ -6569,7 +6569,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
             gForces.LateralG = std::abs(gForces.LateralG);
             if (gForces.LateralG <= 150)
             {
-                if (dword_9A2970[vehicle_sprite_type] < 0)
+                if (dword_9A2970[Pitch] < 0)
                 {
                     if (gForces.VerticalG > -40)
                     {
@@ -6582,7 +6582,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
                 }
             }
 
-            if (vehicle_sprite_type != 8)
+            if (Pitch != 8)
             {
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_DERAILED;
             }
@@ -6596,7 +6596,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
         {
             auto gForces = GetGForces();
 
-            if (dword_9A2970[vehicle_sprite_type] < 0)
+            if (dword_9A2970[Pitch] < 0)
             {
                 if (gForces.VerticalG > -45)
                 {
@@ -6611,7 +6611,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
                 }
             }
 
-            if (vehicle_sprite_type != 8 && vehicle_sprite_type != 55)
+            if (Pitch != 8 && Pitch != 55)
             {
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_DERAILED;
             }
@@ -7283,7 +7283,7 @@ void Vehicle::UpdateAdditionalAnimation()
                             || (status != Vehicle::Status::MovingToEndOfStation && status != Vehicle::Status::Arriving))
                         {
                             int32_t typeIndex = [&] {
-                                switch (vehicle_sprite_type)
+                                switch (Pitch)
                                 {
                                     case 2:
                                         // uphill
@@ -8325,11 +8325,11 @@ loc_6DAEB9:
         unk_F64E20 = loc;
         sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
-        vehicle_sprite_type = moveInfo->vehicle_sprite_type;
+        Pitch = moveInfo->Pitch;
 
-        moveInfovehicleSpriteType = moveInfo->vehicle_sprite_type;
+        moveInfovehicleSpriteType = moveInfo->Pitch;
 
-        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_25) && moveInfo->vehicle_sprite_type != 0)
+        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_25) && moveInfo->Pitch != 0)
         {
             SwingSprite = 0;
             SwingPosition = 0;
@@ -8635,10 +8635,10 @@ loc_6DBA33:;
         unk_F64E20 = loc;
         sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
-        vehicle_sprite_type = moveInfo->vehicle_sprite_type;
-        moveInfoVehicleSpriteType = moveInfo->vehicle_sprite_type;
+        Pitch = moveInfo->Pitch;
+        moveInfoVehicleSpriteType = moveInfo->Pitch;
 
-        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_25) && vehicle_sprite_type != 0)
+        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_25) && Pitch != 0)
         {
             SwingSprite = 0;
             SwingPosition = 0;
@@ -8715,7 +8715,7 @@ void Vehicle::UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* ri
     int32_t direction{};
 
     _vehicleUnkF64E10 = 1;
-    acceleration = dword_9A2970[vehicle_sprite_type];
+    acceleration = dword_9A2970[Pitch];
     if (!HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
     {
         remaining_distance = _vehicleVelocityF64E0C + remaining_distance;
@@ -8989,11 +8989,11 @@ loc_6DC743:
     unk_F64E20 = trackPos;
     sprite_direction = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
-    vehicle_sprite_type = moveInfo->vehicle_sprite_type;
+    Pitch = moveInfo->Pitch;
 
     if (rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_25)
     {
-        if (vehicle_sprite_type != 0)
+        if (Pitch != 0)
         {
             SwingSprite = 0;
             SwingPosition = 0;
@@ -9023,7 +9023,7 @@ loc_6DC99A:
     {
         goto loc_6DCDE4;
     }
-    acceleration = dword_9A2970[vehicle_sprite_type];
+    acceleration = dword_9A2970[Pitch];
     _vehicleUnkF64E10++;
     goto loc_6DC462;
 
@@ -9105,11 +9105,11 @@ loc_6DCC2C:
     unk_F64E20 = trackPos;
     sprite_direction = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
-    vehicle_sprite_type = moveInfo->vehicle_sprite_type;
+    Pitch = moveInfo->Pitch;
 
     if (rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_25)
     {
-        if (vehicle_sprite_type != 0)
+        if (Pitch != 0)
         {
             SwingSprite = 0;
             SwingPosition = 0;
@@ -9134,7 +9134,7 @@ loc_6DCD2B:
     {
         goto loc_6DCDE4;
     }
-    acceleration += dword_9A2970[vehicle_sprite_type];
+    acceleration += dword_9A2970[Pitch];
     _vehicleUnkF64E10++;
     goto loc_6DCA9A;
 
@@ -9333,12 +9333,12 @@ int32_t Vehicle::UpdateTrackMotionMiniGolf(int32_t* outStation)
                 spin_speed = std::clamp(spin_speed, VEHICLE_MIN_SPIN_SPEED_WATER_RIDE, VEHICLE_MAX_SPIN_SPEED_WATER_RIDE);
             }
 
-            if (vehicle_sprite_type != 0)
+            if (Pitch != 0)
             {
                 poweredAcceleration = std::max(0, poweredAcceleration);
                 if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING)
                 {
-                    if (vehicle_sprite_type == 2)
+                    if (Pitch == 2)
                     {
                         spin_speed = 0;
                     }
@@ -9442,7 +9442,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
             spin_speed = std::clamp(spin_speed, VEHICLE_MIN_SPIN_SPEED_WATER_RIDE, VEHICLE_MAX_SPIN_SPEED_WATER_RIDE);
         }
 
-        if (vehicle_sprite_type != 0)
+        if (Pitch != 0)
         {
             if (poweredAcceleration < 0)
             {
@@ -9452,7 +9452,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
             if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING)
             {
                 // If the vehicle is on the up slope kill the spin speedModifier
-                if (vehicle_sprite_type == 2)
+                if (Pitch == 2)
                 {
                     spin_speed = 0;
                 }
@@ -9540,7 +9540,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         {
             car->UpdateAdditionalAnimation();
         }
-        car->acceleration = dword_9A2970[car->vehicle_sprite_type];
+        car->acceleration = dword_9A2970[car->Pitch];
         _vehicleUnkF64E10 = 1;
 
         if (!car->HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
@@ -9569,7 +9569,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
                     {
                         break;
                     }
-                    car->acceleration += dword_9A2970[car->vehicle_sprite_type];
+                    car->acceleration += dword_9A2970[car->Pitch];
                     _vehicleUnkF64E10++;
                     continue;
                 }
@@ -9589,7 +9589,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
                 {
                     break;
                 }
-                car->acceleration = dword_9A2970[car->vehicle_sprite_type];
+                car->acceleration = dword_9A2970[car->Pitch];
                 _vehicleUnkF64E10++;
                 continue;
             }

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -43,7 +43,7 @@ struct rct_vehicle_info
     int16_t y;                   // 0x02
     int16_t z;                   // 0x04
     uint8_t direction;           // 0x06
-    uint8_t vehicle_sprite_type; // 0x07
+    uint8_t Pitch; // 0x07
     uint8_t bank_rotation;       // 0x08
 };
 
@@ -98,7 +98,7 @@ struct Vehicle : SpriteBase
     };
 
     Type SubType;
-    uint8_t vehicle_sprite_type;
+    uint8_t Pitch;
     uint8_t bank_rotation;
     int32_t remaining_distance;
     int32_t velocity;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -39,12 +39,12 @@ struct GForces
 // Size: 0x09
 struct rct_vehicle_info
 {
-    int16_t x;                   // 0x00
-    int16_t y;                   // 0x02
-    int16_t z;                   // 0x04
-    uint8_t direction;           // 0x06
-    uint8_t Pitch; // 0x07
-    uint8_t bank_rotation;       // 0x08
+    int16_t x;             // 0x00
+    int16_t y;             // 0x02
+    int16_t z;             // 0x04
+    uint8_t direction;     // 0x06
+    uint8_t Pitch;         // 0x07
+    uint8_t bank_rotation; // 0x08
 };
 
 struct SoundIdVolume;

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -2499,7 +2499,7 @@ static void vehicle_sprite_24(
     }
     if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_CORKSCREWS)
     {
-        int32_t eax = ((vehicle->vehicle_sprite_type - 24) * 4);
+        int32_t eax = ((vehicle->Pitch - 24) * 4);
         int32_t ecx = (imageDirection / 8) + eax + 144;
         int32_t ebx = (((imageDirection / 8) + eax) * vehicleEntry->base_num_frames) + vehicleEntry->corkscrew_image_id;
         vehicle_sprite_paint_6D520E(session, vehicle, ebx, ecx, z, vehicleEntry);
@@ -2995,7 +2995,7 @@ static void vehicle_visual_splash2_effect(paint_session* session, int32_t z, con
     {
         return;
     }
-    if (vehicle->vehicle_sprite_type != 0)
+    if (vehicle->Pitch != 0)
     {
         return;
     }
@@ -3018,7 +3018,7 @@ static void vehicle_visual_splash3_effect(paint_session* session, int32_t z, con
     {
         return;
     }
-    if (vehicle->vehicle_sprite_type != 0)
+    if (vehicle->Pitch != 0)
     {
         return;
     }
@@ -3050,7 +3050,7 @@ static void vehicle_visual_splash4_effect(paint_session* session, int32_t z, con
     {
         return;
     }
-    if (vehicle->vehicle_sprite_type != 0)
+    if (vehicle->Pitch != 0)
     {
         return;
     }
@@ -3078,7 +3078,7 @@ static void vehicle_visual_splash5_effect(paint_session* session, int32_t z, con
     {
         return;
     }
-    if (vehicle->vehicle_sprite_type != 0)
+    if (vehicle->Pitch != 0)
     {
         return;
     }
@@ -3122,9 +3122,9 @@ void vehicle_visual_default(
     paint_session* session, int32_t imageDirection, int32_t z, const Vehicle* vehicle,
     const rct_ride_entry_vehicle* vehicleEntry)
 {
-    if (vehicle->vehicle_sprite_type < std::size(vehicle_sprite_funcs))
+    if (vehicle->Pitch < std::size(vehicle_sprite_funcs))
     {
-        vehicle_sprite_funcs[vehicle->vehicle_sprite_type](session, vehicle, imageDirection, z, vehicleEntry);
+        vehicle_sprite_funcs[vehicle->Pitch](session, vehicle, imageDirection, z, vehicleEntry);
     }
 }
 

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -158,7 +158,7 @@ void vehicle_visual_virginia_reel(
     const uint8_t rotation = session->CurrentRotation;
     int32_t ecx = ((vehicle->spin_sprite / 8) + (rotation * 8)) & 31;
     int32_t baseImage_id = [&] {
-        switch (vehicle->vehicle_sprite_type)
+        switch (vehicle->Pitch)
         {
             case 1:
                 return (imageDirection & 24) + 8;

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -79,7 +79,7 @@ static void paint_ferris_wheel_structure(
     uint32_t imageOffset = 0;
     if (vehicle != nullptr)
     {
-        imageOffset = vehicle->vehicle_sprite_type % 8;
+        imageOffset = vehicle->Pitch % 8;
     }
 
     uint32_t imageColourFlags = session->TrackColours[SCHEME_MISC];
@@ -110,7 +110,7 @@ static void paint_ferris_wheel_structure(
                 continue;
             }
 
-            int32_t frameNum = (vehicle->vehicle_sprite_type + i * 4) % 128;
+            int32_t frameNum = (vehicle->Pitch + i * 4) % 128;
             imageColourFlags = SPRITE_ID_PALETTE_COLOUR_2(vehicle->peep_tshirt_colours[i], vehicle->peep_tshirt_colours[i + 1]);
             imageId = (baseImageId + 32 + direction * 128 + frameNum) | imageColourFlags;
             PaintAddImageAsChild(

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -53,7 +53,7 @@ static void paint_haunted_house_structure(
     {
         session->InteractionType = ViewportInteractionItem::Entity;
         session->CurrentlyDrawnItem = vehicle;
-        frameNum = vehicle->vehicle_sprite_type;
+        frameNum = vehicle->Pitch;
     }
 
     uint32_t imageId = (baseImageId + direction) | session->TrackColours[SCHEME_MISC];

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -55,7 +55,7 @@ static void paint_merry_go_round_structure(
     if (vehicle != nullptr)
     {
         uint32_t rotation = ((vehicle->sprite_direction >> 3) + session->CurrentRotation) << 5;
-        rotationOffset = (vehicle->vehicle_sprite_type + rotation) % 128;
+        rotationOffset = (vehicle->Pitch + rotation) % 128;
     }
 
     uint32_t imageOffset = rotationOffset & 0x1F;

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -49,7 +49,7 @@ static void paint_space_rings_structure(paint_session* session, Ride* ride, uint
         {
             session->InteractionType = ViewportInteractionItem::Entity;
             session->CurrentlyDrawnItem = vehicle;
-            frameNum += static_cast<int8_t>(vehicle->vehicle_sprite_type) * 4;
+            frameNum += static_cast<int8_t>(vehicle->Pitch) * 4;
         }
 
         uint32_t imageColourFlags = session->TrackColours[SCHEME_MISC];

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -42,7 +42,7 @@ static void paint_enterprise_structure(
     uint32_t imageOffset = tileElement->GetDirectionWithOffset(session->CurrentRotation);
     if (vehicle != nullptr)
     {
-        imageOffset = (vehicle->vehicle_sprite_type << 2) + (((vehicle->sprite_direction >> 3) + session->CurrentRotation) % 4);
+        imageOffset = (vehicle->Pitch << 2) + (((vehicle->sprite_direction >> 3) + session->CurrentRotation) % 4);
     }
 
     uint32_t imageColourFlags = session->TrackColours[SCHEME_MISC];

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -185,7 +185,7 @@ static void paint_magic_carpet_structure(
     uint32_t swingImageId = 0;
     if (vehicle != nullptr)
     {
-        swingImageId = vehicle->vehicle_sprite_type;
+        swingImageId = vehicle->Pitch;
         session->InteractionType = ViewportInteractionItem::Entity;
         session->CurrentlyDrawnItem = vehicle;
     }

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -64,7 +64,7 @@ static void paint_motionsimulator_vehicle(
         }
         else
         {
-            simulatorImageId += vehicle->vehicle_sprite_type * 4;
+            simulatorImageId += vehicle->Pitch * 4;
         }
     }
 

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -68,7 +68,7 @@ static void paint_swinging_inverter_ship_structure(
     uint32_t vehicleImageId = rideEntry->vehicles[0].base_image_id + swinging_inverter_ship_base_sprite_offset[direction];
     if (vehicle != nullptr)
     {
-        int32_t rotation = static_cast<int8_t>(vehicle->vehicle_sprite_type);
+        int32_t rotation = static_cast<int8_t>(vehicle->Pitch);
         if (rotation != 0)
         {
             vehicleImageId = rideEntry->vehicles[0].base_image_id

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -81,7 +81,7 @@ static void paint_swinging_ship_structure(
     baseImageId = rideEntry->vehicles[0].base_image_id + swinging_ship_base_sprite_offset[direction];
     if (vehicle != nullptr)
     {
-        int32_t rotation = static_cast<int8_t>(vehicle->vehicle_sprite_type);
+        int32_t rotation = static_cast<int8_t>(vehicle->Pitch);
         if (rotation != 0)
         {
             if (direction & 2)

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -66,7 +66,7 @@ static void top_spin_paint_vehicle(
         session->InteractionType = ViewportInteractionItem::Entity;
         session->CurrentlyDrawnItem = vehicle;
 
-        armRotation = vehicle->vehicle_sprite_type;
+        armRotation = vehicle->Pitch;
         seatRotation = vehicle->bank_rotation;
     }
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -44,7 +44,7 @@ static void paint_twist_structure(
     if (vehicle != nullptr)
     {
         frameNum += (vehicle->sprite_direction >> 3) << 4;
-        frameNum += vehicle->vehicle_sprite_type;
+        frameNum += vehicle->Pitch;
         frameNum = frameNum % 216;
     }
 

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -186,15 +186,15 @@ void vehicle_visual_river_rapids(
     uint32_t rotation = session->CurrentRotation;
     int32_t ecx = ((vehicle->spin_sprite / 8) + (rotation * 8)) & 31;
     int32_t j = 0;
-    if (vehicle->vehicle_sprite_type == 0)
+    if (vehicle->Pitch == 0)
     {
         baseImage_id = ecx & 7;
     }
     else
     {
-        if (vehicle->vehicle_sprite_type == 1 || vehicle->vehicle_sprite_type == 5)
+        if (vehicle->Pitch == 1 || vehicle->Pitch == 5)
         {
-            if (vehicle->vehicle_sprite_type == 5)
+            if (vehicle->Pitch == 5)
             {
                 baseImage_id = imageDirection ^ 16;
             }
@@ -203,9 +203,9 @@ void vehicle_visual_river_rapids(
             baseImage_id += (ecx & 7);
             baseImage_id += 8;
         }
-        else if (vehicle->vehicle_sprite_type == 2 || vehicle->vehicle_sprite_type == 6)
+        else if (vehicle->Pitch == 2 || vehicle->Pitch == 6)
         {
-            if (vehicle->vehicle_sprite_type == 6)
+            if (vehicle->Pitch == 6)
             {
                 baseImage_id = imageDirection ^ 16;
             }

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -311,7 +311,7 @@ namespace OpenRCT2::Scripting
         uint8_t spriteType_get() const
         {
             auto vehicle = GetVehicle();
-            return vehicle != nullptr ? vehicle->vehicle_sprite_type : 0;
+            return vehicle != nullptr ? vehicle->Pitch : 0;
         }
         void spriteType_set(uint8_t value)
         {
@@ -319,7 +319,7 @@ namespace OpenRCT2::Scripting
             auto vehicle = GetVehicle();
             if (vehicle != nullptr)
             {
-                vehicle->vehicle_sprite_type = value;
+                vehicle->Pitch = value;
             }
         }
 

--- a/src/openrct2/world/Entity.cpp
+++ b/src/openrct2/world/Entity.cpp
@@ -234,7 +234,7 @@ void Vehicle::Serialise(DataSerialiser& stream)
 {
     EntityBaseSerialise(*this, stream);
     stream << SubType;
-    stream << vehicle_sprite_type;
+    stream << Pitch;
     stream << bank_rotation;
     stream << remaining_distance;
     stream << velocity;

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -286,7 +286,7 @@ static void CompareSpriteDataStaff(const Staff& left, const Staff& right)
 static void CompareSpriteDataVehicle(const Vehicle& left, const Vehicle& right)
 {
     COMPARE_FIELD(SubType);
-    COMPARE_FIELD(vehicle_sprite_type);
+    COMPARE_FIELD(Pitch);
     COMPARE_FIELD(bank_rotation);
     COMPARE_FIELD(remaining_distance);
     COMPARE_FIELD(velocity);


### PR DESCRIPTION
technically a followup of #11956 and upon a discussion with Duncanspumpkin on vehicle namings. Originated from the Screaming Issue: #11293

