### PR TITLE
Invalidate screen when toggling transparent water flag

### DIFF
--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -711,6 +711,7 @@ static void ShortcutToggleTransparentWater()
 
     gConfigGeneral.transparent_water ^= 1;
     config_save_default();
+    gfx_invalidate_screen();
 }
 
 #pragma endregion


### PR DESCRIPTION
Pointed out here: https://github.com/OpenRCT2/OpenRCT2/issues/14753#issuecomment-849024680