### PR TITLE
Fix #14893. Only check map capacity with valid locations

### DIFF
--- a/src/openrct2/actions/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/BannerPlaceAction.cpp
@@ -55,15 +55,15 @@ GameActions::Result::Ptr BannerPlaceAction::Query() const
     res->Expenditure = ExpenditureType::Landscaping;
     res->ErrorTitle = STR_CANT_POSITION_THIS_HERE;
 
+    if (!LocationValid(_loc))
+    {
+        return MakeResult(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE);
+    }
+
     if (!MapCheckCapacityAndReorganise(_loc))
     {
         log_error("No free map elements.");
         return MakeResult(GameActions::Status::NoFreeElements, STR_CANT_POSITION_THIS_HERE);
-    }
-
-    if (!LocationValid(_loc))
-    {
-        return MakeResult(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE);
     }
 
     auto pathElement = GetValidPathElement();

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -142,12 +142,6 @@ GameActions::Result::Ptr LargeSceneryPlaceAction::Query() const
         }
     }
 
-    if (!CheckMapCapacity(sceneryEntry->tiles, totalNumTiles))
-    {
-        log_error("No free map elements available");
-        return std::make_unique<LargeSceneryPlaceActionResult>(GameActions::Status::NoFreeElements);
-    }
-
     uint8_t tileNum = 0;
     for (rct_large_scenery_tile* tile = sceneryEntry->tiles; tile->x_offset != -1; tile++, tileNum++)
     {
@@ -196,6 +190,12 @@ GameActions::Result::Ptr LargeSceneryPlaceAction::Query() const
         }
     }
 
+    if (!CheckMapCapacity(sceneryEntry->tiles, totalNumTiles))
+    {
+        log_error("No free map elements available");
+        return std::make_unique<LargeSceneryPlaceActionResult>(GameActions::Status::NoFreeElements);
+    }
+
     // Force ride construction to recheck area
     _currentTrackSelectionFlags |= TRACK_SELECTION_FLAG_RECHECK;
 
@@ -230,7 +230,6 @@ GameActions::Result::Ptr LargeSceneryPlaceAction::Execute() const
         return std::make_unique<LargeSceneryPlaceActionResult>(GameActions::Status::InvalidParameters);
     }
 
-    uint32_t totalNumTiles = GetTotalNumTiles(sceneryEntry->tiles);
     int16_t maxHeight = GetMaxSurfaceHeight(sceneryEntry->tiles);
 
     if (_loc.z != 0)
@@ -239,12 +238,6 @@ GameActions::Result::Ptr LargeSceneryPlaceAction::Execute() const
     }
 
     res->Position.z = maxHeight;
-
-    if (!CheckMapCapacity(sceneryEntry->tiles, totalNumTiles))
-    {
-        log_error("No free map elements available");
-        return std::make_unique<LargeSceneryPlaceActionResult>(GameActions::Status::NoFreeElements);
-    }
 
     uint8_t tileNum = 0;
     for (rct_large_scenery_tile* tile = sceneryEntry->tiles; tile->x_offset != -1; tile++, tileNum++)

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -39,12 +39,6 @@ GameActions::Result::Ptr MazePlaceTrackAction::Query() const
     res->Position = _loc + CoordsXYZ{ 8, 8, 0 };
     res->Expenditure = ExpenditureType::RideConstruction;
     res->ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        res->Error = GameActions::Status::NoFreeElements;
-        res->ErrorMessage = STR_TILE_ELEMENT_LIMIT_REACHED;
-        return res;
-    }
     if ((_loc.z & 0xF) != 0)
     {
         res->Error = GameActions::Status::Unknown;
@@ -59,6 +53,12 @@ GameActions::Result::Ptr MazePlaceTrackAction::Query() const
         return res;
     }
 
+    if (!MapCheckCapacityAndReorganise(_loc))
+    {
+        res->Error = GameActions::Status::NoFreeElements;
+        res->ErrorMessage = STR_TILE_ELEMENT_LIMIT_REACHED;
+        return res;
+    }
     auto surfaceElement = map_get_surface_element_at(_loc);
     if (surfaceElement == nullptr)
     {
@@ -133,13 +133,6 @@ GameActions::Result::Ptr MazePlaceTrackAction::Execute() const
     if (ride == nullptr)
     {
         res->Error = GameActions::Status::InvalidParameters;
-        res->ErrorMessage = STR_NONE;
-        return res;
-    }
-
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        res->Error = GameActions::Status::NoFreeElements;
         res->ErrorMessage = STR_NONE;
         return res;
     }

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -51,12 +51,6 @@ GameActions::Result::Ptr MazeSetTrackAction::Query() const
     res->Position = _loc + CoordsXYZ{ 8, 8, 0 };
     res->Expenditure = ExpenditureType::RideConstruction;
     res->ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        res->Error = GameActions::Status::NoFreeElements;
-        res->ErrorMessage = STR_TILE_ELEMENT_LIMIT_REACHED;
-        return res;
-    }
     if ((_loc.z & 0xF) != 0 && _mode == GC_SET_MAZE_TRACK_BUILD)
     {
         res->Error = GameActions::Status::Unknown;
@@ -71,6 +65,12 @@ GameActions::Result::Ptr MazeSetTrackAction::Query() const
         return res;
     }
 
