### PR TITLE
Backport object selection improvements

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3691,6 +3691,9 @@ STR_6445    :Footpath Railings
 STR_6446    :{WINDOW_COLOUR_2}Surface name: {BLACK}{STRINGID}
 STR_6447    :{WINDOW_COLOUR_2}Railing name: {BLACK}{STRINGID}
 STR_6448    :Unsupported object format
+STR_6449    :{WINDOW_COLOUR_2}Tracks:
+STR_6450    :{BLACK}“{STRING}”
+STR_6451    :{BLACK}“{STRING}” - {STRING}
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3694,6 +3694,7 @@ STR_6448    :Unsupported object format
 STR_6449    :{WINDOW_COLOUR_2}Tracks:
 STR_6450    :{BLACK}“{STRING}”
 STR_6451    :{BLACK}“{STRING}” - {STRING}
+STR_6452    :{WINDOW_COLOUR_2}Sells: {BLACK}{STRING}
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -28,6 +28,7 @@
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/ObjectRepository.h>
 #include <openrct2/object/RideObject.h>
+#include <openrct2/object/SceneryGroupObject.h>
 #include <openrct2/platform/platform.h>
 #include <openrct2/ride/RideData.h>
 #include <openrct2/scenario/Scenario.h>
@@ -1072,8 +1073,14 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
 
         screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_WINDOW_COLOUR_2_STRINGID, ft);
     }
-
-    if (get_selected_object_type(w) == ObjectType::Music)
+    if (get_selected_object_type(w) == ObjectType::SceneryGroup)
+    {
+        const auto* sceneryGroupObject = reinterpret_cast<SceneryGroupObject*>(_loadedObject.get());
+        auto ft = Formatter();
+        ft.Add<uint16_t>(sceneryGroupObject->GetNumIncludedObjects());
+        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_INCLUDES_X_OBJECTS, ft) + 2;
+    }
+    else if (get_selected_object_type(w) == ObjectType::Music)
     {
         screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
         const auto* musicObject = reinterpret_cast<MusicObject*>(_loadedObject.get());

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -938,6 +938,120 @@ static void window_editor_object_selection_invalidate(rct_window* w)
     }
 }
 
