### PR TITLE
Rearrange WallSceneryEntry to enforce types

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -383,8 +383,9 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
             return info;
         }
         case ViewportInteractionItem::Wall:
-            sceneryEntry = tileElement->AsWall()->GetEntry();
-            if (sceneryEntry->wall.scrolling_mode != SCROLLING_MODE_NONE)
+        {
+            auto* wallEntry = tileElement->AsWall()->GetEntry();
+            if (wallEntry->scrolling_mode != SCROLLING_MODE_NONE)
             {
                 auto banner = tileElement->AsWall()->GetBanner();
                 if (banner != nullptr)
@@ -393,13 +394,13 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
                     ft.Add<rct_string_id>(STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);
                     banner->FormatTextTo(ft);
                     ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
-                    ft.Add<rct_string_id>(sceneryEntry->name);
+                    ft.Add<rct_string_id>(wallEntry->name);
                     SetMapTooltip(ft);
                     return info;
                 }
             }
             break;
-
+        }
         case ViewportInteractionItem::LargeScenery:
             sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             if (sceneryEntry->large_scenery.scrolling_mode != SCROLLING_MODE_NONE)
@@ -487,12 +488,13 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
             return info;
 
         case ViewportInteractionItem::Wall:
-            sceneryEntry = tileElement->AsWall()->GetEntry();
+        {
+            auto* wallEntry = tileElement->AsWall()->GetEntry();
             ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
-            ft.Add<rct_string_id>(sceneryEntry->name);
+            ft.Add<rct_string_id>(wallEntry->name);
             SetMapTooltip(ft);
             return info;
-
+        }
         case ViewportInteractionItem::LargeScenery:
             sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
@@ -656,8 +658,8 @@ void ViewportInteractionRemoveParkEntrance(TileElement* tileElement, CoordsXY ma
  */
 static void ViewportInteractionRemoveParkWall(TileElement* tileElement, const CoordsXY& mapCoords)
 {
-    rct_scenery_entry* sceneryEntry = tileElement->AsWall()->GetEntry();
-    if (sceneryEntry->wall.scrolling_mode != SCROLLING_MODE_NONE)
+    auto* wallEntry = tileElement->AsWall()->GetEntry();
+    if (wallEntry->scrolling_mode != SCROLLING_MODE_NONE)
     {
         context_open_detail_window(WD_SIGN_SMALL, tileElement->AsWall()->GetBannerIndex());
     }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1272,8 +1272,7 @@ void window_scenery_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t s
                     }
                     gfx_draw_sprite(&clipdpi, imageId, { 0x2F, spriteTop }, tertiaryColour);
 
-                    imageId = (wallEntry->image + 0x40000006)
-                        | (EnumValue(GlassPaletteIds[gWindowSceneryPrimaryColour]) << 19);
+                    imageId = (wallEntry->image + 0x40000006) | (EnumValue(GlassPaletteIds[gWindowSceneryPrimaryColour]) << 19);
                     gfx_draw_sprite(&clipdpi, imageId, { 0x2F, spriteTop }, tertiaryColour);
                 }
                 else

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -184,8 +184,7 @@ static ScenerySelection window_scenery_tab_entries[SCENERY_WINDOW_TABS][SCENERY_
  * Was part of 0x006DFA00
  * The same code repeated five times for every scenery entry type
  */
-static void init_scenery_entry(
-    rct_scenery_entry* sceneryEntry, const ScenerySelection& selection, ObjectEntryIndex sceneryTabId)
+static void init_scenery_entry(const ScenerySelection& selection, ObjectEntryIndex sceneryTabId)
 {
     Guard::ArgumentInRange<int32_t>(selection.EntryIndex, 0, WINDOW_SCENERY_TAB_SELECTION_UNDEFINED);
     if (scenery_is_invented(selection) || gCheatsIgnoreResearchStatus)
@@ -271,7 +270,7 @@ void window_scenery_init()
         if (sceneryEntry == nullptr)
             continue;
 
-        init_scenery_entry(sceneryEntry, { SCENERY_TYPE_SMALL, sceneryId }, sceneryEntry->small_scenery.scenery_tab_id);
+        init_scenery_entry({ SCENERY_TYPE_SMALL, sceneryId }, sceneryEntry->small_scenery.scenery_tab_id);
     }
 
     // large scenery
@@ -281,17 +280,17 @@ void window_scenery_init()
         if (sceneryEntry == nullptr)
             continue;
 
-        init_scenery_entry(sceneryEntry, { SCENERY_TYPE_LARGE, sceneryId }, sceneryEntry->large_scenery.scenery_tab_id);
+        init_scenery_entry({ SCENERY_TYPE_LARGE, sceneryId }, sceneryEntry->large_scenery.scenery_tab_id);
     }
 
     // walls
     for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_WALL_SCENERY_OBJECTS; sceneryId++)
     {
-        rct_scenery_entry* sceneryEntry = get_wall_entry(sceneryId);
+        auto* sceneryEntry = get_wall_entry(sceneryId);
         if (sceneryEntry == nullptr)
             continue;
 
-        init_scenery_entry(sceneryEntry, { SCENERY_TYPE_WALL, sceneryId }, sceneryEntry->wall.scenery_tab_id);
+        init_scenery_entry({ SCENERY_TYPE_WALL, sceneryId }, sceneryEntry->scenery_tab_id);
     }
 
     // banners
@@ -301,7 +300,7 @@ void window_scenery_init()
         if (sceneryEntry == nullptr)
             continue;
 
-        init_scenery_entry(sceneryEntry, { SCENERY_TYPE_BANNER, sceneryId }, sceneryEntry->banner.scenery_tab_id);
+        init_scenery_entry({ SCENERY_TYPE_BANNER, sceneryId }, sceneryEntry->banner.scenery_tab_id);
     }
 
     // path bits
