### PR TITLE
Windows console changes

### DIFF
--- a/distribution/scripting.md
+++ b/distribution/scripting.md
@@ -46,7 +46,7 @@ registerPlugin({
 });
 ```
 
-This will log a message to the terminal screen (`stdout`) when you open any park. If you are on Windows, make sure to run `openrct2.com` instead of `openrct2.exe` so you can interact with the `stdin` / `stdout` console. The console is a JavaScript interpreter (REPL), this means you can write and test expressions similar to the console found in web browsers when you press `F12`. When you make changes to your script, you must exit your current game and open it again for the script to reload... unless you use the hot reload feature.
+This will log a message to the terminal screen (`stdout`) when you open any park. If you are on Windows, make sure to run `openrct2.exe` with a `--console` argument so you can interact with the `stdin` / `stdout` console. The console is a JavaScript interpreter (REPL), this means you can write and test expressions similar to the console found in web browsers when you press `F12`. When you make changes to your script, you must exit your current game and open it again for the script to reload... unless you use the hot reload feature.
 
 The hot reload feature can be enabled by editing your `config.ini` file and setting `enable_hot_reloading` to `true` under `[plugin]`. When this is enabled, the game will auto-reload the script in real-time whenever you save your JavaScript file. This allows rapid development of plug-ins as you can write code and quickly preview your changes, such as closing and opening a specific custom window on startup. A demonstration of this can be found on YouTube: [OpenRCT2 plugin hot-reload demo](https://www.youtube.com/watch?v=jmjWzEhmDjk)
 

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -4,7 +4,6 @@
 !define APPNAMEANDVERSION   "${APPNAME} ${APPVERSION}"
 !define APPURLLINK          "https://github.com/OpenRCT2/OpenRCT2"
 !define OPENRCT2_EXE        "openrct2.exe"
-!define OPENRCT2_COM        "openrct2.com"
 
 !if "${PLATFORM}" == "Win32"
     !define APPBITS         32
@@ -179,7 +178,6 @@ Section "!OpenRCT2" Section1
 
     ; Copy executable
     File /oname=${OPENRCT2_EXE} ${BINARY_DIR}\${OPENRCT2_EXE}
-    File /oname=${OPENRCT2_COM} ${BINARY_DIR}\${OPENRCT2_COM}
 
     ; Create the Registry Entries
     WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OpenRCT2" "Comments" "Visit ${APPURLLINK}"
@@ -199,7 +197,7 @@ Section "!OpenRCT2" Section1
     CreateShortCut "$DESKTOP\OpenRCT2.lnk" "$INSTDIR\${OPENRCT2_EXE}"
     CreateDirectory "$SMPROGRAMS\$SHORTCUTS"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\OpenRCT2.lnk" "$INSTDIR\${OPENRCT2_EXE}"
-    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\OpenRCT2-verbose.lnk" "%WINDIR%\System32\cmd.exe" '/C "$INSTDIR\${OPENRCT2_COM}" --verbose'
+    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\OpenRCT2-verbose.lnk" "%WINDIR%\System32\cmd.exe" '/C "$INSTDIR\${OPENRCT2_EXE}" --console --verbose'
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Uninstall.lnk" "$INSTDIR\uninstall.exe"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Readme.lnk" "$INSTDIR\Readme.txt"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Changelog.lnk" "$INSTDIR\Changelog.txt"
@@ -249,7 +247,6 @@ Section "Uninstall"
     Delete "$INSTDIR\scripting.md"
     Delete "$INSTDIR\openrct2.d.ts"
     Delete "$INSTDIR\${OPENRCT2_EXE}"
-    Delete "$INSTDIR\${OPENRCT2_COM}"
     Delete "$INSTDIR\INSTALL.LOG"
 
     ; Data files

--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,8 @@ Refer to https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-Linux#re
 
 Once you have ran msbuild once, further development can be done within Visual Studio by opening `openrct2.sln`. Make sure to select the correct target platform for which you ran the build in point #3 (`Win32` for the 32-bit version, `x64` for the 64-bit version), otherwise the build will fail in Visual Studio.
 
+`Debug` configurations always display a debug console, for `Release` configurations it can be shown with a `--console` command line argument.
+
 Other examples:
 ```
 set platform=x64

