### PR TITLE
Fix path finding for larger maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,9 @@ set(OBJECTS_VERSION "1.0.21")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_VERSION "0.0.43")
+set(REPLAYS_VERSION "0.0.44")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "269E4FC432A73AE9A5D601EC2A1C882F3D9BDF3C")
+set(REPLAYS_SHA1 "586F3930DE8D2C3880AAFD30ABC4D81ABC0B64A4")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
     <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.43/replays.zip</ReplaysUrl>
-    <ReplaysSha1>269E4FC432A73AE9A5D601EC2A1C882F3D9BDF3C</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.44/replays.zip</ReplaysUrl>
+    <ReplaysSha1>586F3930DE8D2C3880AAFD30ABC4D81ABC0B64A4</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -253,10 +253,16 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Peep, InteractionRideIndex);
         COMPARE_FIELD(Peep, Id);
         COMPARE_FIELD(Peep, PathCheckOptimisation);
-        COMPARE_FIELD(Peep, PathfindGoal);
+        COMPARE_FIELD(Peep, PathfindGoal.x);
+        COMPARE_FIELD(Peep, PathfindGoal.y);
+        COMPARE_FIELD(Peep, PathfindGoal.z);
+        COMPARE_FIELD(Peep, PathfindGoal.direction);
         for (int i = 0; i < 4; i++)
         {
-            COMPARE_FIELD(Peep, PathfindHistory[i]);
+            COMPARE_FIELD(Peep, PathfindHistory[i].x);
+            COMPARE_FIELD(Peep, PathfindHistory[i].y);
+            COMPARE_FIELD(Peep, PathfindHistory[i].z);
+            COMPARE_FIELD(Peep, PathfindHistory[i].direction);
         }
         COMPARE_FIELD(Peep, WalkingFrameNum);
     }

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -867,3 +867,32 @@ template<> struct DataSerializerTraits_t<rct_peep_thought>
         stream->Write(msg, strlen(msg));
     }
 };
+
+template<> struct DataSerializerTraits_t<TileCoordsXYZD>
+{
+    static void encode(OpenRCT2::IStream* stream, const TileCoordsXYZD& coord)
+    {
+        stream->WriteValue(ByteSwapBE(coord.x));
+        stream->WriteValue(ByteSwapBE(coord.y));
+        stream->WriteValue(ByteSwapBE(coord.z));
+        stream->WriteValue(ByteSwapBE(coord.direction));
+    }
+
+    static void decode(OpenRCT2::IStream* stream, TileCoordsXYZD& coord)
+    {
+        auto x = ByteSwapBE(stream->ReadValue<int32_t>());
+        auto y = ByteSwapBE(stream->ReadValue<int32_t>());
+        auto z = ByteSwapBE(stream->ReadValue<int32_t>());
+        auto d = ByteSwapBE(stream->ReadValue<Direction>());
+        coord = TileCoordsXYZD{ x, y, z, d };
+    }
+
+    static void log(OpenRCT2::IStream* stream, const TileCoordsXYZD& coord)
+    {
+        char msg[128] = {};
+        snprintf(
+            msg, sizeof(msg), "TileCoordsXYZD(x = %d, y = %d, z = %d, direction = %d)", coord.x, coord.y, coord.z,
+            coord.direction);
+        stream->Write(msg, strlen(msg));
+    }
+};

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -612,8 +612,8 @@ struct Peep : SpriteBase
     ride_id_t InteractionRideIndex;
     uint32_t Id;
     uint8_t PathCheckOptimisation; // see peep.checkForPath
-    rct12_xyzd8 PathfindGoal;
-    std::array<rct12_xyzd8, 4> PathfindHistory;
+    TileCoordsXYZD PathfindGoal;
+    std::array<TileCoordsXYZD, 4> PathfindHistory;
     uint8_t WalkingFrameNum;
     uint32_t PeepFlags;
 

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1343,10 +1343,27 @@ void S6Exporter::ExportEntityPeep(RCT2SpritePeep* dst, const Peep* src)
     dst->id = src->Id;
     dst->path_check_optimisation = src->PathCheckOptimisation;
     dst->peep_flags = src->PeepFlags;
