### PR TITLE
PathBitsEntry refactor

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -465,16 +465,17 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
             return info;
 
         case ViewportInteractionItem::FootpathItem:
-            sceneryEntry = tileElement->AsPath()->GetAdditionEntry();
+        {
+            auto* pathAddEntry = tileElement->AsPath()->GetAdditionEntry();
             ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
             if (tileElement->AsPath()->IsBroken())
             {
                 ft.Add<rct_string_id>(STR_BROKEN);
             }
-            ft.Add<rct_string_id>(sceneryEntry->name);
+            ft.Add<rct_string_id>(pathAddEntry->name);
             SetMapTooltip(ft);
             return info;
-
+        }
         case ViewportInteractionItem::ParkEntrance:
             if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
                 break;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -306,11 +306,11 @@ void window_scenery_init()
     // path bits
     for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_PATH_ADDITION_OBJECTS; sceneryId++)
     {
-        rct_scenery_entry* sceneryEntry = get_footpath_item_entry(sceneryId);
-        if (sceneryEntry == nullptr)
+        auto* pathBitEntry = get_footpath_item_entry(sceneryId);
+        if (pathBitEntry == nullptr)
             continue;
 
-        init_scenery_entry({ SCENERY_TYPE_PATH_ITEM, sceneryId }, sceneryEntry->path_bit.scenery_tab_id);
+        init_scenery_entry({ SCENERY_TYPE_PATH_ITEM, sceneryId }, pathBitEntry->scenery_tab_id);
     }
 
     for (rct_widgetindex widgetIndex = WIDX_SCENERY_TAB_1; widgetIndex < WIDX_SCENERY_LIST; widgetIndex++)
