### PR TITLE
Fix #14638: Make 'About OpenRCT2' themeable; more RCT1 window colours

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#14449] Surface smoothing at extra zoom levels not working.
 - Fix: [#14493] [Plugin] isHidden only works for tile elements up to the first element with a base height of over 32.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
+- Fix: [#14638] The “About OpenRCT2” window cannot be themed.
 
 0.3.3 (2021-03-13)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -130,7 +130,7 @@ static constexpr const WindowThemeDesc WindowThemeDescriptors[] =
     { THEME_WC(WC_DEMOLISH_RIDE_PROMPT),           STR_THEMES_WINDOW_DEMOLISH_RIDE_PROMPT,           COLOURS_1(TRANSLUCENT(COLOUR_BORDEAUX_RED)                                                                                     ) },
     { THEME_WC(WC_SCENERY),                        STR_THEMES_WINDOW_SCENERY,                        COLOURS_3(COLOUR_DARK_BROWN,               COLOUR_DARK_GREEN,               COLOUR_DARK_GREEN                                  ) },
     { THEME_WC(WC_SCENERY_SCATTER),                STR_THEMES_WINDOW_SCENERY_SCATTER,                COLOURS_3(COLOUR_DARK_BROWN,               COLOUR_DARK_GREEN,               COLOUR_DARK_GREEN                                  ) },
-    { THEME_WC(WC_OPTIONS),                        STR_THEMES_WINDOW_OPTIONS,                        COLOURS_3(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                  ) },
+    { THEME_WC(WC_OPTIONS),                        STR_THEMES_WINDOW_OPTIONS,                        COLOURS_3(COLOUR_GREY,                     COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                  ) },
     { THEME_WC(WC_FOOTPATH),                       STR_THEMES_WINDOW_FOOTPATH,                       COLOURS_3(COLOUR_DARK_BROWN,               COLOUR_DARK_BROWN,               COLOUR_DARK_BROWN                                  ) },
     { THEME_WC(WC_LAND),                           STR_THEMES_WINDOW_LAND,                           COLOURS_3(COLOUR_DARK_BROWN,               COLOUR_DARK_BROWN,               COLOUR_DARK_BROWN                                  ) },
     { THEME_WC(WC_WATER),                          STR_THEMES_WINDOW_WATER,                          COLOURS_3(COLOUR_DARK_BROWN,               COLOUR_DARK_BROWN,               COLOUR_DARK_BROWN                                  ) },
@@ -174,6 +174,7 @@ static constexpr const WindowThemeDesc WindowThemeDescriptors[] =
     { THEME_WC(WC_TITLE_EDITOR),                   STR_TITLE_EDITOR_TITLE,                           COLOURS_3(COLOUR_GREY,                     COLOUR_OLIVE_GREEN,              COLOUR_OLIVE_GREEN                                 ) },
     { THEME_WC(WC_TILE_INSPECTOR),                 STR_TILE_INSPECTOR_TITLE,                         COLOURS_2(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                                                   ) },
     { THEME_WC(WC_VIEW_CLIPPING),                  STR_VIEW_CLIPPING_TITLE,                          COLOURS_1(COLOUR_DARK_GREEN                                                                                                    ) },
+    { THEME_WC(WC_ABOUT),                          STR_ABOUT,                                        COLOURS_2(COLOUR_GREY,                     COLOUR_LIGHT_BLUE                                                                   ) },
     { THEME_WC(WC_CHANGELOG),                      STR_CHANGELOG_TITLE,                              COLOURS_2(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                                                   ) },
     { THEME_WC(WC_MULTIPLAYER),                    STR_MULTIPLAYER,                                  COLOURS_3(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                  ) },
     { THEME_WC(WC_PLAYER),                         STR_THEMES_WINDOW_PLAYER,                         COLOURS_3(COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE,               COLOUR_LIGHT_BLUE                                  ) },
@@ -205,9 +206,12 @@ static constexpr const UIThemeWindowEntry PredefinedThemeRCT1_Entries[] =
     { WC_NEW_CAMPAIGN,             COLOURS_RCT1(COLOUR_LIGHT_PURPLE,       COLOUR_LIGHT_PURPLE,        COLOUR_GREY,                COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
     { WC_TITLE_OPTIONS,            COLOURS_RCT1(TRANSLUCENT(COLOUR_GREY),  TRANSLUCENT(COLOUR_GREY),   TRANSLUCENT(COLOUR_GREY),   COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
     { WC_STAFF,                    COLOURS_RCT1(COLOUR_DARK_GREEN,         COLOUR_LIGHT_PURPLE,        COLOUR_LIGHT_PURPLE,        COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
-    { WC_OPTIONS,                  COLOURS_RCT1(COLOUR_DARK_BROWN,         COLOUR_DARK_BROWN,          COLOUR_DARK_BROWN,          COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
+    { WC_OPTIONS,                  COLOURS_RCT1(COLOUR_GREY,               COLOUR_DARK_BROWN,          COLOUR_DARK_BROWN,          COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
     { WC_KEYBOARD_SHORTCUT_LIST,   COLOURS_RCT1(COLOUR_DARK_BROWN,         COLOUR_DARK_BROWN,          COLOUR_DARK_BROWN,          COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
     { WC_CHANGE_KEYBOARD_SHORTCUT, COLOURS_RCT1(COLOUR_DARK_BROWN,         COLOUR_DARK_BROWN,          COLOUR_DARK_BROWN,          COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
+    { WC_TRACK_DESIGN_LIST,        COLOURS_RCT1(COLOUR_DARK_BROWN,         COLOUR_DARK_BROWN,          COLOUR_DARK_BROWN,          COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
+    { WC_MAP,                      COLOURS_RCT1(COLOUR_DARK_BROWN,         COLOUR_GREY,                COLOUR_GREY,                COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
+    { WC_ABOUT,                    COLOURS_RCT1(COLOUR_GREY,               COLOUR_DARK_BROWN,          COLOUR_WHITE,               COLOUR_BLACK,    COLOUR_BLACK,    COLOUR_BLACK)    },
 
     THEME_DEF_END
 };

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -128,9 +128,6 @@ rct_window* window_about_open()
     window_about_set_page(window, WINDOW_ABOUT_PAGE_OPENRCT2);
 
     WindowInitScrollWidgets(window);
-    window->colours[0] = COLOUR_GREY;
-    window->colours[1] = COLOUR_LIGHT_BLUE;
-    window->colours[2] = COLOUR_LIGHT_BLUE;
 
     return window;
 }
@@ -196,7 +193,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t width = w->width - 20;
 
     aboutCoords.y += DrawTextWrapped(
-                         dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION, {}, { w->colours[2], TextAlignment::CENTRE })
+                         dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION, {}, { w->colours[1], TextAlignment::CENTRE })
         + lineHeight;
 
     rct_size16 logoSize = gfx_get_sprite_size(SPR_G2_LOGO);
@@ -206,7 +203,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // About OpenRCT2 text
     aboutCoords.y += DrawTextWrapped(
                          dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_2, {},
-                         { w->colours[2], TextAlignment::CENTRE })
+                         { w->colours[1], TextAlignment::CENTRE })
         + lineHeight + 5;
 
     // Copyright disclaimer; hidden when using truetype fonts to prevent
@@ -214,7 +211,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (!LocalisationService_UseTrueTypeFont())
     {
         DrawTextWrapped(
-            dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_3, {}, { w->colours[2], TextAlignment::CENTRE });
+            dpi, aboutCoords, width, STR_ABOUT_OPENRCT2_DESCRIPTION_3, {}, { w->colours[1], TextAlignment::CENTRE });
     }
 
     // Version info
@@ -225,7 +222,7 @@ static void window_about_openrct2_paint(rct_window* w, rct_drawpixelinfo* dpi)
     ft.Add<const char*>(buffer);
 
     aboutCoords.y = w->windowPos.y + WH - 25;
-    DrawTextWrapped(dpi, aboutCoords, width, STR_STRING, ft, { w->colours[2], TextAlignment::CENTRE });
+    DrawTextWrapped(dpi, aboutCoords, width, STR_STRING, ft, { w->colours[1], TextAlignment::CENTRE });
 }
 
 static void window_about_openrct2_invalidate(rct_window* w)

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -225,6 +225,7 @@ static rct_windowclass window_themes_tab_6_classes[] = {
     WC_KEYBOARD_SHORTCUT_LIST,
     WC_CHANGE_KEYBOARD_SHORTCUT,
     WC_LOADSAVE,
+    WC_ABOUT,
     WC_CHANGELOG,
     WC_SERVER_LIST,
     WC_MULTIPLAYER,


### PR DESCRIPTION
In tabbed windows, using the same colour twice looks awful. As such, I have taken the liberty of making the background grey. I hope that Majora will at some point forgive me.

![Forest Frontiers 2021-05-13 17-47-26](https://user-images.githubusercontent.com/1478678/118151412-e0926180-b413-11eb-81b0-b9e139823ec2.png)