@@ -311,7 +310,7 @@ void window_scenery_init()
         if (sceneryEntry == nullptr)
             continue;
 
-        init_scenery_entry(sceneryEntry, { SCENERY_TYPE_PATH_ITEM, sceneryId }, sceneryEntry->path_bit.scenery_tab_id);
+        init_scenery_entry({ SCENERY_TYPE_PATH_ITEM, sceneryId }, sceneryEntry->path_bit.scenery_tab_id);
     }
 
     for (rct_widgetindex widgetIndex = WIDX_SCENERY_TAB_1; widgetIndex < WIDX_SCENERY_LIST; widgetIndex++)
@@ -825,7 +824,7 @@ static void window_scenery_update(rct_window* w)
             }
             else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_WALL)
             {
-                gCurrentToolId = static_cast<Tool>(get_wall_entry(tabSelectedScenery.EntryIndex)->wall.tool_id);
+                gCurrentToolId = static_cast<Tool>(get_wall_entry(tabSelectedScenery.EntryIndex)->tool_id);
             }
             else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_PATH_ITEM)
             { // path bit
@@ -1043,18 +1042,18 @@ void window_scenery_invalidate(rct_window* w)
         }
         else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_WALL)
         {
-            sceneryEntry = get_wall_entry(tabSelectedScenery.EntryIndex);
-            if (sceneryEntry->wall.flags & (WALL_SCENERY_HAS_PRIMARY_COLOUR | WALL_SCENERY_HAS_GLASS))
+            auto* wallEntry = get_wall_entry(tabSelectedScenery.EntryIndex);
+            if (wallEntry->flags & (WALL_SCENERY_HAS_PRIMARY_COLOUR | WALL_SCENERY_HAS_GLASS))
             {
                 window_scenery_widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WindowWidgetType::ColourBtn;
 
-                if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
+                if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
                 {
                     window_scenery_widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WindowWidgetType::ColourBtn;
 
-                    if (sceneryEntry->wall.flags2 & WALL_SCENERY_2_NO_SELECT_PRIMARY_COLOUR)
+                    if (wallEntry->flags2 & WALL_SCENERY_2_NO_SELECT_PRIMARY_COLOUR)
                         window_scenery_widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WindowWidgetType::Empty;
-                    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
+                    if (wallEntry->flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
                         window_scenery_widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WindowWidgetType::ColourBtn;
                 }
             }
@@ -1134,29 +1133,36 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     uint32_t price = 0;
-
+    rct_string_id name = STR_UNKNOWN_OBJECT_TYPE;
     rct_scenery_entry* sceneryEntry = nullptr;
     switch (selectedSceneryEntry.SceneryType)
     {
         case SCENERY_TYPE_SMALL:
             sceneryEntry = get_small_scenery_entry(selectedSceneryEntry.EntryIndex);
             price = sceneryEntry->small_scenery.price * 10;
+            name = sceneryEntry->name;
             break;
         case SCENERY_TYPE_PATH_ITEM:
             sceneryEntry = get_footpath_item_entry(selectedSceneryEntry.EntryIndex);
             price = sceneryEntry->path_bit.price;
+            name = sceneryEntry->name;
             break;
         case SCENERY_TYPE_WALL:
-            sceneryEntry = get_wall_entry(selectedSceneryEntry.EntryIndex);
-            price = sceneryEntry->wall.price;
+        {
+            auto* wallEntry = get_wall_entry(selectedSceneryEntry.EntryIndex);
+            price = wallEntry->price;
+            name = wallEntry->name;
             break;
+        }
         case SCENERY_TYPE_LARGE:
             sceneryEntry = get_large_scenery_entry(selectedSceneryEntry.EntryIndex);
             price = sceneryEntry->large_scenery.price * 10;
+            name = sceneryEntry->name;
             break;
         case SCENERY_TYPE_BANNER:
             sceneryEntry = get_banner_entry(selectedSceneryEntry.EntryIndex);
             price = sceneryEntry->banner.price;
+            name = sceneryEntry->name;
             break;
     }
 
@@ -1177,7 +1183,7 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 
     auto ft = Formatter();
-    ft.Add<rct_string_id>(sceneryEntry != nullptr ? sceneryEntry->name : static_cast<rct_string_id>(STR_UNKNOWN_OBJECT_TYPE));
+    ft.Add<rct_string_id>(name);
     DrawTextEllipsised(dpi, { w->windowPos.x + 3, w->windowPos.y + w->height - 13 }, w->width - 19, STR_BLACK_STRING, ft);
 }
 
@@ -1251,22 +1257,22 @@ void window_scenery_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t s
             }
             else if (currentSceneryGlobal.SceneryType == SCENERY_TYPE_WALL)
             {
-                sceneryEntry = get_wall_entry(currentSceneryGlobal.EntryIndex);
-                uint32_t imageId = sceneryEntry->image;
+                auto* wallEntry = get_wall_entry(currentSceneryGlobal.EntryIndex);
+                uint32_t imageId = wallEntry->image;
                 uint8_t tertiaryColour = w->colours[1];
-                uint16_t spriteTop = (sceneryEntry->wall.height * 2) + 0x32;
+                uint16_t spriteTop = (wallEntry->height * 2) + 0x32;
 
-                if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_GLASS)
+                if (wallEntry->flags & WALL_SCENERY_HAS_GLASS)
                 {
                     imageId |= (gWindowSceneryPrimaryColour << 19) | IMAGE_TYPE_REMAP;
 
-                    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
+                    if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
                     {
                         imageId |= (gWindowScenerySecondaryColour << 24) | IMAGE_TYPE_REMAP_2_PLUS;
                     }
                     gfx_draw_sprite(&clipdpi, imageId, { 0x2F, spriteTop }, tertiaryColour);
 
-                    imageId = (sceneryEntry->image + 0x40000006)
+                    imageId = (wallEntry->image + 0x40000006)
                         | (EnumValue(GlassPaletteIds[gWindowSceneryPrimaryColour]) << 19);
                     gfx_draw_sprite(&clipdpi, imageId, { 0x2F, spriteTop }, tertiaryColour);
                 }
