### PR TITLE
Remove old serialiser of steam particle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,9 @@ set(OBJECTS_VERSION "1.0.21")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_VERSION "0.0.42")
+set(REPLAYS_VERSION "0.0.43")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "C60FC1D6526DB8EDDF4AFBB0EE52A4A0D561646E")
+set(REPLAYS_SHA1 "269E4FC432A73AE9A5D601EC2A1C882F3D9BDF3C")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
     <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.42/replays.zip</ReplaysUrl>
-    <ReplaysSha1>C60FC1D6526DB8EDDF4AFBB0EE52A4A0D561646E</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.43/replays.zip</ReplaysUrl>
+    <ReplaysSha1>269E4FC432A73AE9A5D601EC2A1C882F3D9BDF3C</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -107,7 +107,6 @@ struct GameStateSnapshot_t
                     break;
                 case EntityType::SteamParticle:
                     reinterpret_cast<SteamParticle&>(sprite).Serialise(ds);
-                    ds << reinterpret_cast<uint8_t(&)[sizeof(SteamParticle)]>(sprite.steam_particle);
                     break;
                 case EntityType::Null:
                     break;


### PR DESCRIPTION
Accidentally missed this in the network serialiser branch

Will need new replay but no change to network version.