### PR TITLE
Partially solve #5165

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -196,7 +196,15 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     int32_t res = set_operating_setting(ride_index, RideSetSetting::RideType, type);
                     if (res == MONEY32_UNDEFINED)
                     {
-                        console.WriteFormatLine("That didn't work");
+                        if (!gCheatsAllowArbitraryRideTypeChanges)
+                        {
+                            console.WriteFormatLine(
+                                "That didn't work. Try enabling the 'Allow arbitrary ride type changes' cheat");
+                        }
+                        else
+                        {
+                            console.WriteFormatLine("That didn't work");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Suggest enabling the `Allow arbitrary ride type changes` cheat if the `rides set type` command fails while the cheat is disabled.