### PR TITLE
Remove LocationXY(Z)16

### DIFF
--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -42,8 +42,9 @@ void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
 
     if (_legacyType.flags & LARGE_SCENERY_FLAG_3D_TEXT)
     {
-        _3dFont = std::make_unique<rct_large_scenery_text>();
-        stream->Read(_3dFont.get());
+        rct_large_scenery_text _3dFontLegacy = {};
+        stream->Read(&_3dFontLegacy);
+        _3dFont = std::make_unique<LargeSceneryText>(_3dFontLegacy);
         _legacyType.text = _3dFont.get();
     }
 
@@ -207,11 +208,11 @@ std::vector<rct_large_scenery_tile> LargeSceneryObject::ReadJsonTiles(json_t& jT
     return tiles;
 }
 
-std::unique_ptr<rct_large_scenery_text> LargeSceneryObject::ReadJson3dFont(json_t& j3dFont)
+std::unique_ptr<LargeSceneryText> LargeSceneryObject::ReadJson3dFont(json_t& j3dFont)
 {
     Guard::Assert(j3dFont.is_object(), "LargeSceneryObject::ReadJson3dFont expects parameter j3dFont to be object");
 
-    auto font = std::make_unique<rct_large_scenery_text>();
+    auto font = std::make_unique<LargeSceneryText>();
 
     auto jOffsets = j3dFont["offsets"];
     if (jOffsets.is_array())
@@ -222,7 +223,7 @@ std::unique_ptr<rct_large_scenery_text> LargeSceneryObject::ReadJson3dFont(json_
     }
 
     font->max_width = Json::GetNumber<uint16_t>(j3dFont["maxWidth"]);
-    font->num_images = Json::GetNumber<uint8_t>(j3dFont["numImages"]);
+    font->num_images = Json::GetNumber<uint16_t>(j3dFont["numImages"]);
 
     font->flags = Json::GetFlags<uint8_t>(
         j3dFont,
@@ -242,14 +243,14 @@ std::unique_ptr<rct_large_scenery_text> LargeSceneryObject::ReadJson3dFont(json_
     return font;
 }
 
-std::vector<LocationXY16> LargeSceneryObject::ReadJsonOffsets(json_t& jOffsets)
+std::vector<CoordsXY> LargeSceneryObject::ReadJsonOffsets(json_t& jOffsets)
 {
-    std::vector<LocationXY16> offsets;
+    std::vector<CoordsXY> offsets;
     for (auto& jOffset : jOffsets)
     {
         if (jOffset.is_object())
         {
-            LocationXY16 offset = {};
+            CoordsXY offset = {};
             offset.x = Json::GetNumber<int16_t>(jOffset["x"]);
             offset.y = Json::GetNumber<int16_t>(jOffset["y"]);
             offsets.push_back(offset);

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -21,7 +21,7 @@ private:
     LargeSceneryEntry _legacyType = {};
     uint32_t _baseImageId = 0;
     std::vector<rct_large_scenery_tile> _tiles;
-    std::unique_ptr<rct_large_scenery_text> _3dFont;
+    std::unique_ptr<LargeSceneryText> _3dFont;
 
 public:
     explicit LargeSceneryObject(const rct_object_entry& entry)
@@ -45,7 +45,7 @@ public:
 private:
     static std::vector<rct_large_scenery_tile> ReadTiles(OpenRCT2::IStream* stream);
     static std::vector<rct_large_scenery_tile> ReadJsonTiles(json_t& jTiles);
-    static std::unique_ptr<rct_large_scenery_text> ReadJson3dFont(json_t& j3dFont);
-    static std::vector<LocationXY16> ReadJsonOffsets(json_t& jOffsets);
+    static std::unique_ptr<LargeSceneryText> ReadJson3dFont(json_t& j3dFont);
+    static std::vector<CoordsXY> ReadJsonOffsets(json_t& jOffsets);
     static std::vector<rct_large_scenery_text_glyph> ReadJsonGlyphs(json_t& jGlyphs);
 };

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -112,9 +112,9 @@ union paint_entry
 struct sprite_bb
 {
     uint32_t sprite_id;
-    LocationXYZ16 offset;
-    LocationXYZ16 bb_offset;
-    LocationXYZ16 bb_size;
+    CoordsXYZ offset;
+    CoordsXYZ bb_offset;
+    CoordsXYZ bb_size;
 };
 
 enum PAINT_STRUCT_FLAGS

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -67,7 +67,7 @@ static void large_scenery_paint_supports(
     paint_util_set_general_support_height(session, clearanceHeight, 0x20);
 }
 
-static rct_large_scenery_text_glyph* large_scenery_sign_get_glyph(rct_large_scenery_text* text, uint32_t codepoint)
+static rct_large_scenery_text_glyph* large_scenery_sign_get_glyph(LargeSceneryText* text, uint32_t codepoint)
 {
     if (codepoint >= std::size(text->glyphs))
     {
@@ -76,7 +76,7 @@ static rct_large_scenery_text_glyph* large_scenery_sign_get_glyph(rct_large_scen
     return &text->glyphs[codepoint];
 }
 
-static int32_t large_scenery_sign_text_width(const utf8* str, rct_large_scenery_text* text)
+static int32_t large_scenery_sign_text_width(const utf8* str, LargeSceneryText* text)
 {
     int32_t width = 0;
     uint32_t codepoint;
@@ -87,7 +87,7 @@ static int32_t large_scenery_sign_text_width(const utf8* str, rct_large_scenery_
     return width;
 }
 
-static int32_t large_scenery_sign_text_height(const utf8* str, rct_large_scenery_text* text)
+static int32_t large_scenery_sign_text_height(const utf8* str, LargeSceneryText* text)
 {
     int32_t height = 0;
     uint32_t codepoint;
@@ -98,7 +98,7 @@ static int32_t large_scenery_sign_text_height(const utf8* str, rct_large_scenery
     return height;
 }
 
-static void large_scenery_sign_fit_text(const utf8* str, rct_large_scenery_text* text, bool height, utf8* fitStr, size_t bufLen)
+static void large_scenery_sign_fit_text(const utf8* str, LargeSceneryText* text, bool height, utf8* fitStr, size_t bufLen)
 {
     utf8* fitStrEnd = fitStr;
     safe_strcpy(fitStr, str, bufLen);
@@ -124,8 +124,8 @@ static int32_t div_to_minus_infinity(int32_t a, int32_t b)
 }
 
 static void large_scenery_sign_paint_line(
-    paint_session* session, const utf8* str, rct_large_scenery_text* text, int32_t textImage, int32_t textColour,
-    uint8_t direction, int32_t y_offset)
+    paint_session* session, const utf8* str, LargeSceneryText* text, int32_t textImage, int32_t textColour, uint8_t direction,
+    int32_t y_offset)
 {
     utf8 fitStr[32];
     large_scenery_sign_fit_text(str, text, false, fitStr, sizeof(fitStr));
@@ -190,29 +190,29 @@ static void large_scenery_sign_paint_line(
 
 struct boundbox
 {
-    LocationXY16 offset;
-    LocationXY16 length;
+    CoordsXY offset;
+    CoordsXY length;
 };
 
 // clang-format off
 static constexpr const boundbox s98E3C4[] = {
-    { 3, 3, 26, 26 },
-    { 17, 17, 12, 12 },
-    { 17, 3, 12, 12 },
-    { 17, 3, 12, 26 },
-    { 3, 3, 12, 12 },
-    { 3, 3, 26, 26 },
-    { 3, 3, 28, 12 },
-    { 3, 3, 26, 26 },
-    { 3, 17, 12, 12 },
-    { 3, 17, 26, 12 },
-    { 3, 3, 26, 26 },
-    { 3, 3, 26, 26 },
-    { 3, 3, 12, 28 },
-    { 3, 3, 26, 26 },
-    { 3, 3, 26, 26 },
-    { 3, 3, 26, 26 },
-    { 1, 1, 30, 30 },
+    { { 3, 3 }, { 26, 26 } },
+    { { 17, 17 }, { 12, 12 } },
+    { { 17, 3 }, { 12, 12 } },
+    { { 17, 3 }, { 12, 26 } },
+    { { 3, 3 }, { 12, 12 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 3, 3 }, { 28, 12 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 3, 17 }, { 12, 12 } },
+    { { 3, 17 }, { 26, 12 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 3, 3 }, { 12, 28 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 3, 3 }, { 26, 26 } },
+    { { 1, 1 }, { 30, 30 } },
 };
 // clang-format on
 
@@ -244,8 +244,8 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
     uint32_t dword_F4387C = 0;
     image_id |= SPRITE_ID_PALETTE_COLOUR_2(
         tileElement->AsLargeScenery()->GetPrimaryColour(), tileElement->AsLargeScenery()->GetSecondaryColour());
-    LocationXYZ16 boxlength;
-    LocationXYZ16 boxoffset;
+    CoordsXYZ boxlength;
+    CoordsXYZ boxoffset;
     if (gTrackDesignSaveMode)
     {
         if (!track_design_save_contains_tile_element(tileElement))
@@ -264,12 +264,12 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
         dword_F4387C = sequenceNum;
         image_id |= dword_F4387C;
     }
-    int32_t ah = tile->z_clearance;
-    if (ah > 0x80)
+    int32_t boxlengthZ = tile->z_clearance;
+    if (boxlengthZ > 0x80)
     {
-        ah = 0x80;
+        boxlengthZ = 0x80;
     }
-    ah -= 3;
+    boxlengthZ -= 3;
     uint16_t edi = tile->flags;
     int32_t esi = 16;
     if (edi & 0xF00)
@@ -283,8 +283,9 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
     boxoffset.z = height;
     boxlength.x = s98E3C4[esi].length.x;
     boxlength.y = s98E3C4[esi].length.y;
-    boxlength.z = ah;
-    PaintAddImageAsParent(session, image_id, 0, 0, boxlength.x, boxlength.y, ah, height, boxoffset.x, boxoffset.y, boxoffset.z);
+    boxlength.z = boxlengthZ;
+    PaintAddImageAsParent(
+        session, image_id, 0, 0, boxlength.x, boxlength.y, boxlengthZ, height, boxoffset.x, boxoffset.y, boxoffset.z);
     if (sceneryEntry->scrolling_mode == SCROLLING_MODE_NONE || direction == 1 || direction == 2)
     {
         large_scenery_paint_supports(session, direction, height, tileElement, dword_F4387C, tile);
@@ -322,7 +323,7 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
             banner->FormatTextTo(ft);
             utf8 signString[256];
             format_string(signString, sizeof(signString), STR_STRINGID, ft.Data());
-            rct_large_scenery_text* text = sceneryEntry->text;
+            LargeSceneryText* text = sceneryEntry->text;
             int32_t y_offset = (text->offset[(direction & 1)].y * 2);
             if (text->flags & LARGE_SCENERY_TEXT_FLAG_VERTICAL)
             {

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -1002,8 +1002,8 @@ void path_paint_box_support(
     uint8_t corners = (((tileElement->AsPath()->GetCorners()) << session->CurrentRotation) & 0xF)
         | (((tileElement->AsPath()->GetCorners()) << session->CurrentRotation) >> 4);
 
-    LocationXY16 boundBoxOffset = { stru_98D804[edges][0], stru_98D804[edges][1] };
-    LocationXY16 boundBoxSize = { stru_98D804[edges][2], stru_98D804[edges][3] };
+    CoordsXY boundBoxOffset = { stru_98D804[edges][0], stru_98D804[edges][1] };
+    CoordsXY boundBoxSize = { stru_98D804[edges][2], stru_98D804[edges][3] };
 
     uint16_t edi = edges | (corners << 4);
 
@@ -1149,9 +1149,9 @@ void path_paint_pole_support(
     uint8_t edges = ((tileElement->AsPath()->GetEdges() << session->CurrentRotation) & 0xF)
         | (((tileElement->AsPath()->GetEdges()) << session->CurrentRotation) >> 4);
 
-    LocationXY16 boundBoxOffset = { stru_98D804[edges][0], stru_98D804[edges][1] };
+    CoordsXY boundBoxOffset = { stru_98D804[edges][0], stru_98D804[edges][1] };
 
-    LocationXY16 boundBoxSize = { stru_98D804[edges][2], stru_98D804[edges][3] };
+    CoordsXY boundBoxSize = { stru_98D804[edges][2], stru_98D804[edges][3] };
 
     uint8_t corners = (((tileElement->AsPath()->GetCorners()) << session->CurrentRotation) & 0xF)
         | (((tileElement->AsPath()->GetCorners()) << session->CurrentRotation) >> 4);

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -20,7 +20,7 @@
 #include "../Supports.h"
 #include "Paint.TileElement.h"
 
-static constexpr const LocationXY16 lengths[] = {
+static constexpr const CoordsXY lengths[] = {
     { 12, 26 },
     { 26, 12 },
     { 12, 26 },
@@ -39,8 +39,8 @@ void scenery_paint(paint_session* session, uint8_t direction, int32_t height, co
     }
     const SmallSceneryElement* sceneryElement = tileElement->AsSmallScenery();
     session->InteractionType = ViewportInteractionItem::Scenery;
-    LocationXYZ16 boxlength;
-    LocationXYZ16 boxoffset;
+    CoordsXYZ boxlength;
+    CoordsXYZ boxoffset;
     boxoffset.x = 0;
     boxoffset.y = 0;
     boxoffset.z = height;
@@ -76,7 +76,7 @@ void scenery_paint(paint_session* session, uint8_t direction, int32_t height, co
         if (scenery_small_entry_has_flag(sceneryEntry, SMALL_SCENERY_FLAG_HALF_SPACE))
         {
             // 6DFFE3:
-            static constexpr const LocationXY16 scenery_half_tile_offsets[] = {
+            static constexpr const CoordsXY scenery_half_tile_offsets[] = {
                 { 3, 3 },
                 { 3, 17 },
                 { 17, 3 },

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -43,7 +43,7 @@ static constexpr const uint8_t byte_97B444[] =
 };
 
 // rct2: 0x97B464, 0x97B474, 0x97B484, 0x97B494
-static constexpr const LocationXY16 viewport_surface_paint_data[][4] = {
+static constexpr const CoordsXY viewport_surface_paint_data[][4] = {
     {
         { 32, 0 },
         { -32, 32 },
@@ -561,8 +561,8 @@ static void viewport_surface_draw_tile_side_bottom(
 
     CoordsXY offset = { 0, 0 };
     CoordsXY bounds = { 0, 0 };
-    LocationXY16 tunnelBounds = { 1, 1 };
-    LocationXY16 tunnelTopBoundBoxOffset = { 0, 0 };
+    CoordsXY tunnelBounds = { 1, 1 };
+    CoordsXY tunnelTopBoundBoxOffset = { 0, 0 };
 
     const tunnel_entry* tunnelArray;
     switch (edge)
@@ -992,11 +992,8 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
 
     for (int32_t i = 0; i < 4; i++)
     {
-        const LocationXY16& offset = viewport_surface_paint_data[i][rotation];
-        const CoordsXY position = {
-            static_cast<int32_t>(base.x + offset.x),
-            static_cast<int32_t>(base.y + offset.y),
-        };
+        const CoordsXY& offset = viewport_surface_paint_data[i][rotation];
+        const CoordsXY position = base + offset;
 
         tile_descriptor& descriptor = tileDescriptors[i + 1];
 

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -41,8 +41,8 @@ static constexpr const uint8_t byte_9A40CC[] = {
 
 static void fence_paint_door(
     paint_session* session, uint32_t imageId, WallSceneryEntry* wallEntry, uint32_t imageColourFlags, uint32_t tertiaryColour,
-    uint32_t dword_141F710, LocationXYZ16 offset, LocationXYZ16 boundsR1, LocationXYZ16 boundsR1_, LocationXYZ16 boundsR2,
-    LocationXYZ16 boundsR2_, LocationXYZ16 boundsL1, LocationXYZ16 boundsL1_)
+    uint32_t dword_141F710, CoordsXYZ offset, CoordsXYZ boundsR1, CoordsXYZ boundsR1_, CoordsXYZ boundsR2, CoordsXYZ boundsR2_,
+    CoordsXYZ boundsL1, CoordsXYZ boundsL1_)
 {
     if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
     {
@@ -98,8 +98,8 @@ static void fence_paint_door(
 
 static void fence_paint_wall(
     paint_session* session, uint32_t frameNum, const WallSceneryEntry* wallEntry, uint32_t dword_141F710,
-    uint32_t imageColourFlags, uint32_t dword_141F718, uint32_t tertiaryColour, uint32_t imageOffset, LocationXYZ16 offset,
-    LocationXYZ16 bounds, LocationXYZ16 boundsOffset)
+    uint32_t imageColourFlags, uint32_t dword_141F718, uint32_t tertiaryColour, uint32_t imageOffset, CoordsXYZ offset,
+    CoordsXYZ bounds, CoordsXYZ boundsOffset)
 {
     uint32_t baseImageId = wallEntry->image + imageOffset + frameNum;
     uint32_t imageId = baseImageId;
@@ -210,8 +210,8 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
 
     if (wallEntry->flags & WALL_SCENERY_IS_DOOR)
     {
-        LocationXYZ16 offset;
-        LocationXYZ16 boundsR1, boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_;
+        CoordsXYZ offset;
+        CoordsXYZ boundsR1, boundsR1_, boundsR2, boundsR2_, boundsL1, boundsL1_;
         uint8_t animationFrame = tile_element->AsWall()->GetAnimationFrame();
         // Add the direction as well
         if (tile_element->AsWall()->AnimationIsBackwards())
@@ -296,7 +296,7 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     }
 
     uint32_t imageOffset = 0;
-    LocationXYZ16 offset = { 0, 0, 0 }, bounds = { 0, 0, 0 }, boundsOffset = { 0, 0, 0 };
+    CoordsXYZ offset = { 0, 0, 0 }, bounds = { 0, 0, 0 }, boundsOffset = { 0, 0, 0 };
 
     switch (direction)
     {

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -22,21 +22,6 @@ constexpr const int32_t COORDS_Z_PER_TINY_Z = 16;
 
 constexpr const auto NumOrthogonalDirections = 4;
 
-#pragma pack(push, 1)
-
-struct LocationXY16
-{
-    int16_t x, y;
-};
-assert_struct_size(LocationXY16, 4);
-
-struct LocationXYZ16
-{
-    int16_t x, y, z;
-};
-assert_struct_size(LocationXYZ16, 6);
-#pragma pack(pop)
-
 constexpr int32_t COORDS_NULL = 0xFFFF8000;
 
 struct ScreenCoordsXY

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -20,6 +20,8 @@
 #define SCENERY_WITHER_AGE_THRESHOLD_1 0x28
 #define SCENERY_WITHER_AGE_THRESHOLD_2 0x37
 
+struct LargeSceneryText;
+
 #pragma pack(push, 1)
 
 struct SceneryEntryBase
@@ -56,7 +58,10 @@ assert_struct_size(rct_large_scenery_text_glyph, 4);
 
 struct rct_large_scenery_text
 {
-    LocationXY16 offset[2];                   // 0x0
+    struct
+    {
+        int16_t x, y;
+    } offset[2];                              // 0x0
     uint16_t max_width;                       // 0x8
     uint16_t pad_A;                           // 0xA
     uint8_t flags;                            // 0xC
@@ -80,7 +85,7 @@ struct LargeSceneryEntry : SceneryEntryBase
     rct_large_scenery_tile* tiles;
     ObjectEntryIndex scenery_tab_id;
     uint8_t scrolling_mode;
-    rct_large_scenery_text* text;
+    LargeSceneryText* text;
     uint32_t text_image;
 };
 
@@ -157,6 +162,33 @@ struct BannerSceneryEntry : SceneryEntryBase
 };
 
 #pragma pack(pop)
+
+struct LargeSceneryText
+{
+    CoordsXY offset[2];
+    uint16_t max_width;
+    uint8_t flags;
+    uint16_t num_images;
+    rct_large_scenery_text_glyph glyphs[256];
+
+    LargeSceneryText() = default;
+
+    explicit LargeSceneryText(const rct_large_scenery_text& original)
+    {
+        for (size_t i = 0; i < std::size(original.offset); i++)
+        {
+            offset[i].x = original.offset[i].x;
+            offset[i].y = original.offset[i].y;
+        }
+        max_width = original.max_width;
+        flags = original.flags;
+        num_images = original.num_images;
+        for (size_t i = 0; i < std::size(original.glyphs); i++)
+        {
+            glyphs[i] = original.glyphs[i];
+        }
+    }
+};
 
 struct rct_scenery_group_entry
 {


### PR DESCRIPTION
This also splits `rct_large_scenery_text` into a .DAT version and an in-memory version. This was originally done to get rid of the dependency on LocationXY16. If desired, I could split that off.