### PR TITLE
Fix #14707: Crash when window was closed during text input.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#14587] Confusing message when joining server with mismatched network version.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
 - Fix: [#14638] The “About OpenRCT2” window cannot be themed.
+- Fix: [#14707] Crash when window was closed during text input.
 - Fix: [#14710] Ride/Track Design preview does not show if it costs more money than available.
 - Improved: [#14712]: Improve startup times.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,7 +21,7 @@
 - Fix: [#14587] Confusing message when joining server with mismatched network version.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
 - Fix: [#14638] The “About OpenRCT2” window cannot be themed.
-- Fix: [#14707] Crash when window was closed during text input.
+- Fix: [#14707] Crash when window is closed during text input.
 - Fix: [#14710] Ride/Track Design preview does not show if it costs more money than available.
 - Improved: [#14712]: Improve startup times.
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -408,6 +408,9 @@ void window_text_input_open(
 
 void window_text_input_key(rct_window* w, char keychar)
 {
+    const auto wndNumber = w->number;
+    const auto wndClass = w->classification;
+
     // If the return button is pressed stop text input
     if (keychar == '\r')
     {
@@ -417,5 +420,9 @@ void window_text_input_key(rct_window* w, char keychar)
             textInputWindow->OnReturnPressed();
         }
     }
-    w->Invalidate();
+
+    // The window can be potentially closed within a callback, we need to check if its still alive.
+    w = window_find_by_number(wndClass, wndNumber);
+    if (w != nullptr)
+        w->Invalidate();
 }


### PR DESCRIPTION
This one has been there for some time I believe, however recent refactors made it easier to figure it out. 

Closes #14707