### PR TITLE
Correct palette indexes of remap colors in image importer

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -165,6 +165,7 @@ The following people are not part of the development team, but have been contrib
 * Adam Bloom (adam-bloom)
 * Geoff B. (geoff-B)
 * Ryan D. (rctdude2)
+* (zrowny)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/drawing/ImageImporter.cpp
+++ b/src/openrct2/drawing/ImageImporter.cpp
@@ -312,11 +312,11 @@ bool ImageImporter::IsChangablePixel(int32_t paletteIndex)
         return true;
     if (paletteIndex == 0)
         return false;
-    if (paletteIndex >= 203 && paletteIndex < 214)
+    if (paletteIndex >= 202 && paletteIndex <= 213)
         return false;
     if (paletteIndex == 226)
         return false;
-    if (paletteIndex >= 227 && paletteIndex < 229)
+    if (paletteIndex >= 227 && paletteIndex <= 229)
         return false;
     if (paletteIndex >= 243)
         return false;

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -273,7 +273,7 @@ constexpr const GamePalette StandardPalette = { {
     { 231, 231, 171, 255 },
     { 255, 255, 207, 255 },
 
-    // 203 - 214 (Secondary remap)
+    // 202 - 214 (Secondary remap)
     { 27, 0, 63, 255 },
     { 51, 0, 103, 255 },
     { 63, 11, 123, 255 },

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -273,7 +273,7 @@ constexpr const GamePalette StandardPalette = { {
     { 231, 231, 171, 255 },
     { 255, 255, 207, 255 },
 
-    // 202 - 214 (Secondary remap)
+    // 202 - 213 (Secondary remap)
     { 27, 0, 63, 255 },
     { 51, 0, 103, 255 },
     { 63, 11, 123, 255 },


### PR DESCRIPTION
The code that finds the closest entry that isn't used for remapping has the indices of remappable colors slightly off, and would make some colors in the imported image remappable even though they shouldn't have been.

The header file also has a comment that had the wrong number for the remappable color indices.