### PR TITLE
Fix OpenRCT2#12262: Add y coordinate checking in ClampWindowToScreen

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -170,6 +170,7 @@ The following people are not part of the development team, but have been contrib
 * Ryan D. (rctdude2)
 * (zrowny)
 * Emre Aydin (aemreaydin)
+* Daniel Karandikar (DKarandikar)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
 - Change: [#14751] “No construction above tree height” limitation now allows placing high trees.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.
+- Fix: [#12262] Windows can appear off screen with small screens or high scaling.
 - Fix: [#13581] Opening the Options menu causes a noticeable drop in FPS.
 - Fix: [#13894] Block brakes do not animate.
 - Fix: [#13986] OpenGL: Track preview window, flip/rotate button do not update the thumbnail.

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -86,11 +86,8 @@ static bool WindowFitsOnScreen(const ScreenCoordsXY& loc, int32_t width, int32_t
     return WindowFitsBetweenOthers(loc, width, height);
 }
 
-static ScreenCoordsXY ClampWindowToScreen(const ScreenCoordsXY& pos,
-                                          const int32_t screenWidth,
-                                          const int32_t screenHeight,
-                                          const int32_t width,
-                                          const int32_t height)
+static ScreenCoordsXY ClampWindowToScreen(
+    const ScreenCoordsXY& pos, const int32_t screenWidth, const int32_t screenHeight, const int32_t width, const int32_t height)
 {
     auto screenPos = pos;
     if (screenPos.x < 0)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -90,14 +90,14 @@ static ScreenCoordsXY ClampWindowToScreen(
     const ScreenCoordsXY& pos, const int32_t screenWidth, const int32_t screenHeight, const int32_t width, const int32_t height)
 {
     auto screenPos = pos;
-    if (screenPos.x < 0)
+    if (width > screenWidth || screenPos.x < 0)
         screenPos.x = 0;
-    if (screenPos.x + width > screenWidth)
+    else if (screenPos.x + width > screenWidth)
         screenPos.x = screenWidth - width;
 
-    if (screenPos.y < 0)
+    if (height > screenHeight || screenPos.y)
         screenPos.y = 0;
-    if (screenPos.y + height > screenHeight)
+    else if (screenPos.y + height > screenHeight)
         screenPos.y = screenHeight - height;
 
     return screenPos;

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -95,10 +95,11 @@ static ScreenCoordsXY ClampWindowToScreen(
     else if (screenPos.x + width > screenWidth)
         screenPos.x = screenWidth - width;
 
-    if (height > screenHeight || screenPos.y)
-        screenPos.y = 0;
-    else if (screenPos.y + height > screenHeight)
-        screenPos.y = screenHeight - height;
+    auto toolbarAllowance = (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) ? 0 : (TOP_TOOLBAR_HEIGHT + 1);
+    if (height - toolbarAllowance > screenHeight || screenPos.y < toolbarAllowance)
+        screenPos.y = toolbarAllowance;
+    else if (screenPos.y + height - toolbarAllowance > screenHeight)
+        screenPos.y = screenHeight + toolbarAllowance - height;
 
     return screenPos;
 }

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -86,13 +86,22 @@ static bool WindowFitsOnScreen(const ScreenCoordsXY& loc, int32_t width, int32_t
     return WindowFitsBetweenOthers(loc, width, height);
 }
 
-static ScreenCoordsXY ClampWindowToScreen(const ScreenCoordsXY& pos, const int32_t screenWidth, const int32_t width)
+static ScreenCoordsXY ClampWindowToScreen(const ScreenCoordsXY& pos,
+                                          const int32_t screenWidth,
+                                          const int32_t screenHeight,
+                                          const int32_t width,
+                                          const int32_t height)
 {
     auto screenPos = pos;
     if (screenPos.x < 0)
         screenPos.x = 0;
     if (screenPos.x + width > screenWidth)
         screenPos.x = screenWidth - width;
+
+    if (screenPos.y < 0)
+        screenPos.y = 0;
+    if (screenPos.y + height > screenHeight)
+        screenPos.y = screenHeight - height;
 
     return screenPos;
 }
@@ -115,7 +124,7 @@ static ScreenCoordsXY GetAutoPositionForNewWindow(int32_t width, int32_t height)
     {
         if (WindowFitsWithinSpace(cornerPos, width, height))
         {
-            return ClampWindowToScreen(cornerPos, screenWidth, width);
+            return ClampWindowToScreen(cornerPos, screenWidth, screenHeight, width, height);
         }
     }
 
@@ -139,7 +148,7 @@ static ScreenCoordsXY GetAutoPositionForNewWindow(int32_t width, int32_t height)
             auto screenPos = w->windowPos + offset;
             if (WindowFitsWithinSpace(screenPos, width, height))
             {
-                return ClampWindowToScreen(screenPos, screenWidth, width);
+                return ClampWindowToScreen(screenPos, screenWidth, screenHeight, width, height);
             }
         }
     }
@@ -164,7 +173,7 @@ static ScreenCoordsXY GetAutoPositionForNewWindow(int32_t width, int32_t height)
             auto screenPos = w->windowPos + offset;
             if (WindowFitsOnScreen(screenPos, width, height))
             {
-                return ClampWindowToScreen(screenPos, screenWidth, width);
+                return ClampWindowToScreen(screenPos, screenWidth, screenHeight, width, height);
             }
         }
     }
@@ -180,7 +189,7 @@ static ScreenCoordsXY GetAutoPositionForNewWindow(int32_t width, int32_t height)
         }
     }
 
-    return ClampWindowToScreen(screenPos, screenWidth, width);
+    return ClampWindowToScreen(screenPos, screenWidth, screenHeight, width, height);
 }
 
 static ScreenCoordsXY GetCentrePositionForNewWindow(int32_t width, int32_t height)


### PR DESCRIPTION
Replicate logic for checking x coordinate for y in ClampWindowToScreen