@@ -1274,11 +1280,11 @@ void window_scenery_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t s
                 {
                     imageId |= (gWindowSceneryPrimaryColour << 19) | IMAGE_TYPE_REMAP;
 
-                    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
+                    if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
                     {
                         imageId |= (gWindowScenerySecondaryColour << 24) | IMAGE_TYPE_REMAP_2_PLUS;
 
-                        if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
+                        if (wallEntry->flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
                         {
                             imageId &= 0xDFFFFFFF;
                             tertiaryColour = gWindowSceneryTertiaryColour;
@@ -1286,7 +1292,7 @@ void window_scenery_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t s
                     }
                     gfx_draw_sprite(&clipdpi, imageId, { 0x2F, spriteTop }, tertiaryColour);
 
-                    if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOOR)
+                    if (wallEntry->flags & WALL_SCENERY_IS_DOOR)
                     {
                         gfx_draw_sprite(&clipdpi, imageId + 1, { 0x2F, spriteTop }, tertiaryColour);
                     }

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -222,16 +222,16 @@ public:
 
         if (_isSmall)
         {
-            rct_scenery_entry* scenery_entry = get_wall_entry(SceneryEntry);
+            auto* wallEntry = get_wall_entry(SceneryEntry);
 
             main_colour_btn->type = WindowWidgetType::Empty;
             text_colour_btn->type = WindowWidgetType::Empty;
 
-            if (scenery_entry->wall.flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
+            if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
             {
                 main_colour_btn->type = WindowWidgetType::ColourBtn;
             }
-            if (scenery_entry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
+            if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
             {
                 text_colour_btn->type = WindowWidgetType::ColourBtn;
             }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1635,12 +1635,11 @@ static void window_tile_inspector_invalidate(rct_window* w)
         {
             bool canBeSloped = false;
             bool hasAnimation = false;
-            const auto sceneryEntry = tileElement->AsWall()->GetEntry();
-            if (sceneryEntry != nullptr)
+            const auto wallEntry = tileElement->AsWall()->GetEntry();
+            if (wallEntry != nullptr)
             {
-                const rct_wall_scenery_entry wallEntry = sceneryEntry->wall;
-                canBeSloped = !(wallEntry.flags & WALL_SCENERY_CANT_BUILD_ON_SLOPE);
-                hasAnimation = wallEntry.flags & WALL_SCENERY_IS_DOOR;
+                canBeSloped = !(wallEntry->flags & WALL_SCENERY_CANT_BUILD_ON_SLOPE);
+                hasAnimation = wallEntry->flags & WALL_SCENERY_IS_DOOR;
             }
 
             w->widgets[WIDX_WALL_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
@@ -2094,6 +2093,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 int16_t wallType = tileElement->AsWall()->GetEntryIndex();
                 DrawTextBasic(dpi, screenCoords, STR_TILE_INSPECTOR_WALL_TYPE, &wallType, { COLOUR_WHITE });
 
+                // Banner info
                 auto banner = tileElement->AsWall()->GetBanner();
                 if (banner != nullptr && !banner->IsNull())
                 {

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1012,10 +1012,10 @@ static void repaint_scenery_tool_down(const ScreenCoordsXY& windowPos, rct_widge
         }
         case ViewportInteractionItem::Wall:
         {
-            rct_scenery_entry* scenery_entry = info.Element->AsWall()->GetEntry();
+            auto* scenery_entry = info.Element->AsWall()->GetEntry();
 
             // If can't repaint
-            if (!(scenery_entry->wall.flags & (WALL_SCENERY_HAS_PRIMARY_COLOUR | WALL_SCENERY_HAS_GLASS)))
+            if (!(scenery_entry->flags & (WALL_SCENERY_HAS_PRIMARY_COLOUR | WALL_SCENERY_HAS_GLASS)))
                 return;
 
             auto repaintScenery = WallSetColourAction(
@@ -1090,7 +1090,7 @@ static void scenery_eyedropper_tool_down(const ScreenCoordsXY& windowPos, rct_wi
         case ViewportInteractionItem::Wall:
         {
             auto entryIndex = info.Element->AsWall()->GetEntryIndex();
-            rct_scenery_entry* sceneryEntry = get_wall_entry(entryIndex);
+            auto* sceneryEntry = get_wall_entry(entryIndex);
             if (sceneryEntry != nullptr)
             {
                 if (window_scenery_set_selected_item({ SCENERY_TYPE_WALL, entryIndex }))
@@ -1463,10 +1463,10 @@ static void sub_6E1F34_wall(
     auto screenPos = sourceScreenPos;
     uint16_t maxPossibleHeight = (std::numeric_limits<decltype(TileElement::base_height)>::max() - 32) * ZoomLevel::max();
 
-    rct_scenery_entry* scenery_entry = get_wall_entry(sceneryIndex);
-    if (scenery_entry)
+    auto* wallEntry = get_wall_entry(sceneryIndex);
+    if (wallEntry != nullptr)
     {
-        maxPossibleHeight -= scenery_entry->wall.height;
+        maxPossibleHeight -= wallEntry->height;
     }
 
     sub_6E1F34_update_screen_coords_and_buttons_pressed(true, screenPos);

--- a/src/openrct2/actions/WallPlaceAction.h
+++ b/src/openrct2/actions/WallPlaceAction.h
@@ -61,8 +61,7 @@ private:
      *
      *  rct2: 0x006E5C1A
      */
-    GameActions::Result::Ptr WallCheckObstruction(WallSceneryEntry * wall, int32_t z0, int32_t z1, bool* wallAcrossTrack)
-        const;
+    GameActions::Result::Ptr WallCheckObstruction(WallSceneryEntry * wall, int32_t z0, int32_t z1, bool* wallAcrossTrack) const;
 
     /**
      * Gets whether the given track type can have a wall placed on the edge of the given direction.

--- a/src/openrct2/actions/WallPlaceAction.h
+++ b/src/openrct2/actions/WallPlaceAction.h
@@ -55,13 +55,13 @@ private:
      *
      *  rct2: 0x006E5CBA
      */
-    bool WallCheckObstructionWithTrack(rct_scenery_entry * wall, int32_t z0, TrackElement * trackElement, bool* wallAcrossTrack)
+    bool WallCheckObstructionWithTrack(WallSceneryEntry * wall, int32_t z0, TrackElement * trackElement, bool* wallAcrossTrack)
         const;
     /**
      *
      *  rct2: 0x006E5C1A
      */
-    GameActions::Result::Ptr WallCheckObstruction(rct_scenery_entry * wall, int32_t z0, int32_t z1, bool* wallAcrossTrack)
+    GameActions::Result::Ptr WallCheckObstruction(WallSceneryEntry * wall, int32_t z0, int32_t z1, bool* wallAcrossTrack)
         const;
 
     /**

--- a/src/openrct2/actions/WallSetColourAction.cpp
+++ b/src/openrct2/actions/WallSetColourAction.cpp
@@ -74,8 +74,8 @@ GameActions::Result::Ptr WallSetColourAction::Query() const
         return res;
     }
 
-    rct_scenery_entry* sceneryEntry = wallElement->GetEntry();
-    if (sceneryEntry == nullptr)
+    auto* wallEntry = wallElement->GetEntry();
+    if (wallEntry == nullptr)
     {
         log_error("Could not find wall object");
         return MakeResult(GameActions::Status::Unknown, STR_CANT_REPAINT_THIS);
@@ -93,7 +93,7 @@ GameActions::Result::Ptr WallSetColourAction::Query() const
         return MakeResult(GameActions::Status::InvalidParameters, STR_CANT_REPAINT_THIS);
     }
 
-    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
+    if (wallEntry->flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
     {
         if (_tertiaryColour > 31)
         {
@@ -126,8 +126,8 @@ GameActions::Result::Ptr WallSetColourAction::Execute() const
         return res;
     }
 
-    rct_scenery_entry* sceneryEntry = wallElement->GetEntry();
-    if (sceneryEntry == nullptr)
+    auto* wallEntry = wallElement->GetEntry();
+    if (wallEntry == nullptr)
     {
         log_error("Could not find wall object");
         return MakeResult(GameActions::Status::Unknown, STR_CANT_REPAINT_THIS);
@@ -136,7 +136,7 @@ GameActions::Result::Ptr WallSetColourAction::Execute() const
     wallElement->SetPrimaryColour(_primaryColour);
     wallElement->SetSecondaryColour(_secondaryColour);
 
-    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
+    if (wallEntry->flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
     {
         wallElement->SetTertiaryColour(_tertiaryColour);
     }

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -497,8 +497,8 @@ private:
                     }
                     case ObjectType::Walls:
                     {
-                        sceneryEntry = static_cast<rct_scenery_entry*>(loadedObject->GetLegacyData());
-                        sceneryEntry->wall.scenery_tab_id = GetPrimarySceneryGroupEntryIndex(loadedObject.get());
+                        auto* wallEntry = static_cast<WallSceneryEntry*>(loadedObject->GetLegacyData());
+                        wallEntry->scenery_tab_id = GetPrimarySceneryGroupEntryIndex(loadedObject.get());
                         break;
                     }
                     case ObjectType::Banners:

--- a/src/openrct2/object/WallObject.h
+++ b/src/openrct2/object/WallObject.h
@@ -15,7 +15,7 @@
 class WallObject final : public SceneryObject
 {
 private:
-    rct_scenery_entry _legacyType = {};
+    WallSceneryEntry _legacyType = {};
 
 public:
     explicit WallObject(const rct_object_entry& entry)

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -40,11 +40,11 @@ static constexpr const uint8_t byte_9A40CC[] = {
 };
 
 static void fence_paint_door(
-    paint_session* session, uint32_t imageId, rct_scenery_entry* sceneryEntry, uint32_t imageColourFlags,
-    uint32_t tertiaryColour, uint32_t dword_141F710, LocationXYZ16 offset, LocationXYZ16 boundsR1, LocationXYZ16 boundsR1_,
-    LocationXYZ16 boundsR2, LocationXYZ16 boundsR2_, LocationXYZ16 boundsL1, LocationXYZ16 boundsL1_)
+    paint_session* session, uint32_t imageId, WallSceneryEntry* wallEntry, uint32_t imageColourFlags, uint32_t tertiaryColour,
+    uint32_t dword_141F710, LocationXYZ16 offset, LocationXYZ16 boundsR1, LocationXYZ16 boundsR1_, LocationXYZ16 boundsR2,
+    LocationXYZ16 boundsR2_, LocationXYZ16 boundsL1, LocationXYZ16 boundsL1_)
 {
-    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
+    if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
     {
         imageId |= imageColourFlags;
     }
@@ -54,7 +54,7 @@ static void fence_paint_door(
         imageId = (imageId & 0x7FFFF) | dword_141F710;
     }
 
-    if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOUBLE_SIDED)
+    if (wallEntry->flags & WALL_SCENERY_IS_DOUBLE_SIDED)
     {
         paint_struct* ps;
 
@@ -97,16 +97,16 @@ static void fence_paint_door(
 }
 
 static void fence_paint_wall(
-    paint_session* session, uint32_t frameNum, const rct_scenery_entry* sceneryEntry, uint32_t dword_141F710,
+    paint_session* session, uint32_t frameNum, const WallSceneryEntry* wallEntry, uint32_t dword_141F710,
     uint32_t imageColourFlags, uint32_t dword_141F718, uint32_t tertiaryColour, uint32_t imageOffset, LocationXYZ16 offset,
     LocationXYZ16 bounds, LocationXYZ16 boundsOffset)
 {
-    uint32_t baseImageId = sceneryEntry->image + imageOffset + frameNum;
+    uint32_t baseImageId = wallEntry->image + imageOffset + frameNum;
     uint32_t imageId = baseImageId;
 
-    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_GLASS)
+    if (wallEntry->flags & WALL_SCENERY_HAS_GLASS)
     {
-        if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
+        if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
         {
             imageId |= imageColourFlags;
         }
@@ -129,7 +129,7 @@ static void fence_paint_wall(
     }
     else
     {
-        if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
+        if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
         {
             imageId |= imageColourFlags;
         }
@@ -158,14 +158,14 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
 {
     session->InteractionType = ViewportInteractionItem::Wall;
 
-    rct_scenery_entry* sceneryEntry = tile_element->AsWall()->GetEntry();
-    if (sceneryEntry == nullptr)
+    auto* wallEntry = tile_element->AsWall()->GetEntry();
+    if (wallEntry == nullptr)
     {
         return;
     }
     uint32_t frameNum = 0;
 
-    if (sceneryEntry->wall.flags2 & WALL_SCENERY_2_ANIMATED)
+    if (wallEntry->flags2 & WALL_SCENERY_2_ANIMATED)
     {
         frameNum = (gCurrentTicks & 7) * 2;
     }
@@ -174,14 +174,14 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     uint32_t imageColourFlags = SPRITE_ID_PALETTE_COLOUR_1(primaryColour);
     uint32_t dword_141F718 = imageColourFlags + 0x23800006;
 
-    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
+    if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
     {
         uint8_t secondaryColour = tile_element->AsWall()->GetSecondaryColour();
         imageColourFlags |= secondaryColour << 24 | IMAGE_TYPE_REMAP_2_PLUS;
     }
 
     uint32_t tertiaryColour = 0;
-    if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
+    if (wallEntry->flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
     {
         tertiaryColour = tile_element->AsWall()->GetTertiaryColour();
         imageColourFlags &= 0x0DFFFFFFF;
@@ -206,9 +206,9 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
 
     // Save tile_element
 
-    uint8_t ah = sceneryEntry->wall.height * 8 - 2;
+    uint8_t ah = wallEntry->height * 8 - 2;
 
-    if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOOR)
+    if (wallEntry->flags & WALL_SCENERY_IS_DOOR)
     {
         LocationXYZ16 offset;
         LocationXYZ16 boundsR1, boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_;
@@ -220,7 +220,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
         switch (direction)
         {
             case 0:
-                imageId = sceneryEntry->image + byte_9A406C[animationFrame];
+                imageId = wallEntry->image + byte_9A406C[animationFrame];
 
                 boundsR1 = { 1, 3, static_cast<int16_t>(ah - 5) };
                 boundsR1_ = { 1, 1, static_cast<int16_t>(height + 1) };
@@ -233,12 +233,12 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
                 offset = { 0, 0, static_cast<int16_t>(height) };
 
                 fence_paint_door(
-                    session, imageId, sceneryEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1,
-                    boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_);
+                    session, imageId, wallEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1, boundsR1_,
+                    boundsR2, boundsR2_, boundsL1, boundsL1_);
                 break;
 
             case 1:
-                imageId = sceneryEntry->image + byte_9A408C[animationFrame];
+                imageId = wallEntry->image + byte_9A408C[animationFrame];
 
                 boundsR1 = { 3, 3, static_cast<int16_t>(ah - 5) };
                 boundsR1_ = { 1, 30, static_cast<int16_t>(height + 1) };
@@ -251,12 +251,12 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
                 offset = { 1, 31, static_cast<int16_t>(height) };
 
                 fence_paint_door(
-                    session, imageId, sceneryEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1,
-                    boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_);
+                    session, imageId, wallEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1, boundsR1_,
+                    boundsR2, boundsR2_, boundsL1, boundsL1_);
                 break;
 
             case 2:
-                imageId = sceneryEntry->image + byte_9A40AC[animationFrame];
+                imageId = wallEntry->image + byte_9A40AC[animationFrame];
 
                 boundsR1 = { 3, 3, static_cast<int16_t>(ah - 5) };
                 boundsR1_ = { 30, 1, static_cast<int16_t>(height + 1) };
@@ -269,12 +269,12 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
                 offset = { 31, 0, static_cast<int16_t>(height) };
 
                 fence_paint_door(
-                    session, imageId, sceneryEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1,
-                    boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_);
+                    session, imageId, wallEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1, boundsR1_,
+                    boundsR2, boundsR2_, boundsL1, boundsL1_);
                 break;
 
             case 3:
-                imageId = sceneryEntry->image + byte_9A40CC[animationFrame];
+                imageId = wallEntry->image + byte_9A40CC[animationFrame];
 
                 boundsR1 = { 3, 1, static_cast<int16_t>(ah - 5) };
                 boundsR1_ = { 1, 1, static_cast<int16_t>(height + 1) };
@@ -287,8 +287,8 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
                 offset = { 2, 1, static_cast<int16_t>(height) };
 
                 fence_paint_door(
-                    session, imageId, sceneryEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1,
-                    boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_);
+                    session, imageId, wallEntry, imageColourFlags, tertiaryColour, dword_141F710, offset, boundsR1, boundsR1_,
+                    boundsR2, boundsR2_, boundsL1, boundsL1_);
                 break;
         }
 
@@ -333,16 +333,16 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
                 imageOffset = 0;
             }
 
-            if (sceneryEntry->wall.flags & WALL_SCENERY_HAS_GLASS)
+            if (wallEntry->flags & WALL_SCENERY_HAS_GLASS)
             {
-                if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOUBLE_SIDED)
+                if (wallEntry->flags & WALL_SCENERY_IS_DOUBLE_SIDED)
                 {
                     imageOffset += 12;
                 }
             }
             else
             {
-                if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOUBLE_SIDED)
+                if (wallEntry->flags & WALL_SCENERY_IS_DOUBLE_SIDED)
                 {
                     imageOffset += 6;
                 }
@@ -367,7 +367,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
                 imageOffset = 1;
             }
 
-            if (sceneryEntry->wall.flags & WALL_SCENERY_IS_DOUBLE_SIDED)
+            if (wallEntry->flags & WALL_SCENERY_IS_DOUBLE_SIDED)
             {
                 imageOffset += 6;
             }
@@ -398,10 +398,10 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     }
 
     fence_paint_wall(
-        session, frameNum, sceneryEntry, dword_141F710, imageColourFlags, dword_141F718, tertiaryColour, imageOffset, offset,
+        session, frameNum, wallEntry, dword_141F710, imageColourFlags, dword_141F718, tertiaryColour, imageOffset, offset,
         bounds, boundsOffset);
 
-    if (sceneryEntry->wall.scrolling_mode == SCROLLING_MODE_NONE)
+    if (wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
     {
         return;
     }
@@ -425,7 +425,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
         secondaryColour = ColourMapA[secondaryColour].light;
     }
 
-    uint16_t scrollingMode = sceneryEntry->wall.scrolling_mode + ((direction + 1) & 0x3);
+    uint16_t scrollingMode = wallEntry->scrolling_mode + ((direction + 1) & 0x3);
     if (scrollingMode >= MAX_SCROLLING_TEXT_MODES)
     {
         return;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -6256,7 +6256,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (tileElement->GetDirection() != edge)
             continue;
         auto wallEntry = tileElement->AsWall()->GetEntry();
-        if (wallEntry == nullptr || (wallEntry->wall.flags2 & WALL_SCENERY_2_IS_OPAQUE))
+        if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
             continue;
         if (peep->NextLoc.z + (4 * COORDS_Z_STEP) <= tileElement->GetBaseZ())
             continue;
@@ -6295,7 +6295,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (direction_reverse(tileElement->GetDirection()) != edge)
             continue;
         auto wallEntry = tileElement->AsWall()->GetEntry();
-        if (wallEntry == nullptr || (wallEntry->wall.flags2 & WALL_SCENERY_2_IS_OPAQUE))
+        if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
             continue;
         // TODO: Check whether this shouldn't be <=, as the other loops use. If so, also extract as loop A.
         if (peep->NextLoc.z + (4 * COORDS_Z_STEP) >= tileElement->GetBaseZ())
@@ -6374,7 +6374,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (tileElement->GetType() == TILE_ELEMENT_TYPE_WALL)
         {
             auto wallEntry = tileElement->AsWall()->GetEntry();
-            if (wallEntry == nullptr || (wallEntry->wall.flags2 & WALL_SCENERY_2_IS_OPAQUE))
+            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
             {
                 continue;
             }
@@ -6414,7 +6414,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (direction_reverse(tileElement->GetDirection()) != edge)
             continue;
         auto wallEntry = tileElement->AsWall()->GetEntry();
-        if (wallEntry == nullptr || (wallEntry->wall.flags2 & WALL_SCENERY_2_IS_OPAQUE))
+        if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
             continue;
         if (peep->NextLoc.z + (6 * COORDS_Z_STEP) <= tileElement->GetBaseZ())
             continue;
@@ -6491,7 +6491,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (tileElement->GetType() == TILE_ELEMENT_TYPE_WALL)
         {
             auto wallEntry = tileElement->AsWall()->GetEntry();
-            if (wallEntry == nullptr || (wallEntry->wall.flags2 & WALL_SCENERY_2_IS_OPAQUE))
+            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
             {
                 continue;
             }
@@ -6530,7 +6530,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (direction_reverse(tileElement->GetDirection()) != edge)
             continue;
         auto wallEntry = tileElement->AsWall()->GetEntry();
-        if (wallEntry == nullptr || (wallEntry->wall.flags2 & WALL_SCENERY_2_IS_OPAQUE))
+        if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
             continue;
         if (peep->NextLoc.z + (8 * COORDS_Z_STEP) <= tileElement->GetBaseZ())
             continue;

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -509,11 +509,13 @@ uint8_t RCT12TileElement::GetBannerIndex()
 
             return AsLargeScenery()->GetBannerIndex();
         case TILE_ELEMENT_TYPE_WALL:
-            sceneryEntry = get_wall_entry(AsWall()->GetEntryIndex());
-            if (sceneryEntry == nullptr || sceneryEntry->wall.scrolling_mode == SCROLLING_MODE_NONE)
+        {
+            auto* wallEntry = get_wall_entry(AsWall()->GetEntryIndex());
+            if (wallEntry == nullptr || wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
                 return RCT12_BANNER_INDEX_NULL;
 
             return AsWall()->GetBannerIndex();
+        }
         case TILE_ELEMENT_TYPE_BANNER:
             return AsBanner()->GetIndex();
         default:

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1748,7 +1748,7 @@ void S6Exporter::ExportTileElement(RCT12TileElement* dst, TileElement* src)
             dst2->SetAnimationIsBackwards(src2->AnimationIsBackwards());
 
             auto entry = src2->GetEntry();
-            if (entry != nullptr && entry->wall.scrolling_mode != SCROLLING_MODE_NONE)
+            if (entry != nullptr && entry->scrolling_mode != SCROLLING_MODE_NONE)
             {
                 auto bannerIndex = src2->GetBannerIndex();
                 if (bannerIndex != BANNER_INDEX_NULL)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1239,7 +1239,7 @@ public:
                 // Import banner information
                 dst2->SetBannerIndex(BANNER_INDEX_NULL);
                 auto entry = dst2->GetEntry();
-                if (entry != nullptr && entry->wall.scrolling_mode != SCROLLING_MODE_NONE)
+                if (entry != nullptr && entry->scrolling_mode != SCROLLING_MODE_NONE)
                 {
                     auto bannerIndex = src2->GetBannerIndex();
                     if (bannerIndex < std::size(_s6.banners))

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7387,7 +7387,7 @@ void Vehicle::UpdateAdditionalAnimation()
  */
 static void play_scenery_door_open_sound(const CoordsXYZ& loc, WallElement* tileElement)
 {
-    rct_scenery_entry* wallEntry = tileElement->GetEntry();
+    auto* wallEntry = tileElement->GetEntry();
     int32_t doorSoundType = wall_entry_get_door_sound(wallEntry);
     if (doorSoundType != 0)
     {
@@ -7405,7 +7405,7 @@ static void play_scenery_door_open_sound(const CoordsXYZ& loc, WallElement* tile
  */
 static void play_scenery_door_close_sound(const CoordsXYZ& loc, WallElement* tileElement)
 {
-    rct_scenery_entry* wallEntry = tileElement->GetEntry();
+    auto* wallEntry = tileElement->GetEntry();
     int32_t doorSoundType = wall_entry_get_door_sound(wallEntry);
     if (doorSoundType != 0)
     {

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -202,8 +202,8 @@ WallElement* banner_get_scrolling_wall_tile_element(BannerIndex bannerIndex)
         if (wallElement == nullptr)
             continue;
 
-        rct_scenery_entry* scenery_entry = wallElement->GetEntry();
-        if (scenery_entry->wall.scrolling_mode == SCROLLING_MODE_NONE)
+        auto* wallEntry = wallElement->GetEntry();
+        if (wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
             continue;
         if (wallElement->GetBannerIndex() != bannerIndex)
             continue;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1235,10 +1235,10 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             break;
         case TILE_ELEMENT_TYPE_WALL:
         {
-            sceneryEntry = tileElement->AsWall()->GetEntry();
+            auto* wallEntry = tileElement->AsWall()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
             auto ft = Formatter(res.ErrorMessageArgs.data());
-            rct_string_id stringId = sceneryEntry != nullptr ? sceneryEntry->name : static_cast<rct_string_id>(STR_EMPTY);
+            rct_string_id stringId = wallEntry != nullptr ? wallEntry->name : static_cast<rct_string_id>(STR_EMPTY);
             ft.Add<rct_string_id>(stringId);
             break;
         }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -557,7 +557,7 @@ static bool map_animation_invalidate_wall(const CoordsXYZ& loc)
 
         auto* wallEntry = tileElement->AsWall()->GetEntry();
 
-        if (wallEntry != nullptr
+        if (wallEntry == nullptr
             || (!(wallEntry->flags2 & WALL_SCENERY_2_ANIMATED) && wallEntry->scrolling_mode == SCROLLING_MODE_NONE))
             continue;
 

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -479,7 +479,6 @@ static bool map_animation_invalidate_wall_door(const CoordsXYZ& loc)
 {
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
-    rct_scenery_entry* sceneryEntry;
 
     if (gCurrentTicks & 1)
         return false;
@@ -495,8 +494,8 @@ static bool map_animation_invalidate_wall_door(const CoordsXYZ& loc)
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
             continue;
 
-        sceneryEntry = tileElement->AsWall()->GetEntry();
-        if (sceneryEntry == nullptr || !(sceneryEntry->wall.flags & WALL_SCENERY_IS_DOOR))
+        auto* wallEntry = tileElement->AsWall()->GetEntry();
+        if (wallEntry == nullptr || !(wallEntry->flags & WALL_SCENERY_IS_DOOR))
             continue;
 
         if (game_is_paused())
@@ -519,7 +518,7 @@ static bool map_animation_invalidate_wall_door(const CoordsXYZ& loc)
                 if (currentFrame != 5)
                 {
                     currentFrame++;
-                    if (currentFrame == 13 && !(sceneryEntry->wall.flags & WALL_SCENERY_LONG_DOOR_ANIMATION))
+                    if (currentFrame == 13 && !(wallEntry->flags & WALL_SCENERY_LONG_DOOR_ANIMATION))
                         currentFrame = 15;
 
                     invalidate = true;
@@ -544,7 +543,6 @@ static bool map_animation_invalidate_wall(const CoordsXYZ& loc)
 {
     TileCoordsXYZ tileLoc{ loc };
     TileElement* tileElement;
-    rct_scenery_entry* sceneryEntry;
 
     bool wasInvalidated = false;
     tileElement = map_get_first_element_at(loc);
@@ -557,11 +555,10 @@ static bool map_animation_invalidate_wall(const CoordsXYZ& loc)
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_WALL)
             continue;
 
-        sceneryEntry = tileElement->AsWall()->GetEntry();
+        auto* wallEntry = tileElement->AsWall()->GetEntry();
 
-        if (!sceneryEntry
-            || (!(sceneryEntry->wall.flags2 & WALL_SCENERY_2_ANIMATED)
-                && sceneryEntry->wall.scrolling_mode == SCROLLING_MODE_NONE))
+        if (wallEntry != nullptr
+            || (!(wallEntry->flags2 & WALL_SCENERY_2_ANIMATED) && wallEntry->scrolling_mode == SCROLLING_MODE_NONE))
             continue;
 
         map_invalidate_tile_zoom1({ loc, loc.z, loc.z + 16 });
@@ -632,9 +629,9 @@ void AutoCreateMapAnimations()
             case TILE_ELEMENT_TYPE_WALL:
             {
                 auto wallEl = el->AsWall();
-                auto entry = wallEl->GetEntry();
+                auto* entry = wallEl->GetEntry();
                 if (entry != nullptr
-                    && ((entry->wall.flags2 & WALL_SCENERY_2_ANIMATED) || entry->wall.scrolling_mode != SCROLLING_MODE_NONE))
+                    && ((entry->flags2 & WALL_SCENERY_2_ANIMATED) || entry->scrolling_mode != SCROLLING_MODE_NONE))
                 {
                     map_animation_create(MAP_ANIMATION_TYPE_WALL, loc);
                 }

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -229,14 +229,14 @@ void scenery_remove_ghost_tool_placement()
     }
 }
 
-rct_scenery_entry* get_wall_entry(ObjectEntryIndex entryIndex)
+WallSceneryEntry* get_wall_entry(ObjectEntryIndex entryIndex)
 {
-    rct_scenery_entry* result = nullptr;
+    WallSceneryEntry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
     auto obj = objMgr.GetLoadedObject(ObjectType::Walls, entryIndex);
     if (obj != nullptr)
     {
-        result = static_cast<rct_scenery_entry*>(obj->GetLegacyData());
+        result = static_cast<WallSceneryEntry*>(obj->GetLegacyData());
     }
     return result;
 }
@@ -277,7 +277,7 @@ rct_scenery_group_entry* get_scenery_group_entry(ObjectEntryIndex entryIndex)
     return result;
 }
 
-int32_t wall_entry_get_door_sound(const rct_scenery_entry* wallEntry)
+int32_t wall_entry_get_door_sound(const WallSceneryEntry* wallEntry)
 {
-    return (wallEntry->wall.flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT;
+    return (wallEntry->flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT;
 }

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -100,17 +100,6 @@ enum LARGE_SCENERY_FLAGS
     LARGE_SCENERY_FLAG_PHOTOGENIC = (1 << 4),           // 0x10
 };
 
-struct rct_wall_scenery_entry
-{
-    CursorID tool_id;
-    uint8_t flags;
-    uint8_t height;
-    uint8_t flags2;
-    int16_t price;
-    ObjectEntryIndex scenery_tab_id;
-    uint8_t scrolling_mode;
-};
-
 enum WALL_SCENERY_FLAGS
 {
     WALL_SCENERY_HAS_PRIMARY_COLOUR = (1 << 0),   // 0x1
@@ -149,6 +138,12 @@ struct rct_banner_scenery_entry
     ObjectEntryIndex scenery_tab_id; // 0x0A
 };
 
+struct SceneryEntryBase
+{
+    rct_string_id name;
+    uint32_t image;
+};
+
 struct rct_scenery_entry
 {
     rct_string_id name; // 0x00
@@ -157,10 +152,20 @@ struct rct_scenery_entry
     {
         rct_small_scenery_entry small_scenery;
         rct_large_scenery_entry large_scenery;
-        rct_wall_scenery_entry wall;
         rct_path_bit_scenery_entry path_bit;
         rct_banner_scenery_entry banner;
     };
+};
+
+struct WallSceneryEntry : SceneryEntryBase
+{
+    CursorID tool_id;
+    uint8_t flags;
+    uint8_t height;
+    uint8_t flags2;
+    int16_t price;
+    ObjectEntryIndex scenery_tab_id;
+    uint8_t scrolling_mode;
 };
 
 #pragma pack(pop)
@@ -257,11 +262,11 @@ void scenery_update_tile(const CoordsXY& sceneryPos);
 void scenery_set_default_placement_configuration();
 void scenery_remove_ghost_tool_placement();
 
-rct_scenery_entry* get_wall_entry(ObjectEntryIndex entryIndex);
+WallSceneryEntry* get_wall_entry(ObjectEntryIndex entryIndex);
 rct_scenery_entry* get_banner_entry(ObjectEntryIndex entryIndex);
 rct_scenery_entry* get_footpath_item_entry(ObjectEntryIndex entryIndex);
 rct_scenery_group_entry* get_scenery_group_entry(ObjectEntryIndex entryIndex);
 
-int32_t wall_entry_get_door_sound(const rct_scenery_entry* wallEntry);
+int32_t wall_entry_get_door_sound(const WallSceneryEntry* wallEntry);
 
 #endif

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -42,11 +42,13 @@ BannerIndex TileElement::GetBannerIndex() const
 
             return AsLargeScenery()->GetBannerIndex();
         case TILE_ELEMENT_TYPE_WALL:
-            sceneryEntry = AsWall()->GetEntry();
-            if (sceneryEntry == nullptr || sceneryEntry->wall.scrolling_mode == SCROLLING_MODE_NONE)
+        {
+            auto* wallEntry = AsWall()->GetEntry();
+            if (wallEntry == nullptr || wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
                 return BANNER_INDEX_NULL;
 
             return AsWall()->GetBannerIndex();
+        }
         case TILE_ELEMENT_TYPE_BANNER:
             return AsBanner()->GetIndex();
         default:

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -18,6 +18,7 @@
 struct Banner;
 struct CoordsXY;
 struct rct_scenery_entry;
+struct WallSceneryEntry;
 struct rct_footpath_entry;
 class LargeSceneryObject;
 class TerrainSurfaceObject;
@@ -531,7 +532,7 @@ private:
 public:
     uint16_t GetEntryIndex() const;
     void SetEntryIndex(uint16_t newIndex);
-    rct_scenery_entry* GetEntry() const;
+    WallSceneryEntry* GetEntry() const;
 
     uint8_t GetSlope() const;
     void SetSlope(uint8_t newslope);

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -138,7 +138,7 @@ uint16_t WallElement::GetEntryIndex() const
     return entryIndex;
 }
 
-rct_scenery_entry* WallElement::GetEntry() const
+WallSceneryEntry* WallElement::GetEntry() const
 {
     return get_wall_entry(entryIndex);
 }


### PR DESCRIPTION
I encoutered a very minor mistake when i was correcting a bug and it got me thinking the way that Objects are handled is a little unsafe. So this looks to correct that by changing the structure and enforcing the type. I've done this like this so that we can do one object type at a time. Eventually I'd like to get rid of the legacy type but I feel we are too early for that at the moment.