### PR TITLE
More startup speed optimizations

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,7 +21,7 @@
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
 - Fix: [#14638] The “About OpenRCT2” window cannot be themed.
 - Fix: [#14710] Ride/Track Design preview does not show if it costs more money than available.
-- Improved: [#14712]: Improve startup times.
+- Improved: [#14712, #14716]: Improve startup times.
 
 0.3.3 (2021-03-13)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct12/SawyerChunk.cpp
+++ b/src/openrct2/rct12/SawyerChunk.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -10,6 +10,7 @@
 #include "SawyerChunk.h"
 
 #include "../core/Memory.hpp"
+#include "SawyerChunkReader.h"
 
 SawyerChunk::SawyerChunk(SAWYER_ENCODING encoding, void* data, size_t length)
 {
@@ -20,5 +21,5 @@ SawyerChunk::SawyerChunk(SAWYER_ENCODING encoding, void* data, size_t length)
 
 SawyerChunk::~SawyerChunk()
 {
-    Memory::Free(_data);
+    SawyerChunkReader::FreeChunk(_data);
 }

--- a/src/openrct2/rct12/SawyerChunkReader.cpp
+++ b/src/openrct2/rct12/SawyerChunkReader.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -156,6 +156,11 @@ void SawyerChunkReader::ReadChunk(void* dst, size_t length)
             std::fill_n(offset, remainingLength, 0x00);
         }
     }
+}
+
+void SawyerChunkReader::FreeChunk(void* data)
+{
+    FreeLargeTempBuffer(data);
 }
 
 size_t SawyerChunkReader::DecodeChunk(void* dst, size_t dstCapacity, const void* src, const sawyercoding_chunk_header& header)
@@ -315,9 +320,7 @@ void* SawyerChunkReader::AllocateLargeTempBuffer()
 void* SawyerChunkReader::FinaliseLargeTempBuffer(void* buffer, size_t len)
 {
 #ifdef __USE_HEAP_ALLOC__
-    auto finalBuffer = std::malloc(len);
-    std::memcpy(finalBuffer, buffer, len);
-    HeapFree(GetProcessHeap(), 0, buffer);
+    auto finalBuffer = HeapReAlloc(GetProcessHeap(), 0, buffer, len);
 #else
     auto finalBuffer = static_cast<uint8_t*>(std::realloc(buffer, len));
 #endif

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -36,15 +36,17 @@ namespace OpenRCT2
 
 /**
  * Reads sawyer encoding chunks from a data stream. This can be used to read
- * SC6, SV6 and RCT2 objects.
+ * SC6, SV6 and RCT2 objects. persistentChunks is a hint to the reader that the chunk will be preserved,
+ * and thus the chunk memory should be shrunk.
  */
 class SawyerChunkReader final
 {
 private:
     OpenRCT2::IStream* const _stream = nullptr;
+    const bool _createsPersistentChunks = false;
 
 public:
-    explicit SawyerChunkReader(OpenRCT2::IStream* stream);
+    explicit SawyerChunkReader(OpenRCT2::IStream* stream, bool persistentChunks = false);
 
     /**
      * Skips the next chunk in the stream without decoding or reading its data

--- a/src/openrct2/rct12/SawyerChunkReader.h
+++ b/src/openrct2/rct12/SawyerChunkReader.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -83,6 +83,11 @@ public:
         ReadChunk(&result, sizeof(result));
         return result;
     }
+
+    /**
+     * Frees the chunk data, to be used when destructing SawyerChunks
+     */
+    static void FreeChunk(void* data);
 
 private:
     static size_t DecodeChunk(void* dst, size_t dstCapacity, const void* src, const sawyercoding_chunk_header& header);


### PR DESCRIPTION
A follow up to #14712, optimizing startup times further. When investigating `SawyerChunkReader`, I spotted that every chunk buffer followed an `allocate 16MB -> shrink down to real size` pattern when reading. However, **all** current instances of `SawyerChunk` are just short lived local variables that get freed soon after reading, so reallocation is a pointless memory optimization.

In this PR I made `SawyerChunkReader` not shrink allocations by default and instead introduced a (currently never used) `persistentChunks` parameter that acts as a hint to the reader that the `SawyerChunk` will be persisted and thus it makes sense to shrink that memory.

On my machine, those changes shorten the startup time by 80-100ms, and shorten the object index building by around 200ms.
![image](https://user-images.githubusercontent.com/7947461/119228510-9136ea00-bb13-11eb-9995-e07719132e4e.png)

**NOTE:** I'm not happy how `SawyerChunk` has to call to `SawyerChunkReader` to free memory without an allocator mismatch. In my opinion, this would be best refactored into a small, static-only `SawyerChunkAllocator` class that would essentially only house what is currently `AllocateLargeTempBuffer`, `FinaliseLargeTempBuffer` and `FreeLargeTempBuffer`.
EDIT: Alternately, those three functions could just use `Memory::Allocate`, `Memory::Reallocate` and `Memory::Free` internally - this would remove the need to modify `SawyerChunk` completely, but would remove the `__USE_HEAP_ALLOC__` Debug optimization.