### PR TITLE
new-save-format: Fix overly-long comment

### DIFF
--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -865,7 +865,8 @@ private:
 };
 
 // The number of elements in the PatrolArea.Data array per staff member. Every bit in the array represents a 4x4 square.
-// Right now, it's a 32-bit array like in RCT2. 32 * 2048 = 65536 bits, which is also the number of 4x4 squares on a 1024x1024 map.
+// Right now, it's a 32-bit array like in RCT2. 32 * 2048 = 65536 bits, which is also the number of 4x4 squares on a 1024x1024
+// map.
 constexpr size_t STAFF_PATROL_AREA_BLOCKS_PER_LINE = 1024 / 4;
 constexpr size_t STAFF_PATROL_AREA_SIZE = (STAFF_PATROL_AREA_BLOCKS_PER_LINE * STAFF_PATROL_AREA_BLOCKS_PER_LINE) / 32;
 


### PR DESCRIPTION
There! Are you happy now, clang-format!?