### PR TITLE
Enhancement: Improve Peep Falling and Drowning

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -92,6 +92,7 @@ The following people are not part of the development team, but have been contrib
 * Helio Batimarqui (batimarqui) - Misc.
 * Keith Stellyes (keithstellyes) - Misc.
 * Bas Cantrijn (Basssiiie) - Misc.
+* Hiram Anderson (hjk321) - Misc.
 
 ## Bug fixes
 * (halfbro)

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -753,8 +753,10 @@ void Peep::UpdateFalling()
                             guest->InsertNewThought(PeepThoughtType::Drowning, PEEP_THOUGHT_ITEM_NONE);
                         }
 
+                        // Determine start frame for drowning based on peep energy.
+                        // The minimum peep energy starts the animation on frame 48 causing very quick death.
+                        ActionFrame = (PEEP_MAX_ENERGY - Energy) / 2;
                         Action = PeepActionType::Drowning;
-                        ActionFrame = 0;
                         ActionSpriteImageOffset = 0;
 
                         UpdateCurrentActionSpriteType();
@@ -935,6 +937,9 @@ void Peep::Update()
         if (State == PeepState::Queuing)
             stepsToTake += stepsToTake / 2;
     }
+    // Falling should be at maximum speed.
+    if (State == PeepState::Falling)
+        stepsToTake = PEEP_MAX_ENERGY;
 
     uint32_t carryCheck = StepProgress + stepsToTake;
     StepProgress = carryCheck;


### PR DESCRIPTION
This pull addresses odd behavior showcased in [this MarcelVos video](https://www.youtube.com/watch?v=0hHCv-KNLh4).

Previously, tired peeps would fall slower than energized peeps. This commit modifies the walkspeed logic to make gravity affect everyone the same while falling, regardless of their energy level. This has the side effect of normalizing the drowning animation speed as well since drowning is a subset of falling.

Since the drowning animation speed is now the same across the board, the amount of time a peep swims before drowning is now based on energy. (People with more energy can swim longer, after all!) This is achieved by dynamically setting the starting frame when first drowning. Maximum energy plays the animation in full, scaling all the way down to minimum energy levels, which starts on frame 48, giving the peep only about a second to flail helplessly before succumbing to fatigue.

The formula to determine the starting frame is `(MAX_ENERGY - Energy) / 2`.