### PR TITLE
Add Malgun Gothic and change Nanum Gothic for Korean

### DIFF
--- a/src/openrct2/interface/FontFamilies.cpp
+++ b/src/openrct2/interface/FontFamilies.cpp
@@ -34,6 +34,7 @@ TTFontFamily const TTFFamilyJapanese = {
 TTFontFamily const TTFFamilyKorean = {
     &TTFFontGulim,
     &TTFFontNanum,
+    &TTFFontMalgun,
 };
 
 TTFontFamily const TTFFamilySansSerif = {

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -72,6 +72,12 @@ TTFFontSetDescriptor TTFFontGulim = { {
     { "gulim.ttc", "Gulim", 12, 1, 0, 15, HINTING_THRESHOLD_MEDIUM, nullptr },
 } };
 
+TTFFontSetDescriptor TTFFontMalgun = { {
+    { "malgun.ttf", "Malgun Gothic", 10, 1, -3, 10, HINTING_THRESHOLD_LOW, nullptr },
+    { "malgun.ttf", "Malgun Gothic", 12, 1, -3, 15, HINTING_THRESHOLD_LOW, nullptr },
+    { "malgun.ttf", "Malgun Gothic", 12, 1, -3, 15, HINTING_THRESHOLD_LOW, nullptr },
+} };
+
 TTFFontSetDescriptor TTFFontNanum = { {
     { "NanumGothic.ttc", "Nanum Gothic", 10, 1, 0, 10, HINTING_DISABLED,      nullptr },
     { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },

--- a/src/openrct2/interface/Fonts.cpp
+++ b/src/openrct2/interface/Fonts.cpp
@@ -79,9 +79,9 @@ TTFFontSetDescriptor TTFFontMalgun = { {
 } };
 
 TTFFontSetDescriptor TTFFontNanum = { {
-    { "NanumGothic.ttc", "Nanum Gothic", 10, 1, 0, 10, HINTING_DISABLED,      nullptr },
-    { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
-    { "NanumGothic.ttc", "Nanum Gothic", 12, 1, 0, 15, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttf", "Nanum Gothic", 10, 1, -2, 10, HINTING_DISABLED, nullptr },
+    { "NanumGothic.ttf", "Nanum Gothic", 12, 1, -2, 15, HINTING_THRESHOLD_LOW, nullptr },
+    { "NanumGothic.ttf", "Nanum Gothic", 12, 1, -2, 15, HINTING_THRESHOLD_LOW, nullptr },
 } };
 
 TTFFontSetDescriptor TTFFontArial = { {

--- a/src/openrct2/interface/Fonts.h
+++ b/src/openrct2/interface/Fonts.h
@@ -26,6 +26,7 @@ extern TTFFontSetDescriptor TTFFontHeiti;
 extern TTFFontSetDescriptor TTFFontSimSun;
 extern TTFFontSetDescriptor TTFFontLiHeiPro;
 extern TTFFontSetDescriptor TTFFontGulim;
+extern TTFFontSetDescriptor TTFFontMalgun;
 extern TTFFontSetDescriptor TTFFontNanum;
 extern TTFFontSetDescriptor TTFFontArial;
 extern TTFFontSetDescriptor TTFFontArialUnicode;


### PR DESCRIPTION
# Add Malgun Gothic
I tested OpenRCT2 in Windows 11 today ~~and noticed that it seems Gulim is not exist in Windows 11.~~ (Maybe there is, I'm checking the facts)
Thus Korean users will run into mangled strings like ``ㅁㅁ`` as you can see below when Windows 11 is introduced at the late of this year, unless Windows 11 contains gulim.ttc again.

**Issue screenshot:** (Windows 11, not installed neither Gulim nor NanumGothic)
![image](https://user-images.githubusercontent.com/10726524/124345695-6614df80-dc15-11eb-8880-2bdf201b2aec.png)


So adding ``Malgun Gothic`` as an alternative TTF font will solve this problem beforehand which will be occured in the future.
For notes, Malgun Gothic is introduced since Windows Vista and is used as a main font in modern Korean Windows.


**Applied screenshot:**
![image](https://user-images.githubusercontent.com/10726524/124345725-8a70bc00-dc15-11eb-91f1-7bdceaa27355.png)



# Change Nanum Gothic
Nanum Gothic is introduced by [Naver](https://www.naver.com), which is the biggest site in Korean, and it is able to download via [its official webpage](https://hangeul.naver.com/font).
The official download file of NanumGothic is a zip file which contains four ``*.ttf`` files, not ``*.ttc``.
So OpenRCT2 does not detect (and maybe is not detecting currently too) NanumGothic in current state and causes mangled strings.
I have no idea why @AaronVanGeffen used *.ttc in here: (please comment if you had some thoughts at that moment 😃)
https://github.com/OpenRCT2/OpenRCT2/blob/a5a63f839aca539ad75abf09a765e590e5ba973b/src/openrct2/interface/Fonts.cpp#L76

I changed them into ``*.ttf`` and changes y_offset value and hinting options for NanumGothic as well.

**Applied screenshot:** (NanumGothic)
![image](https://user-images.githubusercontent.com/10726524/124345460-f7835200-dc13-11eb-9a21-977c03bf10db.png)
