### PR TITLE
Add more properties to Park API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#14071] “Vandals stopped” statistic for security guards.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
 - Feature: [#14538] [Plugin] Add property for getting current plugin api version.
+- Feature: [#14620] [Plugin] Add properties related to guest generation.
 - Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript's Object interface.
 - Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1619,6 +1619,40 @@ declare global {
         readonly guests: number;
 
         /**
+         * The maximum number of guests that will spawn naturally (soft guest cap).
+         * In scenarios with difficult guest generation, guests will not spawn above
+         * this value without advertisements.
+         */
+        readonly suggestedGuestMaximum: number;
+
+        /**
+         * The probability out of 65535 that guests will spawn per tick.
+         * The number of guest spawns per second is equal to
+         * guests per second = 40 * (guestGenerationProbability / 65535)
+         */
+        readonly guestGenerationProbability: number;
+
+        /**
+         * The average amount of cash guests will spawn with.
+         */
+        readonly guestInitialCash: number;
+
+        /**
+         * The average happiness guests will spawn at out of 255.
+         */
+        readonly guestInitialHappiness: number;
+
+        /**
+         * The average hunger guests will spawn at out of 255.
+         */
+        readonly guestInitialHunger: number;
+
+        /**
+         * The average thirst guests will spawn at out of 255.
+         */
+        readonly guestInitialThirst: number;
+
+        /**
          * The park value, will be updated every 512 ticks.
          */
         value: number;
@@ -1628,6 +1662,13 @@ declare global {
          * Calculation is: `park.value + park.cash - park.bankLoan`
          */
         companyValue: number;
+
+        /**
+         * The sum of ride values, used to determine the most guests will
+         * pay to enter the park and for some awards.
+         * Calculated as the sum of (ride value - ride price) * 2.
+         */
+        readonly totalRideValueForMoney: number;
 
         /**
          * The total number of guests that have entered the park.

--- a/src/openrct2/scripting/ScPark.hpp
+++ b/src/openrct2/scripting/ScPark.hpp
@@ -332,6 +332,36 @@ namespace OpenRCT2::Scripting
             return gNumGuestsInPark;
         }
 
+        uint32_t suggestedGuestMaximum_get() const
+        {
+            return _suggestedGuestMaximum;
+        }
+
+        int32_t guestGenerationProbability_get() const
+        {
+            return _guestGenerationProbability;
+        }
+
+        money16 guestInitialCash_get() const
+        {
+            return gGuestInitialCash;
+        }
+
+        uint8_t guestInitialHappiness_get() const
+        {
+            return gGuestInitialHappiness;
+        }
+
+        uint8_t guestInitialHunger_get() const
+        {
+            return gGuestInitialHunger;
+        }
+
+        uint8_t guestInitialThirst_get() const
+        {
+            return gGuestInitialThirst;
+        }
+
         money32 value_get() const
         {
             return gParkValue;
@@ -362,6 +392,11 @@ namespace OpenRCT2::Scripting
                 auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
                 context_broadcast_intent(&intent);
             }
+        }
+
+        money16 totalRideValueForMoney_get() const
+        {
+            return gTotalRideValueForMoney;
         }
 
         uint32_t totalAdmissions_get() const
@@ -546,8 +581,15 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScPark::maxBankLoan_get, &ScPark::maxBankLoan_set, "maxBankLoan");
             dukglue_register_property(ctx, &ScPark::entranceFee_get, &ScPark::entranceFee_set, "entranceFee");
             dukglue_register_property(ctx, &ScPark::guests_get, nullptr, "guests");
+            dukglue_register_property(ctx, &ScPark::suggestedGuestMaximum_get, nullptr, "suggestedGuestMaximum");
+            dukglue_register_property(ctx, &ScPark::guestGenerationProbability_get, nullptr, "guestGenerationProbability");
+            dukglue_register_property(ctx, &ScPark::guestInitialCash_get, nullptr, "guestInitialCash");
+            dukglue_register_property(ctx, &ScPark::guestInitialHappiness_get, nullptr, "guestInitialHappiness");
+            dukglue_register_property(ctx, &ScPark::guestInitialHunger_get, nullptr, "guestInitialHunger");
+            dukglue_register_property(ctx, &ScPark::guestInitialThirst_get, nullptr, "guestInitialThirst");
             dukglue_register_property(ctx, &ScPark::value_get, &ScPark::value_set, "value");
             dukglue_register_property(ctx, &ScPark::companyValue_get, &ScPark::companyValue_set, "companyValue");
+            dukglue_register_property(ctx, &ScPark::totalRideValueForMoney_get, nullptr, "totalRideValueForMoney");
             dukglue_register_property(ctx, &ScPark::totalAdmissions_get, &ScPark::totalAdmissions_set, "totalAdmissions");
             dukglue_register_property(
                 ctx, &ScPark::totalIncomeFromAdmissions_get, &ScPark::totalIncomeFromAdmissions_set,

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 28;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 29;
 
 #    ifndef DISABLE_NETWORK
     class ScSocketBase;


### PR DESCRIPTION
Adds more properties to the plugin Park API that are useful for certain kinds of plugins (for example, automatic price management). I added the guestInitialX properties here since the flags e.g. difficult guest generation that are also set in the scenario editor are also here.