### PR TITLE
Simplify code for Peep easter eggs

### DIFF
--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -816,9 +816,7 @@ private:
     void UpdateRideShopLeave();
     void loc_68F9F3();
     void loc_68FA89();
-    using easter_egg_function = void (Guest::*)(Guest* otherGuest);
     int32_t CheckEasterEggName(int32_t index) const;
-    void ApplyEasterEggToNearbyGuests(easter_egg_function easter_egg);
     bool GuestHasValidXY() const;
     void GivePassingPeepsPurpleClothes(Guest* passingPeep);
     void GivePassingPeepsPizza(Guest* passingPeep);


### PR DESCRIPTION
This cleans up the easter egg code a bit, the functions are now passed via template argument rather than function pointer, this allows the compiler to inline. I also moved out the location check out of the easter egg functions, this was previously done each iteration of nearby peeps. I know this is a micro optimization but with soon lifted limits small things accumulate quickly.

Develop:
![devenv_2021-05-13_18-36-24](https://user-images.githubusercontent.com/5415177/118149463-3f5ad980-b41a-11eb-9ba3-9d9f9888b8fe.png)
It had to load the pointer and does a call later on, not optimal.

PR:
![devenv_2021-05-13_18-44-17](https://user-images.githubusercontent.com/5415177/118150463-40d8d180-b41b-11eb-9a8c-e636f5c7e520.png)

All the easter egg functions inlined now.