### PR TITLE
Fix: Close button broken when failed to load version or changelog

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Fix: [#14774] Incorrect import of scenery research caused all scenery to be unlocked.
 - Fix: [#14806] Incorrect function call in WallPlaceAction plugin code.
 - Fix: [#14871] Crash when trying to place track when there are no free tile elements.
+- Fix: [#14880] Unable to close changelog window when its content fails to load.
 - Improved: [#14511] “Unlock operating limits” cheat now also unlocks all music.
 - Improved: [#14712, #14716]: Improve startup times.
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -85,6 +85,8 @@ public:
      */
     bool SetPersonality(int personality)
     {
+        enabled_widgets = (1ULL << WIDX_CLOSE);
+
         switch (personality)
         {
             case WV_NEW_VERSION_INFO:
@@ -94,7 +96,7 @@ public:
                 }
                 _personality = WV_NEW_VERSION_INFO;
                 NewVersionProcessInfo();
-                enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_OPEN_URL);
+                enabled_widgets |= (1ULL << WIDX_OPEN_URL);
                 widgets[WIDX_OPEN_URL].type = WindowWidgetType::Button;
                 return true;
 
@@ -103,7 +105,6 @@ public:
                 {
                     return false;
                 }
-                enabled_widgets = (1ULL << WIDX_CLOSE);
                 _personality = WV_CHANGELOG;
                 return true;
 


### PR DESCRIPTION
Found this little issue while working on #14841. When the version info or the changelog file could not be loaded, the close button would not be enabled. Only with hot-keys the window could be closed.