### PR TITLE
Adding check to match RCTC save games with RCT2 scenarios

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -95,7 +95,6 @@ The following people are not part of the development team, but have been contrib
 * Adrian Zdanowicz (CookiePLMonster) - Misc.
 
 ## Bug fixes
-* Struan Clark (xtruan)
 * (KirilAngelov)
 * (halfbro)
 * (Myrtle)
@@ -172,6 +171,7 @@ The following people are not part of the development team, but have been contrib
 * (zrowny)
 * Emre Aydin (aemreaydin)
 * Daniel Karandikar (DKarandikar)
+* Struan Clark (xtruan)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/contributors.md
+++ b/contributors.md
@@ -95,6 +95,7 @@ The following people are not part of the development team, but have been contrib
 * Adrian Zdanowicz (CookiePLMonster) - Misc.
 
 ## Bug fixes
+* Struan Clark (xtruan)
 * (KirilAngelov)
 * (halfbro)
 * (Myrtle)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.3.4+ (in development)
 ------------------------------------------------------------------------
+- Improved: [#12626] Allow using RCT2 saves to mark RCT Classic (.sea) parks as finished and vice versa. 
 
 0.3.4 (2021-07-19)
 ------------------------------------------------------------------------

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -423,6 +423,17 @@ public:
         Scan(language);
 
         scenario_index_entry* scenario = GetByFilename(scenarioFileName);
+
+        // Check if this is an RCTC scenario that corresponds to a known RCT1/2 scenario, see #12626
+        if (scenario == nullptr && String::Equals(Path::GetExtension(scenarioFileName), ".sea", true))
+        {
+            // Get base scenario name (without file extension)
+            std::string scenarioBaseName = String::ToStd(Path::GetFileNameWithoutExtension(scenarioFileName));
+
+            // Get scenario using RCT2 style name of RCTC scenario
+            scenario = GetByFilename((scenarioBaseName + ".sc6").c_str());
+        }
+
         if (scenario != nullptr)
         {
             // Check if record company value has been broken or the highscore is the same but no name is registered
@@ -705,10 +716,10 @@ private:
     {
         for (auto& highscore : _highscores)
         {
-            scenario_index_entry* scenerio = GetByFilename(highscore->fileName);
-            if (scenerio != nullptr)
+            scenario_index_entry* scenario = GetByFilename(highscore->fileName);
+            if (scenario != nullptr)
             {
-                scenerio->highscore = highscore;
+                scenario->highscore = highscore;
             }
         }
     }

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -424,14 +424,22 @@ public:
 
         scenario_index_entry* scenario = GetByFilename(scenarioFileName);
 
-        // Check if this is an RCTC scenario that corresponds to a known RCT1/2 scenario, see #12626
-        if (scenario == nullptr && String::Equals(Path::GetExtension(scenarioFileName), ".sea", true))
+        // Check if this is an RCTC scenario that corresponds to a known RCT1/2 scenario or vice versa, see #12626
+        if (scenario == nullptr)
         {
-            // Get base scenario name (without file extension)
-            std::string scenarioBaseName = String::ToStd(Path::GetFileNameWithoutExtension(scenarioFileName));
+            const std::string scenarioBaseName = String::ToStd(Path::GetFileNameWithoutExtension(scenarioFileName));
+            const std::string scenarioExtension = String::ToStd(Path::GetExtension(scenarioFileName));
 
-            // Get scenario using RCT2 style name of RCTC scenario
-            scenario = GetByFilename((scenarioBaseName + ".sc6").c_str());
+            if (String::Equals(scenarioExtension, ".sea", true))
+            {
+                // Get scenario using RCT2 style name of RCTC scenario
+                scenario = GetByFilename((scenarioBaseName + ".sc6").c_str());
+            }
+            else if (String::Equals(scenarioExtension, ".sc6", true))
+            {
+                // Get scenario using RCTC style name of RCT2 scenario
+                scenario = GetByFilename((scenarioBaseName + ".sea").c_str());
+            }
         }
 
         if (scenario != nullptr)


### PR DESCRIPTION
RCTC save games which were originally created from scenarios with the extension `.sea` are now correctly matched with their RCT2 `.sc6` equivalents when trying to add high score/flag as complete.

See #12626