-    dst->pathfind_goal = src->PathfindGoal;
+    if (src->PathfindGoal.isNull())
+    {
+        dst->pathfind_goal = { 0xFF, 0xFF, 0xFF, INVALID_DIRECTION };
+    }
+    else
+    {
+        dst->pathfind_goal = { static_cast<uint8_t>(src->PathfindGoal.x), static_cast<uint8_t>(src->PathfindGoal.y),
+                               static_cast<uint8_t>(src->PathfindGoal.z), src->PathfindGoal.direction };
+    }
     for (size_t i = 0; i < std::size(src->PathfindHistory); i++)
     {
-        dst->pathfind_history[i] = src->PathfindHistory[i];
+        if (src->PathfindHistory[i].isNull())
+        {
+            dst->pathfind_history[i] = { 0xFF, 0xFF, 0xFF, INVALID_DIRECTION };
+        }
+        else
+        {
+            dst->pathfind_history[i] = { static_cast<uint8_t>(src->PathfindHistory[i].x),
+                                         static_cast<uint8_t>(src->PathfindHistory[i].y),
+                                         static_cast<uint8_t>(src->PathfindHistory[i].z), src->PathfindHistory[i].direction };
+        }
     }
     dst->no_action_frame_num = src->WalkingFrameNum;
 }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1365,6 +1365,10 @@ public:
 
     void ImportEntityPeep(Peep* dst, const RCT2SpritePeep* src)
     {
+        const auto isNullLocation = [](const rct12_xyzd8& pos) {
+            return pos.x == 0xFF && pos.y == 0xFF && pos.z == 0xFF && pos.direction == INVALID_DIRECTION;
+        };
+
         ImportEntityCommonProperties(static_cast<SpriteBase*>(dst), src);
         if (is_user_string_id(src->name_string_idx))
         {
@@ -1401,10 +1405,28 @@ public:
         dst->Id = src->id;
         dst->PathCheckOptimisation = src->path_check_optimisation;
         dst->PeepFlags = src->peep_flags;
-        dst->PathfindGoal = src->pathfind_goal;
+        if (isNullLocation(src->pathfind_goal))
+        {
+            dst->PathfindGoal.setNull();
+            dst->PathfindGoal.direction = INVALID_DIRECTION;
+        }
+        else
+        {
+            dst->PathfindGoal = { src->pathfind_goal.x, src->pathfind_goal.y, src->pathfind_goal.z,
+                                  src->pathfind_goal.direction };
+        }
         for (size_t i = 0; i < std::size(src->pathfind_history); i++)
         {
-            dst->PathfindHistory[i] = src->pathfind_history[i];
+            if (isNullLocation(src->pathfind_history[i]))
+            {
+                dst->PathfindHistory[i].setNull();
+                dst->PathfindHistory[i].direction = INVALID_DIRECTION;
+            }
+            else
+            {
+                dst->PathfindHistory[i] = { src->pathfind_history[i].x, src->pathfind_history[i].y, src->pathfind_history[i].z,
+                                            src->pathfind_history[i].direction };
+            }
         }
         dst->WalkingFrameNum = src->no_action_frame_num;
     }

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -615,6 +615,12 @@ struct TileCoordsXYZD : public TileCoordsXYZ
     {
     }
 
+    TileCoordsXYZD(const TileCoordsXYZ& t_, Direction d_)
+        : TileCoordsXYZ(t_)
+        , direction(d_)
+    {
+    }
+
     TileCoordsXYZD(const TileCoordsXY& t_, int32_t z_, Direction d_)
         : TileCoordsXYZ(t_, z_)
         , direction(d_)

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -268,6 +268,12 @@ struct CoordsXYZ : public CoordsXY
     {
         return ToTileStart() + CoordsXYZ{ COORDS_XY_HALF_TILE, COORDS_XY_HALF_TILE, 0 };
     }
+
+    void setNull()
+    {
+        CoordsXY::setNull();
+        z = 0;
+    }
 };
 
 struct CoordsXYRangedZ : public CoordsXY
@@ -458,6 +464,12 @@ struct TileCoordsXYZ : public TileCoordsXY
             return ret;
         }
         return { x * COORDS_XY_STEP, y * COORDS_XY_STEP, z * COORDS_Z_STEP };
+    }
+
+    void setNull()
+    {
+        TileCoordsXY::setNull();
+        z = 0;
     }
 };
 
@@ -654,6 +666,12 @@ struct TileCoordsXYZD : public TileCoordsXYZ
             return ret;
         }
         return { x * COORDS_XY_STEP, y * COORDS_XY_STEP, z * COORDS_Z_STEP, direction };
+    }
+
+    void setNull()
+    {
+        TileCoordsXYZ::setNull();
+        direction = INVALID_DIRECTION;
     }
 };
 


### PR DESCRIPTION
The current structure is capped to uint8_t so the biggest tile position would be 0xFE, 0xFE before it considers it invalid. Probably breaks replays as the null value for TileCoords is 0xFFFF8000 if I remember right.