### PR TITLE
Fix #13465: Creating a scenario based on a won save game results in a scenario that's instantly won.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -175,6 +175,7 @@ The following people are not part of the development team, but have been contrib
 * Struan Clark (xtruan)
 * Kane Shaw (seifer7)
 * Saad Rehman (SaadRehmanCS)
+* (ocalhoun6)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.
+- Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Fix: [#15142] ToonTowner's mine roofs were moved into the pirate theme scenery group instead of the mine theme scenery group.

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -140,6 +140,7 @@ namespace Editor
 
         // reset whether the scenario has been won, to make sure it hasn't:
         gParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+        gScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
 
         gScreenFlags = SCREEN_FLAGS_SCENARIO_EDITOR;
         gS6Info.editor_step = EditorStep::ObjectiveSelection;

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -138,7 +138,7 @@ namespace Editor
         gS6Info.objective_arg_3 = gScenarioObjective.NumGuests;
         climate_reset(gClimate);
 
-        // reset whether the scenario has been won, to make sure it hasn't:
+        // Clear the scenario completion status
         gParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
         gScenarioCompletedCompanyValue = MONEY64_UNDEFINED;
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -138,6 +138,9 @@ namespace Editor
         gS6Info.objective_arg_3 = gScenarioObjective.NumGuests;
         climate_reset(gClimate);
 
+        // reset whether the scenario has been won, to make sure it hasn't:
+        gParkFlags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+
         gScreenFlags = SCREEN_FLAGS_SCENARIO_EDITOR;
         gS6Info.editor_step = EditorStep::ObjectiveSelection;
         gS6Info.category = SCENARIO_CATEGORY_OTHER;


### PR DESCRIPTION
Yeah ... I have _very_ little idea what I'm doing here. C++ is weird, and I'm not sure I'm doing this github stuff the right way, either.

Also very hazy on how setting these park flags works. I _think_ gParkFlags is some kind of array or vector full of binary true/false flags? But I'm not sure how it knows which flag to set based on these big variable names like "PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT". And I'm new to C++, so these bitwise operators like &= and |= are kind of mind-boggling for me. Don't really understand why they're used this way. And _really_ not sure if I should be using &= or |= in this instance.

Also not sure if I'm doing everything that's necessary.
To fix this from the console takes two commands: 
`scenario.status = "inProgress" `
`park.setFlag("scenarioCompleteNameInput", false)`
But in the scenario.cpp code, I can't find _anything_ about scenario.status or the inProgress flag.

So, yeah ... this _might_ be an utter failure and only messing things up. But I think I've got it at least _close_ to where it needs to be. The extra line of code is in the right place, and if I got lucky enough to guess the correct operator _and_ there really aren't any other flags, this should work.