### PR TITLE
Clean up create_new_banner()

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1974,7 +1974,7 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
 
             CoordsXYZD loc{ gridPos, z, direction };
             auto primaryColour = gWindowSceneryPrimaryColour;
-            auto bannerIndex = create_new_banner(0);
+            auto bannerIndex = BannerGetNewIndex();
             if (bannerIndex == BANNER_INDEX_NULL)
             {
                 context_show_error(STR_CANT_POSITION_THIS_HERE, STR_TOO_MANY_BANNERS_IN_GAME, {});
@@ -2573,7 +2573,7 @@ static money32 try_place_ghost_banner(CoordsXYZD loc, ObjectEntryIndex entryInde
 
     // 6e2612
     auto primaryColour = gWindowSceneryPrimaryColour;
-    auto bannerIndex = create_new_banner(0);
+    auto bannerIndex = BannerGetNewIndex();
     if (bannerIndex == BANNER_INDEX_NULL)
     {
         // Silently fail as this is just for the ghost

--- a/src/openrct2/actions/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/BannerPlaceAction.cpp
@@ -31,7 +31,7 @@ void BannerPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
     visitor.Visit(_loc);
     visitor.Visit("object", _bannerType);
     visitor.Visit("primaryColour", _primaryColour);
-    _bannerIndex = create_new_banner(0);
+    _bannerIndex = BannerGetNewIndex();
 }
 
 uint16_t BannerPlaceAction::GetActionFlags() const

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -49,7 +49,7 @@ LargeSceneryPlaceAction::LargeSceneryPlaceAction(
     {
         if (sceneryEntry->scrolling_mode != SCROLLING_MODE_NONE)
         {
-            _bannerId = create_new_banner(0);
+            _bannerId = BannerGetNewIndex();
         }
     }
 }
@@ -65,7 +65,7 @@ void LargeSceneryPlaceAction::AcceptParameters(GameActionParameterVisitor& visit
     {
         if (sceneryEntry->scrolling_mode != SCROLLING_MODE_NONE)
         {
-            _bannerId = create_new_banner(0);
+            _bannerId = BannerGetNewIndex();
         }
     }
 }

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -55,7 +55,7 @@ WallPlaceAction::WallPlaceAction(
     {
         if (sceneryEntry->scrolling_mode != SCROLLING_MODE_NONE)
         {
-            _bannerId = create_new_banner(0);
+            _bannerId = BannerGetNewIndex();
         }
     }
 }
@@ -73,7 +73,7 @@ void WallPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
     {
         if (sceneryEntry->scrolling_mode != SCROLLING_MODE_NONE)
         {
-            _bannerId = create_new_banner(0);
+            _bannerId = BannerGetNewIndex();
         }
     }
 }

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -110,7 +110,7 @@ static ride_id_t banner_get_ride_index_at(const CoordsXYZ& bannerCoords)
     return resultRideIndex;
 }
 
-static BannerIndex BannerGetNewIndex()
+BannerIndex BannerGetNewIndex()
 {
     for (BannerIndex bannerIndex = 0; bannerIndex < MAX_BANNERS; bannerIndex++)
     {
@@ -135,33 +135,28 @@ void banner_init()
 }
 
 /**
- * Creates a new banner and returns the index of the banner
- * If the flag GAME_COMMAND_FLAG_APPLY is NOT set then returns
- * the first unused index but does NOT mark the banner as created.
- * returns 0xFF on failure.
+ * Creates a new banner and returns the index of the banner,
+ * or BANNER_INDEX_NULL on failure.
  *
  *  rct2: 0x006BA278
  */
-BannerIndex create_new_banner(uint8_t flags)
+BannerIndex create_new_banner()
 {
     BannerIndex bannerIndex = BannerGetNewIndex();
 
     if (bannerIndex == BANNER_INDEX_NULL)
     {
-        gGameCommandErrorText = STR_TOO_MANY_BANNERS_IN_GAME;
         return bannerIndex;
     }
 
-    if (flags & GAME_COMMAND_FLAG_APPLY)
-    {
-        auto banner = &_banners[bannerIndex];
+    auto banner = &_banners[bannerIndex];
 
-        banner->flags = 0;
-        banner->type = 0;
-        banner->text = {};
-        banner->colour = 2;
-        banner->text_colour = 2;
-    }
+    banner->flags = 0;
+    banner->type = 0;
+    banner->text = {};
+    banner->colour = 2;
+    banner->text_colour = 2;
+
     return bannerIndex;
 }
 
@@ -299,7 +294,7 @@ void fix_duplicated_banners()
                                 tileElement->base_height);
 
                             // Banner index is already in use by another banner, so duplicate it
-                            auto newBannerIndex = create_new_banner(GAME_COMMAND_FLAG_APPLY);
+                            auto newBannerIndex = create_new_banner();
                             if (newBannerIndex == BANNER_INDEX_NULL)
                             {
                                 log_error("Failed to create new banner.");

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -56,10 +56,11 @@ enum BANNER_FLAGS
 };
 
 void banner_init();
-BannerIndex create_new_banner(uint8_t flags);
+BannerIndex create_new_banner();
 TileElement* banner_get_tile_element(BannerIndex bannerIndex);
 WallElement* banner_get_scrolling_wall_tile_element(BannerIndex bannerIndex);
 ride_id_t banner_get_closest_ride_index(const CoordsXYZ& mapPos);
 void banner_reset_broken_index();
 void fix_duplicated_banners();
 Banner* GetBanner(BannerIndex id);
+BannerIndex BannerGetNewIndex();

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -373,10 +373,11 @@ namespace OpenRCT2::TileInspector
             if (bannerIndex != BANNER_INDEX_NULL)
             {
                 // The element to be pasted refers to a banner index - make a copy of it
-                auto newBannerIndex = create_new_banner(GAME_COMMAND_FLAG_APPLY);
+                auto newBannerIndex = create_new_banner();
                 if (newBannerIndex == BANNER_INDEX_NULL)
                 {
-                    return std::make_unique<GameActions::Result>(GameActions::Status::Unknown, STR_NONE);
+                    return std::make_unique<GameActions::Result>(
+                        GameActions::Status::Unknown, STR_CANT_POSITION_THIS_HERE, STR_TOO_MANY_BANNERS_IN_GAME);
                 }
                 auto& newBanner = *GetBanner(newBannerIndex);
                 newBanner = *GetBanner(bannerIndex);


### PR DESCRIPTION
This function essentially did two things - looking up the next free banner ID and placing banners. Now it just does the latter. Also, setting the error message is not its responsibility, that should be set by the game action.