### PR TITLE
Startup speed optimizations

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#14587] Confusing message when joining server with mismatched network version.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
 - Fix: [#14638] The “About OpenRCT2” window cannot be themed.
+- Improved: [#14712]: Improve startup times.
 
 0.3.3 (2021-03-13)
 ------------------------------------------------------------------------

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -57,8 +57,7 @@ namespace File
         }
 
         std::vector<uint8_t> result;
-        fs.seekg(0, std::ios::end);
-        auto fsize = static_cast<size_t>(fs.tellg());
+        auto fsize = Platform::GetFileSize(path);
         if (fsize > SIZE_MAX)
         {
             std::string message = String::StdFormat(
@@ -68,7 +67,6 @@ namespace File
         else
         {
             result.resize(fsize);
-            fs.seekg(0);
             fs.read(reinterpret_cast<char*>(result.data()), result.size());
             fs.exceptions(fs.failbit);
         }

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -122,6 +122,11 @@ namespace File
     uint64_t GetLastModified(const std::string& path)
     {
         return Platform::GetLastModified(path);
+    }
+
+    uint64_t GetSize(std::string_view path)
+    {
+        return Platform::GetFileSize(path);
     }
 } // namespace File
 

--- a/src/openrct2/core/File.h
+++ b/src/openrct2/core/File.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -26,4 +26,5 @@ namespace File
     std::vector<std::string> ReadAllLines(std::string_view path);
     void WriteAllBytes(const std::string& path, const void* buffer, size_t length);
     uint64_t GetLastModified(const std::string& path);
+    uint64_t GetSize(std::string_view path);
 } // namespace File

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -165,13 +165,9 @@ namespace OpenRCT2
 
     void FileStream::Read(void* buffer, uint64_t length)
     {
-        uint64_t remainingBytes = GetLength() - GetPosition();
-        if (length <= remainingBytes)
+        if (fread(buffer, 1, static_cast<size_t>(length), _file) == length)
         {
-            if (fread(buffer, static_cast<size_t>(length), 1, _file) == 1)
-            {
-                return;
-            }
+            return;
         }
         throw IOException("Attempted to read past end of file.");
     }

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -16,6 +16,8 @@
 
 #ifndef _WIN32
 #    include <sys/stat.h>
+#else
+#    include <io.h>
 #endif
 
 #if defined(__linux__) && !defined(__ANDROID__)
@@ -98,9 +100,12 @@ namespace OpenRCT2
             throw IOException(String::StdFormat("Unable to open '%s'", path));
         }
 
-        Seek(0, STREAM_SEEK_END);
-        _fileSize = GetPosition();
-        Seek(0, STREAM_SEEK_BEGIN);
+#ifdef _WIN32
+        _fileSize = _filelengthi64(_fileno(_file));
+#else
+        std::error_code ec;
+        _fileSize = fs::file_size(fs::u8path(path), ec);
+#endif
 
         _ownsFilePtr = true;
     }

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -252,18 +252,11 @@ bool ObjectAsset::IsAvailable() const
     }
 }
 
-size_t ObjectAsset::GetSize() const
+uint64_t ObjectAsset::GetSize() const
 {
     if (_zipPath.empty())
     {
-        try
-        {
-            return File::ReadAllBytes(_path).size();
-        }
-        catch (...)
-        {
-            return 0;
-        }
+        return File::GetSize(_path);
     }
     else
     {

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -223,7 +223,7 @@ public:
     }
 
     bool IsAvailable() const;
-    size_t GetSize() const;
+    uint64_t GetSize() const;
     std::unique_ptr<OpenRCT2::IStream> GetStream() const;
 };
 

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -175,6 +175,19 @@ namespace Platform
             lastModified = statInfo.st_mtime;
         }
         return lastModified;
+    }
+
+    uint64_t GetFileSize(std::string_view path)
+    {
+        uint64_t size = 0;
+        struct stat statInfo
+        {
+        };
+        if (stat(std::string(path).c_str(), &statInfo) == 0)
+        {
+            size = statInfo.st_size;
+        }
+        return size;
     }
 
     bool ShouldIgnoreCase()

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -552,6 +552,21 @@ namespace Platform
             CloseHandle(hFile);
         }
         return lastModified;
+    }
+
+    uint64_t GetFileSize(std::string_view path)
+    {
+        uint64_t size = 0;
+        auto pathW = String::ToWideChar(path);
+        WIN32_FILE_ATTRIBUTE_DATA attributes;
+        if (GetFileAttributesExW(pathW.c_str(), GetFileExInfoStandard, &attributes) != FALSE)
+        {
+            ULARGE_INTEGER fileSize;
+            fileSize.LowPart = attributes.nFileSizeLow;
+            fileSize.HighPart = attributes.nFileSizeHigh;
+            size = fileSize.QuadPart;
+        }
+        return size;
     }
 
     bool ShouldIgnoreCase()

--- a/src/openrct2/platform/Platform2.h
+++ b/src/openrct2/platform/Platform2.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -39,6 +39,7 @@ namespace Platform
     bool IsPathSeparator(char c);
     utf8* GetAbsolutePath(utf8* buffer, size_t bufferSize, const utf8* relativePath);
     uint64_t GetLastModified(const std::string& path);
+    uint64_t GetFileSize(std::string_view path);
     std::string ResolveCasing(const std::string& path, bool fileExists);
     rct2_time GetTimeLocal();
     rct2_date GetDateLocal();


### PR DESCRIPTION
This PR consists of 3 changes to the file IO, resulting in a significant speedup to the startup times:

1. `ObjectAsset::GetSize()` obtained the size of the file by reading it all to memory and counting bytes read, then discarding the contents. This was especially wasteful when used on music tracks and took over 400ms during startup on my setup. To remedy this, I introduced a `File::GetSize()` function that queries the size without reading the file contents. Also made `ObjectAsset::GetSize()` return a 64-bit value, because there is no reason why should the file size be truncated in 32-bit builds.
2. Because of these changes, a "seek to end, tell, seek to begin" idiom can be replaced with a proper size check.
3. After the above two changes, `ftell` showed up as the second hottest function when profiling startup, The culprit turned out to be `FileStream::Read` repeatedly checking for EOF before attempting to read. Since this is an exceptional case that should never/rarely happen, I now let the game try to read from the file and throw an exception if it doesn't read enough - hitting EOF while reading is one of the cases where this will happen. This effectively "optimizes" the function for a success case, while previously it was closer to being "optimized" for a failure case.

I also took the liberty of adding this change to a changelog, since halving the startup time is something easily noticeable for the end user. On my machine, startup times **went down from ~830ms to ~380ms**:

Before: `TitleScreen::Load() took 835ms.`
After: `TitleScreen::Load() took 376ms.`