+static void window_editor_object_selection_paint_descriptions(rct_window* w, rct_drawpixelinfo* dpi)
+{
+    auto widget = &w->widgets[WIDX_PREVIEW];
+    auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LIST].right + 4, widget->bottom + 23 };
+    auto width = w->windowPos.x + w->width - screenPos.x - 4;
+
+    auto description = object_get_description(_loadedObject.get());
+    if (!description.empty())
+    {
+        auto ft = Formatter();
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(description.c_str());
+
+        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_WINDOW_COLOUR_2_STRINGID, ft) + LIST_ROW_HEIGHT;
+    }
+    if (get_selected_object_type(w) == ObjectType::Ride)
+    {
+        auto* rideObject = reinterpret_cast<RideObject*>(_loadedObject.get());
+        const auto* rideEntry = reinterpret_cast<rct_ride_entry*>(rideObject->GetLegacyData());
+        if (rideEntry->shop_item[0] != ShopItem::None)
+        {
+            std::string sells = "";
+            for (size_t i = 0; i < std::size(rideEntry->shop_item); i++)
+            {
+                if (rideEntry->shop_item[i] == ShopItem::None)
+                    continue;
+
+                if (!sells.empty())
+                    sells += ", ";
+
+                sells += language_get_string(GetShopItemDescriptor(rideEntry->shop_item[i]).Naming.Plural);
+            }
+            auto ft = Formatter();
+            ft.Add<const char*>(sells.c_str());
+            screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_RIDE_OBJECT_SHOP_SELLS, ft) + 2;
+        }
+    }
+    else if (get_selected_object_type(w) == ObjectType::SceneryGroup)
+    {
+        const auto* sceneryGroupObject = reinterpret_cast<SceneryGroupObject*>(_loadedObject.get());
+        auto ft = Formatter();
+        ft.Add<uint16_t>(sceneryGroupObject->GetNumIncludedObjects());
+        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_INCLUDES_X_OBJECTS, ft) + 2;
+    }
+    else if (get_selected_object_type(w) == ObjectType::Music)
+    {
+        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
+        const auto* musicObject = reinterpret_cast<MusicObject*>(_loadedObject.get());
+        for (size_t i = 0; i < musicObject->GetTrackCount(); i++)
+        {
+            const auto* track = musicObject->GetTrack(i);
+            if (track->Name.empty())
+                continue;
+
+            auto stringId = track->Composer.empty() ? STR_MUSIC_OBJECT_TRACK_LIST_ITEM
+                                                    : STR_MUSIC_OBJECT_TRACK_LIST_ITEM_WITH_COMPOSER;
+            auto ft = Formatter();
+            ft.Add<const char*>(track->Name.c_str());
+            ft.Add<const char*>(track->Composer.c_str());
+            screenPos.y += DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, width, stringId, ft);
+        }
+    }
+}
+
+static void window_editor_object_selection_paint_debug_data(rct_window* w, rct_drawpixelinfo* dpi)
+{
+    list_item* listItem = &_listItems[w->selected_list_item];
+    auto screenPos = w->windowPos + ScreenCoordsXY{ w->width - 5, w->height - (LIST_ROW_HEIGHT * 5) };
+    // Draw ride type.
+    if (get_selected_object_type(w) == ObjectType::Ride)
+    {
+        auto stringId = get_ride_type_string_id(listItem->repositoryItem);
+        DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+    }
+
+    screenPos.y += LIST_ROW_HEIGHT;
+
+    // Draw object source
+    auto stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
+    DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+    screenPos.y += LIST_ROW_HEIGHT;
+
+    // Draw object dat name
+    {
+        const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
+        auto ft = Formatter();
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(path);
+        DrawTextBasic(
+            dpi, { w->windowPos.x + w->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
+            { COLOUR_BLACK, TextAlignment::RIGHT });
+        screenPos.y += LIST_ROW_HEIGHT;
+    }
+
+    // Draw object author (will be blank space if no author in file or a non JSON object)
+    {
+        auto ft = Formatter();
+        std::string authorsString;
+        for (size_t i = 0; i < listItem->repositoryItem->Authors.size(); i++)
+        {
+            if (i > 0)
+            {
+                authorsString.append(", ");
+            }
+            authorsString.append(listItem->repositoryItem->Authors[i]);
+        }
+        ft.Add<rct_string_id>(STR_STRING);
+        ft.Add<const char*>(authorsString.c_str());
+        DrawTextEllipsised(
+            dpi, { w->windowPos.x + w->width - 5, screenPos.y }, w->width - w->widgets[WIDX_LIST].right - 4,
+            STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::RIGHT });
+    }
+}
+
 /**
  *
  *  rct2: 0x006AAB56
@@ -1061,89 +1175,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
         DrawTextEllipsised(dpi, screenPos, width, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
     }
 
-    auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LIST].right + 4, widget->bottom + 23 };
-    width = w->windowPos.x + w->width - screenPos.x - 4;
-
-    auto description = object_get_description(_loadedObject.get());
-    if (!description.empty())
-    {
-        auto ft = Formatter();
-        ft.Add<rct_string_id>(STR_STRING);
-        ft.Add<const char*>(description.c_str());
-
-        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_WINDOW_COLOUR_2_STRINGID, ft);
-    }
-    if (get_selected_object_type(w) == ObjectType::SceneryGroup)
-    {
-        const auto* sceneryGroupObject = reinterpret_cast<SceneryGroupObject*>(_loadedObject.get());
-        auto ft = Formatter();
-        ft.Add<uint16_t>(sceneryGroupObject->GetNumIncludedObjects());
-        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_INCLUDES_X_OBJECTS, ft) + 2;
-    }
-    else if (get_selected_object_type(w) == ObjectType::Music)
-    {
-        screenPos.y += DrawTextWrapped(dpi, screenPos, width, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
-        const auto* musicObject = reinterpret_cast<MusicObject*>(_loadedObject.get());
-        for (size_t i = 0; i < musicObject->GetTrackCount(); i++)
-        {
-            const auto* track = musicObject->GetTrack(i);
-            if (track->Name.empty())
-                continue;
-
-            auto stringId = track->Composer.empty() ? STR_MUSIC_OBJECT_TRACK_LIST_ITEM
-                                                    : STR_MUSIC_OBJECT_TRACK_LIST_ITEM_WITH_COMPOSER;
-            auto ft = Formatter();
-            ft.Add<const char*>(track->Name.c_str());
-            ft.Add<const char*>(track->Composer.c_str());
-            screenPos.y += DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, width, stringId, ft);
-        }
-    }
-
-    screenPos = w->windowPos + ScreenCoordsXY{ w->width - 5, w->height - (LIST_ROW_HEIGHT * 5) };
-    // Draw ride type.
-    if (get_selected_object_type(w) == ObjectType::Ride)
-    {
-        auto stringId = get_ride_type_string_id(listItem->repositoryItem);
-        DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
-    }
-
-    screenPos.y += LIST_ROW_HEIGHT;
-
-    // Draw object source
-    auto stringId = object_manager_get_source_game_string(listItem->repositoryItem->GetFirstSourceGame());
-    DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
-    screenPos.y += LIST_ROW_HEIGHT;
-
-    // Draw object dat name
-    {
-        const char* path = path_get_filename(listItem->repositoryItem->Path.c_str());
-        auto ft = Formatter();
-        ft.Add<rct_string_id>(STR_STRING);
-        ft.Add<const char*>(path);
-        DrawTextBasic(
-            dpi, { w->windowPos.x + w->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
-            { COLOUR_BLACK, TextAlignment::RIGHT });
-        screenPos.y += LIST_ROW_HEIGHT;
-    }
-
-    // Draw object author (will be blank space if no author in file or a non JSON object)
-    {
-        auto ft = Formatter();
-        std::string authorsString;
-        for (size_t i = 0; i < listItem->repositoryItem->Authors.size(); i++)
-        {
-            if (i > 0)
-            {
-                authorsString.append(", ");
-            }
-            authorsString.append(listItem->repositoryItem->Authors[i]);
-        }
-        ft.Add<rct_string_id>(STR_STRING);
-        ft.Add<const char*>(authorsString.c_str());
-        DrawTextEllipsised(
-            dpi, { w->windowPos.x + w->width - 5, screenPos.y }, w->width - w->widgets[WIDX_LIST].right - 4,
-            STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::RIGHT });
-    }
+    window_editor_object_selection_paint_descriptions(w, dpi);
+    window_editor_object_selection_paint_debug_data(w, dpi);
 }
 /**
  *

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3943,6 +3943,10 @@ enum
 
     STR_VIEWPORT_TRANSPARENT_WATER = 6440,
 
+    STR_MUSIC_OBJECT_TRACK_HEADER = 6449,
+    STR_MUSIC_OBJECT_TRACK_LIST_ITEM = 6450,
+    STR_MUSIC_OBJECT_TRACK_LIST_ITEM_WITH_COMPOSER = 6451,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3947,6 +3947,8 @@ enum
     STR_MUSIC_OBJECT_TRACK_LIST_ITEM = 6450,
     STR_MUSIC_OBJECT_TRACK_LIST_ITEM_WITH_COMPOSER = 6451,
 
+    STR_RIDE_OBJECT_SHOP_SELLS = 6452,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -106,6 +106,7 @@ void MusicObject::ParseTracks(IReadObjectContext& context, json_t& jTracks)
         {
             MusicObjectTrack track;
             track.Name = Json::GetString(jTrack["name"]);
+            track.Composer = Json::GetString(jTrack["composer"]);
             auto source = Json::GetString(jTrack["source"]);
             if (source.empty())
             {

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -18,6 +18,7 @@ class MusicObjectTrack
 {
 public:
     std::string Name;
+    std::string Composer;
     ObjectAsset Asset;
 
     /**

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -176,3 +176,8 @@ std::vector<ObjectEntryDescriptor> SceneryGroupObject::ReadJsonEntries(json_t& j
     }
     return entries;
 }
+
+uint16_t SceneryGroupObject::GetNumIncludedObjects() const
+{
+    return static_cast<uint16_t>(_items.size());
+}

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -45,6 +45,8 @@ public:
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 
+    uint16_t GetNumIncludedObjects() const;
+
 private:
     static std::vector<ObjectEntryDescriptor> ReadItems(OpenRCT2::IStream* stream);
     static uint32_t ReadJsonEntertainerCostumes(json_t& jCostumes);


### PR DESCRIPTION
These are all in the `new-save-format` branch already, but they’re not tied to it. I’m backporting them to benefit the 0.3.4 release and to make the size of the NSF PR a bit smaller.