### PR TITLE
Downgrade “Image table longer than expected” to a verbose warning

### DIFF
--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -315,7 +315,7 @@ void ImageTable::Read(IReadObjectContext* context, OpenRCT2::IStream* stream)
         uint64_t remainingBytes = stream->GetLength() - stream->GetPosition() - headerTableSize;
         if (remainingBytes > imageDataSize)
         {
-            context->LogWarning(ObjectError::BadImageTable, "Image table size longer than expected.");
+            context->LogVerbose(ObjectError::BadImageTable, "Image table size longer than expected.");
             imageDataSize = static_cast<uint32_t>(remainingBytes);
         }
 

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -237,6 +237,7 @@ struct IReadObjectContext
     virtual std::vector<uint8_t> GetData(std::string_view path) abstract;
     virtual ObjectAsset GetAsset(std::string_view path) abstract;
 
+    virtual void LogVerbose(ObjectError code, const utf8* text) abstract;
     virtual void LogWarning(ObjectError code, const utf8* text) abstract;
     virtual void LogError(ObjectError code, const utf8* text) abstract;
 };

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -105,10 +105,15 @@ private:
     std::string _identifier;
     bool _loadImages;
     std::string _basePath;
+    bool _wasVerbose = false;
     bool _wasWarning = false;
     bool _wasError = false;
 
 public:
+    bool WasVerbose() const
+    {
+        return _wasVerbose;
+    }
     bool WasWarning() const
     {
         return _wasWarning;
@@ -159,6 +164,16 @@ public:
             return _fileDataRetriever->GetAsset(path);
         }
         return {};
+    }
+
+    void LogVerbose(ObjectError code, const utf8* text) override
+    {
+        _wasVerbose = true;
+
+        if (!String::IsNullOrEmpty(text))
+        {
+            log_verbose("[%s] Info (%d): %s", _identifier.c_str(), code, text);
+        }
     }
 
     void LogWarning(ObjectError code, const utf8* text) override


### PR DESCRIPTION
There are lots of custom objects like this and there is little point spewing the console full of them, since they’re unlikely to cause many problems.