### PR TITLE
Actually allocate a banner when using GetOrCreateBanner

### DIFF
--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -406,7 +406,10 @@ Banner* GetOrCreateBanner(BannerIndex id)
         {
             _banners.resize(id + 1);
         }
-        return &_banners[id];
+        // Create the banner
+        auto& banner = _banners[id];
+        banner.id = id;
+        return &banner;
     }
     return nullptr;
 }


### PR DESCRIPTION
When importing a file this function is used to create a banner at a certain index. Previously this was not assigning the id to the banner id. Luckily as banner id is a new field this did not cause any issues except in the nsf which does use the banner id more extensively