### PR TITLE
Fix 15063

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Fix: [#15028] Crash when placing large scenery.
 - Fix: [#15048] Crash when removing litter with cheats.
 - Fix: [#15052] Crash when using banner window.
+- Fix: [#15063] Crash when opening large scenery signs.
 - Improved: [#12626] Allow using RCT2 saves to mark RCT Classic (.sea) parks as finished and vice versa. 
 
 0.3.4 (2021-07-19)

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -102,15 +102,25 @@ public:
 
         if (_isSmall)
         {
-            list_information_type = tileElement->AsWall()->GetPrimaryColour();
-            var_492 = tileElement->AsWall()->GetSecondaryColour();
-            SceneryEntry = tileElement->AsWall()->GetEntryIndex();
+            auto* wallElement = tileElement->AsWall();
+            if (wallElement == nullptr)
+            {
+                return false;
+            }
+            list_information_type = wallElement->GetPrimaryColour();
+            var_492 = wallElement->GetSecondaryColour();
+            SceneryEntry = wallElement->GetEntryIndex();
         }
         else
         {
-            list_information_type = tileElement->AsLargeScenery()->GetPrimaryColour();
-            var_492 = tileElement->AsLargeScenery()->GetSecondaryColour();
-            SceneryEntry = tileElement->AsLargeScenery()->GetEntryIndex();
+            auto* sceneryElement = tileElement->AsLargeScenery();
+            if (sceneryElement == nullptr)
+            {
+                return false;
+            }
+            list_information_type = sceneryElement->GetPrimaryColour();
+            var_492 = sceneryElement->GetSecondaryColour();
+            SceneryEntry = sceneryElement->GetEntryIndex();
         }
 
         // Create viewport


### PR DESCRIPTION
Crash when opening large signs. Couldn't reproduce the crash but this will handle bad tileElement pointers that i assume caused the crash.