@@ -828,7 +828,7 @@ static void window_scenery_update(rct_window* w)
             }
             else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_PATH_ITEM)
             { // path bit
-                gCurrentToolId = static_cast<Tool>(get_footpath_item_entry(tabSelectedScenery.EntryIndex)->path_bit.tool_id);
+                gCurrentToolId = static_cast<Tool>(get_footpath_item_entry(tabSelectedScenery.EntryIndex)->tool_id);
             }
             else
             { // small scenery
@@ -1143,10 +1143,12 @@ void window_scenery_paint(rct_window* w, rct_drawpixelinfo* dpi)
             name = sceneryEntry->name;
             break;
         case SCENERY_TYPE_PATH_ITEM:
-            sceneryEntry = get_footpath_item_entry(selectedSceneryEntry.EntryIndex);
-            price = sceneryEntry->path_bit.price;
-            name = sceneryEntry->name;
+        {
+            auto* pathBitEntry = get_footpath_item_entry(selectedSceneryEntry.EntryIndex);
+            price = pathBitEntry->price;
+            name = pathBitEntry->name;
             break;
+        }
         case SCENERY_TYPE_WALL:
         {
             auto* wallEntry = get_wall_entry(selectedSceneryEntry.EntryIndex);
@@ -1299,8 +1301,8 @@ void window_scenery_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t s
             }
             else if (currentSceneryGlobal.SceneryType == SCENERY_TYPE_PATH_ITEM)
             {
-                sceneryEntry = get_footpath_item_entry(currentSceneryGlobal.EntryIndex);
-                uint32_t imageId = sceneryEntry->image;
+                auto* pathBitEntry = get_footpath_item_entry(currentSceneryGlobal.EntryIndex);
+                uint32_t imageId = pathBitEntry->image;
 
                 gfx_draw_sprite(&clipdpi, imageId, { 0x0B, 0x10 }, w->colours[1]);
             }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1869,9 +1869,9 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
                 if (tileElement->AsPath()->HasAddition())
                 {
                     const auto pathAdditionType = tileElement->AsPath()->GetAdditionEntryIndex();
-                    const auto* sceneryElement = get_footpath_item_entry(pathAdditionType);
-                    rct_string_id additionNameId = sceneryElement != nullptr
-                        ? sceneryElement->name
+                    const auto* pathBitEntry = get_footpath_item_entry(pathAdditionType);
+                    rct_string_id additionNameId = pathBitEntry != nullptr
+                        ? pathBitEntry->name
                         : static_cast<rct_string_id>(STR_UNKNOWN_OBJECT_TYPE);
                     DrawTextBasic(
                         dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS, &additionNameId,

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1138,8 +1138,8 @@ static void scenery_eyedropper_tool_down(const ScreenCoordsXY& windowPos, rct_wi
         case ViewportInteractionItem::FootpathItem:
         {
             auto entryIndex = info.Element->AsPath()->GetAdditionEntryIndex();
-            rct_scenery_entry* sceneryEntry = get_footpath_item_entry(entryIndex);
-            if (sceneryEntry != nullptr)
+            auto* pathBitEntry = get_footpath_item_entry(entryIndex);
+            if (pathBitEntry != nullptr)
             {
                 if (window_scenery_set_selected_item({ SCENERY_TYPE_PATH_ITEM, entryIndex }))
                 {

--- a/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
@@ -93,12 +93,12 @@ GameActions::Result::Ptr FootpathAdditionPlaceAction::Query() const
 
     if (_pathItemType != 0)
     {
-        rct_scenery_entry* sceneryEntry = get_footpath_item_entry(_pathItemType - 1);
-        if (sceneryEntry == nullptr)
+        auto* pathBitEntry = get_footpath_item_entry(_pathItemType - 1);
+        if (pathBitEntry == nullptr)
         {
             return MakeResult(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE);
         }
-        uint16_t sceneryFlags = sceneryEntry->path_bit.flags;
+        uint16_t sceneryFlags = pathBitEntry->flags;
 
         if ((sceneryFlags & PATH_BIT_FLAG_DONT_ALLOW_ON_SLOPE) && pathElement->IsSloped())
         {
@@ -124,7 +124,7 @@ GameActions::Result::Ptr FootpathAdditionPlaceAction::Query() const
                 GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_CAN_ONLY_PLACE_THESE_ON_QUEUE_AREA);
         }
 
-        res->Cost = sceneryEntry->path_bit.price;
+        res->Cost = pathBitEntry->price;
     }
 
     // Should place a ghost?
@@ -163,13 +163,13 @@ GameActions::Result::Ptr FootpathAdditionPlaceAction::Execute() const
 
     if (_pathItemType != 0)
     {
-        rct_scenery_entry* sceneryEntry = get_footpath_item_entry(_pathItemType - 1);
-        if (sceneryEntry == nullptr)
+        auto* pathBitEntry = get_footpath_item_entry(_pathItemType - 1);
+        if (pathBitEntry == nullptr)
         {
             return MakeResult(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE);
         }
 
-        res->Cost = sceneryEntry->path_bit.price;
+        res->Cost = pathBitEntry->price;
     }
 
     if (GetFlags() & GAME_COMMAND_FLAG_GHOST)
@@ -191,8 +191,8 @@ GameActions::Result::Ptr FootpathAdditionPlaceAction::Execute() const
     pathElement->SetIsBroken(false);
     if (_pathItemType != 0)
     {
-        rct_scenery_entry* scenery_entry = get_footpath_item_entry(_pathItemType - 1);
-        if (scenery_entry != nullptr && scenery_entry->path_bit.flags & PATH_BIT_FLAG_IS_BIN)
+        auto* pathBitEntry = get_footpath_item_entry(_pathItemType - 1);
+        if (pathBitEntry != nullptr && pathBitEntry->flags & PATH_BIT_FLAG_IS_BIN)
         {
             pathElement->SetAdditionStatus(255);
         }

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -185,13 +185,13 @@ GameActions::Result::Ptr FootpathPlaceAction::ElementUpdateExecute(PathElement* 
     bool isQueue = _type & FOOTPATH_ELEMENT_INSERT_QUEUE;
     pathElement->SetIsQueue(isQueue);
 
-    rct_scenery_entry* elem = pathElement->GetAdditionEntry();
+    auto* elem = pathElement->GetAdditionEntry();
     if (elem != nullptr)
     {
         if (isQueue)
         {
             // remove any addition that isn't a TV or a lamp
-            if ((elem->path_bit.flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN) == 0 && (elem->path_bit.flags & PATH_BIT_FLAG_LAMP) == 0)
+            if ((elem->flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN) == 0 && (elem->flags & PATH_BIT_FLAG_LAMP) == 0)
             {
                 pathElement->SetIsBroken(false);
                 pathElement->SetAddition(0);
@@ -200,7 +200,7 @@ GameActions::Result::Ptr FootpathPlaceAction::ElementUpdateExecute(PathElement* 
         else
         {
             // remove all TVs
-            if ((elem->path_bit.flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN) != 0)
+            if ((elem->flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN) != 0)
             {
                 pathElement->SetIsBroken(false);
                 pathElement->SetAddition(0);

--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -418,7 +418,6 @@ void SetCheatAction::RemoveLitter() const
     }
 
     tile_element_iterator it;
-    rct_scenery_entry* sceneryEntry;
 
     tile_element_iterator_begin(&it);
     do
@@ -429,8 +428,8 @@ void SetCheatAction::RemoveLitter() const
         if (!(it.element)->AsPath()->HasAddition())
             continue;
 
-        sceneryEntry = it.element->AsPath()->GetAdditionEntry();
-        if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BIN)
+        auto* pathBitEntry = it.element->AsPath()->GetAdditionEntry();
+        if (pathBitEntry->flags & PATH_BIT_FLAG_IS_BIN)
             it.element->AsPath()->SetAdditionStatus(0xFF);
 
     } while (tile_element_iterator_next(&it));

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -23,11 +23,11 @@
 void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
 {
     stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
-    _legacyType.path_bit.flags = stream->ReadValue<uint16_t>();
-    _legacyType.path_bit.draw_type = stream->ReadValue<uint8_t>();
-    _legacyType.path_bit.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
-    _legacyType.path_bit.price = stream->ReadValue<int16_t>();
-    _legacyType.path_bit.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
+    _legacyType.flags = stream->ReadValue<uint16_t>();
+    _legacyType.draw_type = stream->ReadValue<uint8_t>();
+    _legacyType.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
+    _legacyType.price = stream->ReadValue<int16_t>();
+    _legacyType.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
     stream->Seek(2, OpenRCT2::STREAM_SEEK_CURRENT);
 
     GetStringTable().Read(context, stream, ObjectStringID::NAME);
@@ -38,7 +38,7 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     GetImageTable().Read(context, stream);
 
     // Validate properties
-    if (_legacyType.large_scenery.price <= 0)
+    if (_legacyType.price <= 0)
     {
         context->LogError(ObjectError::InvalidProperty, "Price can not be free or negative.");
     }
@@ -67,7 +67,7 @@ void FootpathItemObject::Load()
     _legacyType.name = language_allocate_object_string(GetName());
     _legacyType.image = gfx_object_allocate_images(GetImageTable().GetImages(), GetImageTable().GetCount());
 
-    _legacyType.path_bit.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
+    _legacyType.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
 }
 
 void FootpathItemObject::Unload()
@@ -106,14 +106,14 @@ void FootpathItemObject::ReadJson(IReadObjectContext* context, json_t& root)
 
     if (properties.is_object())
     {
-        _legacyType.path_bit.draw_type = ParseDrawType(Json::GetString(properties["renderAs"]));
-        _legacyType.path_bit.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::LamppostDown);
-        _legacyType.path_bit.price = Json::GetNumber<int16_t>(properties["price"]);
+        _legacyType.draw_type = ParseDrawType(Json::GetString(properties["renderAs"]));
+        _legacyType.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::LamppostDown);
+        _legacyType.price = Json::GetNumber<int16_t>(properties["price"]);
 
         SetPrimarySceneryGroup(ObjectEntryDescriptor(Json::GetString(properties["sceneryGroup"])));
 
         // clang-format off
-        _legacyType.path_bit.flags = Json::GetFlags<uint16_t>(
+        _legacyType.flags = Json::GetFlags<uint16_t>(
             properties,
             {
                 { "isBin",                  PATH_BIT_FLAG_IS_BIN,                   Json::FlagType::Normal },

--- a/src/openrct2/object/FootpathItemObject.h
+++ b/src/openrct2/object/FootpathItemObject.h
@@ -15,7 +15,7 @@
 class FootpathItemObject final : public SceneryObject
 {
 private:
-    rct_scenery_entry _legacyType = {};
+    PathBitEntry _legacyType = {};
 
 public:
     explicit FootpathItemObject(const rct_object_entry& entry)

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -509,8 +509,8 @@ private:
                     }
                     case ObjectType::PathBits:
                     {
-                        sceneryEntry = static_cast<rct_scenery_entry*>(loadedObject->GetLegacyData());
-                        sceneryEntry->path_bit.scenery_tab_id = GetPrimarySceneryGroupEntryIndex(loadedObject.get());
+                        auto* pathBitEntry = static_cast<PathBitEntry*>(loadedObject->GetLegacyData());
+                        pathBitEntry->scenery_tab_id = GetPrimarySceneryGroupEntryIndex(loadedObject.get());
                         break;
                     }
                     case ObjectType::SceneryGroup:

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -91,7 +91,7 @@ void path_paint_pole_support(
 
 /* rct2: 0x006A5AE5 */
 static void path_bit_lights_paint(
-    paint_session* session, rct_scenery_entry* pathBitEntry, const TileElement* tileElement, int32_t height, uint8_t edges,
+    paint_session* session, PathBitEntry* pathBitEntry, const TileElement* tileElement, int32_t height, uint8_t edges,
     uint32_t pathBitImageFlags)
 {
     if (tileElement->AsPath()->IsSloped())
@@ -149,7 +149,7 @@ static void path_bit_lights_paint(
 
 /* rct2: 0x006A5C94 */
 static void path_bit_bins_paint(
-    paint_session* session, rct_scenery_entry* pathBitEntry, const TileElement* tileElement, int32_t height, uint8_t edges,
+    paint_session* session, PathBitEntry* pathBitEntry, const TileElement* tileElement, int32_t height, uint8_t edges,
     uint32_t pathBitImageFlags)
 {
     if (tileElement->AsPath()->IsSloped())
@@ -248,7 +248,7 @@ static void path_bit_bins_paint(
 
 /* rct2: 0x006A5E81 */
 static void path_bit_benches_paint(
-    paint_session* session, rct_scenery_entry* pathBitEntry, const TileElement* tileElement, int32_t height, uint8_t edges,
+    paint_session* session, PathBitEntry* pathBitEntry, const TileElement* tileElement, int32_t height, uint8_t edges,
     uint32_t pathBitImageFlags)
 {
     uint32_t imageId;
@@ -303,7 +303,7 @@ static void path_bit_benches_paint(
 
 /* rct2: 0x006A6008 */
 static void path_bit_jumping_fountains_paint(
-    paint_session* session, rct_scenery_entry* pathBitEntry, int32_t height, uint32_t pathBitImageFlags, rct_drawpixelinfo* dpi)
+    paint_session* session, PathBitEntry* pathBitEntry, int32_t height, uint32_t pathBitImageFlags, rct_drawpixelinfo* dpi)
 {
     if (dpi->zoom_level > 0)
         return;
@@ -700,40 +700,40 @@ static void sub_6A3F61(
                 }
 
                 // Draw additional path bits (bins, benches, lamps, queue screens)
-                rct_scenery_entry* sceneryEntry = tile_element->AsPath()->GetAdditionEntry();
+                auto* pathAddEntry = tile_element->AsPath()->GetAdditionEntry();
 
                 // Can be null if the object is not loaded.
-                if (sceneryEntry == nullptr)
+                if (pathAddEntry == nullptr)
                 {
                     paintScenery = false;
                 }
                 else if (
                     (session->ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES) && !(tile_element->AsPath()->IsBroken())
-                    && !(sceneryEntry->path_bit.draw_type == PATH_BIT_DRAW_TYPE_BINS))
+                    && !(pathAddEntry->draw_type == PATH_BIT_DRAW_TYPE_BINS))
                 {
                     paintScenery = false;
                 }
                 else
                 {
-                    switch (sceneryEntry->path_bit.draw_type)
+                    switch (pathAddEntry->draw_type)
                     {
                         case PATH_BIT_DRAW_TYPE_LIGHTS:
                             path_bit_lights_paint(
-                                session, sceneryEntry, tile_element, height, static_cast<uint8_t>(connectedEdges),
+                                session, pathAddEntry, tile_element, height, static_cast<uint8_t>(connectedEdges),
                                 sceneryImageFlags);
                             break;
                         case PATH_BIT_DRAW_TYPE_BINS:
                             path_bit_bins_paint(
-                                session, sceneryEntry, tile_element, height, static_cast<uint8_t>(connectedEdges),
+                                session, pathAddEntry, tile_element, height, static_cast<uint8_t>(connectedEdges),
                                 sceneryImageFlags);
                             break;
                         case PATH_BIT_DRAW_TYPE_BENCHES:
                             path_bit_benches_paint(
-                                session, sceneryEntry, tile_element, height, static_cast<uint8_t>(connectedEdges),
+                                session, pathAddEntry, tile_element, height, static_cast<uint8_t>(connectedEdges),
                                 sceneryImageFlags);
                             break;
                         case PATH_BIT_DRAW_TYPE_JUMPING_FOUNTAINS:
-                            path_bit_jumping_fountains_paint(session, sceneryEntry, height, sceneryImageFlags, dpi);
+                            path_bit_jumping_fountains_paint(session, pathAddEntry, height, sceneryImageFlags, dpi);
                             break;
                     }
 
@@ -962,8 +962,8 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
     {
         if (tile_element->AsPath()->HasAddition() && !(tile_element->AsPath()->IsBroken()))
         {
-            rct_scenery_entry* sceneryEntry = tile_element->AsPath()->GetAdditionEntry();
-            if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & PATH_BIT_FLAG_LAMP)
+            auto* pathAddEntry = tile_element->AsPath()->GetAdditionEntry();
+            if (pathAddEntry != nullptr && pathAddEntry->flags & PATH_BIT_FLAG_LAMP)
             {
                 if (!(tile_element->AsPath()->GetEdges() & EDGE_NE))
                 {

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -1151,9 +1151,8 @@ void Guest::Tick128UpdateGuest(int32_t index)
                         // Check if the footpath has a queue line TV monitor on it
                         if (pathElement->HasAddition() && !pathElement->AdditionIsGhost())
                         {
-                            auto pathSceneryIndex = pathElement->GetAdditionEntryIndex();
-                            rct_scenery_entry* sceneryEntry = get_footpath_item_entry(pathSceneryIndex);
-                            if (sceneryEntry != nullptr && (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN))
+                            auto* pathAddEntry = pathElement->GetAdditionEntry();
+                            if (pathAddEntry != nullptr && (pathAddEntry->flags & PATH_BIT_FLAG_IS_QUEUE_SCREEN))
                             {
                                 found = true;
                             }
@@ -2888,24 +2887,23 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
             for (auto* tileElement : TileElementsView({ x, y }))
             {
                 Ride* ride;
-                rct_scenery_entry* scenery;
 
                 switch (tileElement->GetType())
                 {
                     case TILE_ELEMENT_TYPE_PATH:
+                    {
                         if (!tileElement->AsPath()->HasAddition())
                             break;
 
-                        scenery = tileElement->AsPath()->GetAdditionEntry();
-                        if (scenery == nullptr)
+                        auto* pathAddEntry = tileElement->AsPath()->GetAdditionEntry();
+                        if (pathAddEntry == nullptr)
                         {
                             return PeepThoughtType::None;
                         }
                         if (tileElement->AsPath()->AdditionIsGhost())
                             break;
 
-                        if (scenery->path_bit.flags
-                            & (PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER | PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW))
+                        if (pathAddEntry->flags & (PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER | PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW))
                         {
                             num_fountains++;
                             break;
@@ -2915,6 +2913,7 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
                             num_rubbish++;
                         }
                         break;
+                    }
                     case TILE_ELEMENT_TYPE_LARGE_SCENERY:
                     case TILE_ELEMENT_TYPE_SMALL_SCENERY:
                         num_scenery++;
@@ -5360,13 +5359,13 @@ void Guest::UpdateWalking()
     {
         if (!tileElement->AsPath()->AdditionIsGhost())
         {
-            rct_scenery_entry* sceneryEntry = tileElement->AsPath()->GetAdditionEntry();
-            if (sceneryEntry == nullptr)
+            auto* pathAddEntry = tileElement->AsPath()->GetAdditionEntry();
+            if (pathAddEntry == nullptr)
             {
                 return;
             }
 
-            if (!(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BENCH))
+            if (!(pathAddEntry->flags & PATH_BIT_FLAG_IS_BENCH))
                 positions_free = 9;
         }
     }
@@ -5757,8 +5756,8 @@ void Guest::UpdateUsingBin()
                 if (!pathElement->HasAddition())
                     break;
 
-                rct_scenery_entry* sceneryEntry = pathElement->GetAdditionEntry();
-                if (!(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BIN))
+                auto* pathAddEntry = pathElement->GetAdditionEntry();
+                if (!(pathAddEntry->flags & PATH_BIT_FLAG_IS_BIN))
                     break;
 
                 if (pathElement->IsBroken())
@@ -5869,8 +5868,8 @@ static PathElement* FindBench(const CoordsXYZ& loc)
         if (!pathElement->HasAddition())
             continue;
 
-        rct_scenery_entry* sceneryEntry = pathElement->GetAdditionEntry();
-        if (sceneryEntry == nullptr || !(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BENCH))
+        auto* pathAddEntry = pathElement->GetAdditionEntry();
+        if (pathAddEntry == nullptr || !(pathAddEntry->flags & PATH_BIT_FLAG_IS_BENCH))
             continue;
 
         if (pathElement->IsBroken())
@@ -5958,8 +5957,8 @@ static PathElement* FindBin(const CoordsXYZ& loc)
         if (!pathElement->HasAddition())
             continue;
 
-        rct_scenery_entry* sceneryEntry = pathElement->GetAdditionEntry();
-        if (sceneryEntry == nullptr || !(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BIN))
+        auto* pathAddEntry = pathElement->GetAdditionEntry();
+        if (pathAddEntry == nullptr || !(pathAddEntry->flags & PATH_BIT_FLAG_IS_BIN))
             continue;
 
         if (pathElement->IsBroken())
@@ -6036,8 +6035,8 @@ static PathElement* FindBreakableElement(const CoordsXYZ& loc)
         if (!pathElement->HasAddition())
             continue;
 
-        rct_scenery_entry* sceneryEntry = pathElement->GetAdditionEntry();
-        if (sceneryEntry == nullptr || !(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_BREAKABLE))
+        auto* pathAddEntry = pathElement->GetAdditionEntry();
+        if (pathAddEntry == nullptr || !(pathAddEntry->flags & PATH_BIT_FLAG_BREAKABLE))
             continue;
 
         if (pathElement->IsBroken())

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1314,8 +1314,8 @@ void Staff::UpdateEmptyingBin()
             return;
         }
 
-        rct_scenery_entry* scenery_entry = tile_element->AsPath()->GetAdditionEntry();
-        if (!(scenery_entry->path_bit.flags & PATH_BIT_FLAG_IS_BIN) || tile_element->AsPath()->IsBroken()
+        auto* pathAddEntry = tile_element->AsPath()->GetAdditionEntry();
+        if (!(pathAddEntry->flags & PATH_BIT_FLAG_IS_BIN) || tile_element->AsPath()->IsBroken()
             || tile_element->AsPath()->AdditionIsGhost())
         {
             StateReset();
@@ -1682,11 +1682,11 @@ bool Staff::UpdatePatrollingFindBin()
 
     if (!tileElement->AsPath()->HasAddition())
         return false;
-    rct_scenery_entry* sceneryEntry = tileElement->AsPath()->GetAdditionEntry();
-    if (sceneryEntry == nullptr)
+    auto* pathAddEntry = tileElement->AsPath()->GetAdditionEntry();
+    if (pathAddEntry == nullptr)
         return false;
 
-    if (!(sceneryEntry->path_bit.flags & PATH_BIT_FLAG_IS_BIN))
+    if (!(pathAddEntry->flags & PATH_BIT_FLAG_IS_BIN))
         return false;
 
     if (tileElement->AsPath()->IsBroken())

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1616,7 +1616,7 @@ ObjectEntryIndex PathElement::GetAdditionEntryIndex() const
     return GetAddition() - 1;
 }
 
-rct_scenery_entry* PathElement::GetAdditionEntry() const
+PathBitEntry* PathElement::GetAdditionEntry() const
 {
     if (!HasAddition())
         return nullptr;

--- a/src/openrct2/world/Fountain.cpp
+++ b/src/openrct2/world/Fountain.cpp
@@ -257,9 +257,8 @@ bool JumpingFountain::IsJumpingFountain(const JumpingFountainType newType, const
         if (!tileElement->AsPath()->HasAddition())
             continue;
 
-        const auto additionIndex = tileElement->AsPath()->GetAdditionEntryIndex();
-        rct_scenery_entry* sceneryEntry = get_footpath_item_entry(additionIndex);
-        if (sceneryEntry != nullptr && sceneryEntry->path_bit.flags & pathBitFlagMask)
+        auto* pathBitEntry = tileElement->AsPath()->GetAdditionEntry();
+        if (pathBitEntry != nullptr && pathBitEntry->flags & pathBitFlagMask)
         {
             return true;
         }

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -80,14 +80,14 @@ void scenery_update_tile(const CoordsXY& sceneryPos)
         {
             if (tileElement->AsPath()->HasAddition() && !tileElement->AsPath()->AdditionIsGhost())
             {
-                rct_scenery_entry* sceneryEntry = tileElement->AsPath()->GetAdditionEntry();
-                if (sceneryEntry != nullptr)
+                auto* pathAddEntry = tileElement->AsPath()->GetAdditionEntry();
+                if (pathAddEntry != nullptr)
                 {
-                    if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER)
+                    if (pathAddEntry->flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_WATER)
                     {
                         JumpingFountain::StartAnimation(JumpingFountainType::Water, sceneryPos, tileElement);
                     }
-                    else if (sceneryEntry->path_bit.flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW)
+                    else if (pathAddEntry->flags & PATH_BIT_FLAG_JUMPING_FOUNTAIN_SNOW)
                     {
                         JumpingFountain::StartAnimation(JumpingFountainType::Snow, sceneryPos, tileElement);
                     }
@@ -253,14 +253,14 @@ rct_scenery_entry* get_banner_entry(ObjectEntryIndex entryIndex)
     return result;
 }
 
-rct_scenery_entry* get_footpath_item_entry(ObjectEntryIndex entryIndex)
+PathBitEntry* get_footpath_item_entry(ObjectEntryIndex entryIndex)
 {
-    rct_scenery_entry* result = nullptr;
+    PathBitEntry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
     auto obj = objMgr.GetLoadedObject(ObjectType::PathBits, entryIndex);
     if (obj != nullptr)
     {
-        result = static_cast<rct_scenery_entry*>(obj->GetLegacyData());
+        result = static_cast<PathBitEntry*>(obj->GetLegacyData());
     }
     return result;
 }

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -121,15 +121,6 @@ enum WALL_SCENERY_2_FLAGS
     WALL_SCENERY_2_ANIMATED = (1 << 4),  // 0x10
 };
 
-struct rct_path_bit_scenery_entry
-{
-    uint16_t flags;                  // 0x06
-    uint8_t draw_type;               // 0x08
-    CursorID tool_id;                // 0x09
-    int16_t price;                   // 0x0A
-    ObjectEntryIndex scenery_tab_id; // 0x0C
-};
-
 struct rct_banner_scenery_entry
 {
     uint8_t scrolling_mode;          // 0x06
@@ -152,7 +143,6 @@ struct rct_scenery_entry
     {
         rct_small_scenery_entry small_scenery;
         rct_large_scenery_entry large_scenery;
-        rct_path_bit_scenery_entry path_bit;
         rct_banner_scenery_entry banner;
     };
 };
@@ -166,6 +156,15 @@ struct WallSceneryEntry : SceneryEntryBase
     int16_t price;
     ObjectEntryIndex scenery_tab_id;
     uint8_t scrolling_mode;
+};
+
+struct PathBitEntry : SceneryEntryBase
+{
+    uint16_t flags;
+    uint8_t draw_type;
+    CursorID tool_id;
+    int16_t price;
+    ObjectEntryIndex scenery_tab_id;
 };
 
 #pragma pack(pop)
@@ -264,7 +263,7 @@ void scenery_remove_ghost_tool_placement();
 
 WallSceneryEntry* get_wall_entry(ObjectEntryIndex entryIndex);
 rct_scenery_entry* get_banner_entry(ObjectEntryIndex entryIndex);
-rct_scenery_entry* get_footpath_item_entry(ObjectEntryIndex entryIndex);
+PathBitEntry* get_footpath_item_entry(ObjectEntryIndex entryIndex);
 rct_scenery_group_entry* get_scenery_group_entry(ObjectEntryIndex entryIndex);
 
 int32_t wall_entry_get_door_sound(const WallSceneryEntry* wallEntry);

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -19,6 +19,7 @@ struct Banner;
 struct CoordsXY;
 struct rct_scenery_entry;
 struct WallSceneryEntry;
+struct PathBitEntry;
 struct rct_footpath_entry;
 class LargeSceneryObject;
 class TerrainSurfaceObject;
@@ -325,7 +326,7 @@ public:
     bool HasAddition() const;
     uint8_t GetAddition() const;
     ObjectEntryIndex GetAdditionEntryIndex() const;
-    rct_scenery_entry* GetAdditionEntry() const;
+    PathBitEntry* GetAdditionEntry() const;
     void SetAddition(uint8_t newAddition);
 
     bool AdditionIsGhost() const;


### PR DESCRIPTION
Follow on from #14808. Same changes but this time for the path additions/bits.

Found one potential bug whilst doing this. In the object validation code it accessed the wrong member variable. This is undefined behaviour but more importantly would cause valid objects to fail validation. I've not seen any reports of that though.