### PR TITLE
Fix #14964: Building in multiplayer while paused

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#14871] Crash when trying to place track when there are no free tile elements.
 - Fix: [#14880] Unable to close changelog window when its content fails to load.
 - Fix: [#14945] Incorrect drop height penalty on log flume ride.
+- Fix: [#14964] Unable to build in multiplayer as client with "Build while paused" cheat enabled when the host is paused.
 - Improved: [#14511] “Unlock operating limits” cheat now also unlocks all music.
 - Improved: [#14712, #14716]: Improve startup times.
 

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -151,14 +151,24 @@ void GameState::Update()
         }
         else
         {
+            // NOTE: Here are a few special cases that would be normally handled in UpdateLogic.
+            // If the game is paused it will not call UpdateLogic at all.
             numUpdates = 0;
+
+            if (network_get_mode() == NETWORK_MODE_SERVER)
+            {
+                // Make sure the client always knows about what tick the host is on.
+                network_send_tick();
+            }
+
             // Update the animation list. Note this does not
             // increment the map animation.
             map_animation_invalidate_all();
 
-            // Special case because we set numUpdates to 0, otherwise in game_logic_update.
+            // Post-tick network update
             network_process_pending();
 
+            // Post-tick game actions.
             GameActions::ProcessQueue();
         }
     }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -37,7 +37,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
The simple explanation: The client never received the last incremented tick when the host paused the game.