### PR TITLE
Fix #14682: Crash when painting Swinging Ships with invalid sub type

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#14587] Confusing message when joining server with mismatched network version.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
 - Fix: [#14638] The “About OpenRCT2” window cannot be themed.
+- Fix: [#14682] Crash when painting Swinging Ships with invalid subtype.
 - Fix: [#14707] Crash when window is closed during text input.
 - Fix: [#14710] Ride/Track Design preview does not show if it costs more money than available.
 - Improved: [#14712]: Improve startup times.

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -63,6 +63,11 @@ static void paint_swinging_ship_structure(
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
     rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    if (rideEntry == nullptr)
+    {
+        return;
+    }
+
     Vehicle* vehicle = nullptr;
 
     int8_t xOffset = !(direction & 1) ? axisOffset : 0;


### PR DESCRIPTION
Closes #14682