### PR TITLE
Improve corrupt element handling

### DIFF
--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1019,7 +1019,10 @@ public:
                     auto tileElementType = static_cast<RCT12TileElementType>(srcElement->GetType());
                     if (tileElementType == RCT12TileElementType::Corrupt)
                     {
-                        nextElementInvisible = true;
+                        // One property of corrupt elements was to hide tops of tower tracks, and to avoid the next element from
+                        // being hidden, multiple consecutive corrupt elements were sometimes used. This would essentially
+                        // toggle the flag, so we inverse nextElementInvisible here instead of always setting it to true.
+                        nextElementInvisible = !nextElementInvisible;
                         continue;
                     }
                     if (tileElementType == RCT12TileElementType::EightCarsCorrupt14


### PR DESCRIPTION
The way corrupt elements are replaced by the invisibility flag is not 100% accurate to how they behave in pre-NSF OpenRCT2.

Before NSF (middle tile of observation tower selected, there are 2 corrupt elements below the sloped path too):
![Before](https://user-images.githubusercontent.com/9705046/118367275-4829e780-b5a1-11eb-987d-a7688dc3aeba.png)

How it currently gets handled:
![After Before](https://user-images.githubusercontent.com/9705046/118367435-537d1300-b5a1-11eb-9b4b-74a5deaceb43.png)

How it gets handled with this fix:
![After After](https://user-images.githubusercontent.com/9705046/118367359-4e1fc880-b5a1-11eb-8239-ae6138f6a657.png)

Notice how the only difference now is the observation tower top. AFAIK this cannot be solved currently, until we add a new standard "nothing" element or separate the tower parts and tower tops into separate track pieces. The first is more like a hack, so we should probably avoid that, and is out of scope for this PR.