--- a/scripts/build
+++ b/scripts/build
@@ -23,11 +23,6 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     # Build everything
     echo -e "\033[0;36mBuilding OpenRCT2 for Windows $CONFIGURATION|$PLATFORM...\033[0m"
     vstool msbuild openrct2.proj //t:build
-
-    # Create openrct2.exe and openrct2.com with correct subsystem
-    cp bin/openrct2.exe bin/openrct2.com
-    vstool editbin //subsystem:console bin/openrct2.com
-    vstool editbin //subsystem:windows bin/openrct2.exe
 else
     echo -e "\033[0;36mBuilding OpenRCT2...\033[0m"
     mkdir -p bin && cd bin

--- a/scripts/build-portable
+++ b/scripts/build-portable
@@ -18,7 +18,7 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
         rm $destination
     fi
     7z a -r $destination \
-        openrct2.exe openrct2.com data \
+        openrct2.exe data \
         ../contributors.md \
         ../licence.txt \
         ../distribution/changelog.txt \

--- a/scripts/build-symbols
+++ b/scripts/build-symbols
@@ -20,7 +20,7 @@ echo -e "\033[0;36mCreating symbols archive for OpenRCT2...\033[0m"
 if [[ -f $destination ]]; then
     rm $destination
 fi
-$archiver $destination openrct2.exe openrct2.com openrct2-win.pdb
+$archiver $destination openrct2.exe openrct2-win.pdb
 
 destination=$(cygpath -w $(readlink -f $destination))
 printf '\033[0;32m%s\033[0m\n' "${destination} created successfully"

--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -33,11 +33,7 @@ template<typename T> static std::shared_ptr<T> to_shared(std::unique_ptr<T>&& sr
 /**
  * Main entry point for non-Windows systems. Windows instead uses its own DLL proxy.
  */
-#if defined(_MSC_VER) && !defined(__DISABLE_DLL_PROXY__)
-int NormalisedMain(int argc, const char** argv)
-#else
 int main(int argc, const char** argv)
-#endif
 {
     std::unique_ptr<IContext> context;
     int32_t rc = EXIT_SUCCESS;

--- a/src/openrct2-ui/Ui.h
+++ b/src/openrct2-ui/Ui.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -10,5 +10,5 @@
 #pragma once
 
 #ifdef _MSC_VER
-int NormalisedMain(int argc, const char** argv);
+int main(int argc, const char** argv);
 #endif

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -20,37 +20,78 @@
 #include <iterator>
 #include <openrct2-ui/Ui.h>
 #include <openrct2/core/String.hpp>
+#include <shellapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
 #include <vector>
 
-static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW);
+static std::vector<std::string> GetCommandLineArgs(const wchar_t* cmdLine);
+static void CreateConsole();
 
 /**
- * Windows entry point to OpenRCT2 with a console window using a traditional C main function.
+ * Windows entry point to OpenRCT2 for a GUI application, calling to the traditional C main function.
  */
-int wmain(int argc, wchar_t** argvW, [[maybe_unused]] wchar_t* envp)
+int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpCmdLine*/, int /*nShowCmd*/)
 {
-    auto argvStrings = GetCommandLineArgs(argc, argvW);
+    auto argvStrings = GetCommandLineArgs(GetCommandLineW());
 
-    SetConsoleCP(CODE_PAGE::CP_UTF8);
-    SetConsoleOutputCP(CODE_PAGE::CP_UTF8);
+    // Handle a special Windows-only commandline argument "--console". If present, create our own console and point stdin/stdout
+    // at that.
+#ifdef DEBUG
+    constexpr bool alwaysCreateConsole = true;
+#else
+    constexpr bool alwaysCreateConsole = false;
+#endif
+
+    auto consoleArg = std::find(argvStrings.begin(), argvStrings.end(), "--console");
+    if (consoleArg != argvStrings.end())
+    {
+        CreateConsole();
+
+        // Remove this argument so the game doesn't throw an unknown argument error.
+        argvStrings.erase(consoleArg);
+    }
+    else if constexpr (alwaysCreateConsole)
+    {
+        CreateConsole();
+    }
 
     std::vector<const char*> argv;
     std::transform(
         argvStrings.begin(), argvStrings.end(), std::back_inserter(argv), [](const auto& string) { return string.c_str(); });
-    auto exitCode = NormalisedMain(argc, argv.data());
+    argv.push_back(nullptr);
+    auto exitCode = main(static_cast<int>(argvStrings.size()), argv.data());
     return exitCode;
 }
 