+    if (!MapCheckCapacityAndReorganise(_loc))
+    {
+        res->Error = GameActions::Status::NoFreeElements;
+        res->ErrorMessage = STR_TILE_ELEMENT_LIMIT_REACHED;
+        return res;
+    }
     auto surfaceElement = map_get_surface_element_at(_loc);
     if (surfaceElement == nullptr)
     {
@@ -155,13 +155,6 @@ GameActions::Result::Ptr MazeSetTrackAction::Execute() const
     if (ride == nullptr)
     {
         res->Error = GameActions::Status::InvalidParameters;
-        res->ErrorMessage = STR_NONE;
-        return res;
-    }
-
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        res->Error = GameActions::Status::NoFreeElements;
         res->ErrorMessage = STR_NONE;
         return res;
     }

--- a/src/openrct2/actions/PlaceParkEntranceAction.cpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.cpp
@@ -51,17 +51,17 @@ GameActions::Result::Ptr PlaceParkEntranceAction::Query() const
     res->Expenditure = ExpenditureType::LandPurchase;
     res->Position = { _loc.x, _loc.y, _loc.z };
 
-    if (!CheckMapCapacity(3))
-    {
-        return std::make_unique<GameActions::Result>(
-            GameActions::Status::NoFreeElements, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
-    }
-
     if (!LocationValid(_loc) || _loc.x <= 32 || _loc.y <= 32 || _loc.x >= (gMapSizeUnits - 32)
         || _loc.y >= (gMapSizeUnits - 32))
     {
         return std::make_unique<GameActions::Result>(
             GameActions::Status::InvalidParameters, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_TOO_CLOSE_TO_EDGE_OF_MAP);
+    }
+
+    if (!CheckMapCapacity(3))
+    {
+        return std::make_unique<GameActions::Result>(
+            GameActions::Status::NoFreeElements, STR_CANT_BUILD_PARK_ENTRANCE_HERE, STR_NONE);
     }
 
     if (gParkEntrances.size() >= MAX_PARK_ENTRANCES)

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -50,10 +50,6 @@ GameActions::Result::Ptr RideEntranceExitPlaceAction::Query() const
 {
     auto errorTitle = _isExit ? STR_CANT_BUILD_MOVE_EXIT_FOR_THIS_RIDE_ATTRACTION
                               : STR_CANT_BUILD_MOVE_ENTRANCE_FOR_THIS_RIDE_ATTRACTION;
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        return MakeResult(GameActions::Status::NoFreeElements, errorTitle);
-    }
 
     auto ride = get_ride(_rideIndex);
     if (ride == nullptr)
@@ -98,6 +94,10 @@ GameActions::Result::Ptr RideEntranceExitPlaceAction::Query() const
         return MakeResult(GameActions::Status::NotOwned, errorTitle);
     }
 
+    if (!MapCheckCapacityAndReorganise(_loc))
+    {
+        return MakeResult(GameActions::Status::NoFreeElements, errorTitle);
+    }
     auto clear_z = z + (_isExit ? RideExitHeight : RideEntranceHeight);
     auto cost = MONEY32_UNDEFINED;
     if (!map_can_construct_with_clear_at(
@@ -217,16 +217,16 @@ GameActions::Result::Ptr RideEntranceExitPlaceAction::TrackPlaceQuery(const Coor
 {
     auto errorTitle = isExit ? STR_CANT_BUILD_MOVE_EXIT_FOR_THIS_RIDE_ATTRACTION
                              : STR_CANT_BUILD_MOVE_ENTRANCE_FOR_THIS_RIDE_ATTRACTION;
-    if (!MapCheckCapacityAndReorganise(loc))
-    {
-        return MakeResult(GameActions::Status::NoFreeElements, errorTitle);
-    }
 
     if (!gCheatsSandboxMode && !map_is_location_owned(loc))
     {
         return MakeResult(GameActions::Status::NotOwned, errorTitle);
     }
 
+    if (!MapCheckCapacityAndReorganise(loc))
+    {
+        return MakeResult(GameActions::Status::NoFreeElements, errorTitle);
+    }
     int16_t baseZ = loc.z;
     int16_t clearZ = baseZ + (isExit ? RideExitHeight : RideEntranceHeight);
     auto cost = MONEY32_UNDEFINED;

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -111,14 +111,14 @@ GameActions::Result::Ptr SmallSceneryPlaceAction::Query() const
         res->Position.z = surfaceHeight;
     }
 
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        return std::make_unique<SmallSceneryPlaceActionResult>(GameActions::Status::NoFreeElements);
-    }
-
     if (!LocationValid(_loc))
     {
         return MakeResult(GameActions::Status::InvalidParameters);
+    }
+
+    if (!MapCheckCapacityAndReorganise(_loc))
+    {
+        return std::make_unique<SmallSceneryPlaceActionResult>(GameActions::Status::NoFreeElements);
     }
 
     if (!byte_9D8150 && (_loc.x > gMapSizeMaxXY || _loc.y > gMapSizeMaxXY))

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -361,11 +361,6 @@ GameActions::Result::Ptr WallPlaceAction::Execute() const
         }
     }
 
-    if (!MapCheckCapacityAndReorganise(_loc))
-    {
-        return MakeResult(GameActions::Status::NoFreeElements, STR_TILE_ELEMENT_LIMIT_REACHED);
-    }
-
     if (wallEntry->scrolling_mode != SCROLLING_MODE_NONE)
     {
         if (_bannerId == BANNER_INDEX_NULL)


### PR DESCRIPTION
Found the source of these unexplained crashes. It happens when invalid coordinates are passed to the map reorganiser. This was happening because the call that checks if the location was valid was later in the query of the game action. Easy way to trigger this was using the scenery scatter tool off the map edge.

I also took the  opertunity to delete duplicated calls that were in the  query and execute. There is no need to do this check in both.