### PR TITLE
Fix Options window not closing on Android #14468

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#14315] Crash when trying to rename Air Powered Vertical Coaster in Korean.
 - Fix: [#14330] join_server uses default_port from config.
 - Fix: [#14449] Surface smoothing at extra zoom levels not working.
+- Fix: [#14468] Cannot close Options window on Android.
 - Fix: [#14493] [Plugin] isHidden only works for tile elements up to the first element with a base height of over 32.
 - Fix: [#14587] Confusing message when joining server with mismatched network version.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -583,8 +583,8 @@ static void window_options_common_invalidate_before(rct_window* w)
     auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
     if (!hasFilePicker)
     {
-        w->enabled_widgets &= ~WIDX_ALWAYS_NATIVE_LOADSAVE;
-        w->disabled_widgets |= WIDX_ALWAYS_NATIVE_LOADSAVE;
+        w->enabled_widgets &= ~ (1ULL << WIDX_ALWAYS_NATIVE_LOADSAVE);
+        w->disabled_widgets |= (1ULL << WIDX_ALWAYS_NATIVE_LOADSAVE);
         w->widgets[WIDX_ALWAYS_NATIVE_LOADSAVE].type = WindowWidgetType::Empty;
     }
 }


### PR DESCRIPTION
Issue was caused by the WIDX_ALWAYS_NATIVE_LOADSAVE flag not being enabled/disabled correctly

Fixes issue #14468 