-static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW)
+static std::vector<std::string> GetCommandLineArgs(const wchar_t* cmdLine)
 {
     // Allocate UTF-8 strings
     std::vector<std::string> argv;
-    for (int i = 0; i < argc; i++)
+    int numArgs;
+    LPWSTR* args = CommandLineToArgvW(cmdLine, &numArgs);
+    if (args != nullptr)
     {
-        argv.push_back(String::ToUtf8(argvW[i]));
+        for (int i = 0; i < numArgs; i++)
+        {
+            argv.push_back(String::ToUtf8(args[i]));
+        }
     }
+    LocalFree(args);
     return argv;
+}
+
+static void CreateConsole()
+{
+    if (AllocConsole())
+    {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "CONIN$", "r", stdin);
+        freopen_s(&dummyFile, "CONOUT$", "w", stderr);
+        freopen_s(&dummyFile, "CONOUT$", "w", stdout);
+
+        SetConsoleCP(CODE_PAGE::CP_UTF8);
+        SetConsoleOutputCP(CODE_PAGE::CP_UTF8);
+    }
 }

--- a/src/openrct2-win/openrct2-win.vcxproj
+++ b/src/openrct2-win/openrct2-win.vcxproj
@@ -41,7 +41,7 @@
     <Link>
       <AdditionalDependencies>libopenrct2.lib;libopenrct2ui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)openrct2-win.pdb</ProgramDatabaseFile>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
     </Link>
     <Lib>
       <TargetMachine Condition="'$(Platform)'=='Win32'">MachineX86</TargetMachine>

--- a/src/thirdparty/linenoise.hpp
+++ b/src/thirdparty/linenoise.hpp
@@ -135,12 +135,8 @@
 #undef interface
 #include <windows.h>
 #include <io.h>
-#ifndef STDIN_FILENO
 #define STDIN_FILENO (_fileno(stdin))
-#endif
-#ifndef STDOUT_FILENO
-#define STDOUT_FILENO 1
-#endif
+#define STDOUT_FILENO (_fileno(stdout))
 #define isatty _isatty
 #define write win32_write
 #define read _read


### PR DESCRIPTION
This PR changes the way Windows version of the game handles standard input/output and removes the need for a duplicate `OpenRCT2.com` file. Now only one executable is needed, with those remarks:
* Running the game normally will **not** spawn a console window.
* To show a console window, run the game with a newly added `--console` commandline argument. When the parent process has its own console (e.g. when running from `cmd.exe` or a batch file), OpenRCT2 will attach to it and use it for its own standard input/output. Otherwise, when the parent process doesn't have a console (e.g. when running from a shortcut file), a new console will be spawned.

![image](https://user-images.githubusercontent.com/7947461/118858495-8264f300-b8d9-11eb-85f3-27c81280beb1.png)


I removed all mentions of `OpenRCT2.com` from readme files, build scripts and the installer. I did **not** add a "replacement" `OpenRCT2.bat` file, but if people are in favour of shipping such an one-liner helper batch file (running the game with a `--console` argument) I can add it.