### PR TITLE
Minor paint refactor

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/network/network.h>
+#include <openrct2/paint/tile_element/Paint.TileElement.h>
 #include <openrct2/platform/platform.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/ride/RideData.h>
@@ -2446,7 +2447,7 @@ static void sub_6CBCE2(
         _tempTrackTileElement.AsTrack()->SetRideIndex(rideIndex);
 
         // Draw this map tile
-        sub_68B2B7(session, coords);
+        tile_element_paint_setup(session, coords, true);
 
         // Restore map elements
         map_set_tile_element(centreTileCoords, _backupTileElementArrays[0]);

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -147,7 +147,6 @@ bool ViewportInteractionRightOver(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionRightClick(const ScreenCoordsXY& screenCoords);
 
 CoordsXY ViewportInteractionGetTileStartAtCursor(const ScreenCoordsXY& screenCoords);
-void sub_68B2B7(paint_session* session, const CoordsXY& mapCoords);
 
 void viewport_invalidate(const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom);
 

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -209,14 +209,14 @@ template<uint8_t direction> void PaintSessionGenerateRotate(paint_session* sessi
 
     for (; numVerticalTiles > 0; --numVerticalTiles)
     {
-        tile_element_paint_setup(session, mapTile.x, mapTile.y);
+        tile_element_paint_setup(session, mapTile);
         sprite_paint_setup(session, mapTile.x, mapTile.y);
 
         auto loc1 = mapTile + adjacentTiles[0];
         sprite_paint_setup(session, loc1.x, loc1.y);
 
         auto loc2 = mapTile + adjacentTiles[1];
-        tile_element_paint_setup(session, loc2.x, loc2.y);
+        tile_element_paint_setup(session, loc2);
         sprite_paint_setup(session, loc2.x, loc2.y);
 
         auto loc3 = mapTile + adjacentTiles[2];

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -472,7 +472,7 @@ bool wooden_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session->Unk141E9DB & G141E9DB_FLAG_1))
+    if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -652,7 +652,7 @@ bool wooden_b_supports_paint_setup(
         return false;
     }
 
-    if (!(session->Unk141E9DB & G141E9DB_FLAG_1))
+    if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
         if (underground != nullptr)
             *underground = false; // AND
@@ -834,7 +834,7 @@ bool metal_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session->Unk141E9DB & G141E9DB_FLAG_1))
+    if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -1033,7 +1033,7 @@ bool metal_b_supports_paint_setup(
         return false; // AND
     }
 
-    if (!(session->Unk141E9DB & G141E9DB_FLAG_1))
+    if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
         return false; // AND
     }
@@ -1216,7 +1216,7 @@ bool path_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session->Unk141E9DB & G141E9DB_FLAG_1))
+    if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -1362,7 +1362,7 @@ bool path_b_supports_paint_setup(
         return false; // AND
     }
 
-    if (!(session->Unk141E9DB & G141E9DB_FLAG_1))
+    if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
         return false; // AND
     }

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1393,7 +1393,7 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
     }
 
     session->InteractionType = ViewportInteractionItem::Terrain;
-    session->Unk141E9DB |= G141E9DB_FLAG_1;
+    session->Unk141E9DB |= PaintSessionFlags::IsPassedSurface;
 
     switch (surfaceShape)
     {

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -45,35 +45,14 @@ const int32_t SEGMENTS_ALL = SEGMENT_B4 | SEGMENT_B8 | SEGMENT_BC | SEGMENT_C0 |
  *
  *  rct2: 0x0068B35F
  */
-void tile_element_paint_setup(paint_session* session, int32_t x, int32_t y)
-{
-    if (x < gMapSizeUnits && y < gMapSizeUnits && x >= 32 && y >= 32)
-    {
-        paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
-        paint_util_force_set_general_support_height(session, -1, 0);
-        session->Unk141E9DB = 0;
-        session->WaterHeight = 0xFFFF;
-
-        sub_68B3FB(session, x, y);
-    }
-    else if (!(session->ViewFlags & VIEWPORT_FLAG_TRANSPARENT_BACKGROUND))
-    {
-        blank_tiles_paint(session, x, y);
-    }
-}
-
-/**
- *
- *  rct2: 0x0068B2B7
- */
-void sub_68B2B7(paint_session* session, const CoordsXY& mapCoords)
+void tile_element_paint_setup(paint_session* session, const CoordsXY& mapCoords, bool isTrackPiecePreview)
 {
     if (mapCoords.x < gMapSizeUnits && mapCoords.y < gMapSizeUnits && mapCoords.x >= 32 && mapCoords.y >= 32)
     {
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_force_set_general_support_height(session, -1, 0);
+        session->Unk141E9DB = isTrackPiecePreview ? PaintSessionFlags::IsTrackPiecePreview : 0;
         session->WaterHeight = 0xFFFF;
-        session->Unk141E9DB = G141E9DB_FLAG_2;
 
         sub_68B3FB(session, mapCoords.x, mapCoords.y);
     }

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -72,11 +72,12 @@ enum
     TUNNEL_TYPE_COUNT
 };
 
-enum
+namespace PaintSessionFlags
 {
-    G141E9DB_FLAG_1 = 1,
-    G141E9DB_FLAG_2 = 2,
-};
+    // Unsure as to why this exists and DidPassSurface
+    constexpr uint8_t IsPassedSurface = 1;
+    constexpr uint8_t IsTrackPiecePreview = 2;
+} // namespace PaintSessionFlags
 
 #ifdef __TESTPAINT__
 extern uint16_t testPaintVerticalTunnelHeight;
@@ -100,7 +101,7 @@ void paint_util_force_set_general_support_height(paint_session* session, int16_t
 void paint_util_set_segment_support_height(paint_session* session, int32_t segments, uint16_t height, uint8_t slope);
 uint16_t paint_util_rotate_segments(uint16_t segments, uint8_t rotation);
 
-void tile_element_paint_setup(paint_session* session, int32_t x, int32_t y);
+void tile_element_paint_setup(paint_session* session, const CoordsXY& mapCoords, bool isTrackPiecePreview = false);
 
 void entrance_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tile_element);
 void banner_paint(paint_session* session, uint8_t direction, int32_t height, const TileElement* tile_element);

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -749,7 +749,7 @@ bool track_paint_util_draw_station_covers_2(
         return false;
     }
 
-    if (!(session->Unk141E9DB & (G141E9DB_FLAG_1 | G141E9DB_FLAG_2)))
+    if (!(session->Unk141E9DB & (PaintSessionFlags::IsPassedSurface | PaintSessionFlags::IsTrackPiecePreview)))
     {
         return false;
     }


### PR DESCRIPTION
Names a few unknown flags.

I've no idea why there is both IsPassedSurface  and DidPassSurface. They are both set in the same situations. I would remove it but not sure if @OpenRCT2/developers have any better ideas as to why it exists.