### PR TITLE
Fix #14668: Ensure to flush network data when paused

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -183,6 +183,8 @@ void GameState::Update()
         }
     }
 
+    network_flush();
+
     if (!gOpenRCT2Headless)
     {
         input_set_flag(INPUT_FLAG_VIEWPORT_SCROLLING, false);


### PR DESCRIPTION
The only issues I was able to find being when the host paused that the clients disconnect and that while the game was paused me being unable to connect. The master server always worked prior to this fix, so this needs to be tested.