### PR TITLE
Fix #13445: Make FileScanner::ScanDirectory return a unique_ptr instead of a raw one

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -92,6 +92,7 @@ The following people are not part of the development team, but have been contrib
 * Helio Batimarqui (batimarqui) - Misc.
 * Keith Stellyes (keithstellyes) - Misc.
 * Bas Cantrijn (Basssiiie) - Misc.
+* Adrian Zdanowicz (CookiePLMonster) - Misc.
 
 ## Bug fixes
 * (halfbro)

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -536,7 +536,7 @@ namespace ThemeManager
         }
 
         auto themesPattern = Path::Combine(GetThemePath(), "*.json");
-        auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(themesPattern, true));
+        auto scanner = Path::ScanDirectory(themesPattern, true);
         while (scanner->Next())
         {
             auto fileInfo = scanner->GetFileInfo();

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -913,7 +913,7 @@ static void window_loadsave_populate_list(rct_window* w, int32_t includeNewItem,
             safe_strcat_path(filter, "*", std::size(filter));
             path_append_extension(filter, extToken, std::size(filter));
 
-            auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(filter, false));
+            auto scanner = Path::ScanDirectory(filter, false);
             while (scanner->Next())
             {
                 LoadSaveListItem newListItem;

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1189,7 +1189,6 @@ namespace OpenRCT2
                     }
                 }
             }
-            delete scanner;
         }
 
 #ifndef DISABLE_HTTP

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -678,7 +678,7 @@ static void limit_autosave_count(const size_t numberOfFilesToKeep, bool processL
 
     // At first, count how many autosaves there are
     {
-        auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(filter, false));
+        auto scanner = Path::ScanDirectory(filter, false);
         while (scanner->Next())
         {
             autosavesCount++;
@@ -693,7 +693,7 @@ static void limit_autosave_count(const size_t numberOfFilesToKeep, bool processL
 
     auto autosaveFiles = std::vector<std::string>(autosavesCount);
     {
-        auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(filter, false));
+        auto scanner = Path::ScanDirectory(filter, false);
         for (size_t i = 0; i < autosavesCount; i++)
         {
             autosaveFiles[i].resize(MAX_PATH, 0);

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -161,7 +161,6 @@ private:
 
                 files.push_back(std::move(path));
             }
-            delete scanner;
         }
         return ScanResult(stats, files);
     }

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -50,7 +51,7 @@ namespace Path
      * @param recurse Whether to scan sub directories or not.
      * @returns A new FileScanner, this must be deleted when no longer needed.
      */
-    IFileScanner* ScanDirectory(const std::string& pattern, bool recurse);
+    std::unique_ptr<IFileScanner> ScanDirectory(const std::string& pattern, bool recurse);
 
     /**
      * Scans a directory and all sub directories

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -274,7 +274,7 @@ std::string ImageTable::FindLegacyObject(const std::string& name)
     {
         // Search recursively for any file with the target name (case insensitive)
         auto filter = Path::Combine(objectsPath, "*.dat");
-        auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(filter, true));
+        auto scanner = Path::ScanDirectory(filter, true);
         while (scanner->Next())
         {
             auto currentName = Path::GetFileName(scanner->GetPathRelative());

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -443,7 +443,7 @@ void ScriptEngine::LoadPlugins()
     if (Path::DirectoryExists(base))
     {
         auto pattern = Path::Combine(base, "*.js");
-        auto scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(pattern, true));
+        auto scanner = Path::ScanDirectory(pattern, true);
         while (scanner->Next())
         {
             auto path = std::string(scanner->GetPath());

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -292,7 +292,7 @@ static std::vector<std::string> GetSaves(const std::string& directory)
     std::vector<std::string> saves;
 
     auto pattern = Path::Combine(directory, "*.sc6;*.sv6");
-    IFileScanner* scanner = Path::ScanDirectory(pattern, true);
+    auto scanner = Path::ScanDirectory(pattern, true);
     while (scanner->Next())
     {
         const utf8* path = scanner->GetPathRelative();

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -209,12 +209,11 @@ namespace TitleSequenceManager
     static void Scan(const std::string& directory)
     {
         auto pattern = Path::Combine(directory, "script.txt;*.parkseq");
-        IFileScanner* fileScanner = Path::ScanDirectory(pattern, true);
+        auto fileScanner = Path::ScanDirectory(pattern, true);
         while (fileScanner->Next())
         {
             AddSequence(fileScanner->GetPath());
         }
-        delete fileScanner;
     }
 
     static void AddSequence(const std::string& scanPath)

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -53,7 +53,7 @@ static std::vector<ReplayTestData> GetReplayFiles()
     std::string replayPathPattern = Path::Combine(replayPath, "*.sv6r");
     std::vector<std::string> files;
 
-    std::unique_ptr<IFileScanner> scanner = std::unique_ptr<IFileScanner>(Path::ScanDirectory(replayPathPattern, true));
+    auto scanner = Path::ScanDirectory(replayPathPattern, true);
     while (scanner->Next())
     {
         ReplayTestData test;


### PR DESCRIPTION
This PR implements a refactor todo, turning the usage of raw pointers in `FileScanner::ScanDirectory` to a `std::unique_ptr`.

* Usage of `auto` has been unified, as there were a few odd places where the type was specified explicitly, but most places used `auto` for the scanner.
* This implicitly fixed a resource leak in `TitleSequence::GetSaves` that held a raw pointer to the scanner and did not call `delete` on it.

Closes #13445.