### PR TITLE
[NSF] Fix various implicit type casting warnings

### DIFF
--- a/src/openrct2/ParkFile.cpp
+++ b/src/openrct2/ParkFile.cpp
@@ -865,11 +865,12 @@ namespace OpenRCT2
                         cs.ReadWriteVector(banners, [version, &cs](Banner& banner) { ReadWriteBanner(version, cs, banner); });
                         for (size_t i = 0; i < banners.size(); i++)
                         {
-                            auto banner = GetOrCreateBanner(i);
+                            auto bannerIndex = static_cast<BannerIndex>(i);
+                            auto banner = GetOrCreateBanner(bannerIndex);
                             if (banner != nullptr)
                             {
                                 *banner = std::move(banners[i]);
-                                banner->id = static_cast<BannerIndex>(i);
+                                banner->id = bannerIndex;
                             }
                         }
                     }

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -359,8 +359,8 @@ static std::pair<int32_t, int32_t> getPatrolAreaOffsetIndex(const CoordsXY& coor
     auto x = tilePos.x / 4;
     auto y = tilePos.y / 4;
     auto bitIndex = (y * STAFF_PATROL_AREA_BLOCKS_PER_LINE) + x;
-    auto byteIndex = bitIndex / 32;
-    auto byteBitIndex = bitIndex % 32;
+    auto byteIndex = int32_t(bitIndex / 32);
+    auto byteBitIndex = int32_t(bitIndex % 32);
     return { byteIndex, byteBitIndex };
 }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1338,7 +1338,7 @@ private:
         //                                          index in the array ----^     ^--- bit position in the 8-bit value
         // We do the opposite in this function to recover the x and y values.
 
-        int32_t peepOffset = staffId * RCT12_PATROL_AREA_SIZE;
+        int32_t peepOffset = static_cast<int32_t>(staffId) * RCT12_PATROL_AREA_SIZE;
         for (int32_t i = 0; i < RCT12_PATROL_AREA_SIZE; i++)
         {
             staffmember->ClearPatrolArea();


### PR DESCRIPTION
These warnings caused compilation to fail on VS2019 Version 16.10.0 Preview 2.1, because warnings are being treated as errors.