### PR TITLE
Change track paint signature to pass ride instead of ride index

### DIFF
--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -202,7 +202,7 @@ enum
 // clang-format on
 
 bool track_paint_util_has_fence(
-    enum edge_t edge, const CoordsXY& position, const TileElement* tileElement, Ride* ride, uint8_t rotation)
+    enum edge_t edge, const CoordsXY& position, const TileElement* tileElement, const Ride* ride, uint8_t rotation)
 {
     const auto* stationObject = ride_get_station_object(ride);
     if (stationObject != nullptr && stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -264,7 +264,7 @@ void track_paint_util_paint_floor(
 }
 
 void track_paint_util_paint_fences(
-    paint_session* session, uint8_t edges, const CoordsXY& position, const TileElement* tileElement, Ride* ride,
+    paint_session* session, uint8_t edges, const CoordsXY& position, const TileElement* tileElement, const Ride* ride,
     uint32_t colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
 {
     uint32_t imageId;
@@ -304,34 +304,33 @@ bool track_paint_util_should_paint_supports(const CoordsXY& position)
 }
 
 static void track_paint_util_draw_station_impl(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TileElement* tileElement, int32_t fenceOffsetA, int32_t fenceOffsetB);
 
 void track_paint_util_draw_station(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, const TileElement* tileElement)
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TileElement* tileElement)
 {
-    track_paint_util_draw_station_impl(session, rideIndex, direction, height, height, tileElement, 5, 7);
+    track_paint_util_draw_station_impl(session, ride, direction, height, height, tileElement, 5, 7);
 }
 
 void track_paint_util_draw_station_2(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, const TileElement* tileElement,
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TileElement* tileElement,
     int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
-    track_paint_util_draw_station_impl(session, rideIndex, direction, height, height, tileElement, fenceOffsetA, fenceOffsetB);
+    track_paint_util_draw_station_impl(session, ride, direction, height, height, tileElement, fenceOffsetA, fenceOffsetB);
 }
 
 void track_paint_util_draw_station_3(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TileElement* tileElement)
 {
-    track_paint_util_draw_station_impl(session, rideIndex, direction, height, coverHeight, tileElement, 5, 7);
+    track_paint_util_draw_station_impl(session, ride, direction, height, coverHeight, tileElement, 5, 7);
 }
 
 static void track_paint_util_draw_station_impl(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TileElement* tileElement, int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -539,10 +538,9 @@ static void track_paint_util_draw_station_impl(
 }
 
 void track_paint_util_draw_station_inverted(
-    paint_session* session, ride_id_t rideIndex, Direction direction, int32_t height, const TileElement* tileElement,
+    paint_session* session, const Ride* ride, Direction direction, int32_t height, const TileElement* tileElement,
     uint8_t stationVariant)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -853,7 +851,8 @@ bool track_paint_util_draw_station_covers_2(
 }
 
 void track_paint_util_draw_narrow_station_platform(
-    paint_session* session, Ride* ride, Direction direction, int32_t height, int32_t zOffset, const TileElement* tileElement)
+    paint_session* session, const Ride* ride, Direction direction, int32_t height, int32_t zOffset,
+    const TileElement* tileElement)
 {
     CoordsXY position = session->MapPosition;
     auto stationObj = ride_get_station_object(ride);
@@ -901,7 +900,7 @@ void track_paint_util_draw_narrow_station_platform(
 }
 
 void track_paint_util_draw_pier(
-    paint_session* session, Ride* ride, const StationObject* stationObj, const CoordsXY& position, Direction direction,
+    paint_session* session, const Ride* ride, const StationObject* stationObj, const CoordsXY& position, Direction direction,
     int32_t height, const TileElement* tileElement, uint8_t rotation)
 {
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -2263,7 +2262,7 @@ void track_paint(paint_session* session, Direction direction, int32_t height, co
             TRACK_PAINT_FUNCTION paintFunction = paintFunctionGetter(trackType);
             if (paintFunction != nullptr)
             {
-                paintFunction(session, rideIndex, trackSequence, direction, height, tileElement);
+                paintFunction(session, ride, trackSequence, direction, height, tileElement);
             }
         }
     }

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -278,12 +278,12 @@ extern const uint8_t mapLeftEighthTurnToOrthogonal[5];
 extern const size_t mini_golf_peep_animation_lengths[];
 
 bool track_paint_util_has_fence(
-    enum edge_t edge, const CoordsXY& position, const TileElement* tileElement, Ride* ride, uint8_t rotation);
+    enum edge_t edge, const CoordsXY& position, const TileElement* tileElement, const Ride* ride, uint8_t rotation);
 void track_paint_util_paint_floor(
     paint_session* session, uint8_t edges, uint32_t colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle);
 void track_paint_util_paint_fences(
-    paint_session* session, uint8_t edges, const CoordsXY& position, const TileElement* tileElement, Ride* ride,
+    paint_session* session, uint8_t edges, const CoordsXY& position, const TileElement* tileElement, const Ride* ride,
     uint32_t colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 bool track_paint_util_draw_station_covers(
     paint_session* session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
@@ -291,21 +291,22 @@ bool track_paint_util_draw_station_covers_2(
     paint_session* session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
     uint8_t stationVariant);
 void track_paint_util_draw_narrow_station_platform(
-    paint_session* session, Ride* ride, Direction direction, int32_t height, int32_t zOffset, const TileElement* tileElement);
+    paint_session* session, const Ride* ride, Direction direction, int32_t height, int32_t zOffset,
+    const TileElement* tileElement);
 void track_paint_util_draw_station(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, const TileElement* tileElement);
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TileElement* tileElement);
 void track_paint_util_draw_station_2(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, const TileElement* tileElement,
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TileElement* tileElement,
     int32_t fenceOffsetA, int32_t fenceOffsetB);
 void track_paint_util_draw_station_3(
-    paint_session* session, ride_id_t rideIndex, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TileElement* tileElement);
 void track_paint_util_draw_station_inverted(
-    paint_session* session, ride_id_t rideIndex, Direction direction, int32_t height, const TileElement* tileElement,
+    paint_session* session, const Ride* ride, Direction direction, int32_t height, const TileElement* tileElement,
     uint8_t stationVariant);
 bool track_paint_util_should_paint_supports(const CoordsXY& position);
 void track_paint_util_draw_pier(
-    paint_session* session, Ride* ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
+    paint_session* session, const Ride* ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
     int32_t height, const TileElement* tileElement, uint8_t rotation);
 void track_paint_util_draw_station_metal_supports(
     paint_session* session, Direction direction, uint16_t height, uint32_t colour);
@@ -394,7 +395,7 @@ void track_paint_util_right_vertical_loop_segments(paint_session* session, Direc
 void track_paint_util_left_corkscrew_up_supports(paint_session* session, Direction direction, uint16_t height);
 
 using TRACK_PAINT_FUNCTION = void (*)(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, Direction direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TileElement* tileElement);
 using TRACK_PAINT_FUNCTION_GETTER = TRACK_PAINT_FUNCTION (*)(int32_t trackType);
 

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -177,7 +177,7 @@ static uint32_t air_powered_vertical_rc_get_support_colour(paint_session* sessio
 
 /** rct2: 0x008AFAD4 */
 static void air_powered_vertical_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -199,7 +199,7 @@ static void air_powered_vertical_rc_track_flat(
 }
 
 static void air_powered_vertical_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -218,7 +218,6 @@ static void air_powered_vertical_rc_track_station(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, tileElement);
 
@@ -229,7 +228,7 @@ static void air_powered_vertical_rc_track_station(
 }
 
 static void air_powered_vertical_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -312,17 +311,16 @@ static void air_powered_vertical_rc_track_right_quarter_turn_5(
 }
 
 static void air_powered_vertical_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    air_powered_vertical_rc_track_right_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    air_powered_vertical_rc_track_right_quarter_turn_5(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AFB74 */
 static void air_powered_vertical_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -351,7 +349,7 @@ static void air_powered_vertical_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AFB84 */
 static void air_powered_vertical_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -379,24 +377,22 @@ static void air_powered_vertical_rc_track_flat_to_right_bank(
 }
 
 static void air_powered_vertical_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    air_powered_vertical_rc_track_flat_to_right_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    air_powered_vertical_rc_track_flat_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFBA4 */
 static void air_powered_vertical_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    air_powered_vertical_rc_track_flat_to_left_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    air_powered_vertical_rc_track_flat_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -493,17 +489,17 @@ static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
 }
 
 static void air_powered_vertical_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     air_powered_vertical_rc_track_banked_right_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AFBD4 */
 static void air_powered_vertical_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -532,14 +528,14 @@ static void air_powered_vertical_rc_track_left_bank(
 }
 
 static void air_powered_vertical_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    air_powered_vertical_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    air_powered_vertical_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void air_powered_vertical_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -561,7 +557,7 @@ static void air_powered_vertical_rc_track_brakes(
 }
 
 static void air_powered_vertical_rc_track_vertical_slope_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t trackImageIds[7][4] = {
@@ -761,7 +757,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
 }
 
 static void air_powered_vertical_rc_track_vertical_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -798,13 +794,12 @@ static void air_powered_vertical_rc_track_vertical_up(
 }
 
 static void air_powered_vertical_rc_track_vertical_top(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
     {
-        air_powered_vertical_rc_track_vertical_top(
-            session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        air_powered_vertical_rc_track_vertical_top(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
         return;
     }
 
@@ -881,22 +876,21 @@ static void air_powered_vertical_rc_track_vertical_top(
 }
 
 static void air_powered_vertical_rc_track_vertical_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    air_powered_vertical_rc_track_vertical_up(session, rideIndex, trackSequence ^ 1, (direction + 2) & 3, height, tileElement);
+    air_powered_vertical_rc_track_vertical_up(session, ride, trackSequence ^ 1, (direction + 2) & 3, height, tileElement);
 }
 
 static void air_powered_vertical_rc_track_vertical_slope_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    air_powered_vertical_rc_track_vertical_slope_up(
-        session, rideIndex, 6 - trackSequence, (direction + 2) & 3, height, tileElement);
+    air_powered_vertical_rc_track_vertical_slope_up(session, ride, 6 - trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void air_powered_vertical_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     // The booster piece is borrowed from the Reverse Freefall Colour.
@@ -929,7 +923,7 @@ static void air_powered_vertical_rc_track_booster(
 }
 
 static void air_powered_vertical_rc_track_onride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _BobsleighBlockBrakeImages[NumOrthogonalDirectio
 
 /** rct2: 0x006FE5B4 */
 static void bobsleigh_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -90,7 +90,7 @@ static void bobsleigh_rc_track_flat(
 }
 
 static void bobsleigh_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -106,7 +106,7 @@ static void bobsleigh_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -114,7 +114,7 @@ static void bobsleigh_rc_track_station(
 
 /** rct2: 0x006FE5C4 */
 static void bobsleigh_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -200,7 +200,7 @@ static void bobsleigh_rc_track_25_deg_up(
 
 /** rct2: 0x006FE5D4 */
 static void bobsleigh_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -286,7 +286,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x006FE5E4 */
 static void bobsleigh_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -372,31 +372,31 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x006FE5F4 */
 static void bobsleigh_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE604 */
 static void bobsleigh_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE614 */
 static void bobsleigh_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE624 */
 static void bobsleigh_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -620,16 +620,16 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x006FE634 */
 static void bobsleigh_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    bobsleigh_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    bobsleigh_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE644 */
 static void bobsleigh_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -671,7 +671,7 @@ static void bobsleigh_rc_track_flat_to_left_bank(
 
 /** rct2: 0x006FE654 */
 static void bobsleigh_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -713,7 +713,7 @@ static void bobsleigh_rc_track_flat_to_right_bank(
 
 /** rct2: 0x006FE664 */
 static void bobsleigh_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -755,7 +755,7 @@ static void bobsleigh_rc_track_left_bank_to_flat(
 
 /** rct2: 0x006FE674 */
 static void bobsleigh_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -797,7 +797,7 @@ static void bobsleigh_rc_track_right_bank_to_flat(
 
 /** rct2: 0x006FE684 */
 static void bobsleigh_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1021,16 +1021,16 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x006FE694 */
 static void bobsleigh_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    bobsleigh_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    bobsleigh_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE6A4 */
 static void bobsleigh_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1079,7 +1079,7 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x006FE6B4 */
 static void bobsleigh_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1128,7 +1128,7 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x006FE6C4 */
 static void bobsleigh_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1177,7 +1177,7 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x006FE6D4 */
 static void bobsleigh_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1226,39 +1226,39 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x006FE6E4 */
 static void bobsleigh_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE6F4 */
 static void bobsleigh_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE704 */
 static void bobsleigh_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE714 */
 static void bobsleigh_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE724 */
 static void bobsleigh_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1300,15 +1300,15 @@ static void bobsleigh_rc_track_left_bank(
 
 /** rct2: 0x006FE734 */
 static void bobsleigh_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bobsleigh_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    bobsleigh_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE744 */
 static void bobsleigh_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1491,7 +1491,7 @@ static void bobsleigh_rc_track_s_bend_left(
 
 /** rct2: 0x006FE754 */
 static void bobsleigh_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1674,7 +1674,7 @@ static void bobsleigh_rc_track_s_bend_right(
 
 /** rct2: 0x006FE794 */
 static void bobsleigh_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1813,16 +1813,16 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x006FE7A4 */
 static void bobsleigh_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    bobsleigh_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    bobsleigh_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE7B4 */
 static void bobsleigh_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1961,16 +1961,16 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x006FE7C4 */
 static void bobsleigh_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    bobsleigh_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    bobsleigh_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE7D4 */
 static void bobsleigh_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2242,7 +2242,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x006FE7E4 */
 static void bobsleigh_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2514,7 +2514,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x006FE7F4 */
 static void bobsleigh_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -2523,13 +2523,12 @@ static void bobsleigh_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    bobsleigh_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    bobsleigh_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE804 */
 static void bobsleigh_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -2538,13 +2537,12 @@ static void bobsleigh_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    bobsleigh_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    bobsleigh_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE814 */
 static void bobsleigh_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2986,7 +2984,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x006FE824 */
 static void bobsleigh_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3428,7 +3426,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x006FE834 */
 static void bobsleigh_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3437,13 +3435,12 @@ static void bobsleigh_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    bobsleigh_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    bobsleigh_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE844 */
 static void bobsleigh_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3452,13 +3449,12 @@ static void bobsleigh_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    bobsleigh_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    bobsleigh_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x006FE854 */
 static void bobsleigh_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3490,7 +3486,7 @@ static void bobsleigh_rc_track_brakes(
 
 /** rct2: 0x006FE864 */
 static void bobsleigh_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -3524,7 +3520,7 @@ static void bobsleigh_rc_track_block_brakes(
 }
 
 static void bobsleigh_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.cpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.cpp
@@ -33,7 +33,7 @@ static constexpr const uint32_t _BolligerMabillardBlockBrakeImages[NumOrthogonal
 };
 
 void bolliger_mabillard_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -68,7 +68,7 @@ void bolliger_mabillard_track_flat(
 }
 
 void bolliger_mabillard_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -96,7 +96,6 @@ void bolliger_mabillard_track_station(
     track_paint_util_draw_station_metal_supports_2(
         session, direction, height, session->TrackColours[SCHEME_SUPPORTS], supportType);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 9, tileElement);
 
@@ -106,7 +105,7 @@ void bolliger_mabillard_track_station(
 }
 
 void bolliger_mabillard_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -175,7 +174,7 @@ void bolliger_mabillard_track_25_deg_up(
 }
 
 void bolliger_mabillard_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -244,7 +243,7 @@ void bolliger_mabillard_track_60_deg_up(
 }
 
 void bolliger_mabillard_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -313,7 +312,7 @@ void bolliger_mabillard_track_flat_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -390,7 +389,7 @@ void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
 }
 
 void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -467,7 +466,7 @@ void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -536,55 +535,53 @@ void bolliger_mabillard_track_25_deg_up_to_flat(
 }
 
 void bolliger_mabillard_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
-    bolliger_mabillard_track_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+    bolliger_mabillard_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
-    bolliger_mabillard_track_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+    bolliger_mabillard_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -747,16 +744,16 @@ void bolliger_mabillard_track_left_quarter_turn_5(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_left_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -793,7 +790,7 @@ void bolliger_mabillard_track_flat_to_left_bank(
 }
 
 void bolliger_mabillard_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -830,7 +827,7 @@ void bolliger_mabillard_track_flat_to_right_bank(
 }
 
 void bolliger_mabillard_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -867,7 +864,7 @@ void bolliger_mabillard_track_left_bank_to_flat(
 }
 
 void bolliger_mabillard_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -904,7 +901,7 @@ void bolliger_mabillard_track_right_bank_to_flat(
 }
 
 void bolliger_mabillard_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -1080,16 +1077,16 @@ void bolliger_mabillard_track_banked_left_quarter_turn_5(
 }
 
 void bolliger_mabillard_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_banked_left_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -1133,7 +1130,7 @@ void bolliger_mabillard_track_left_bank_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -1177,7 +1174,7 @@ void bolliger_mabillard_track_right_bank_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -1221,7 +1218,7 @@ void bolliger_mabillard_track_25_deg_up_to_left_bank(
 }
 
 void bolliger_mabillard_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -1265,39 +1262,39 @@ void bolliger_mabillard_track_25_deg_up_to_right_bank(
 }
 
 void bolliger_mabillard_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -1330,15 +1327,14 @@ void bolliger_mabillard_track_left_bank(
 }
 
 void bolliger_mabillard_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
-    bolliger_mabillard_track_left_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+    bolliger_mabillard_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -1501,7 +1497,7 @@ void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -1664,25 +1660,25 @@ void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -1812,7 +1808,7 @@ void bolliger_mabillard_track_s_bend_left(
 }
 
 void bolliger_mabillard_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -1942,7 +1938,7 @@ void bolliger_mabillard_track_s_bend_right(
 }
 
 void bolliger_mabillard_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -2204,7 +2200,7 @@ void bolliger_mabillard_track_left_vertical_loop(
 }
 
 void bolliger_mabillard_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -2428,7 +2424,7 @@ void bolliger_mabillard_track_right_vertical_loop(
 }
 
 void bolliger_mabillard_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -2530,16 +2526,16 @@ void bolliger_mabillard_track_left_quarter_turn_3(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_left_quarter_turn_3(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -2650,16 +2646,16 @@ void bolliger_mabillard_track_left_quarter_turn_3_bank(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_left_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -2737,7 +2733,7 @@ void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -2818,25 +2814,25 @@ void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -3053,7 +3049,7 @@ void bolliger_mabillard_track_left_half_banked_helix_up_small(
 }
 
 void bolliger_mabillard_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -3270,7 +3266,7 @@ void bolliger_mabillard_track_right_half_banked_helix_up_small(
 }
 
 void bolliger_mabillard_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (trackSequence >= 4)
@@ -3280,11 +3276,11 @@ void bolliger_mabillard_track_left_half_banked_helix_down_small(
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (trackSequence >= 4)
@@ -3294,11 +3290,11 @@ void bolliger_mabillard_track_right_half_banked_helix_down_small(
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -3639,7 +3635,7 @@ void bolliger_mabillard_track_left_half_banked_helix_up_large(
 }
 
 void bolliger_mabillard_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -3986,7 +3982,7 @@ void bolliger_mabillard_track_right_half_banked_helix_up_large(
 }
 
 void bolliger_mabillard_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (trackSequence >= 7)
@@ -3996,11 +3992,11 @@ void bolliger_mabillard_track_left_half_banked_helix_down_large(
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (trackSequence >= 7)
@@ -4010,11 +4006,11 @@ void bolliger_mabillard_track_right_half_banked_helix_down_large(
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4050,7 +4046,7 @@ void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4086,23 +4082,23 @@ void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
 }
 
 void bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4129,7 +4125,7 @@ void bolliger_mabillard_track_brakes(
 }
 
 void bolliger_mabillard_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4169,7 +4165,7 @@ void bolliger_mabillard_track_25_deg_up_left_banked(
 }
 
 void bolliger_mabillard_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4209,7 +4205,7 @@ void bolliger_mabillard_track_25_deg_up_right_banked(
 }
 
 void bolliger_mabillard_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4250,23 +4246,23 @@ void bolliger_mabillard_track_on_ride_photo(
 }
 
 void bolliger_mabillard_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_right_banked(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_left_banked(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -4306,15 +4302,14 @@ void bolliger_mabillard_track_90_deg_up(
 }
 
 void bolliger_mabillard_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
-    bolliger_mabillard_track_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+    bolliger_mabillard_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -4356,15 +4351,15 @@ void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
 }
 
 void bolliger_mabillard_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -4401,7 +4396,7 @@ void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
 }
 
 void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -4444,7 +4439,7 @@ void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
 }
 
 void bolliger_mabillard_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -4578,7 +4573,7 @@ void bolliger_mabillard_track_left_eighth_to_diag(
 }
 
 void bolliger_mabillard_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -4711,25 +4706,25 @@ void bolliger_mabillard_track_right_eighth_to_diag(
 }
 
 void bolliger_mabillard_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
     bolliger_mabillard_track_right_eighth_to_diag(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
     bolliger_mabillard_track_left_eighth_to_diag(
-        session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 3) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -4866,7 +4861,7 @@ void bolliger_mabillard_track_left_eighth_bank_to_diag(
 }
 
 void bolliger_mabillard_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5003,25 +4998,25 @@ void bolliger_mabillard_track_right_eighth_bank_to_diag(
 }
 
 void bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
     bolliger_mabillard_track_right_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
     bolliger_mabillard_track_left_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 3) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5166,7 +5161,7 @@ void bolliger_mabillard_track_diag_flat(
 }
 
 void bolliger_mabillard_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5311,7 +5306,7 @@ void bolliger_mabillard_track_diag_25_deg_up(
 }
 
 void bolliger_mabillard_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5456,7 +5451,7 @@ void bolliger_mabillard_track_diag_60_deg_up(
 }
 
 void bolliger_mabillard_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5601,7 +5596,7 @@ void bolliger_mabillard_track_diag_flat_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5746,7 +5741,7 @@ void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
 }
 
 void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -5891,7 +5886,7 @@ void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6036,7 +6031,7 @@ void bolliger_mabillard_track_diag_25_deg_up_to_flat(
 }
 
 void bolliger_mabillard_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6181,7 +6176,7 @@ void bolliger_mabillard_track_diag_25_deg_down(
 }
 
 void bolliger_mabillard_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6326,7 +6321,7 @@ void bolliger_mabillard_track_diag_60_deg_down(
 }
 
 void bolliger_mabillard_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6469,7 +6464,7 @@ void bolliger_mabillard_track_diag_flat_to_25_deg_down(
 }
 
 void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6614,7 +6609,7 @@ void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
 }
 
 void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6759,7 +6754,7 @@ void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
 }
 
 void bolliger_mabillard_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -6904,7 +6899,7 @@ void bolliger_mabillard_track_diag_25_deg_down_to_flat(
 }
 
 void bolliger_mabillard_track_diag_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7049,7 +7044,7 @@ void bolliger_mabillard_track_diag_flat_to_60_deg_up(
 }
 
 void bolliger_mabillard_track_diag_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7194,7 +7189,7 @@ void bolliger_mabillard_track_diag_60_deg_up_to_flat(
 }
 
 void bolliger_mabillard_track_diag_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7339,7 +7334,7 @@ void bolliger_mabillard_track_diag_flat_to_60_deg_down(
 }
 
 void bolliger_mabillard_track_diag_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7484,7 +7479,7 @@ void bolliger_mabillard_track_diag_60_deg_down_to_flat(
 }
 
 void bolliger_mabillard_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7558,7 +7553,7 @@ void bolliger_mabillard_track_diag_flat_to_left_bank(
 }
 
 void bolliger_mabillard_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7632,7 +7627,7 @@ void bolliger_mabillard_track_diag_flat_to_right_bank(
 }
 
 void bolliger_mabillard_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7706,7 +7701,7 @@ void bolliger_mabillard_track_diag_left_bank_to_flat(
 }
 
 void bolliger_mabillard_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7780,7 +7775,7 @@ void bolliger_mabillard_track_diag_right_bank_to_flat(
 }
 
 void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7854,7 +7849,7 @@ void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -7928,7 +7923,7 @@ void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8002,7 +7997,7 @@ void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
 }
 
 void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8076,7 +8071,7 @@ void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
 }
 
 void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8148,7 +8143,7 @@ void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
 }
 
 void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8220,7 +8215,7 @@ void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
 }
 
 void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8294,7 +8289,7 @@ void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
 }
 
 void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8368,7 +8363,7 @@ void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
 }
 
 void bolliger_mabillard_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8439,7 +8434,7 @@ void bolliger_mabillard_track_diag_left_bank(
 }
 
 void bolliger_mabillard_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8510,7 +8505,7 @@ void bolliger_mabillard_track_diag_right_bank(
 }
 
 void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8591,7 +8586,7 @@ void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8675,7 +8670,7 @@ void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8759,7 +8754,7 @@ void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8840,7 +8835,7 @@ void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
 }
 
 void bolliger_mabillard_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -8872,7 +8867,7 @@ void bolliger_mabillard_track_block_brakes(
 }
 
 void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -8953,7 +8948,7 @@ void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -9037,25 +9032,25 @@ void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -9224,7 +9219,7 @@ void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -9393,25 +9388,25 @@ void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9453,7 +9448,7 @@ void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
 }
 
 void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9495,7 +9490,7 @@ void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9537,7 +9532,7 @@ void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9579,39 +9574,39 @@ void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
 }
 
 void bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9651,7 +9646,7 @@ void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
 }
 
 void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9691,7 +9686,7 @@ void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9731,7 +9726,7 @@ void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
 }
 
 void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9771,39 +9766,39 @@ void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
 }
 
 void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9845,7 +9840,7 @@ void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
 }
 
 void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9887,7 +9882,7 @@ void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
 }
 
 void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9929,7 +9924,7 @@ void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
 }
 
 void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -9971,39 +9966,39 @@ void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
 }
 
 void bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10049,7 +10044,7 @@ void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
 }
 
 void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10095,24 +10090,24 @@ void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
 }
 
 void bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 /* The following track elements used to be specific to the Vertical Roller Coaster */
 void bolliger_mabillard_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -10187,7 +10182,7 @@ void bolliger_mabillard_track_flat_to_60_deg_up(
 }
 
 void bolliger_mabillard_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -10262,23 +10257,23 @@ void bolliger_mabillard_track_60_deg_up_to_flat(
 }
 
 void bolliger_mabillard_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_60_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_flat_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_brake_for_drop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -10320,7 +10315,7 @@ void bolliger_mabillard_track_brake_for_drop(
 
 /* The following track elements used to be specific to the Steel Twister */
 void bolliger_mabillard_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10444,14 +10439,14 @@ void bolliger_mabillard_track_half_loop_up(
 }
 
 void bolliger_mabillard_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
-    bolliger_mabillard_track_half_loop_up(session, rideIndex, 3 - trackSequence, direction, height, tileElement, supportType);
+    bolliger_mabillard_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10561,7 +10556,7 @@ void bolliger_mabillard_track_left_corkscrew_up(
 }
 
 void bolliger_mabillard_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10672,23 +10667,23 @@ void bolliger_mabillard_track_right_corkscrew_up(
 }
 
 void bolliger_mabillard_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_corkscrew_up(
-        session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement, supportType);
+        session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_corkscrew_up(
-        session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement, supportType);
+        session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10825,7 +10820,7 @@ void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008AC104 */
 void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -10961,23 +10956,23 @@ void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
 }
 
 void bolliger_mabillard_track_flat_to_60_deg_down_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-        session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_60_deg_up_to_flat_long_base122(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-        session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -11116,7 +11111,7 @@ void bolliger_mabillard_track_left_barrel_roll_up_to_down(
 }
 
 void bolliger_mabillard_track_right_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -11255,23 +11250,23 @@ void bolliger_mabillard_track_right_barrel_roll_up_to_down(
 }
 
 void bolliger_mabillard_track_left_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_barrel_roll_up_to_down(
-        session, rideIndex, 2 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, 2 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_right_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_barrel_roll_up_to_down(
-        session, rideIndex, 2 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
+        session, ride, 2 - trackSequence, (direction + 2) & 3, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_powered_lift(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (direction)
@@ -11308,7 +11303,7 @@ void bolliger_mabillard_track_powered_lift(
 }
 
 void bolliger_mabillard_track_left_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -11528,7 +11523,7 @@ void bolliger_mabillard_track_left_large_half_loop_up(
 }
 
 void bolliger_mabillard_track_right_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -11748,23 +11743,23 @@ void bolliger_mabillard_track_right_large_half_loop_up(
 }
 
 void bolliger_mabillard_track_right_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_right_large_half_loop_up(
-        session, rideIndex, 6 - trackSequence, direction, height, tileElement, supportType);
+        session, ride, 6 - trackSequence, direction, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_left_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_left_large_half_loop_up(
-        session, rideIndex, 6 - trackSequence, direction, height, tileElement, supportType);
+        session, ride, 6 - trackSequence, direction, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     switch (trackSequence)
@@ -11861,15 +11856,15 @@ void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
 }
 
 void bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-        session, rideIndex, 2 - trackSequence, direction, height, tileElement, supportType);
+        session, ride, 2 - trackSequence, direction, height, tileElement, supportType);
 }
 
 void bolliger_mabillard_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.h
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.h
@@ -16,544 +16,544 @@ struct paint_session;
 struct TileElement;
 
 void bolliger_mabillard_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 
 /* Previously specific to the Vertical RC */
 void bolliger_mabillard_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_brake_for_drop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_diag_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 
 /* Previously specific to the Steel Twister */
 void bolliger_mabillard_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_flat_to_60_deg_down_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_60_deg_up_to_flat_long_base122(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_powered_lift(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_right_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_left_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 void bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);
 
 void bolliger_mabillard_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement, int32_t supportType);

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008AE6E0 */
 static void compact_inverted_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -74,7 +74,7 @@ static void compact_inverted_rc_track_flat(
 
 /** rct2: 0x008AE950, 0x008AE960, 0x008AE970 */
 static void compact_inverted_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -93,7 +93,7 @@ static void compact_inverted_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -101,7 +101,7 @@ static void compact_inverted_rc_track_station(
 
 /** rct2: 0x008AE6F0 */
 static void compact_inverted_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -195,7 +195,7 @@ static void compact_inverted_rc_track_25_deg_up(
 
 /** rct2: 0x008AE700 */
 static void compact_inverted_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -265,7 +265,7 @@ static void compact_inverted_rc_track_60_deg_up(
 
 /** rct2: 0x008AE710 */
 static void compact_inverted_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -359,7 +359,7 @@ static void compact_inverted_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AE720 */
 static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -441,7 +441,7 @@ static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AE730 */
 static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -547,7 +547,7 @@ static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AE740 */
 static void compact_inverted_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -641,57 +641,55 @@ static void compact_inverted_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AE750 */
 static void compact_inverted_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE760 */
 static void compact_inverted_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE770 */
 static void compact_inverted_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE780 */
 static void compact_inverted_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE790 */
 static void compact_inverted_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE7A0 */
 static void compact_inverted_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE7B0 */
 static void compact_inverted_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -871,16 +869,16 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AE7C0 */
 static void compact_inverted_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    compact_inverted_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    compact_inverted_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE7D0 */
 static void compact_inverted_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -923,7 +921,7 @@ static void compact_inverted_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AE7E0 */
 static void compact_inverted_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -966,7 +964,7 @@ static void compact_inverted_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AE7F0 */
 static void compact_inverted_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1009,7 +1007,7 @@ static void compact_inverted_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AE800 */
 static void compact_inverted_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1052,7 +1050,7 @@ static void compact_inverted_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008AE810 */
 static void compact_inverted_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1232,17 +1230,17 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AE820 */
 static void compact_inverted_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     compact_inverted_rc_track_banked_left_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE830 */
 static void compact_inverted_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1309,7 +1307,7 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AE840 */
 static void compact_inverted_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1376,7 +1374,7 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AE850 */
 static void compact_inverted_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1443,7 +1441,7 @@ static void compact_inverted_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AE860 */
 static void compact_inverted_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1510,43 +1508,39 @@ static void compact_inverted_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AE870 */
 static void compact_inverted_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE880 */
 static void compact_inverted_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE890 */
 static void compact_inverted_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE8A0 */
 static void compact_inverted_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE8B0 */
 static void compact_inverted_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1589,15 +1583,15 @@ static void compact_inverted_rc_track_left_bank(
 
 /** rct2: 0x008AE8C0 */
 static void compact_inverted_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE8D0 */
 static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1762,7 +1756,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AE8E0 */
 static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1927,27 +1921,27 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AE8F0 */
 static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE900 */
 static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE910 */
 static void compact_inverted_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2118,7 +2112,7 @@ static void compact_inverted_rc_track_s_bend_left(
 
 /** rct2: 0x008AE920 */
 static void compact_inverted_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2289,7 +2283,7 @@ static void compact_inverted_rc_track_s_bend_right(
 
 /** rct2: 0x008AE930 */
 static void compact_inverted_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2596,7 +2590,7 @@ static void compact_inverted_rc_track_left_vertical_loop(
 
 /** rct2: 0x008AE940 */
 static void compact_inverted_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2903,7 +2897,7 @@ static void compact_inverted_rc_track_right_vertical_loop(
 
 /** rct2: 0x008AE980 */
 static void compact_inverted_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3022,16 +3016,16 @@ static void compact_inverted_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AE990 */
 static void compact_inverted_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    compact_inverted_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    compact_inverted_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE9A0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3151,17 +3145,16 @@ static void compact_inverted_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AE9B0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    compact_inverted_rc_track_left_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    compact_inverted_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE9C0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3248,7 +3241,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AE9D0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3335,27 +3328,27 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AE9E0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AE9F0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEA00 */
 static void compact_inverted_rc_track_left_twist_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3465,7 +3458,7 @@ static void compact_inverted_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008AEA10 */
 static void compact_inverted_rc_track_right_twist_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3575,7 +3568,7 @@ static void compact_inverted_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008AEA20 */
 static void compact_inverted_rc_track_left_twist_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3685,7 +3678,7 @@ static void compact_inverted_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008AEA30 */
 static void compact_inverted_rc_track_right_twist_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3795,7 +3788,7 @@ static void compact_inverted_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008AEA40 */
 static void compact_inverted_rc_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3948,15 +3941,15 @@ static void compact_inverted_rc_track_half_loop_up(
 
 /** rct2: 0x008AEA50 */
 static void compact_inverted_rc_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_half_loop_up(session, rideIndex, 3 - trackSequence, direction, height, tileElement);
+    compact_inverted_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008AEA60 */
 static void compact_inverted_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4074,7 +4067,7 @@ static void compact_inverted_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008AEA70 */
 static void compact_inverted_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4192,25 +4185,23 @@ static void compact_inverted_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008AEA80 */
 static void compact_inverted_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_right_corkscrew_up(
-        session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
+    compact_inverted_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEA90 */
 static void compact_inverted_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_left_corkscrew_up(
-        session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
+    compact_inverted_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEAD0 */
 static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4251,7 +4242,7 @@ static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AEAB0 */
 static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4293,25 +4284,25 @@ static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AEAC0 */
 static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEAE0 */
 static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEAA0 */
 static void compact_inverted_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4344,7 +4335,7 @@ static void compact_inverted_rc_track_brakes(
 
 /** rct2: 0x008AEAF0 */
 static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4529,7 +4520,7 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x008AEB00 */
 static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4714,7 +4705,7 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x008AEB10 */
 static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4899,7 +4890,7 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x008AEB20 */
 static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5084,7 +5075,7 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x008AEB30 */
 static void compact_inverted_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5138,7 +5129,7 @@ static void compact_inverted_rc_track_on_ride_photo(
 
 /** rct2: 0x008AEDB0 */
 static void compact_inverted_rc_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5208,15 +5199,15 @@ static void compact_inverted_rc_track_90_deg_up(
 
 /** rct2: 0x008AEDC0 */
 static void compact_inverted_rc_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_90_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AED70 */
 static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5290,16 +5281,15 @@ static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008AED80 */
 static void compact_inverted_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    compact_inverted_rc_track_60_deg_up_to_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AED90 */
 static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -5370,7 +5360,7 @@ static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AEDA0 */
 static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5443,7 +5433,7 @@ static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008AEB40 */
 static void compact_inverted_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5606,7 +5596,7 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AEB50 */
 static void compact_inverted_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5769,25 +5759,25 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AEB60 */
 static void compact_inverted_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    compact_inverted_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEB70 */
 static void compact_inverted_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    compact_inverted_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    compact_inverted_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AED30 */
 static void compact_inverted_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5950,7 +5940,7 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008AED40 */
 static void compact_inverted_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6113,27 +6103,25 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008AED50 */
 static void compact_inverted_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    compact_inverted_rc_track_right_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    compact_inverted_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AED60 */
 static void compact_inverted_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    compact_inverted_rc_track_left_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    compact_inverted_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AEB80 */
 static void compact_inverted_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6272,7 +6260,7 @@ static void compact_inverted_rc_track_diag_flat(
 
 /** rct2: 0x008AEBB0 */
 static void compact_inverted_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6411,7 +6399,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AEC10 */
 static void compact_inverted_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6494,7 +6482,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008AEB90 */
 static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6633,7 +6621,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AEBF0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6716,7 +6704,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AEC00 */
 static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6799,7 +6787,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AEBA0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6938,7 +6926,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AEBE0 */
 static void compact_inverted_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7077,7 +7065,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008AEC40 */
 static void compact_inverted_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7160,7 +7148,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008AEBC0 */
 static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7296,7 +7284,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AEC20 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7379,7 +7367,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AEC30 */
 static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7462,7 +7450,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AEBD0 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7601,7 +7589,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008AEC70 */
 static void compact_inverted_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7685,7 +7673,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008AEC80 */
 static void compact_inverted_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7769,7 +7757,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008AEC90 */
 static void compact_inverted_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7853,7 +7841,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008AECA0 */
 static void compact_inverted_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7937,7 +7925,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008AECD0 */
 static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8020,7 +8008,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AECE0 */
 static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8103,7 +8091,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AECB0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8186,7 +8174,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AECC0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8269,7 +8257,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AECF0 */
 static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8349,7 +8337,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AED00 */
 static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8429,7 +8417,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AED10 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8512,7 +8500,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AED20 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8595,7 +8583,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AEC50 */
 static void compact_inverted_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8679,7 +8667,7 @@ static void compact_inverted_rc_track_diag_left_bank(
 
 /** rct2: 0x008AEC60 */
 static void compact_inverted_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8763,7 +8751,7 @@ static void compact_inverted_rc_track_diag_right_bank(
 
 /** rct2: 0x008AEAA0 */
 static void compact_inverted_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _CorkscrewRCBlockBrakeImages[NumOrthogonalDirect
 
 /** rct2: 0x008A7AF8 */
 static void corkscrew_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -89,7 +89,7 @@ static void corkscrew_rc_track_flat(
 
 /** rct2: 0x008A7D68, 0x008A7D78, 0x008A7D88 */
 static void corkscrew_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -115,7 +115,7 @@ static void corkscrew_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -123,7 +123,7 @@ static void corkscrew_rc_track_station(
 
 /** rct2: 0x008A7B08 */
 static void corkscrew_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -193,7 +193,7 @@ static void corkscrew_rc_track_25_deg_up(
 
 /** rct2: 0x008A7B18 */
 static void corkscrew_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -263,7 +263,7 @@ static void corkscrew_rc_track_60_deg_up(
 
 /** rct2: 0x008A7B28 */
 static void corkscrew_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -333,7 +333,7 @@ static void corkscrew_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A7B38 */
 static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -411,7 +411,7 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7B48 */
 static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -489,7 +489,7 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7B58 */
 static void corkscrew_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -559,55 +559,55 @@ static void corkscrew_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A7B68 */
 static void corkscrew_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7B78 */
 static void corkscrew_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7B88 */
 static void corkscrew_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7B98 */
 static void corkscrew_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7BA8 */
 static void corkscrew_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7BB8 */
 static void corkscrew_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7BC8 */
 static void corkscrew_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -771,16 +771,16 @@ static void corkscrew_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A7BD8 */
 static void corkscrew_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    corkscrew_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7BE8 */
 static void corkscrew_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -818,7 +818,7 @@ static void corkscrew_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A7BF8 */
 static void corkscrew_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -856,7 +856,7 @@ static void corkscrew_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A7C08 */
 static void corkscrew_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -894,7 +894,7 @@ static void corkscrew_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A7C18 */
 static void corkscrew_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -932,7 +932,7 @@ static void corkscrew_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A7C28 */
 static void corkscrew_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1106,16 +1106,16 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A7C38 */
 static void corkscrew_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    corkscrew_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7C48 */
 static void corkscrew_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1160,7 +1160,7 @@ static void corkscrew_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7C58 */
 static void corkscrew_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1205,7 +1205,7 @@ static void corkscrew_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7C68 */
 static void corkscrew_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1250,7 +1250,7 @@ static void corkscrew_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7C78 */
 static void corkscrew_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1295,39 +1295,39 @@ static void corkscrew_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A7C88 */
 static void corkscrew_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7C98 */
 static void corkscrew_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7CA8 */
 static void corkscrew_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7CB8 */
 static void corkscrew_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7CC8 */
 static void corkscrew_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1361,15 +1361,15 @@ static void corkscrew_rc_track_left_bank(
 
 /** rct2: 0x008A7CD8 */
 static void corkscrew_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7CE8 */
 static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1533,7 +1533,7 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7CF8 */
 static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1697,27 +1697,25 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7D08 */
 static void corkscrew_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    corkscrew_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7D18 */
 static void corkscrew_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7D28 */
 static void corkscrew_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1852,7 +1850,7 @@ static void corkscrew_rc_track_s_bend_left(
 
 /** rct2: 0x008A7D38 */
 static void corkscrew_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1987,7 +1985,7 @@ static void corkscrew_rc_track_s_bend_right(
 
 /** rct2: 0x008A7D48 */
 static void corkscrew_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2266,7 +2264,7 @@ static void corkscrew_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A7D58 */
 static void corkscrew_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2499,7 +2497,7 @@ static void corkscrew_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A7D98 */
 static void corkscrew_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2602,16 +2600,16 @@ static void corkscrew_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A7DA8 */
 static void corkscrew_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    corkscrew_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7DB8 */
 static void corkscrew_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2723,16 +2721,16 @@ static void corkscrew_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A7DC8 */
 static void corkscrew_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    corkscrew_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7DD8 */
 static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2811,7 +2809,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7DE8 */
 static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2897,27 +2895,25 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7DF8 */
 static void corkscrew_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    corkscrew_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7E08 */
 static void corkscrew_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7E18 */
 static void corkscrew_rc_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3046,15 +3042,15 @@ static void corkscrew_rc_track_half_loop_up(
 
 /** rct2: 0x008A7E28 */
 static void corkscrew_rc_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_half_loop_up(session, rideIndex, 3 - trackSequence, direction, height, tileElement);
+    corkscrew_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008A7E38 */
 static void corkscrew_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3166,7 +3162,7 @@ static void corkscrew_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A7E48 */
 static void corkscrew_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3279,23 +3275,23 @@ static void corkscrew_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A7E58 */
 static void corkscrew_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_right_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
+    corkscrew_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7E68 */
 static void corkscrew_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_left_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7E78 */
 static void corkscrew_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3513,7 +3509,7 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A7E88 */
 static void corkscrew_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3731,7 +3727,7 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A7E98 */
 static void corkscrew_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3740,13 +3736,12 @@ static void corkscrew_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    corkscrew_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    corkscrew_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7EA8 */
 static void corkscrew_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3755,13 +3750,12 @@ static void corkscrew_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    corkscrew_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7EB8 */
 static void corkscrew_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4103,7 +4097,7 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A7EC8 */
 static void corkscrew_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4445,7 +4439,7 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A7ED8 */
 static void corkscrew_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4454,13 +4448,12 @@ static void corkscrew_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    corkscrew_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    corkscrew_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7EE8 */
 static void corkscrew_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4469,13 +4462,12 @@ static void corkscrew_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    corkscrew_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7F18 */
 static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4512,7 +4504,7 @@ static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A7EF8 */
 static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4549,25 +4541,23 @@ static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A7F08 */
 static void corkscrew_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    corkscrew_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7F28 */
 static void corkscrew_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    corkscrew_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7F38 */
 static void corkscrew_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4595,7 +4585,7 @@ static void corkscrew_rc_track_brakes(
 
 /** rct2: 0x008A7F48 */
 static void corkscrew_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4637,7 +4627,7 @@ static void corkscrew_rc_track_on_ride_photo(
 
 /** rct2: 0x008A8198 */
 static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4778,7 +4768,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008A81A8 */
 static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4919,25 +4909,23 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
 
 /** rct2: 0x008A81B8 */
 static void corkscrew_rc_track_60_deg_down_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_flat_to_60_deg_up_long_base(
-        session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_flat_to_60_deg_up_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A81C8 */
 static void corkscrew_rc_track_flat_to_60_deg_down_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    corkscrew_rc_track_60_deg_up_to_flat_long_base(
-        session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_60_deg_up_to_flat_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7F68 */
 static void corkscrew_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5076,7 +5064,7 @@ static void corkscrew_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A7F78 */
 static void corkscrew_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5214,25 +5202,25 @@ static void corkscrew_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A7F88 */
 static void corkscrew_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    corkscrew_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7F98 */
 static void corkscrew_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    corkscrew_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    corkscrew_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7FA8 */
 static void corkscrew_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5374,7 +5362,7 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A7FB8 */
 static void corkscrew_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5515,25 +5503,25 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A7FC8 */
 static void corkscrew_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    corkscrew_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    corkscrew_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7FD8 */
 static void corkscrew_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    corkscrew_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    corkscrew_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7F58 */
 static void corkscrew_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5679,7 +5667,7 @@ static void corkscrew_rc_track_diag_flat(
 
 /** rct2: 0x008A8008 */
 static void corkscrew_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5825,7 +5813,7 @@ static void corkscrew_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A8068 */
 static void corkscrew_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5971,7 +5959,7 @@ static void corkscrew_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A7FE8 */
 static void corkscrew_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6117,7 +6105,7 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A8048 */
 static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6263,7 +6251,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A8058 */
 static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6409,7 +6397,7 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7FF8 */
 static void corkscrew_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6555,7 +6543,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A8038 */
 static void corkscrew_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6701,7 +6689,7 @@ static void corkscrew_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A8098 */
 static void corkscrew_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6847,7 +6835,7 @@ static void corkscrew_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A8018 */
 static void corkscrew_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6991,7 +6979,7 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A8078 */
 static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7137,7 +7125,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8088 */
 static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7283,7 +7271,7 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8028 */
 static void corkscrew_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7429,7 +7417,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A80C8 */
 static void corkscrew_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7508,7 +7496,7 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A80D8 */
 static void corkscrew_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7587,7 +7575,7 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A80E8 */
 static void corkscrew_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7666,7 +7654,7 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A80F8 */
 static void corkscrew_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7745,7 +7733,7 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A8128 */
 static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7824,7 +7812,7 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A8138 */
 static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7903,7 +7891,7 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A8108 */
 static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7982,7 +7970,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A8118 */
 static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8061,7 +8049,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A8148 */
 static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8138,7 +8126,7 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A8158 */
 static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8215,7 +8203,7 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A8168 */
 static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8294,7 +8282,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A8178 */
 static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8373,7 +8361,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A80A8 */
 static void corkscrew_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8449,7 +8437,7 @@ static void corkscrew_rc_track_diag_left_bank(
 
 /** rct2: 0x008A80B8 */
 static void corkscrew_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8525,7 +8513,7 @@ static void corkscrew_rc_track_diag_right_bank(
 
 /** rct2: 0x008A8188 */
 static void corkscrew_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -8540,12 +8528,12 @@ static void corkscrew_rc_track_block_brakes(
 }
 
 static void corkscrew_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!is_csg_loaded())
     {
-        corkscrew_rc_track_brakes(session, rideIndex, trackSequence, direction, height, tileElement);
+        corkscrew_rc_track_brakes(session, ride, trackSequence, direction, height, tileElement);
         return;
     }
 

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x007C6FF4 */
 static void flying_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -133,7 +133,7 @@ static void flying_rc_track_flat(
 
 /** rct2: 0x007C7244, 0x007C7254, 0x007C7264 */
 static void flying_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->IsInverted())
@@ -154,7 +154,7 @@ static void flying_rc_track_station(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24,
             0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_1);
     }
     else
     {
@@ -180,7 +180,7 @@ static void flying_rc_track_station(
         PaintAddImageAsParentRotated(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+        track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -190,7 +190,7 @@ static void flying_rc_track_station(
 
 /** rct2: 0x007C7004 */
 static void flying_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -350,7 +350,7 @@ static void flying_rc_track_25_deg_up(
 
 /** rct2: 0x007C7014 */
 static void flying_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -432,7 +432,7 @@ static void flying_rc_track_60_deg_up(
 
 /** rct2: 0x007C7024 */
 static void flying_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -592,7 +592,7 @@ static void flying_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x007C7034 */
 static void flying_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -684,7 +684,7 @@ static void flying_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007C7044 */
 static void flying_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -800,7 +800,7 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7054 */
 static void flying_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -960,55 +960,55 @@ static void flying_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x007C7064 */
 static void flying_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7074 */
 static void flying_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7084 */
 static void flying_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7094 */
 static void flying_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C70A4 */
 static void flying_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C70B4 */
 static void flying_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C70C4 */
 static void flying_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1377,16 +1377,16 @@ static void flying_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x007C70D4 */
 static void flying_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    flying_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C70E4 */
 static void flying_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1467,7 +1467,7 @@ static void flying_rc_track_flat_to_left_bank(
 
 /** rct2: 0x007C70F4 */
 static void flying_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1548,7 +1548,7 @@ static void flying_rc_track_flat_to_right_bank(
 
 /** rct2: 0x007C7104 */
 static void flying_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1629,7 +1629,7 @@ static void flying_rc_track_left_bank_to_flat(
 
 /** rct2: 0x007C7114 */
 static void flying_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1710,7 +1710,7 @@ static void flying_rc_track_right_bank_to_flat(
 
 /** rct2: 0x007C7124 */
 static void flying_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2080,16 +2080,16 @@ static void flying_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x007C7134 */
 static void flying_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    flying_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7144 */
 static void flying_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2201,7 +2201,7 @@ static void flying_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x007C7154 */
 static void flying_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2313,7 +2313,7 @@ static void flying_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x007C7164 */
 static void flying_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2425,7 +2425,7 @@ static void flying_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x007C7174 */
 static void flying_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2537,39 +2537,39 @@ static void flying_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x007C7184 */
 static void flying_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7194 */
 static void flying_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C71A4 */
 static void flying_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C71B4 */
 static void flying_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C71C4 */
 static void flying_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2646,15 +2646,15 @@ static void flying_rc_track_left_bank(
 
 /** rct2: 0x007C71D4 */
 static void flying_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C71E4 */
 static void flying_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2998,7 +2998,7 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C71F4 */
 static void flying_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3342,25 +3342,25 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7204 */
 static void flying_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    flying_rc_track_right_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    flying_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7214 */
 static void flying_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    flying_rc_track_left_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7224 */
 static void flying_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3687,7 +3687,7 @@ static void flying_rc_track_s_bend_left(
 
 /** rct2: 0x007C7234 */
 static void flying_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4014,7 +4014,7 @@ static void flying_rc_track_s_bend_right(
 
 /** rct2: 0x007C7274 */
 static void flying_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4253,16 +4253,16 @@ static void flying_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x007C7284 */
 static void flying_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    flying_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7294 */
 static void flying_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4507,16 +4507,16 @@ static void flying_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x007C72A4 */
 static void flying_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    flying_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C72B4 */
 static void flying_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4687,7 +4687,7 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C72C4 */
 static void flying_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4864,25 +4864,25 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C72D4 */
 static void flying_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    flying_rc_track_right_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    flying_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C72E4 */
 static void flying_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    flying_rc_track_left_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7314 */
 static void flying_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5104,7 +5104,7 @@ static void flying_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x007C7324 */
 static void flying_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5326,7 +5326,7 @@ static void flying_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x007C7334 */
 static void flying_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -5335,13 +5335,12 @@ static void flying_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    flying_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    flying_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7344 */
 static void flying_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -5350,13 +5349,12 @@ static void flying_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    flying_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7354 */
 static void flying_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5702,7 +5700,7 @@ static void flying_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x007C7364 */
 static void flying_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6048,7 +6046,7 @@ static void flying_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x007C7374 */
 static void flying_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -6057,13 +6055,12 @@ static void flying_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    flying_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    flying_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7384 */
 static void flying_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -6072,13 +6069,12 @@ static void flying_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    flying_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C73B4 */
 static void flying_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6161,7 +6157,7 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x007C7394 */
 static void flying_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6243,23 +6239,23 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x007C73A4 */
 static void flying_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_right_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    flying_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C73C4 */
 static void flying_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_left_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    flying_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C73D4 */
 static void flying_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6319,24 +6315,24 @@ static void flying_rc_track_brakes(
 }
 
 static void flying_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
     {
         bolliger_mabillard_track_booster(
-            session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES_INVERTED);
+            session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES_INVERTED);
     }
     else
     {
         // Should not occur, except when converting from other coaster types.
-        flying_rc_track_brakes(session, rideIndex, trackSequence, direction, height, tileElement);
+        flying_rc_track_brakes(session, ride, trackSequence, direction, height, tileElement);
     }
 }
 
 /** rct2: 0x007C7674 */
 static void flying_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6521,7 +6517,7 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x007C7684 */
 static void flying_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6706,7 +6702,7 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x007C7694 */
 static void flying_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6891,7 +6887,7 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x007C76A4 */
 static void flying_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7076,7 +7072,7 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x007C78B4 */
 static void flying_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7182,7 +7178,7 @@ static void flying_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x007C78C4 */
 static void flying_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7288,7 +7284,7 @@ static void flying_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x007C73E4 */
 static void flying_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7399,23 +7395,23 @@ static void flying_rc_track_on_ride_photo(
 
 /** rct2: 0x007C78D4 */
 static void flying_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_right_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C78E4 */
 static void flying_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_left_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7404 */
 static void flying_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7729,7 +7725,7 @@ static void flying_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007C7414 */
 static void flying_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8043,25 +8039,25 @@ static void flying_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007C7424 */
 static void flying_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    flying_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7434 */
 static void flying_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    flying_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    flying_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7444 */
 static void flying_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8376,7 +8372,7 @@ static void flying_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x007C7454 */
 static void flying_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8691,25 +8687,25 @@ static void flying_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x007C7464 */
 static void flying_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    flying_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7474 */
 static void flying_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    flying_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    flying_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C73F4 */
 static void flying_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9001,7 +8997,7 @@ static void flying_rc_track_diag_flat(
 
 /** rct2: 0x007C74A4 */
 static void flying_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9293,7 +9289,7 @@ static void flying_rc_track_diag_25_deg_up(
 
 /** rct2: 0x007C7504 */
 static void flying_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9529,7 +9525,7 @@ static void flying_rc_track_diag_60_deg_up(
 
 /** rct2: 0x007C7484 */
 static void flying_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9821,7 +9817,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x007C74E4 */
 static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10057,7 +10053,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007C74F4 */
 static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10293,7 +10289,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7494 */
 static void flying_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10585,7 +10581,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x007C74D4 */
 static void flying_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10821,7 +10817,7 @@ static void flying_rc_track_diag_25_deg_down(
 
 /** rct2: 0x007C7534 */
 static void flying_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11057,7 +11053,7 @@ static void flying_rc_track_diag_60_deg_down(
 
 /** rct2: 0x007C74B4 */
 static void flying_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11286,7 +11282,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x007C7514 */
 static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11522,7 +11518,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007C7524 */
 static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11758,7 +11754,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C74C4 */
 static void flying_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11994,7 +11990,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x007C7564 */
 static void flying_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12164,7 +12160,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x007C7574 */
 static void flying_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12334,7 +12330,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x007C7584 */
 static void flying_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12504,7 +12500,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x007C7594 */
 static void flying_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12674,7 +12670,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x007C75C4 */
 static void flying_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12843,7 +12839,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x007C75D4 */
 static void flying_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13012,7 +13008,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x007C75A4 */
 static void flying_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13181,7 +13177,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x007C75B4 */
 static void flying_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13350,7 +13346,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x007C75E4 */
 static void flying_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13512,7 +13508,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x007C75F4 */
 static void flying_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13674,7 +13670,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x007C7604 */
 static void flying_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13843,7 +13839,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x007C7614 */
 static void flying_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -14012,7 +14008,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x007C7544 */
 static void flying_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -14179,7 +14175,7 @@ static void flying_rc_track_diag_left_bank(
 
 /** rct2: 0x007C7554 */
 static void flying_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -14346,7 +14342,7 @@ static void flying_rc_track_diag_right_bank(
 
 /** rct2: 0x007C7624 */
 static void flying_rc_track_left_flyer_twist_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14458,7 +14454,7 @@ static void flying_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x007C7634 */
 static void flying_rc_track_right_flyer_twist_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14568,7 +14564,7 @@ static void flying_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x007C7644 */
 static void flying_rc_track_left_flyer_twist_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14680,7 +14676,7 @@ static void flying_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x007C7654 */
 static void flying_rc_track_right_flyer_twist_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14790,7 +14786,7 @@ static void flying_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x007C72F4 */
 static void flying_rc_track_flyer_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14920,7 +14916,7 @@ static void flying_rc_track_flyer_half_loop_up(
 
 /** rct2: 0x007C7304 */
 static void flying_rc_track_flyer_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -15050,7 +15046,7 @@ static void flying_rc_track_flyer_half_loop_down(
 
 /** rct2: 0x007C7664 */
 static void flying_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -15108,7 +15104,7 @@ static void flying_rc_track_block_brakes(
 
 /** rct2: 0x007C76B4 */
 static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -15282,7 +15278,7 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C76C4 */
 static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -15462,27 +15458,27 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C76D4 */
 static void flying_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C76E4 */
 static void flying_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C76F4 */
 static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -15829,7 +15825,7 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7704 */
 static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16176,27 +16172,27 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7714 */
 static void flying_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7724 */
 static void flying_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7734 */
 static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16304,7 +16300,7 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C7744 */
 static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16412,7 +16408,7 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C7754 */
 static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16520,7 +16516,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7764 */
 static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16628,43 +16624,39 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7774 */
 static void flying_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7784 */
 static void flying_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7794 */
 static void flying_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C77A4 */
 static void flying_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C77B4 */
 static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16770,7 +16762,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C77C4 */
 static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16876,7 +16868,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C77F4 */
 static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -16982,7 +16974,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x007C7804 */
 static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -17088,43 +17080,43 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x007C7814 */
 static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7824 */
 static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C77D4 */
 static void flying_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C77E4 */
 static void flying_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7834 */
 static void flying_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -17232,7 +17224,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C7844 */
 static void flying_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -17340,7 +17332,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C7854 */
 static void flying_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -17448,7 +17440,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x007C7864 */
 static void flying_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -17556,34 +17548,34 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x007C7874 */
 static void flying_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_right_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7884 */
 static void flying_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_left_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C7894 */
 static void flying_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_flat_to_right_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007C78A4 */
 static void flying_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    flying_rc_track_flat_to_left_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    flying_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_flying_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -41,7 +41,7 @@ static constexpr const uint32_t _GigaCoasterBrakeImages[NumOrthogonalDirections]
 
 /** rct2: 0x008AD674 */
 static void giga_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -117,7 +117,7 @@ static void giga_rc_track_flat(
 }
 
 static void giga_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -143,7 +143,7 @@ static void giga_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -151,7 +151,7 @@ static void giga_rc_track_station(
 
 /** rct2: 0x008AD684 */
 static void giga_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -247,7 +247,7 @@ static void giga_rc_track_25_deg_up(
 
 /** rct2: 0x008AD694 */
 static void giga_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -317,7 +317,7 @@ static void giga_rc_track_60_deg_up(
 
 /** rct2: 0x008AD6A4 */
 static void giga_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -413,7 +413,7 @@ static void giga_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AD6B4 */
 static void giga_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -491,7 +491,7 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AD6C4 */
 static void giga_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -569,7 +569,7 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AD6D4 */
 static void giga_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasCableLift())
@@ -665,55 +665,55 @@ static void giga_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AD6E4 */
 static void giga_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD6F4 */
 static void giga_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD704 */
 static void giga_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD714 */
 static void giga_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD724 */
 static void giga_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD734 */
 static void giga_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD744 */
 static void giga_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -877,16 +877,16 @@ static void giga_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AD754 */
 static void giga_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD764 */
 static void giga_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -924,7 +924,7 @@ static void giga_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AD774 */
 static void giga_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -962,7 +962,7 @@ static void giga_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AD784 */
 static void giga_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1000,7 +1000,7 @@ static void giga_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AD794 */
 static void giga_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1038,7 +1038,7 @@ static void giga_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008AD7A4 */
 static void giga_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1212,16 +1212,16 @@ static void giga_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AD7B4 */
 static void giga_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD7C4 */
 static void giga_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1266,7 +1266,7 @@ static void giga_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AD7D4 */
 static void giga_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1311,7 +1311,7 @@ static void giga_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AD7E4 */
 static void giga_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1356,7 +1356,7 @@ static void giga_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AD7F4 */
 static void giga_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1401,39 +1401,39 @@ static void giga_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AD804 */
 static void giga_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD814 */
 static void giga_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD824 */
 static void giga_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD834 */
 static void giga_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD844 */
 static void giga_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1467,15 +1467,15 @@ static void giga_rc_track_left_bank(
 
 /** rct2: 0x008AD854 */
 static void giga_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD864 */
 static void giga_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1639,7 +1639,7 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AD874 */
 static void giga_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1803,25 +1803,25 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AD884 */
 static void giga_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_right_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD894 */
 static void giga_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_left_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD8A4 */
 static void giga_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1956,7 +1956,7 @@ static void giga_rc_track_s_bend_left(
 
 /** rct2: 0x008AD8B4 */
 static void giga_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2091,7 +2091,7 @@ static void giga_rc_track_s_bend_right(
 
 /** rct2: 0x008AD8F4 */
 static void giga_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2194,16 +2194,16 @@ static void giga_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AD904 */
 static void giga_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD914 */
 static void giga_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2315,16 +2315,16 @@ static void giga_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AD924 */
 static void giga_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD934 */
 static void giga_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2403,7 +2403,7 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AD944 */
 static void giga_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2489,25 +2489,25 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AD954 */
 static void giga_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_right_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD964 */
 static void giga_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_left_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD974 */
 static void giga_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2725,7 +2725,7 @@ static void giga_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008AD984 */
 static void giga_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2943,7 +2943,7 @@ static void giga_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008AD994 */
 static void giga_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -2952,12 +2952,12 @@ static void giga_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_right_half_banked_helix_up_small(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD9A4 */
 static void giga_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -2966,12 +2966,12 @@ static void giga_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_left_half_banked_helix_up_small(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD9B4 */
 static void giga_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3313,7 +3313,7 @@ static void giga_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008AD9C4 */
 static void giga_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3669,7 +3669,7 @@ static void giga_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008AD9D4 */
 static void giga_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3678,12 +3678,12 @@ static void giga_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_right_half_banked_helix_up_large(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AD9E4 */
 static void giga_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3692,12 +3692,12 @@ static void giga_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_left_half_banked_helix_up_large(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADA14 */
 static void giga_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3734,7 +3734,7 @@ static void giga_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AD9F4 */
 static void giga_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3771,23 +3771,23 @@ static void giga_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ADA04 */
 static void giga_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_right_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADA24 */
 static void giga_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_left_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADA34 */
 static void giga_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3823,7 +3823,7 @@ static void giga_rc_track_brakes(
 
 /** rct2: 0x008ADC84 */
 static void giga_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3864,7 +3864,7 @@ static void giga_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008ADC94 */
 static void giga_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3905,7 +3905,7 @@ static void giga_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008ADA44 */
 static void giga_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3947,23 +3947,23 @@ static void giga_rc_track_on_ride_photo(
 
 /** rct2: 0x008ADCA4 */
 static void giga_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_right_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADCB4 */
 static void giga_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_left_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADED4 */
 static void giga_rc_track_flat_to_60_deg_up_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4254,7 +4254,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008ADEE4 */
 static void giga_rc_track_60_deg_up_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4395,23 +4395,23 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
 
 /** rct2: 0x008ADEF4 */
 static void giga_rc_track_60_deg_down_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_flat_to_60_deg_up_long_base(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_flat_to_60_deg_up_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADF04 */
 static void giga_rc_track_flat_to_60_deg_down_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_60_deg_up_to_flat_long_base(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_60_deg_up_to_flat_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADF14 */
 static void giga_rc_track_cable_lift_hill(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4577,7 +4577,7 @@ static void giga_rc_track_cable_lift_hill(
 
 /** rct2: 0x008ADA64 */
 static void giga_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4716,7 +4716,7 @@ static void giga_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008ADA74 */
 static void giga_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4854,25 +4854,25 @@ static void giga_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008ADA84 */
 static void giga_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    giga_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADA94 */
 static void giga_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    giga_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    giga_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADAA4 */
 static void giga_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5014,7 +5014,7 @@ static void giga_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008ADAB4 */
 static void giga_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5156,25 +5156,25 @@ static void giga_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008ADAC4 */
 static void giga_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    giga_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADAD4 */
 static void giga_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    giga_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    giga_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADA54 */
 static void giga_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5320,7 +5320,7 @@ static void giga_rc_track_diag_flat(
 
 /** rct2: 0x008ADB04 */
 static void giga_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5466,7 +5466,7 @@ static void giga_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008ADB64 */
 static void giga_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5542,7 +5542,7 @@ static void giga_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008ADAE4 */
 static void giga_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5688,7 +5688,7 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008ADB44 */
 static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5764,7 +5764,7 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008ADB54 */
 static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5840,7 +5840,7 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADAF4 */
 static void giga_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5986,7 +5986,7 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008ADB34 */
 static void giga_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6132,7 +6132,7 @@ static void giga_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008ADB94 */
 static void giga_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6208,7 +6208,7 @@ static void giga_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008ADB14 */
 static void giga_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6352,7 +6352,7 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008ADB74 */
 static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6428,7 +6428,7 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008ADB84 */
 static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6504,7 +6504,7 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADB24 */
 static void giga_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6650,7 +6650,7 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008ADBC4 */
 static void giga_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6729,7 +6729,7 @@ static void giga_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008ADBD4 */
 static void giga_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6808,7 +6808,7 @@ static void giga_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008ADBE4 */
 static void giga_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6887,7 +6887,7 @@ static void giga_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008ADBF4 */
 static void giga_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6966,7 +6966,7 @@ static void giga_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008ADC24 */
 static void giga_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7045,7 +7045,7 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008ADC34 */
 static void giga_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7124,7 +7124,7 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008ADC04 */
 static void giga_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7203,7 +7203,7 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008ADC14 */
 static void giga_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7282,7 +7282,7 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008ADC44 */
 static void giga_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7359,7 +7359,7 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008ADC54 */
 static void giga_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7436,7 +7436,7 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008ADC64 */
 static void giga_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7515,7 +7515,7 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ADC74 */
 static void giga_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7594,7 +7594,7 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008ADBA4 */
 static void giga_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7670,7 +7670,7 @@ static void giga_rc_track_diag_left_bank(
 
 /** rct2: 0x008ADBB4 */
 static void giga_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7746,7 +7746,7 @@ static void giga_rc_track_diag_right_bank(
 
 /** rct2: 0x008ADEC4 */
 static void giga_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -7769,7 +7769,7 @@ static void giga_rc_track_block_brakes(
 
 /** rct2: 0x008ADCC4 */
 static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7851,7 +7851,7 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ADCD4 */
 static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7940,27 +7940,25 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ADCE4 */
 static void giga_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_banked_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADCF4 */
 static void giga_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_banked_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADD04 */
 static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8130,7 +8128,7 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ADD14 */
 static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8300,27 +8298,25 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ADD24 */
 static void giga_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    giga_rc_track_right_banked_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADD34 */
 static void giga_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    giga_rc_track_left_banked_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADD44 */
 static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8363,7 +8359,7 @@ static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADD54 */
 static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8406,7 +8402,7 @@ static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADD64 */
 static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8449,7 +8445,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADD74 */
 static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8492,43 +8488,39 @@ static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADD84 */
 static void giga_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADD94 */
 static void giga_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADDA4 */
 static void giga_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADDB4 */
 static void giga_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADDC4 */
 static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8569,7 +8561,7 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADDD4 */
 static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8610,7 +8602,7 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADE04 */
 static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8651,7 +8643,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008ADE14 */
 static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8692,43 +8684,43 @@ static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008ADE24 */
 static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADE34 */
 static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADDE4 */
 static void giga_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADDF4 */
 static void giga_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADE44 */
 static void giga_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8771,7 +8763,7 @@ static void giga_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADE54 */
 static void giga_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8814,7 +8806,7 @@ static void giga_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADE64 */
 static void giga_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8857,7 +8849,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ADE74 */
 static void giga_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8900,38 +8892,38 @@ static void giga_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ADE84 */
 static void giga_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_right_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADE94 */
 static void giga_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_left_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADEA4 */
 static void giga_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_flat_to_right_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ADEB4 */
 static void giga_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    giga_rc_track_flat_to_left_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    giga_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void giga_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x0087694C */
 static void heartline_twister_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -85,7 +85,7 @@ static void heartline_twister_rc_track_flat(
 }
 
 static void heartline_twister_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -101,7 +101,7 @@ static void heartline_twister_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -109,7 +109,7 @@ static void heartline_twister_rc_track_station(
 
 /** rct2: 0x0087695C */
 static void heartline_twister_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -194,7 +194,7 @@ static void heartline_twister_rc_track_25_deg_up(
 
 /** rct2: 0x008769FC */
 static void heartline_twister_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -279,7 +279,7 @@ static void heartline_twister_rc_track_60_deg_up(
 
 /** rct2: 0x0087696C */
 static void heartline_twister_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -364,7 +364,7 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008769BC */
 static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -449,7 +449,7 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008769CC */
 static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -534,7 +534,7 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0087697C */
 static void heartline_twister_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -619,57 +619,55 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0087698C */
 static void heartline_twister_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    heartline_twister_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    heartline_twister_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00876A0C */
 static void heartline_twister_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    heartline_twister_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    heartline_twister_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0087699C */
 static void heartline_twister_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    heartline_twister_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    heartline_twister_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008769DC */
 static void heartline_twister_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    heartline_twister_rc_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    heartline_twister_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008769EC */
 static void heartline_twister_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    heartline_twister_rc_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    heartline_twister_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008769AC */
 static void heartline_twister_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    heartline_twister_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    heartline_twister_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00876A6C */
 static void heartline_twister_rc_track_heartline_transfer_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -879,7 +877,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
 
 /** rct2: 0x00876A7C */
 static void heartline_twister_rc_track_heartline_transfer_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1089,7 +1087,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
 
 /** rct2: 0x00876A4C */
 static void heartline_twister_rc_track_left_heartline_roll(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1335,7 +1333,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
 
 /** rct2: 0x00876A5C */
 static void heartline_twister_rc_track_right_heartline_roll(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -36,7 +36,7 @@ namespace HybridRC
     }
 
     static void TrackFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -58,7 +58,7 @@ namespace HybridRC
     }
 
     static void TrackStation(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -83,7 +83,6 @@ namespace HybridRC
 
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-        auto ride = get_ride(rideIndex);
         if (ride != nullptr)
             track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 10, tileElement);
 
@@ -93,7 +92,7 @@ namespace HybridRC
     }
 
     static void Track25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -123,7 +122,7 @@ namespace HybridRC
     }
 
     static void Track60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -178,7 +177,7 @@ namespace HybridRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -208,7 +207,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpTo60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -290,7 +289,7 @@ namespace HybridRC
     }
 
     static void Track60DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -373,7 +372,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -403,49 +402,49 @@ namespace HybridRC
     }
 
     static void Track25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownTo60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpTo60DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track90DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -483,14 +482,14 @@ namespace HybridRC
     }
 
     static void Track90DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track90DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegUpTo90DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -535,14 +534,14 @@ namespace HybridRC
     }
 
     static void Track90DegDownTo60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpTo90DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpTo90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track90DegUpTo60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -582,7 +581,7 @@ namespace HybridRC
     }
 
     static void Track60DegDownTo90DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -624,7 +623,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -744,15 +743,15 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftQuarterTurn3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -952,15 +951,15 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftQuarterTurn5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1112,7 +1111,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1264,23 +1263,23 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackRightEighthToDiag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightEighthToDiag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackLeftEighthToDiag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+        TrackLeftEighthToDiag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
     }
 
     static void TrackDiagFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1427,7 +1426,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1578,7 +1577,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1729,7 +1728,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1872,7 +1871,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2023,7 +2022,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2172,7 +2171,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2315,7 +2314,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2466,7 +2465,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpTo60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2617,7 +2616,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2768,7 +2767,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2919,7 +2918,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownTo60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3070,7 +3069,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3221,7 +3220,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3260,7 +3259,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3299,21 +3298,21 @@ namespace HybridRC
     }
 
     static void TrackLeftBankToflat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToRightBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBankToflat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToLeftBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3360,7 +3359,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3407,7 +3406,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3454,7 +3453,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3501,35 +3500,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToRightBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToLeftBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBankTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBankTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftbank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3568,14 +3567,14 @@ namespace HybridRC
     }
 
     static void TrackRightbank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftbank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftbank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3665,7 +3664,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3755,7 +3754,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankToflat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3845,7 +3844,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankToflat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3935,7 +3934,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4025,7 +4024,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4115,7 +4114,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4213,7 +4212,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4311,7 +4310,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4407,7 +4406,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4503,7 +4502,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4593,7 +4592,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4683,7 +4682,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4773,7 +4772,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4863,7 +4862,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4995,15 +4994,15 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftQuarterTurn3Bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn3Bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5218,15 +5217,15 @@ namespace HybridRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackBankedLeftQuarterTurn5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackBankedLeftQuarterTurn5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5390,7 +5389,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5555,23 +5554,23 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackRightEighthBankToDiag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightEighthBankToDiag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackLeftEighthBankToDiag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+        TrackLeftEighthBankToDiag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5679,7 +5678,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5787,23 +5786,23 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackRightQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn5Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6003,7 +6002,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6203,23 +6202,23 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackRightQuarterTurn5Tile25DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn5Tile25DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn5Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftQuarterTurn5Tile25DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn5Tile25DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn1Tile60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6267,7 +6266,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn1Tile60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6316,21 +6315,21 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightQuarterTurn1Tile60DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn1Tile60DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn1Tile60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftQuarterTurn1Tile60DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn1Tile60DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn1Tile90DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6375,7 +6374,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn1Tile90DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6420,21 +6419,21 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile90DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightQuarterTurn1Tile90DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn1Tile90DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn1Tile90DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftQuarterTurn1Tile90DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn1Tile90DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void Track25DegUpToLeftBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6478,7 +6477,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToRightBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6522,7 +6521,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6566,7 +6565,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6610,35 +6609,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToRightBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBanked25DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToLeftBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToLeftBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBanked25DegUpTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToRightBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBanked25DegUpTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6685,7 +6684,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedFlatToRightBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6732,7 +6731,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpToLeftBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6779,7 +6778,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpToRightBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6826,35 +6825,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBanked25DegUpToRightBankedFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBanked25DegUpToRightBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBankedFlatToRightBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBanked25DegUpToLeftBankedFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBanked25DegUpToLeftBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBanked25DegDownToLeftBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBankedFlatToRightBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBankedFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBanked25DegDownToRightBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBankedFlatToLeftBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBankedFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegUpLeftBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6895,7 +6894,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpRightBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6936,21 +6935,21 @@ namespace HybridRC
     }
 
     static void Track25DegDownLeftBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpRightBanked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpRightBanked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownRightBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpLeftBanked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpLeftBanked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackFlatToLeftBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6994,7 +6993,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToRightBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7038,7 +7037,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7082,7 +7081,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7126,35 +7125,35 @@ namespace HybridRC
     }
 
     static void TrackFlatToLeftBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBanked25DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackFlatToRightBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBanked25DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBanked25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToRightBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBanked25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToLeftBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7271,7 +7270,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7388,23 +7387,23 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackRightBankedQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightBankedQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftBankedQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftBankedQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftBankedQuarterTurn5Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7622,7 +7621,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn5Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7840,23 +7839,23 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn5Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackRightBankedQuarterTurn5Tile25DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightBankedQuarterTurn5Tile25DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightBankedQuarterTurn5Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftBankedQuarterTurn5Tile25DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftBankedQuarterTurn5Tile25DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackSBendLeft(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8010,7 +8009,7 @@ namespace HybridRC
     }
 
     static void TrackSBendRight(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8164,7 +8163,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8449,7 +8448,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8734,7 +8733,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 4)
@@ -8743,11 +8742,11 @@ namespace HybridRC
             direction = (direction - 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackRightHalfBankedHelixUpSmall(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightHalfBankedHelixUpSmall(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 4)
@@ -8756,11 +8755,11 @@ namespace HybridRC
             direction = (direction + 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftHalfBankedHelixUpSmall(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftHalfBankedHelixUpSmall(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9181,7 +9180,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9602,7 +9601,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 7)
@@ -9611,11 +9610,11 @@ namespace HybridRC
             direction = (direction - 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackRightHalfBankedHelixUpLarge(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightHalfBankedHelixUpLarge(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 7)
@@ -9624,11 +9623,11 @@ namespace HybridRC
             direction = (direction + 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftHalfBankedHelixUpLarge(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftHalfBankedHelixUpLarge(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftBarrelRollUpToDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9773,7 +9772,7 @@ namespace HybridRC
     }
 
     static void TrackRightBarrelRollUpToDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9918,21 +9917,21 @@ namespace HybridRC
     }
 
     static void TrackLeftBarrelRollDownToUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBarrelRollUpToDown(session, rideIndex, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBarrelRollDownToUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBarrelRollUpToDown(session, rideIndex, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track90DegToInvertedFlatQuarterLoopUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10066,14 +10065,14 @@ namespace HybridRC
     }
 
     static void TrackInvertedFlatTo90DegQuarterLoopDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track90DegToInvertedFlatQuarterLoopUp(session, rideIndex, 2 - trackSequence, direction, height, tileElement);
+        Track90DegToInvertedFlatQuarterLoopUp(session, ride, 2 - trackSequence, direction, height, tileElement);
     }
 
     static void Trackbrakes(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         PaintAddImageAsParentRotated(
@@ -10086,7 +10085,7 @@ namespace HybridRC
     }
 
     static void TrackOnRidePhoto(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
@@ -10101,7 +10100,7 @@ namespace HybridRC
     }
 
     static void TrackFlatTo60DegUpLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10239,7 +10238,7 @@ namespace HybridRC
     }
 
     static void Track60DegUpToFlatLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10377,21 +10376,21 @@ namespace HybridRC
     }
 
     static void TrackFlatTo60DegDownLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpToFlatLongBase(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpToFlatLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDownToFlatLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatTo60DegUpLongBase(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatTo60DegUpLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackBlockBrakes(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         PaintAddImageAsParentRotated(
@@ -10404,7 +10403,7 @@ namespace HybridRC
     }
 
     static void Trackbooster(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         PaintAddImageAsParentRotated(
@@ -10417,7 +10416,7 @@ namespace HybridRC
     }
 
     static void Trackpowered_lift(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         PaintAddImageAsParentRotated(
@@ -10438,7 +10437,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10549,7 +10548,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10660,7 +10659,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10771,7 +10770,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x00890CB4 */
 static void inverted_hairpin_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -82,7 +82,7 @@ static void inverted_hairpin_rc_track_flat(
 
 /** rct2: 0x00890D84, 0x00890D94, 0x00890DA4 */
 static void inverted_hairpin_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -101,7 +101,7 @@ static void inverted_hairpin_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24, 0, 6,
         height + 24);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -109,7 +109,7 @@ static void inverted_hairpin_rc_track_station(
 
 /** rct2: 0x00890CC4 */
 static void inverted_hairpin_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -203,7 +203,7 @@ static void inverted_hairpin_rc_track_25_deg_up(
 
 /** rct2: 0x00890CD4 */
 static void inverted_hairpin_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -273,7 +273,7 @@ static void inverted_hairpin_rc_track_60_deg_up(
 
 /** rct2: 0x00890CE4 */
 static void inverted_hairpin_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -367,7 +367,7 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x00890CF4 */
 static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -449,7 +449,7 @@ static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00890D04 */
 static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -555,7 +555,7 @@ static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00890D14 */
 static void inverted_hairpin_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -649,57 +649,55 @@ static void inverted_hairpin_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x00890D24 */
 static void inverted_hairpin_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890D34 */
 static void inverted_hairpin_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890D44 */
 static void inverted_hairpin_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890D54 */
 static void inverted_hairpin_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890D64 */
 static void inverted_hairpin_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890D74 */
 static void inverted_hairpin_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890DB4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -819,16 +817,16 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00890DC4 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    inverted_hairpin_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_hairpin_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890DD4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -915,7 +913,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00890DE4 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1002,27 +1000,27 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00890DF4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890E04 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890E64 */
 static void inverted_hairpin_rc_track_left_quarter_turn_1(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1072,15 +1070,15 @@ static void inverted_hairpin_rc_track_left_quarter_turn_1(
 
 /** rct2: 0x00890E74 */
 static void inverted_hairpin_rc_track_right_quarter_turn_1(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_left_quarter_turn_1(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_hairpin_rc_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890E24 */
 static void inverted_hairpin_rc_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -1162,7 +1160,7 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_up(
 
 /** rct2: 0x00890E34 */
 static void inverted_hairpin_rc_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -1265,23 +1263,23 @@ static void inverted_hairpin_rc_track_60_deg_up_to_flat(
 
 /** rct2: 0x00890E44 */
 static void inverted_hairpin_rc_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_60_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890E54 */
 static void inverted_hairpin_rc_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_hairpin_rc_track_flat_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_hairpin_rc_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00890E14 */
 static void inverted_hairpin_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1314,7 +1312,7 @@ static void inverted_hairpin_rc_track_brakes(
 
 /** rct2: 0x00890E84 */
 static void inverted_hairpin_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008B0460 */
 static void inverted_impulse_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void inverted_impulse_rc_track_flat(
 
 /** rct2: 0x008B0470, 0x008B0480, 0x008B0490 */
 static void inverted_impulse_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -72,7 +72,7 @@ static void inverted_impulse_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -80,7 +80,7 @@ static void inverted_impulse_rc_track_station(
 
 /** rct2: 0x008B04A0 */
 static void inverted_impulse_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -145,7 +145,7 @@ static void inverted_impulse_rc_track_25_deg_up(
 
 /** rct2: 0x008B04B0 */
 static void inverted_impulse_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -186,7 +186,7 @@ static void inverted_impulse_rc_track_60_deg_up(
 
 /** rct2: 0x008B04C0 */
 static void inverted_impulse_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -248,7 +248,7 @@ static void inverted_impulse_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008B04D0 */
 static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -295,7 +295,7 @@ static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008B04E0 */
 static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -342,7 +342,7 @@ static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008B04F0 */
 static void inverted_impulse_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -404,57 +404,55 @@ static void inverted_impulse_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008B0500 */
 static void inverted_impulse_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0510 */
 static void inverted_impulse_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0520 */
 static void inverted_impulse_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0530 */
 static void inverted_impulse_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0540 */
 static void inverted_impulse_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0550 */
 static void inverted_impulse_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B05A0 */
 static void inverted_impulse_rc_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -495,15 +493,15 @@ static void inverted_impulse_rc_track_90_deg_up(
 
 /** rct2: 0x008B05B0 */
 static void inverted_impulse_rc_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_90_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0560 */
 static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -548,16 +546,15 @@ static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008B0570 */
 static void inverted_impulse_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_impulse_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0580 */
 static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -599,7 +596,7 @@ static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008B0590 */
 static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -643,7 +640,7 @@ static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008B05C0 */
 static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -693,7 +690,7 @@ static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008B05D0 */
 static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -743,20 +740,20 @@ static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008B05E0 */
 static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B05F0 */
 static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_inverted_impulse_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A92E8 */
 static void inverted_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -73,7 +73,7 @@ static void inverted_rc_track_flat(
 
 /** rct2: 0x008A9558, 0x008A9568, 0x008A9578 */
 static void inverted_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -92,7 +92,7 @@ static void inverted_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -100,7 +100,7 @@ static void inverted_rc_track_station(
 
 /** rct2: 0x008A92F8 */
 static void inverted_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -194,7 +194,7 @@ static void inverted_rc_track_25_deg_up(
 
 /** rct2: 0x008A9308 */
 static void inverted_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -235,7 +235,7 @@ static void inverted_rc_track_60_deg_up(
 
 /** rct2: 0x008A9318 */
 static void inverted_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -329,7 +329,7 @@ static void inverted_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A9328 */
 static void inverted_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -376,7 +376,7 @@ static void inverted_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A9338 */
 static void inverted_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -447,7 +447,7 @@ static void inverted_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9348 */
 static void inverted_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -541,55 +541,55 @@ static void inverted_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A9358 */
 static void inverted_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9368 */
 static void inverted_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9378 */
 static void inverted_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9388 */
 static void inverted_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9398 */
 static void inverted_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A93A8 */
 static void inverted_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A93B8 */
 static void inverted_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -769,16 +769,16 @@ static void inverted_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A93C8 */
 static void inverted_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    inverted_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A93D8 */
 static void inverted_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -820,7 +820,7 @@ static void inverted_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A93E8 */
 static void inverted_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -862,7 +862,7 @@ static void inverted_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A93F8 */
 static void inverted_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -904,7 +904,7 @@ static void inverted_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A9408 */
 static void inverted_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -946,7 +946,7 @@ static void inverted_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A9418 */
 static void inverted_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1126,16 +1126,16 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A9428 */
 static void inverted_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    inverted_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9438 */
 static void inverted_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1202,7 +1202,7 @@ static void inverted_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A9448 */
 static void inverted_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1269,7 +1269,7 @@ static void inverted_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A9458 */
 static void inverted_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1336,7 +1336,7 @@ static void inverted_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A9468 */
 static void inverted_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1403,39 +1403,39 @@ static void inverted_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A9478 */
 static void inverted_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9488 */
 static void inverted_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9498 */
 static void inverted_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A94A8 */
 static void inverted_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A94B8 */
 static void inverted_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1477,15 +1477,15 @@ static void inverted_rc_track_left_bank(
 
 /** rct2: 0x008A94C8 */
 static void inverted_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A94D8 */
 static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1650,7 +1650,7 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A94E8 */
 static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1815,27 +1815,25 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A94F8 */
 static void inverted_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    inverted_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    inverted_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9508 */
 static void inverted_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    inverted_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9518 */
 static void inverted_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2006,7 +2004,7 @@ static void inverted_rc_track_s_bend_left(
 
 /** rct2: 0x008A9528 */
 static void inverted_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2177,7 +2175,7 @@ static void inverted_rc_track_s_bend_right(
 
 /** rct2: 0x008A9538 */
 static void inverted_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2484,7 +2482,7 @@ static void inverted_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A9548 */
 static void inverted_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2791,7 +2789,7 @@ static void inverted_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A9588 */
 static void inverted_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2910,16 +2908,16 @@ static void inverted_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A9598 */
 static void inverted_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    inverted_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A95A8 */
 static void inverted_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3039,16 +3037,16 @@ static void inverted_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A95B8 */
 static void inverted_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    inverted_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A95C8 */
 static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3135,7 +3133,7 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A95D8 */
 static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3222,27 +3220,25 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A95E8 */
 static void inverted_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    inverted_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    inverted_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A95F8 */
 static void inverted_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    inverted_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9608 */
 static void inverted_rc_track_left_twist_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3351,7 +3347,7 @@ static void inverted_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008A9618 */
 static void inverted_rc_track_right_twist_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3460,7 +3456,7 @@ static void inverted_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008A9628 */
 static void inverted_rc_track_left_twist_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3569,7 +3565,7 @@ static void inverted_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008A9638 */
 static void inverted_rc_track_right_twist_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3678,7 +3674,7 @@ static void inverted_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008A9648 */
 static void inverted_rc_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3831,15 +3827,15 @@ static void inverted_rc_track_half_loop_up(
 
 /** rct2: 0x008A9658 */
 static void inverted_rc_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_half_loop_up(session, rideIndex, 3 - trackSequence, direction, height, tileElement);
+    inverted_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008A9668 */
 static void inverted_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3957,7 +3953,7 @@ static void inverted_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A9678 */
 static void inverted_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4075,23 +4071,23 @@ static void inverted_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A9688 */
 static void inverted_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_right_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
+    inverted_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9698 */
 static void inverted_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_left_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A96D8 */
 static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4128,7 +4124,7 @@ static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A96B8 */
 static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4166,25 +4162,23 @@ static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A96C8 */
 static void inverted_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    inverted_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A96E8 */
 static void inverted_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    inverted_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A96A8 */
 static void inverted_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4216,7 +4210,7 @@ static void inverted_rc_track_brakes(
 
 /** rct2: 0x008A96F8 */
 static void inverted_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4401,7 +4395,7 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x008A9708 */
 static void inverted_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4586,7 +4580,7 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x008A9718 */
 static void inverted_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4771,7 +4765,7 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x008A9728 */
 static void inverted_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4956,7 +4950,7 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x008A9A38 */
 static void inverted_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5021,7 +5015,7 @@ static void inverted_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A9A48 */
 static void inverted_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5086,7 +5080,7 @@ static void inverted_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A9738 */
 static void inverted_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5132,23 +5126,23 @@ static void inverted_rc_track_on_ride_photo(
 
 /** rct2: 0x008A9A58 */
 static void inverted_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up_right_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9A68 */
 static void inverted_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_25_deg_up_left_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9748 */
 static void inverted_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5311,7 +5305,7 @@ static void inverted_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A9758 */
 static void inverted_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5474,25 +5468,25 @@ static void inverted_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A9768 */
 static void inverted_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    inverted_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9778 */
 static void inverted_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    inverted_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    inverted_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9938 */
 static void inverted_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5655,7 +5649,7 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A9948 */
 static void inverted_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5818,25 +5812,25 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A9958 */
 static void inverted_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    inverted_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9968 */
 static void inverted_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    inverted_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    inverted_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9788 */
 static void inverted_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5975,7 +5969,7 @@ static void inverted_rc_track_diag_flat(
 
 /** rct2: 0x008A97B8 */
 static void inverted_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6114,7 +6108,7 @@ static void inverted_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A9818 */
 static void inverted_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6197,7 +6191,7 @@ static void inverted_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A9798 */
 static void inverted_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6336,7 +6330,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A97F8 */
 static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6419,7 +6413,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A9808 */
 static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6502,7 +6496,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A97A8 */
 static void inverted_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6641,7 +6635,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A97E8 */
 static void inverted_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6780,7 +6774,7 @@ static void inverted_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A9848 */
 static void inverted_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6863,7 +6857,7 @@ static void inverted_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A97C8 */
 static void inverted_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6999,7 +6993,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A9828 */
 static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7082,7 +7076,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A9838 */
 static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7165,7 +7159,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A97D8 */
 static void inverted_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7304,7 +7298,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A9878 */
 static void inverted_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7388,7 +7382,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A9888 */
 static void inverted_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7472,7 +7466,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A9898 */
 static void inverted_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7556,7 +7550,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A98A8 */
 static void inverted_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7640,7 +7634,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A98D8 */
 static void inverted_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7723,7 +7717,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A98E8 */
 static void inverted_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7806,7 +7800,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A98B8 */
 static void inverted_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7889,7 +7883,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A98C8 */
 static void inverted_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7972,7 +7966,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A98F8 */
 static void inverted_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8052,7 +8046,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A9908 */
 static void inverted_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8132,7 +8126,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A9918 */
 static void inverted_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8215,7 +8209,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A9928 */
 static void inverted_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8298,7 +8292,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A9858 */
 static void inverted_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8382,7 +8376,7 @@ static void inverted_rc_track_diag_left_bank(
 
 /** rct2: 0x008A9868 */
 static void inverted_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8466,7 +8460,7 @@ static void inverted_rc_track_diag_right_bank(
 
 /** rct2: 0x008A9978 */
 static void inverted_rc_track_left_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8695,7 +8689,7 @@ static void inverted_rc_track_left_large_half_loop_up(
 
 /** rct2: 0x008A9988 */
 static void inverted_rc_track_right_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8924,23 +8918,23 @@ static void inverted_rc_track_right_large_half_loop_up(
 
 /** rct2: 0x008A9998 */
 static void inverted_rc_track_right_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_right_large_half_loop_up(session, rideIndex, 6 - trackSequence, direction, height, tileElement);
+    inverted_rc_track_right_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008A99A8 */
 static void inverted_rc_track_left_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_left_large_half_loop_up(session, rideIndex, 6 - trackSequence, direction, height, tileElement);
+    inverted_rc_track_left_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008A96A8 */
 static void inverted_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8972,7 +8966,7 @@ static void inverted_rc_track_block_brakes(
 
 /** rct2: 0x008A9A78 */
 static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9059,7 +9053,7 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A9A88 */
 static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9146,27 +9140,27 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A9A98 */
 static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9AA8 */
 static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9BB8 */
 static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9331,7 +9325,7 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A9BC8 */
 static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9496,27 +9490,27 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A9BD8 */
 static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9BE8 */
 static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9AB8 */
 static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9581,7 +9575,7 @@ static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A9AC8 */
 static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9646,7 +9640,7 @@ static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A9AD8 */
 static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9711,7 +9705,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9AE8 */
 static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9776,43 +9770,43 @@ static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9AF8 */
 static void inverted_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9B08 */
 static void inverted_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9B18 */
 static void inverted_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9B28 */
 static void inverted_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9B38 */
 static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9877,7 +9871,7 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A9B48 */
 static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9942,7 +9936,7 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A9B58 */
 static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -10007,7 +10001,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A9B68 */
 static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -10072,43 +10066,43 @@ static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A9B78 */
 static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9B88 */
 static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9B98 */
 static void inverted_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9BA8 */
 static void inverted_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A99B8 */
 static void inverted_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -10173,7 +10167,7 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A99C8 */
 static void inverted_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -10238,7 +10232,7 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A99D8 */
 static void inverted_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -10303,7 +10297,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A99E8 */
 static void inverted_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -10368,38 +10362,34 @@ static void inverted_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A99F8 */
 static void inverted_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_right_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9A08 */
 static void inverted_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_left_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9A18 */
 static void inverted_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A9A28 */
 static void inverted_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    inverted_rc_track_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    inverted_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_inverted_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1620,7 +1620,7 @@ static constexpr const uint32_t junior_rc_track_pieces_diag_60_deg_down_to_25_de
 // clang-format on
 
 void junior_rc_paint_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_flat[EnumValue(chainType)][direction] | session->TrackColours[SCHEME_TRACK];
@@ -1640,7 +1640,7 @@ void junior_rc_paint_track_flat(
 }
 
 void junior_rc_paint_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, uint8_t rideType)
 {
     uint32_t imageId;
@@ -1691,14 +1691,14 @@ void junior_rc_paint_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
 void junior_rc_paint_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_25_deg_up[EnumValue(chainType)][direction] | session->TrackColours[SCHEME_TRACK];
@@ -1720,7 +1720,7 @@ void junior_rc_paint_track_25_deg_up(
 }
 
 void junior_rc_paint_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_flat_to_25_deg_up[EnumValue(chainType)][direction]
@@ -1749,7 +1749,7 @@ void junior_rc_paint_track_flat_to_25_deg_up(
 }
 
 void junior_rc_paint_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_25_deg_up_to_flat[EnumValue(chainType)][direction]
@@ -1797,7 +1797,7 @@ static constexpr const int8_t junior_rc_track_right_quarter_turn_5_tiles_support
 };
 
 static void junior_rc_right_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -1877,19 +1877,18 @@ static constexpr const uint8_t junior_rc_left_quarter_turn_5_tiles_to_right_turn
 
 /* rct2: 0x0051917A */
 static void junior_rc_left_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
-    junior_rc_right_quarter_turn_5_tiles_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    junior_rc_right_quarter_turn_5_tiles_paint_setup(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /**
  * rct2: 0x008AAFC0, 0x00521593, 0x005216A1, 0x005217AF, 0x00521884
  */
 static void junior_rc_flat_to_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -1937,7 +1936,7 @@ static void junior_rc_flat_to_left_bank_paint_setup(
  * rct2: 0x008AAFD0, 0x00521959, 0x00521A2E, 0x00521B03, 0x00521C11
  */
 static void junior_rc_flat_to_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -1982,17 +1981,17 @@ static void junior_rc_flat_to_right_bank_paint_setup(
 }
 
 static void junior_rc_left_bank_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_flat_to_right_bank_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_flat_to_right_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void junior_rc_right_bank_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_flat_to_left_bank_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_flat_to_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static constexpr const CoordsXY junior_rc_banked_right_quarter_turn_5_tiles_bound_lengths[4][5] = {
@@ -2059,7 +2058,7 @@ static constexpr const CoordsXYZ junior_rc_banked_right_quarter_turn_5_tiles_bou
 
 /* rct2: 0x008AB010, 0x0052304C */
 static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t thickness = 1;
@@ -2153,19 +2152,19 @@ static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
 
 /* rct2: 0x008AB000 */
 static void junior_rc_banked_left_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
     junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /**
  * rct2: 0x008AB020, 0x00522073, 0x00522182, 0x00522291, 0x00522367
  */
 static void junior_rc_left_bank_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -2225,7 +2224,7 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(
  * rct2: 0x008AB030, 0x0052243D, 0x00522513, 0x005225E9, 0x005226F8
  */
 static void junior_rc_right_bank_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -2285,7 +2284,7 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(
  * rct2: 0x008AB040, 0x00522807, 0x0052291A, 0x00522A2D, 0x00522B07
  */
 static void junior_rc_25_deg_up_to_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -2346,7 +2345,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(
  * rct2: 0x008AB050, 0x00522BE1, 0x00522CBB, 0x00522D95, 0x00522EA8
  */
 static void junior_rc_25_deg_up_to_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -2407,40 +2406,40 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(
  * rct2: 0x008AB060
  */
 static void junior_rc_left_bank_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_25_deg_up_to_right_bank_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_25_deg_up_to_right_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /**
  * rct2: 0x008AB070
  */
 static void junior_rc_right_bank_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_25_deg_up_to_left_bank_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_25_deg_up_to_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /**
  * rct2: 0x008AB080
  */
 static void junior_rc_25_deg_down_to_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_right_bank_to_25_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_right_bank_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /**
  * rct2: 0x008AB090
  */
 static void junior_rc_25_deg_down_to_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_left_bank_to_25_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_left_bank_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static constexpr const CoordsXYZ junior_rc_left_bank_bound_lengths[4] = {
@@ -2461,7 +2460,7 @@ static constexpr const CoordsXY junior_rc_left_bank_bound_offsets[4] = {
  * rct2: 0x008AB0A0, 0x00521D1F, 0x00521DF4, 0x00521EC9, 0x00521F9E
  */
 static void junior_rc_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -2496,14 +2495,14 @@ static void junior_rc_left_bank_paint_setup(
  * rct2: 0x008AB0B0
  */
 static void junior_rc_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_left_bank_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2583,7 +2582,7 @@ void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
 }
 
 void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2664,49 +2663,49 @@ void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
 
 /* rct2: 0x008AAE10, 0x00519D88, 0x00519DAC, 0x00519DD0, 0x00519DF4 */
 static void junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /* rct2: 0x008AAE20, 0x00519E18, 0x0051A148, 0x0051A452, 0x0051A738 */
 static void junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /* rct2: 0x008AAE30, 0x0051AA42, 0x0051AA68, 0x0051AA8C, 0x0051AAB0 */
 static void junior_rc_left_quarter_turn_5_tiles_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
-        session, rideIndex, junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction + 1) & 3, height,
+        session, ride, junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction + 1) & 3, height,
         tileElement);
 }
 
 /* rct2: 0x008AAE40, 0x0051AAD4, 0x0051AE04, 0x0051B10E, 0x0051B3F4 */
 static void junior_rc_right_quarter_turn_5_tiles_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
-        session, rideIndex, junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction - 1) & 3, height,
+        session, ride, junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction - 1) & 3, height,
         tileElement);
 }
 
 /* rct2: 0x008AAE50, 0x0051B6FE, 0x0051B946, 0x0051BB8E, 0x0051BBA8 */
 static void junior_rc_s_bend_left_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -2812,7 +2811,7 @@ static void junior_rc_s_bend_left_paint_setup(
 
 /* rct2: 0x008AAE60, 0x0051BBC0, 0x0051BE06, 0x0051C04E, 0x0051C068 */
 static void junior_rc_s_bend_right_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -2918,7 +2917,7 @@ static void junior_rc_s_bend_right_paint_setup(
 
 /** rct2: 0x008AAEB0, 0x0051C0E0, 0x0051C2C1, 0x0051C47F, 0x0051C61D */
 static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -2957,12 +2956,11 @@ static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
 
 /** rct2: 0x008AAEA0 */
 static void junior_rc_left_quarter_turn_3_tiles_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    junior_rc_right_quarter_turn_3_tiles_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    junior_rc_right_quarter_turn_3_tiles_paint_setup(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static constexpr const CoordsXY junior_rc_right_quarter_turn_3_tiles_bank_bound_lengths[4][3] = {
@@ -3013,7 +3011,7 @@ static constexpr const CoordsXYZ junior_rc_right_quarter_turn_3_tiles_bank_offse
 
 /** rct2: 0x008AA0D0, 0x00523EA0, 0x005240CC, 0x0052430F, 0x00524500*/
 static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t thickness[4][4] = { { 1, 1, 1, 1 }, { 1, 1, 1, 1 }, { 26, 1, 1, 26 }, { 1, 1, 1, 1 } };
@@ -3064,7 +3062,7 @@ static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
 }
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = 0;
@@ -3143,7 +3141,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
 }
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = 0;
@@ -3223,33 +3221,33 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
 
 /** rct2: 0x008AA0C0 */
 static void junior_rc_left_quarter_turn_3_tiles_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AAED0, 0x0051C83C, 0x0051C9EC, 0x0051CB76, 0x0051CCDC*/
 static void junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAEF0, 0x0051CEC8, 0x0051D078, 0x0051D202, 0x0051D368*/
 static void junior_rc_right_quarter_turn_3_tiles_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
@@ -3257,27 +3255,27 @@ static constexpr const uint8_t junior_rc_left_quarter_turn_3_tiles_to_right_turn
 
 /** rct2: 0x008AAEC0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
     junior_rc_right_quarter_turn_3_tiles_25_deg_down_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AAEE0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
     junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AB0F0, 0x0052B3A4, 0x0052B5F8, 0x0052B863, 0x0052BA78 */
 static void junior_rc_right_half_banked_helix_up_small_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t thickness[2] = { 1, 26 };
@@ -3345,7 +3343,7 @@ static void junior_rc_right_half_banked_helix_up_small_paint_setup(
 
 /** rct2: 0x008AB110, 0x0052BD80, 0x0052BFD4, 0x0052C23B, 0x0052C450 */
 static void junior_rc_right_half_banked_helix_down_small_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t thickness[2] = { 1, 26 };
@@ -3413,7 +3411,7 @@ static void junior_rc_right_half_banked_helix_down_small_paint_setup(
 
 /** rct2: 0x008AB0E0 */
 static void junior_rc_left_half_banked_helix_up_small_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence > 3)
@@ -3424,12 +3422,12 @@ static void junior_rc_left_half_banked_helix_up_small_paint_setup(
     }
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
     junior_rc_right_half_banked_helix_down_small_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AB100 */
 static void junior_rc_left_half_banked_helix_down_small_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence > 3)
@@ -3440,12 +3438,12 @@ static void junior_rc_left_half_banked_helix_down_small_paint_setup(
     }
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
     junior_rc_right_half_banked_helix_up_small_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AB130, 0x0052C7BC, 0x0052CB6B, 0x0052CF32, 0x0052D2B3 */
 static void junior_rc_right_half_banked_helix_up_large_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t thickness[2] = { 1, 26 };
@@ -3531,7 +3529,7 @@ static void junior_rc_right_half_banked_helix_up_large_paint_setup(
 
 /** rct2: 0x008AB150, 0x0052D778, 0x0052DB27, 0x0052DEEA, 0x0052E26B */
 static void junior_rc_right_half_banked_helix_down_large_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t thickness[2] = { 1, 26 };
@@ -3617,7 +3615,7 @@ static void junior_rc_right_half_banked_helix_down_large_paint_setup(
 
 /** rct2: 0x008AB120 */
 static void junior_rc_left_half_banked_helix_up_large_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence > 6)
@@ -3628,12 +3626,12 @@ static void junior_rc_left_half_banked_helix_up_large_paint_setup(
     }
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
     junior_rc_right_half_banked_helix_down_large_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AB140 */
 static void junior_rc_left_half_banked_helix_down_large_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence > 6)
@@ -3644,14 +3642,14 @@ static void junior_rc_left_half_banked_helix_down_large_paint_setup(
     }
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
     junior_rc_right_half_banked_helix_up_large_paint_setup(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /**
  * rct2: 0x008AAF00, 0x0051851C, 0x005185D8
  */
 static void junior_rc_brake_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -3685,7 +3683,7 @@ static void junior_rc_brake_paint_setup(
  * rct2: 0x008AB280, 0x00518694, 0x00518759
  */
 static void junior_rc_block_brake_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id;
@@ -3719,7 +3717,7 @@ static void junior_rc_block_brake_paint_setup(
 
 /** rct2: 0x008AAF80 */
 static void junior_rc_left_eighth_to_diag_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -3785,7 +3783,7 @@ static void junior_rc_left_eighth_to_diag_paint_setup(
 
 /** rct2: 0x008AAF90 */
 static void junior_rc_right_eighth_to_diag_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -3851,22 +3849,22 @@ static void junior_rc_right_eighth_to_diag_paint_setup(
 
 /** rct2: 0x008AAFA0 */
 static void junior_rc_left_eighth_to_orthogonal_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
     trackSequence = map[trackSequence];
-    junior_rc_right_eighth_to_diag_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_right_eighth_to_diag_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AAFB0 */
 static void junior_rc_right_eighth_to_orthogonal_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
     trackSequence = map[trackSequence];
-    junior_rc_left_eighth_to_diag_paint_setup(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    junior_rc_left_eighth_to_diag_paint_setup(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static constexpr const CoordsXY junior_rc_left_eighth_to_diag_bank_bound_lengths[4][4] = {
@@ -3952,7 +3950,7 @@ static constexpr const int8_t junior_rc_left_eighth_to_diag_bank_thickness[4][4]
 
 /** rct2: 0x008AB160 */
 static void junior_rc_left_eighth_to_diag_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4099,7 +4097,7 @@ static constexpr const int8_t junior_rc_right_eighth_to_diag_bank_thickness[4][4
 
 /** rct2: 0x008AB170 */
 static void junior_rc_right_eighth_to_diag_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4165,23 +4163,22 @@ static void junior_rc_right_eighth_to_diag_bank_paint_setup(
 
 /** rct2: 0x008AB180 */
 static void junior_rc_left_eighth_to_orthogonal_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
     trackSequence = map[trackSequence];
-    junior_rc_right_eighth_to_diag_bank_paint_setup(
-        session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_right_eighth_to_diag_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AB190 */
 static void junior_rc_right_eighth_to_orthogonal_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
     trackSequence = map[trackSequence];
-    junior_rc_left_eighth_to_diag_bank_paint_setup(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    junior_rc_left_eighth_to_diag_bank_paint_setup(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static constexpr const int32_t junior_rc_diag_blocked_segments[] = { SEGMENT_C4 | SEGMENT_CC | SEGMENT_D4 | SEGMENT_BC,
@@ -4192,7 +4189,7 @@ static constexpr const int32_t junior_rc_diag_blocked_segments[] = { SEGMENT_C4 
 static constexpr const uint8_t junior_rc_diag_support_segment[] = { 1, 0, 2, 3 };
 
 void junior_rc_paint_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4212,7 +4209,7 @@ void junior_rc_paint_track_diag_flat(
 }
 
 void junior_rc_paint_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4232,7 +4229,7 @@ void junior_rc_paint_track_diag_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4253,7 +4250,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4277,7 +4274,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4298,7 +4295,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_flat(
 }
 
 void junior_rc_paint_track_diag_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4322,7 +4319,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_flat(
 }
 
 void junior_rc_paint_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4343,7 +4340,7 @@ void junior_rc_paint_track_diag_25_deg_down(
 }
 
 void junior_rc_paint_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4364,7 +4361,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_down(
 }
 
 void junior_rc_paint_track_diag_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4388,7 +4385,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4409,7 +4406,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_flat(
 }
 
 void junior_rc_paint_track_diag_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4434,124 +4431,124 @@ void junior_rc_paint_track_diag_60_deg_down_to_flat(
 
 /** rct2: 0x008AAF10 */
 static void junior_rc_diag_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAF40 */
 static void junior_rc_diag_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAF20 */
 static void junior_rc_diag_flat_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_flat_to_60_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAF30 */
 static void junior_rc_diag_25_deg_up_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_60_deg_up_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_60_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAF70 */
 static void junior_rc_diag_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAF50 */
 static void junior_rc_diag_flat_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_flat_to_60_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AAF60 */
 static void junior_rc_diag_25_deg_down_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_60_deg_down_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_60_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /** rct2: 0x008AB1C0 */
 static void junior_rc_diag_flat_to_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4578,7 +4575,7 @@ static void junior_rc_diag_flat_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB1D0 */
 static void junior_rc_diag_flat_to_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4605,7 +4602,7 @@ static void junior_rc_diag_flat_to_right_bank_paint_setup(
 
 /** rct2: 0x008AB1E0 */
 static void junior_rc_diag_left_bank_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4632,7 +4629,7 @@ static void junior_rc_diag_left_bank_to_flat_paint_setup(
 
 /** rct2: 0x008AB1F0 */
 static void junior_rc_diag_right_bank_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4659,7 +4656,7 @@ static void junior_rc_diag_right_bank_to_flat_paint_setup(
 
 /** rct2: 0x008AB220 */
 static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4686,7 +4683,7 @@ static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
 
 /** rct2: 0x008AB230 */
 static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4713,7 +4710,7 @@ static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
 
 /** rct2: 0x008AB200 */
 static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4740,7 +4737,7 @@ static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB210 */
 static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4767,7 +4764,7 @@ static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
 
 /** rct2: 0x008AB200 */
 static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4794,7 +4791,7 @@ static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB210 */
 static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4821,7 +4818,7 @@ static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB220 */
 static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4848,7 +4845,7 @@ static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB230 */
 static void junior_rc_diag_25_deg_down_to_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4889,7 +4886,7 @@ static constexpr const CoordsXYZ junior_rc_diag_right_bank_bound_offsets[4] = {
 
 /** rct2: 0x008AB1A0 */
 static void junior_rc_diag_left_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t thickness = direction == 0 ? 0 : 1;
@@ -4912,7 +4909,7 @@ static void junior_rc_diag_left_bank_paint_setup(
 
 /** rct2: 0x008AB1B0 */
 static void junior_rc_diag_right_bank_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t thickness = direction == 2 ? 0 : 1;
@@ -4957,7 +4954,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_bound_lengths[4] = {
 };
 
 void junior_rc_paint_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5000,20 +4997,20 @@ void junior_rc_paint_track_60_deg_up(
 }
 
 static void junior_rc_60_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_60_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_60_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static constexpr const CoordsXY junior_rc_25_deg_up_to_60_deg_up_bound_lengths[4][2] = {
@@ -5033,7 +5030,7 @@ static constexpr const CoordsXY junior_rc_25_deg_up_to_60_deg_up_bound_offsets[4
 };
 
 void junior_rc_paint_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5095,24 +5092,24 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(
 }
 
 static void junior_rc_25_deg_up_to_60_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_60_deg_down_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_25_deg_up_to_60_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_25_deg_up_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 void junior_rc_paint_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5173,24 +5170,24 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(
 }
 
 static void junior_rc_60_deg_up_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_25_deg_down_to_60_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_60_deg_up_to_25_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    junior_rc_60_deg_up_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 void junior_rc_paint_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5210,7 +5207,7 @@ void junior_rc_paint_track_diag_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5231,7 +5228,7 @@ void junior_rc_paint_track_diag_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5252,7 +5249,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     if (direction == 1 && trackSequence == 3)
@@ -5284,7 +5281,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     if (direction == 3 && trackSequence == 0)
@@ -5316,7 +5313,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5337,62 +5334,62 @@ void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
 }
 
 static void junior_rc_diag_60_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_60_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_25_deg_up_to_60_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_60_deg_up_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_25_deg_down_to_60_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 static void junior_rc_diag_60_deg_down_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
@@ -5427,7 +5424,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_to_flat_tile_offsets[4][2] =
 };
 
 static void junior_rc_flat_to_60_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5489,14 +5486,14 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_flat_to_60_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    junior_rc_flat_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void junior_rc_60_deg_up_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5557,90 +5554,90 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(
 }
 
 static void junior_rc_flat_to_60_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_60_deg_up_to_flat_paint_setup(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    junior_rc_60_deg_up_to_flat_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /* rct2: 0x00518394 */
 static void junior_rc_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /* rct2: 0x00515629, 0x00514D22, 0x005151B9 */
 static void paint_junior_rc_station_track(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_paint_station(session, rideIndex, trackSequence, direction, height, tileElement, RIDE_TYPE_JUNIOR_ROLLER_COASTER);
+    junior_rc_paint_station(session, ride, trackSequence, direction, height, tileElement, RIDE_TYPE_JUNIOR_ROLLER_COASTER);
 }
 
 /* rct2: 0x0051881E */
 static void junior_rc_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /* rct2: 0x00518B42 */
 static void junior_rc_flat_to_25_deg_up_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /* rct2: 0x00518E56 */
 static void junior_rc_25_deg_up_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
 
 /* rct2: 0x005189B0 */
 static void junior_rc_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_25_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    junior_rc_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /* rct2: 0x00518FE8 */
 static void junior_rc_flat_to_25_deg_down_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_25_deg_up_to_flat_paint_setup(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    junior_rc_25_deg_up_to_flat_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /* rct2: 0x00518CCC */
 static void junior_rc_25_deg_down_to_flat_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_flat_to_25_deg_up_paint_setup(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    junior_rc_flat_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void junior_rc_booster_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction & 1)
@@ -5670,7 +5667,7 @@ static void junior_rc_booster_paint_setup(
 }
 
 static void junior_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = junior_rc_track_pieces_flat[0][direction] | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.h
@@ -20,96 +20,98 @@ enum class JuniorRcChainType : uint8_t
     ChainLift,
 };
 
+struct Ride;
+
 void junior_rc_paint_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, uint8_t rideType);
 
 void junior_rc_paint_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TileElement* tileElement, JuniorRcChainType chainType);
 
 #endif // _JUNIOR_ROLLER_COASTER_H

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x0082491C */
 static void lay_down_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -132,7 +132,7 @@ static void lay_down_rc_track_flat(
 
 /** rct2: 0x00824B8C, 0x00824B9C, 0x00824BAC */
 static void lay_down_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->IsInverted())
@@ -154,7 +154,7 @@ static void lay_down_rc_track_station(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24,
             0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_1);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     }
     else
@@ -181,7 +181,7 @@ static void lay_down_rc_track_station(
         PaintAddImageAsParentRotated(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+        track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     }
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -190,7 +190,7 @@ static void lay_down_rc_track_station(
 
 /** rct2: 0x0082492C */
 static void lay_down_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -355,7 +355,7 @@ static void lay_down_rc_track_25_deg_up(
 
 /** rct2: 0x0082493C */
 static void lay_down_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -471,7 +471,7 @@ static void lay_down_rc_track_60_deg_up(
 
 /** rct2: 0x0082494C */
 static void lay_down_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -636,7 +636,7 @@ static void lay_down_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0082495C */
 static void lay_down_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -766,7 +766,7 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0082496C */
 static void lay_down_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -920,7 +920,7 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0082497C */
 static void lay_down_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1085,55 +1085,55 @@ static void lay_down_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0082498C */
 static void lay_down_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0082499C */
 static void lay_down_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008249AC */
 static void lay_down_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008249BC */
 static void lay_down_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008249CC */
 static void lay_down_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008249DC */
 static void lay_down_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008249EC */
 static void lay_down_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1502,16 +1502,16 @@ static void lay_down_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008249FC */
 static void lay_down_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    lay_down_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824A0C */
 static void lay_down_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1592,7 +1592,7 @@ static void lay_down_rc_track_flat_to_left_bank(
 
 /** rct2: 0x00824A1C */
 static void lay_down_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1673,7 +1673,7 @@ static void lay_down_rc_track_flat_to_right_bank(
 
 /** rct2: 0x00824A2C */
 static void lay_down_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1754,7 +1754,7 @@ static void lay_down_rc_track_left_bank_to_flat(
 
 /** rct2: 0x00824A3C */
 static void lay_down_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1835,7 +1835,7 @@ static void lay_down_rc_track_right_bank_to_flat(
 
 /** rct2: 0x00824A4C */
 static void lay_down_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2205,16 +2205,16 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x00824A5C */
 static void lay_down_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    lay_down_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824A6C */
 static void lay_down_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2326,7 +2326,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x00824A7C */
 static void lay_down_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2438,7 +2438,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x00824A8C */
 static void lay_down_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2550,7 +2550,7 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x00824A9C */
 static void lay_down_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2662,39 +2662,39 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x00824AAC */
 static void lay_down_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824ABC */
 static void lay_down_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824ACC */
 static void lay_down_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824ADC */
 static void lay_down_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824AEC */
 static void lay_down_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2771,15 +2771,15 @@ static void lay_down_rc_track_left_bank(
 
 /** rct2: 0x00824AFC */
 static void lay_down_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824B0C */
 static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3123,7 +3123,7 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x00824B1C */
 static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3467,27 +3467,25 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x00824B2C */
 static void lay_down_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    lay_down_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    lay_down_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824B3C */
 static void lay_down_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    lay_down_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824B4C */
 static void lay_down_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3814,7 +3812,7 @@ static void lay_down_rc_track_s_bend_left(
 
 /** rct2: 0x00824B5C */
 static void lay_down_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4141,7 +4139,7 @@ static void lay_down_rc_track_s_bend_right(
 
 /** rct2: 0x00824B6C */
 static void lay_down_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4420,7 +4418,7 @@ static void lay_down_rc_track_left_vertical_loop(
 
 /** rct2: 0x00824B7C */
 static void lay_down_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4655,7 +4653,7 @@ static void lay_down_rc_track_right_vertical_loop(
 
 /** rct2: 0x00824BBC */
 static void lay_down_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4894,16 +4892,16 @@ static void lay_down_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00824BCC */
 static void lay_down_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    lay_down_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824BDC */
 static void lay_down_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5148,16 +5146,16 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x00824BEC */
 static void lay_down_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    lay_down_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824BFC */
 static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5328,7 +5326,7 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00824C0C */
 static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5505,27 +5503,25 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00824C1C */
 static void lay_down_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    lay_down_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    lay_down_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824C2C */
 static void lay_down_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    lay_down_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824C9C */
 static void lay_down_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5747,7 +5743,7 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x00824CAC */
 static void lay_down_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5969,7 +5965,7 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x00824CBC */
 static void lay_down_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -5978,13 +5974,12 @@ static void lay_down_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    lay_down_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    lay_down_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824CCC */
 static void lay_down_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -5993,13 +5988,12 @@ static void lay_down_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    lay_down_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824CDC */
 static void lay_down_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6345,7 +6339,7 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x00824CEC */
 static void lay_down_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6691,7 +6685,7 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x00824CFC */
 static void lay_down_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -6700,13 +6694,12 @@ static void lay_down_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    lay_down_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    lay_down_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824D0C */
 static void lay_down_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -6715,13 +6708,12 @@ static void lay_down_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    lay_down_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824D3C */
 static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6799,7 +6791,7 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x00824D1C */
 static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6878,25 +6870,23 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x00824D2C */
 static void lay_down_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    lay_down_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824D4C */
 static void lay_down_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lay_down_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824D5C */
 static void lay_down_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6957,7 +6947,7 @@ static void lay_down_rc_track_brakes(
 
 /** rct2: 0x00824D6C */
 static void lay_down_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7068,7 +7058,7 @@ static void lay_down_rc_track_on_ride_photo(
 
 /** rct2: 0x00824D8C */
 static void lay_down_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7382,7 +7372,7 @@ static void lay_down_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x00824D9C */
 static void lay_down_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7696,25 +7686,25 @@ static void lay_down_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x00824DAC */
 static void lay_down_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    lay_down_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824DBC */
 static void lay_down_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    lay_down_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    lay_down_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824DCC */
 static void lay_down_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8029,7 +8019,7 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x00824DDC */
 static void lay_down_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8344,25 +8334,25 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x00824DEC */
 static void lay_down_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    lay_down_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lay_down_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824DFC */
 static void lay_down_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    lay_down_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    lay_down_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x00824D7C */
 static void lay_down_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8654,7 +8644,7 @@ static void lay_down_rc_track_diag_flat(
 
 /** rct2: 0x00824E2C */
 static void lay_down_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8946,7 +8936,7 @@ static void lay_down_rc_track_diag_25_deg_up(
 
 /** rct2: 0x00824E8C */
 static void lay_down_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9182,7 +9172,7 @@ static void lay_down_rc_track_diag_60_deg_up(
 
 /** rct2: 0x00824E0C */
 static void lay_down_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9474,7 +9464,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00824E6C */
 static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9710,7 +9700,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00824E7C */
 static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9946,7 +9936,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00824E1C */
 static void lay_down_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10238,7 +10228,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00824E5C */
 static void lay_down_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10474,7 +10464,7 @@ static void lay_down_rc_track_diag_25_deg_down(
 
 /** rct2: 0x00824EBC */
 static void lay_down_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10710,7 +10700,7 @@ static void lay_down_rc_track_diag_60_deg_down(
 
 /** rct2: 0x00824E3C */
 static void lay_down_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10939,7 +10929,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x00824E9C */
 static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11175,7 +11165,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00824EAC */
 static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11411,7 +11401,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00824E4C */
 static void lay_down_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11647,7 +11637,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x00824EEC */
 static void lay_down_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11817,7 +11807,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x00824EFC */
 static void lay_down_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11987,7 +11977,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x00824F0C */
 static void lay_down_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12157,7 +12147,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x00824F1C */
 static void lay_down_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12327,7 +12317,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x00824F4C */
 static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12496,7 +12486,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x00824F5C */
 static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12665,7 +12655,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x00824F2C */
 static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12834,7 +12824,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x00824F3C */
 static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13003,7 +12993,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x00824F6C */
 static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13165,7 +13155,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x00824F7C */
 static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13327,7 +13317,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x00824F8C */
 static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13496,7 +13486,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x00824F9C */
 static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13665,7 +13655,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x00824ECC */
 static void lay_down_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13832,7 +13822,7 @@ static void lay_down_rc_track_diag_left_bank(
 
 /** rct2: 0x00824EDC */
 static void lay_down_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -13999,7 +13989,7 @@ static void lay_down_rc_track_diag_right_bank(
 
 /** rct2: 0x00824FAC */
 static void lay_down_rc_track_left_flyer_twist_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14111,7 +14101,7 @@ static void lay_down_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x00824FBC */
 static void lay_down_rc_track_right_flyer_twist_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14221,7 +14211,7 @@ static void lay_down_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x00824FCC */
 static void lay_down_rc_track_left_flyer_twist_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14333,7 +14323,7 @@ static void lay_down_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x00824FDC */
 static void lay_down_rc_track_right_flyer_twist_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14443,7 +14433,7 @@ static void lay_down_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x00824C3C */
 static void lay_down_rc_track_flyer_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14573,7 +14563,7 @@ static void lay_down_rc_track_flyer_half_loop_up(
 
 /** rct2: 0x00824C4C */
 static void lay_down_rc_track_flyer_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14703,7 +14693,7 @@ static void lay_down_rc_track_flyer_half_loop_down(
 
 /** rct2: 0x00824C5C */
 static void lay_down_rc_track_left_flyer_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14830,7 +14820,7 @@ static void lay_down_rc_track_left_flyer_corkscrew_up(
 
 /** rct2: 0x00824C6C */
 static void lay_down_rc_track_right_flyer_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -14944,7 +14934,7 @@ static void lay_down_rc_track_right_flyer_corkscrew_up(
 
 /** rct2: 0x00824C7C */
 static void lay_down_rc_track_left_flyer_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -15058,15 +15048,15 @@ static void lay_down_rc_track_left_flyer_corkscrew_down(
 
 /** rct2: 0x00824C8C */
 static void lay_down_rc_track_right_flyer_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lay_down_rc_track_left_flyer_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction + 3) % 4, height, tileElement);
+    lay_down_rc_track_left_flyer_corkscrew_up(session, ride, 2 - trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /** rct2: 0x00824FEC */
 static void lay_down_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -15123,7 +15113,7 @@ static void lay_down_rc_track_block_brakes(
 }
 
 static void lay_down_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -15307,7 +15297,7 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
 }
 
 static void lay_down_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -15491,7 +15481,7 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
 }
 
 static void lay_down_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -15675,7 +15665,7 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
 }
 
 static void lay_down_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _LimLauncherBlockBrakeImages[NumOrthogonalDirect
 
 /** rct2: 0x008A6D50, 0x008A6D60, 0x008A6D70 */
 static void lim_launched_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -58,7 +58,7 @@ static void lim_launched_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -66,7 +66,7 @@ static void lim_launched_rc_track_station(
 
 /** rct2: 0x008A65E0 */
 static void lim_launched_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -329,7 +329,7 @@ static void lim_launched_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A65F0 */
 static void lim_launched_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -546,7 +546,7 @@ static void lim_launched_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A6D10 */
 static void lim_launched_rc_track_left_twist_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -683,7 +683,7 @@ static void lim_launched_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008A6D20 */
 static void lim_launched_rc_track_right_twist_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -820,7 +820,7 @@ static void lim_launched_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008A6D30 */
 static void lim_launched_rc_track_left_twist_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -957,7 +957,7 @@ static void lim_launched_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008A6D40 */
 static void lim_launched_rc_track_right_twist_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1094,7 +1094,7 @@ static void lim_launched_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008A6CD0 */
 static void lim_launched_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1206,7 +1206,7 @@ static void lim_launched_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A6CE0 */
 static void lim_launched_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1319,23 +1319,23 @@ static void lim_launched_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A6CF0 */
 static void lim_launched_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lim_launched_rc_track_right_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
+    lim_launched_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6D00 */
 static void lim_launched_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lim_launched_rc_track_left_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
+    lim_launched_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6D80 */
 static void lim_launched_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1363,7 +1363,7 @@ static void lim_launched_rc_track_brakes(
 
 /** rct2: 0x008A6C10 */
 static void lim_launched_rc_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1404,15 +1404,15 @@ static void lim_launched_rc_track_90_deg_up(
 
 /** rct2: 0x008A6C20 */
 static void lim_launched_rc_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lim_launched_rc_track_90_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lim_launched_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6C30 */
 static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1455,15 +1455,15 @@ static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008A6C40 */
 static void lim_launched_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lim_launched_rc_track_60_deg_up_to_90_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    lim_launched_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6C50 */
 static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1501,7 +1501,7 @@ static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A6C60 */
 static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1545,7 +1545,7 @@ static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008A6C70 */
 static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1643,16 +1643,16 @@ static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
 
 /** rct2: 0x008A6C80 */
 static void lim_launched_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-        session, rideIndex, 2 - trackSequence, direction, height, tileElement);
+        session, ride, 2 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008A6D90 */
 static void lim_launched_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -1671,7 +1671,7 @@ static void lim_launched_rc_track_block_brakes(
 }
 
 static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1718,7 +1718,7 @@ static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008A6CA0 */
 static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1765,20 +1765,19 @@ static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008A6CB0 */
 static void lim_launched_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6CC0 */
 static void lim_launched_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    lim_launched_rc_track_left_quarter_turn_1_90_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_lim_launched_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -23,7 +23,7 @@
 
 /** rct2: 0x008A6370 */
 static void looping_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -79,7 +79,7 @@ static void looping_rc_track_flat(
 }
 
 static void looping_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint32_t stationTrackNESW = is_csg_loaded() ? LOOPING_RC_BOOSTER_NE_SW : 15016;
@@ -98,7 +98,7 @@ static void looping_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -106,7 +106,7 @@ static void looping_rc_track_station(
 
 /** rct2: 0x008A6380 */
 static void looping_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -176,7 +176,7 @@ static void looping_rc_track_25_deg_up(
 
 /** rct2: 0x008A6390 */
 static void looping_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -246,7 +246,7 @@ static void looping_rc_track_60_deg_up(
 
 /** rct2: 0x008A63A0 */
 static void looping_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -316,7 +316,7 @@ static void looping_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A63B0 */
 static void looping_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -394,7 +394,7 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A63C0 */
 static void looping_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -472,7 +472,7 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A63D0 */
 static void looping_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -542,55 +542,55 @@ static void looping_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A63E0 */
 static void looping_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A63F0 */
 static void looping_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6400 */
 static void looping_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6410 */
 static void looping_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6420 */
 static void looping_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6430 */
 static void looping_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6440 */
 static void looping_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -754,16 +754,16 @@ static void looping_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A6450 */
 static void looping_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    looping_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6460 */
 static void looping_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -801,7 +801,7 @@ static void looping_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A6470 */
 static void looping_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -839,7 +839,7 @@ static void looping_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A6480 */
 static void looping_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -877,7 +877,7 @@ static void looping_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A6490 */
 static void looping_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -915,7 +915,7 @@ static void looping_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A64A0 */
 static void looping_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1089,16 +1089,16 @@ static void looping_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A64B0 */
 static void looping_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    looping_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A64C0 */
 static void looping_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1143,7 +1143,7 @@ static void looping_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A64D0 */
 static void looping_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1188,7 +1188,7 @@ static void looping_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A64E0 */
 static void looping_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1233,7 +1233,7 @@ static void looping_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A64F0 */
 static void looping_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1278,39 +1278,39 @@ static void looping_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A6500 */
 static void looping_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6510 */
 static void looping_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6520 */
 static void looping_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6530 */
 static void looping_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6540 */
 static void looping_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1344,15 +1344,15 @@ static void looping_rc_track_left_bank(
 
 /** rct2: 0x008A6550 */
 static void looping_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6560 */
 static void looping_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1516,7 +1516,7 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6570 */
 static void looping_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1680,26 +1680,25 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6580 */
 static void looping_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    looping_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    looping_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6590 */
 static void looping_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    looping_rc_track_left_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A65A0 */
 static void looping_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1834,7 +1833,7 @@ static void looping_rc_track_s_bend_left(
 
 /** rct2: 0x008A65B0 */
 static void looping_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1969,7 +1968,7 @@ static void looping_rc_track_s_bend_right(
 
 /** rct2: 0x008A65C0 */
 static void looping_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2256,7 +2255,7 @@ static void looping_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A65D0 */
 static void looping_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2511,7 +2510,7 @@ static void looping_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A6630 */
 static void looping_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2614,16 +2613,16 @@ static void looping_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A6640 */
 static void looping_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    looping_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6650 */
 static void looping_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2735,16 +2734,16 @@ static void looping_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A6660 */
 static void looping_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    looping_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6670 */
 static void looping_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2823,7 +2822,7 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6680 */
 static void looping_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2909,26 +2908,25 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6690 */
 static void looping_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    looping_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    looping_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A66A0 */
 static void looping_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    looping_rc_track_left_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A66B0 */
 static void looping_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3146,7 +3144,7 @@ static void looping_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A66C0 */
 static void looping_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3364,7 +3362,7 @@ static void looping_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A66D0 */
 static void looping_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3373,13 +3371,12 @@ static void looping_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    looping_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    looping_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A66E0 */
 static void looping_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3388,13 +3385,12 @@ static void looping_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    looping_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A66F0 */
 static void looping_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3736,7 +3732,7 @@ static void looping_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A6700 */
 static void looping_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4078,7 +4074,7 @@ static void looping_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A6710 */
 static void looping_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4087,13 +4083,12 @@ static void looping_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    looping_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    looping_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6720 */
 static void looping_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4102,13 +4097,12 @@ static void looping_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    looping_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6750 */
 static void looping_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4145,7 +4139,7 @@ static void looping_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A6730 */
 static void looping_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4182,24 +4176,23 @@ static void looping_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A6740 */
 static void looping_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    looping_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6760 */
 static void looping_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_left_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    looping_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6770 */
 static void looping_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4231,7 +4224,7 @@ static void looping_rc_track_brakes(
 
 /** rct2: 0x008A6A40 */
 static void looping_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4272,7 +4265,7 @@ static void looping_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A6A50 */
 static void looping_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4313,7 +4306,7 @@ static void looping_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A6780 */
 static void looping_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4359,23 +4352,23 @@ static void looping_rc_track_on_ride_photo(
 
 /** rct2: 0x008A6A60 */
 static void looping_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_right_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6A70 */
 static void looping_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_left_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6860 */
 static void looping_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4514,7 +4507,7 @@ static void looping_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A6870 */
 static void looping_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4652,25 +4645,25 @@ static void looping_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A6880 */
 static void looping_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    looping_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6890 */
 static void looping_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    looping_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    looping_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A68A0 */
 static void looping_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4812,7 +4805,7 @@ static void looping_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A68B0 */
 static void looping_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4954,25 +4947,25 @@ static void looping_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A68C0 */
 static void looping_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    looping_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A68D0 */
 static void looping_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    looping_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    looping_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6790 */
 static void looping_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5118,7 +5111,7 @@ static void looping_rc_track_diag_flat(
 
 /** rct2: 0x008A67C0 */
 static void looping_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5264,7 +5257,7 @@ static void looping_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A67F0 */
 static void looping_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5410,7 +5403,7 @@ static void looping_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A67A0 */
 static void looping_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5556,7 +5549,7 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A67D0 */
 static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5702,7 +5695,7 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A67E0 */
 static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5848,7 +5841,7 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A67B0 */
 static void looping_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5994,7 +5987,7 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A6820 */
 static void looping_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6140,7 +6133,7 @@ static void looping_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A6850 */
 static void looping_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6286,7 +6279,7 @@ static void looping_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A6800 */
 static void looping_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6430,7 +6423,7 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A6830 */
 static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6576,7 +6569,7 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6840 */
 static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6722,7 +6715,7 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6810 */
 static void looping_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6868,7 +6861,7 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A6900 */
 static void looping_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6947,7 +6940,7 @@ static void looping_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A6910 */
 static void looping_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7026,7 +7019,7 @@ static void looping_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A6920 */
 static void looping_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7105,7 +7098,7 @@ static void looping_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A6930 */
 static void looping_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7184,7 +7177,7 @@ static void looping_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A6960 */
 static void looping_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7263,7 +7256,7 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A6970 */
 static void looping_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7342,7 +7335,7 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A6940 */
 static void looping_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7421,7 +7414,7 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A6950 */
 static void looping_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7500,7 +7493,7 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A6980 */
 static void looping_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7577,7 +7570,7 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A6990 */
 static void looping_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7654,7 +7647,7 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A69A0 */
 static void looping_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7733,7 +7726,7 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A69B0 */
 static void looping_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7812,7 +7805,7 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A68E0 */
 static void looping_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7888,7 +7881,7 @@ static void looping_rc_track_diag_left_bank(
 
 /** rct2: 0x008A68F0 */
 static void looping_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7964,7 +7957,7 @@ static void looping_rc_track_diag_right_bank(
 
 /** rct2: 0x008A6C00 */
 static void looping_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -7996,7 +7989,7 @@ static void looping_rc_track_block_brakes(
 
 /** rct2: 0x008A6BC0 */
 static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8078,7 +8071,7 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6BD0 */
 static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8167,27 +8160,27 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6BE0 */
 static void looping_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6BF0 */
 static void looping_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6B80 */
 static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8357,7 +8350,7 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6B90 */
 static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8527,27 +8520,27 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6BA0 */
 static void looping_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6BB0 */
 static void looping_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6A80 */
 static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8590,7 +8583,7 @@ static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A6A90 */
 static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8633,7 +8626,7 @@ static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A6AA0 */
 static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8676,7 +8669,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A6AB0 */
 static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8719,43 +8712,41 @@ static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A6AC0 */
 static void looping_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6AD0 */
 static void looping_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6AE0 */
 static void looping_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6AF0 */
 static void looping_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6B00 */
 static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8796,7 +8787,7 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A6B10 */
 static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8837,7 +8828,7 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A6B40 */
 static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8878,7 +8869,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A6B50 */
 static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8919,43 +8910,43 @@ static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A6B60 */
 static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6B70 */
 static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6B20 */
 static void looping_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6B30 */
 static void looping_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A69C0 */
 static void looping_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8998,7 +8989,7 @@ static void looping_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A69D0 */
 static void looping_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9041,7 +9032,7 @@ static void looping_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A69E0 */
 static void looping_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9084,7 +9075,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A69F0 */
 static void looping_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -9127,45 +9118,43 @@ static void looping_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A6A00 */
 static void looping_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_right_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6A10 */
 static void looping_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_left_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6A20 */
 static void looping_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A6A30 */
 static void looping_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    looping_rc_track_flat_to_left_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    looping_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void looping_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!is_csg_loaded())
     {
-        looping_rc_track_brakes(session, rideIndex, trackSequence, direction, height, tileElement);
+        looping_rc_track_brakes(session, ride, trackSequence, direction, height, tileElement);
         return;
     }
 

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008B08D0 */
 static void mine_ride_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void mine_ride_track_flat(
 }
 
 static void mine_ride_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -69,7 +69,7 @@ static void mine_ride_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -77,7 +77,7 @@ static void mine_ride_track_station(
 
 /** rct2: 0x008B08E0 */
 static void mine_ride_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -134,7 +134,7 @@ static void mine_ride_track_25_deg_up(
 
 /** rct2: 0x008B08F0 */
 static void mine_ride_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -191,7 +191,7 @@ static void mine_ride_track_flat_to_25_deg_up(
 
 /** rct2: 0x008B0900 */
 static void mine_ride_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -248,31 +248,31 @@ static void mine_ride_track_25_deg_up_to_flat(
 
 /** rct2: 0x008B0910 */
 static void mine_ride_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0920 */
 static void mine_ride_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0930 */
 static void mine_ride_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0940 */
 static void mine_ride_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -450,16 +450,16 @@ static void mine_ride_track_left_quarter_turn_5(
 
 /** rct2: 0x008B0950 */
 static void mine_ride_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_ride_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_ride_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0960 */
 static void mine_ride_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -513,7 +513,7 @@ static void mine_ride_track_flat_to_left_bank(
 
 /** rct2: 0x008B0970 */
 static void mine_ride_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -567,7 +567,7 @@ static void mine_ride_track_flat_to_right_bank(
 
 /** rct2: 0x008B0980 */
 static void mine_ride_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -621,7 +621,7 @@ static void mine_ride_track_left_bank_to_flat(
 
 /** rct2: 0x008B0990 */
 static void mine_ride_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -675,7 +675,7 @@ static void mine_ride_track_right_bank_to_flat(
 
 /** rct2: 0x008B09A0 */
 static void mine_ride_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -863,16 +863,16 @@ static void mine_ride_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008B09B0 */
 static void mine_ride_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_ride_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_ride_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B09C0 */
 static void mine_ride_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -933,7 +933,7 @@ static void mine_ride_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008B09D0 */
 static void mine_ride_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -994,7 +994,7 @@ static void mine_ride_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008B09E0 */
 static void mine_ride_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1055,7 +1055,7 @@ static void mine_ride_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008B09F0 */
 static void mine_ride_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1116,39 +1116,39 @@ static void mine_ride_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008B0A00 */
 static void mine_ride_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0A10 */
 static void mine_ride_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0A20 */
 static void mine_ride_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0A30 */
 static void mine_ride_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0A40 */
 static void mine_ride_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1198,15 +1198,15 @@ static void mine_ride_track_left_bank(
 
 /** rct2: 0x008B0A50 */
 static void mine_ride_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_ride_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0A60 */
 static void mine_ride_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1355,7 +1355,7 @@ static void mine_ride_track_s_bend_left(
 
 /** rct2: 0x008B0A70 */
 static void mine_ride_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1504,7 +1504,7 @@ static void mine_ride_track_s_bend_right(
 
 /** rct2: 0x008B0AB0 */
 static void mine_ride_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1621,16 +1621,16 @@ static void mine_ride_track_left_quarter_turn_3(
 
 /** rct2: 0x008B0AC0 */
 static void mine_ride_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_ride_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_ride_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0AD0 */
 static void mine_ride_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1756,16 +1756,16 @@ static void mine_ride_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008B0AE0 */
 static void mine_ride_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_ride_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_ride_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0AF0 */
 static void mine_ride_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2011,7 +2011,7 @@ static void mine_ride_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008B0B00 */
 static void mine_ride_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2257,7 +2257,7 @@ static void mine_ride_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008B0B10 */
 static void mine_ride_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -2266,13 +2266,12 @@ static void mine_ride_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_ride_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mine_ride_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0B20 */
 static void mine_ride_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -2281,13 +2280,12 @@ static void mine_ride_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_ride_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_ride_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0B30 */
 static void mine_ride_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2657,7 +2655,7 @@ static void mine_ride_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008B0B40 */
 static void mine_ride_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3027,7 +3025,7 @@ static void mine_ride_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008B0B50 */
 static void mine_ride_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3036,13 +3034,12 @@ static void mine_ride_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_ride_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mine_ride_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0B60 */
 static void mine_ride_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3051,13 +3048,12 @@ static void mine_ride_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_ride_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_ride_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0B70 */
 static void mine_ride_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3103,7 +3099,7 @@ static void mine_ride_track_on_ride_photo(
 
 /** rct2: 0x008B0B90 */
 static void mine_ride_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3249,7 +3245,7 @@ static void mine_ride_track_left_eighth_to_diag(
 
 /** rct2: 0x008B0BA0 */
 static void mine_ride_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3394,25 +3390,25 @@ static void mine_ride_track_right_eighth_to_diag(
 
 /** rct2: 0x008B0BB0 */
 static void mine_ride_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_ride_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0BC0 */
 static void mine_ride_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_ride_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mine_ride_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0BD0 */
 static void mine_ride_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3561,7 +3557,7 @@ static void mine_ride_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008B0BE0 */
 static void mine_ride_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3710,25 +3706,25 @@ static void mine_ride_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008B0BF0 */
 static void mine_ride_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_ride_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_ride_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0C00 */
 static void mine_ride_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_ride_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mine_ride_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008B0B80 */
 static void mine_ride_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3804,7 +3800,7 @@ static void mine_ride_track_diag_flat(
 
 /** rct2: 0x008B0C30 */
 static void mine_ride_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3880,7 +3876,7 @@ static void mine_ride_track_diag_25_deg_up(
 
 /** rct2: 0x008B0C10 */
 static void mine_ride_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3956,7 +3952,7 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008B0C20 */
 static void mine_ride_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4032,7 +4028,7 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008B0C60 */
 static void mine_ride_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4108,7 +4104,7 @@ static void mine_ride_track_diag_25_deg_down(
 
 /** rct2: 0x008B0C40 */
 static void mine_ride_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4182,7 +4178,7 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008B0C50 */
 static void mine_ride_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4258,7 +4254,7 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008B0C90 */
 static void mine_ride_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4337,7 +4333,7 @@ static void mine_ride_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008B0CA0 */
 static void mine_ride_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4416,7 +4412,7 @@ static void mine_ride_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008B0CB0 */
 static void mine_ride_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4495,7 +4491,7 @@ static void mine_ride_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008B0CC0 */
 static void mine_ride_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4574,7 +4570,7 @@ static void mine_ride_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008B0CF0 */
 static void mine_ride_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4653,7 +4649,7 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008B0D00 */
 static void mine_ride_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4732,7 +4728,7 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008B0CD0 */
 static void mine_ride_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4811,7 +4807,7 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008B0CE0 */
 static void mine_ride_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4890,7 +4886,7 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008B0D10 */
 static void mine_ride_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4967,7 +4963,7 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008B0D20 */
 static void mine_ride_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5044,7 +5040,7 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008B0D30 */
 static void mine_ride_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5123,7 +5119,7 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008B0D40 */
 static void mine_ride_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5202,7 +5198,7 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008B0C70 */
 static void mine_ride_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5278,7 +5274,7 @@ static void mine_ride_track_diag_left_bank(
 
 /** rct2: 0x008B0C80 */
 static void mine_ride_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _MineTrainBlockBrakeImages[NumOrthogonalDirectio
 
 /** rct2: 0x0071BFA4 */
 static void mine_train_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -86,7 +86,7 @@ static void mine_train_rc_track_flat(
 
 /** rct2: 0x0071C154, 0x0071C164, 0x0071C174 */
 static void mine_train_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -113,7 +113,7 @@ static void mine_train_rc_track_station(
             height);
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -121,7 +121,7 @@ static void mine_train_rc_track_station(
 
 /** rct2: 0x0071BFB4 */
 static void mine_train_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -190,7 +190,7 @@ static void mine_train_rc_track_25_deg_up(
 
 /** rct2: 0x0071BFC4 */
 static void mine_train_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -230,7 +230,7 @@ static void mine_train_rc_track_60_deg_up(
 
 /** rct2: 0x0071BFD4 */
 static void mine_train_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -299,7 +299,7 @@ static void mine_train_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0071BFE4 */
 static void mine_train_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -343,7 +343,7 @@ static void mine_train_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0071BFF4 */
 static void mine_train_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -387,7 +387,7 @@ static void mine_train_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0071C004 */
 static void mine_train_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -456,55 +456,55 @@ static void mine_train_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0071C014 */
 static void mine_train_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C024 */
 static void mine_train_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C034 */
 static void mine_train_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C044 */
 static void mine_train_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C054 */
 static void mine_train_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C064 */
 static void mine_train_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C0B4 */
 static void mine_train_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -692,16 +692,16 @@ static void mine_train_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0071C0C4 */
 static void mine_train_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_train_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C074 */
 static void mine_train_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -738,7 +738,7 @@ static void mine_train_rc_track_flat_to_left_bank(
 
 /** rct2: 0x0071C084 */
 static void mine_train_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -775,7 +775,7 @@ static void mine_train_rc_track_flat_to_right_bank(
 
 /** rct2: 0x0071C094 */
 static void mine_train_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -812,7 +812,7 @@ static void mine_train_rc_track_left_bank_to_flat(
 
 /** rct2: 0x0071C0A4 */
 static void mine_train_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -849,7 +849,7 @@ static void mine_train_rc_track_right_bank_to_flat(
 
 /** rct2: 0x0071C0D4 */
 static void mine_train_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1047,16 +1047,16 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x0071C0E4 */
 static void mine_train_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_train_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C204 */
 static void mine_train_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1100,7 +1100,7 @@ static void mine_train_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x0071C214 */
 static void mine_train_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1144,7 +1144,7 @@ static void mine_train_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x0071C224 */
 static void mine_train_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1188,7 +1188,7 @@ static void mine_train_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x0071C234 */
 static void mine_train_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1232,39 +1232,39 @@ static void mine_train_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x0071C244 */
 static void mine_train_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C254 */
 static void mine_train_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C264 */
 static void mine_train_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C274 */
 static void mine_train_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C304 */
 static void mine_train_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1297,15 +1297,15 @@ static void mine_train_rc_track_left_bank(
 
 /** rct2: 0x0071C314 */
 static void mine_train_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mine_train_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C0F4 */
 static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1493,7 +1493,7 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x0071C104 */
 static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1681,27 +1681,25 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x0071C114 */
 static void mine_train_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_train_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mine_train_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C124 */
 static void mine_train_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_train_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C134 */
 static void mine_train_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1840,7 +1838,7 @@ static void mine_train_rc_track_s_bend_left(
 
 /** rct2: 0x0071C144 */
 static void mine_train_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1979,7 +1977,7 @@ static void mine_train_rc_track_s_bend_right(
 
 /** rct2: 0x0071C184 */
 static void mine_train_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2101,16 +2099,16 @@ static void mine_train_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x0071C194 */
 static void mine_train_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_train_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C1A4 */
 static void mine_train_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2241,16 +2239,16 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x0071C1B4 */
 static void mine_train_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_train_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C1C4 */
 static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2350,7 +2348,7 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0071C1D4 */
 static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2450,27 +2448,25 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0071C1E4 */
 static void mine_train_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_train_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mine_train_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C1F4 */
 static void mine_train_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_train_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C284 */
 static void mine_train_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2738,7 +2734,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x0071C294 */
 static void mine_train_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3006,7 +3002,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x0071C2A4 */
 static void mine_train_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3016,12 +3012,12 @@ static void mine_train_rc_track_left_half_banked_helix_down_small(
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     mine_train_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C2B4 */
 static void mine_train_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3030,13 +3026,12 @@ static void mine_train_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mine_train_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C2C4 */
 static void mine_train_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3446,7 +3441,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x0071C2D4 */
 static void mine_train_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3844,7 +3839,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x0071C2E4 */
 static void mine_train_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3854,12 +3849,12 @@ static void mine_train_rc_track_left_half_banked_helix_down_large(
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     mine_train_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C2F4 */
 static void mine_train_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -3868,13 +3863,12 @@ static void mine_train_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mine_train_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mine_train_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C324 */
 static void mine_train_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3899,7 +3893,7 @@ static void mine_train_rc_track_brakes(
 
 /** rct2: 0x0071C334 */
 static void mine_train_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3933,7 +3927,7 @@ static void mine_train_rc_track_on_ride_photo(
 
 /** rct2: 0x0071C354 */
 static void mine_train_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4078,7 +4072,7 @@ static void mine_train_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x0071C364 */
 static void mine_train_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4222,25 +4216,25 @@ static void mine_train_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x0071C374 */
 static void mine_train_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_train_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C384 */
 static void mine_train_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_train_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mine_train_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C394 */
 static void mine_train_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4388,7 +4382,7 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x0071C3A4 */
 static void mine_train_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4536,25 +4530,25 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x0071C3B4 */
 static void mine_train_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_train_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mine_train_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C3C4 */
 static void mine_train_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mine_train_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mine_train_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x0071C344 */
 static void mine_train_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4708,7 +4702,7 @@ static void mine_train_rc_track_diag_flat(
 
 /** rct2: 0x0071C414 */
 static void mine_train_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4878,7 +4872,7 @@ static void mine_train_rc_track_diag_25_deg_up(
 
 /** rct2: 0x0071C474 */
 static void mine_train_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4956,7 +4950,7 @@ static void mine_train_rc_track_diag_60_deg_up(
 
 /** rct2: 0x0071C3F4 */
 static void mine_train_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5110,7 +5104,7 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x0071C454 */
 static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5188,7 +5182,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0071C464 */
 static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5266,7 +5260,7 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0071C404 */
 static void mine_train_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5436,7 +5430,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x0071C444 */
 static void mine_train_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5606,7 +5600,7 @@ static void mine_train_rc_track_diag_25_deg_down(
 
 /** rct2: 0x0071C4A4 */
 static void mine_train_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5684,7 +5678,7 @@ static void mine_train_rc_track_diag_60_deg_down(
 
 /** rct2: 0x0071C424 */
 static void mine_train_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5852,7 +5846,7 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x0071C484 */
 static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5930,7 +5924,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0071C494 */
 static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6008,7 +6002,7 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0071C434 */
 static void mine_train_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6162,7 +6156,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x0071C4D4 */
 static void mine_train_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6243,7 +6237,7 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x0071C4B4 */
 static void mine_train_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6324,7 +6318,7 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x0071C4C4 */
 static void mine_train_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6405,7 +6399,7 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x0071C4E4 */
 static void mine_train_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6486,7 +6480,7 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x0071C514 */
 static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6567,7 +6561,7 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x0071C524 */
 static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6648,7 +6642,7 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x0071C4F4 */
 static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6729,7 +6723,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x0071C504 */
 static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6810,7 +6804,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x0071C534 */
 static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6886,7 +6880,7 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x0071C544 */
 static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6962,7 +6956,7 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x0071C554 */
 static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7043,7 +7037,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x0071C564 */
 static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7124,7 +7118,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x0071C3D4 */
 static void mine_train_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7206,7 +7200,7 @@ static void mine_train_rc_track_diag_left_bank(
 
 /** rct2: 0x0071C3E4 */
 static void mine_train_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7288,7 +7282,7 @@ static void mine_train_rc_track_diag_right_bank(
 
 /** rct2: 0x0071C574 */
 static void mine_train_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _MiniRCBlockBrakeImages[NumOrthogonalDirections]
 
 /** rct2: 0x008A4ABC */
 static void mini_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -110,7 +110,7 @@ static void mini_rc_track_flat(
 }
 
 static void mini_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -136,7 +136,7 @@ static void mini_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -144,7 +144,7 @@ static void mini_rc_track_station(
 
 /** rct2: 0x008A4ACC */
 static void mini_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -246,7 +246,7 @@ static void mini_rc_track_25_deg_up(
 
 /** rct2: 0x008A4ADC */
 static void mini_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -303,7 +303,7 @@ static void mini_rc_track_60_deg_up(
 
 /** rct2: 0x008A4AEC */
 static void mini_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -405,7 +405,7 @@ static void mini_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A4AFC */
 static void mini_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -466,7 +466,7 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A4B0C */
 static void mini_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -527,7 +527,7 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A4B1C */
 static void mini_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -629,55 +629,55 @@ static void mini_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A4B2C */
 static void mini_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4B3C */
 static void mini_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4B4C */
 static void mini_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4B5C */
 static void mini_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4B6C */
 static void mini_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4B7C */
 static void mini_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4B8C */
 static void mini_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -855,16 +855,16 @@ static void mini_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A4B9C */
 static void mini_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4BAC */
 static void mini_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -918,7 +918,7 @@ static void mini_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A4BBC */
 static void mini_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -972,7 +972,7 @@ static void mini_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A4BCC */
 static void mini_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1026,7 +1026,7 @@ static void mini_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A4BDC */
 static void mini_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1080,7 +1080,7 @@ static void mini_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A4BEC */
 static void mini_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1268,16 +1268,16 @@ static void mini_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A4BFC */
 static void mini_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4C0C */
 static void mini_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1338,7 +1338,7 @@ static void mini_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A4C1C */
 static void mini_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1399,7 +1399,7 @@ static void mini_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A4C2C */
 static void mini_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1460,7 +1460,7 @@ static void mini_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A4C3C */
 static void mini_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1521,39 +1521,39 @@ static void mini_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A4C4C */
 static void mini_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4C5C */
 static void mini_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4C6C */
 static void mini_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4C7C */
 static void mini_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4C8C */
 static void mini_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1603,15 +1603,15 @@ static void mini_rc_track_left_bank(
 
 /** rct2: 0x008A4C9C */
 static void mini_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4CAC */
 static void mini_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1789,7 +1789,7 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A4CBC */
 static void mini_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1967,25 +1967,25 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A4CCC */
 static void mini_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_right_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4CDC */
 static void mini_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_left_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4CEC */
 static void mini_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2134,7 +2134,7 @@ static void mini_rc_track_s_bend_left(
 
 /** rct2: 0x008A4CFC */
 static void mini_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2283,7 +2283,7 @@ static void mini_rc_track_s_bend_right(
 
 /** rct2: 0x008A4D3C */
 static void mini_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2400,16 +2400,16 @@ static void mini_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A4D4C */
 static void mini_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4D5C */
 static void mini_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2535,16 +2535,16 @@ static void mini_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A4D6C */
 static void mini_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4D7C */
 static void mini_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2637,7 +2637,7 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A4D8C */
 static void mini_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2730,25 +2730,25 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A4D9C */
 static void mini_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_right_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4DAC */
 static void mini_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_left_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4DBC */
 static void mini_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2994,7 +2994,7 @@ static void mini_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A4DCC */
 static void mini_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3240,7 +3240,7 @@ static void mini_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A4DDC */
 static void mini_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3249,12 +3249,12 @@ static void mini_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_right_half_banked_helix_up_small(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4DEC */
 static void mini_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -3263,12 +3263,12 @@ static void mini_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_left_half_banked_helix_up_small(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4DFC */
 static void mini_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3638,7 +3638,7 @@ static void mini_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A4E0C */
 static void mini_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4008,7 +4008,7 @@ static void mini_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A4E1C */
 static void mini_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4017,12 +4017,12 @@ static void mini_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_right_half_banked_helix_up_large(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4E2C */
 static void mini_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4031,12 +4031,12 @@ static void mini_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_left_half_banked_helix_up_large(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4E5C */
 static void mini_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4073,7 +4073,7 @@ static void mini_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A4E3C */
 static void mini_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4110,23 +4110,23 @@ static void mini_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A4E4C */
 static void mini_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_right_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4E6C */
 static void mini_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_left_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4E7C */
 static void mini_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4160,7 +4160,7 @@ static void mini_rc_track_brakes(
 
 /** rct2: 0x008A50CC */
 static void mini_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4217,7 +4217,7 @@ static void mini_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A50DC */
 static void mini_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4274,7 +4274,7 @@ static void mini_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A4E8C */
 static void mini_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4320,23 +4320,23 @@ static void mini_rc_track_on_ride_photo(
 
 /** rct2: 0x008A50EC */
 static void mini_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_right_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A50FC */
 static void mini_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_left_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4EAC */
 static void mini_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4482,7 +4482,7 @@ static void mini_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A4EBC */
 static void mini_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4627,25 +4627,25 @@ static void mini_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A4ECC */
 static void mini_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mini_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4EDC */
 static void mini_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mini_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mini_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4EEC */
 static void mini_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4794,7 +4794,7 @@ static void mini_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A4EFC */
 static void mini_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4943,25 +4943,25 @@ static void mini_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A4F0C */
 static void mini_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mini_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4F1C */
 static void mini_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mini_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mini_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A4E9C */
 static void mini_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5107,7 +5107,7 @@ static void mini_rc_track_diag_flat(
 
 /** rct2: 0x008A4F4C */
 static void mini_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5253,7 +5253,7 @@ static void mini_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A4FAC */
 static void mini_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5329,7 +5329,7 @@ static void mini_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A4F2C */
 static void mini_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5475,7 +5475,7 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A4F8C */
 static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5551,7 +5551,7 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A4F9C */
 static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5627,7 +5627,7 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A4F3C */
 static void mini_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5773,7 +5773,7 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A4F7C */
 static void mini_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5919,7 +5919,7 @@ static void mini_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A4FDC */
 static void mini_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5995,7 +5995,7 @@ static void mini_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A4F5C */
 static void mini_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6139,7 +6139,7 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A4FBC */
 static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6215,7 +6215,7 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A4FCC */
 static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6291,7 +6291,7 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A4F6C */
 static void mini_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6437,7 +6437,7 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A500C */
 static void mini_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6516,7 +6516,7 @@ static void mini_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A501C */
 static void mini_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6595,7 +6595,7 @@ static void mini_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A502C */
 static void mini_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6674,7 +6674,7 @@ static void mini_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A503C */
 static void mini_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6753,7 +6753,7 @@ static void mini_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A506C */
 static void mini_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6832,7 +6832,7 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A507C */
 static void mini_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6911,7 +6911,7 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A504C */
 static void mini_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6990,7 +6990,7 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A505C */
 static void mini_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7069,7 +7069,7 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A508C */
 static void mini_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7146,7 +7146,7 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A509C */
 static void mini_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7223,7 +7223,7 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A50AC */
 static void mini_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7302,7 +7302,7 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A50BC */
 static void mini_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7381,7 +7381,7 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A4FEC */
 static void mini_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7457,7 +7457,7 @@ static void mini_rc_track_diag_left_bank(
 
 /** rct2: 0x008A4FFC */
 static void mini_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7533,7 +7533,7 @@ static void mini_rc_track_diag_right_bank(
 
 /** rct2: 0x008A530C */
 static void mini_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -7567,7 +7567,7 @@ static void mini_rc_track_block_brakes(
 
 /** rct2: 0x008A510C */
 static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7663,7 +7663,7 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A511C */
 static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7759,27 +7759,25 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A512C */
 static void mini_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_banked_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A513C */
 static void mini_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_banked_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A514C */
 static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7963,7 +7961,7 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A515C */
 static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8147,27 +8145,25 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A516C */
 static void mini_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    mini_rc_track_right_banked_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A517C */
 static void mini_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_rc_track_left_banked_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A518C */
 static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8226,7 +8222,7 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A519C */
 static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8285,7 +8281,7 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A51AC */
 static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8344,7 +8340,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A51BC */
 static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8403,43 +8399,39 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A51CC */
 static void mini_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A51DC */
 static void mini_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A51EC */
 static void mini_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A51FC */
 static void mini_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A520C */
 static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8496,7 +8488,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A521C */
 static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8553,7 +8545,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A524C */
 static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8610,7 +8602,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A525C */
 static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8667,43 +8659,43 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A526C */
 static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A527C */
 static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A522C */
 static void mini_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A523C */
 static void mini_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A528C */
 static void mini_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8762,7 +8754,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A529C */
 static void mini_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8821,7 +8813,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A52AC */
 static void mini_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8880,7 +8872,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A52BC */
 static void mini_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -8939,38 +8931,38 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A52CC */
 static void mini_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_right_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A52DC */
 static void mini_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_left_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A52EC */
 static void mini_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_flat_to_right_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A52FC */
 static void mini_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_rc_track_flat_to_left_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void mini_rc_track_left_curved_lift_hill(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9062,7 +9054,7 @@ static void mini_rc_track_left_curved_lift_hill(
 }
 
 static void mini_rc_track_right_curved_lift_hill(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9154,7 +9146,7 @@ static void mini_rc_track_right_curved_lift_hill(
 }
 
 static void mini_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008AFE9C */
 static void mini_suspended_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -81,7 +81,7 @@ static void mini_suspended_rc_track_flat(
 
 /** rct2: 0x008AFF4C, 0x008AFF5C, 0x008AFF6C */
 static void mini_suspended_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -99,7 +99,7 @@ static void mini_suspended_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24, 0, 2,
         height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -107,7 +107,7 @@ static void mini_suspended_rc_track_station(
 
 /** rct2: 0x008AFEAC */
 static void mini_suspended_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -201,7 +201,7 @@ static void mini_suspended_rc_track_25_deg_up(
 
 /** rct2: 0x008AFEBC */
 static void mini_suspended_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -295,7 +295,7 @@ static void mini_suspended_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AFECC */
 static void mini_suspended_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -389,31 +389,31 @@ static void mini_suspended_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AFEDC */
 static void mini_suspended_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_suspended_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_suspended_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFEEC */
 static void mini_suspended_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_suspended_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_suspended_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFEFC */
 static void mini_suspended_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    mini_suspended_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_suspended_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFF0C */
 static void mini_suspended_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -600,16 +600,16 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AFF1C */
 static void mini_suspended_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    mini_suspended_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_suspended_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFF2C */
 static void mini_suspended_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -790,7 +790,7 @@ static void mini_suspended_rc_track_s_bend_left(
 
 /** rct2: 0x008AFF3C */
 static void mini_suspended_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -971,7 +971,7 @@ static void mini_suspended_rc_track_s_bend_right(
 
 /** rct2: 0x008AFF7C */
 static void mini_suspended_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1101,16 +1101,16 @@ static void mini_suspended_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AFF8C */
 static void mini_suspended_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    mini_suspended_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    mini_suspended_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFFAC */
 static void mini_suspended_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1284,7 +1284,7 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AFFBC */
 static void mini_suspended_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1458,25 +1458,25 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AFFCC */
 static void mini_suspended_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mini_suspended_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    mini_suspended_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFFDC */
 static void mini_suspended_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    mini_suspended_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    mini_suspended_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AFF9C */
 static void mini_suspended_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1615,7 +1615,7 @@ static void mini_suspended_rc_track_diag_flat(
 
 /** rct2: 0x008B000C */
 static void mini_suspended_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1754,7 +1754,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AFFEC */
 static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1893,7 +1893,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AFFFC */
 static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2032,7 +2032,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008B003C */
 static void mini_suspended_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2171,7 +2171,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008B001C */
 static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2307,7 +2307,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008B002C */
 static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -35,7 +35,7 @@ static constexpr const uint32_t MULTI_DIM_INVERTED_BLOCK_BRAKE_NW_SE_CLOSED = 26
 
 /** rct2: 0x00792D88 */
 static void multi_dimension_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -119,7 +119,7 @@ static void multi_dimension_rc_track_flat(
 
 /** rct2: 0x00792F98, 0x00792FA8, 0x00792FB8 */
 static void multi_dimension_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[NumOrthogonalDirections][3] = {
@@ -145,7 +145,6 @@ static void multi_dimension_rc_track_station(
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         auto stationObj = ride_get_station_object(ride);
@@ -180,7 +179,7 @@ static void multi_dimension_rc_track_station(
 
 /** rct2: 0x00792D98 */
 static void multi_dimension_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -315,7 +314,7 @@ static void multi_dimension_rc_track_25_deg_up(
 
 /** rct2: 0x00792DA8 */
 static void multi_dimension_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -396,7 +395,7 @@ static void multi_dimension_rc_track_60_deg_up(
 
 /** rct2: 0x00792DB8 */
 static void multi_dimension_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -531,7 +530,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x00792DC8 */
 static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -622,7 +621,7 @@ static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00792DD8 */
 static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -737,7 +736,7 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00792DE8 */
 static void multi_dimension_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -872,57 +871,55 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x00792DF8 */
 static void multi_dimension_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E08 */
 static void multi_dimension_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E18 */
 static void multi_dimension_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E28 */
 static void multi_dimension_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E38 */
 static void multi_dimension_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E48 */
 static void multi_dimension_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E58 */
 static void multi_dimension_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1289,16 +1286,16 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x00792E68 */
 static void multi_dimension_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    multi_dimension_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    multi_dimension_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792E78 */
 static void multi_dimension_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1378,7 +1375,7 @@ static void multi_dimension_rc_track_flat_to_left_bank(
 
 /** rct2: 0x00792E88 */
 static void multi_dimension_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1458,7 +1455,7 @@ static void multi_dimension_rc_track_flat_to_right_bank(
 
 /** rct2: 0x00792E98 */
 static void multi_dimension_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1538,7 +1535,7 @@ static void multi_dimension_rc_track_left_bank_to_flat(
 
 /** rct2: 0x00792EA8 */
 static void multi_dimension_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1618,7 +1615,7 @@ static void multi_dimension_rc_track_right_bank_to_flat(
 
 /** rct2: 0x00792EB8 */
 static void multi_dimension_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -1986,17 +1983,16 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x00792EC8 */
 static void multi_dimension_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    multi_dimension_rc_track_banked_left_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    multi_dimension_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792ED8 */
 static void multi_dimension_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2107,7 +2103,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x00792EE8 */
 static void multi_dimension_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2218,7 +2214,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x00792EF8 */
 static void multi_dimension_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2329,7 +2325,7 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x00792F08 */
 static void multi_dimension_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2440,43 +2436,39 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x00792F18 */
 static void multi_dimension_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792F28 */
 static void multi_dimension_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792F38 */
 static void multi_dimension_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792F48 */
 static void multi_dimension_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792F58 */
 static void multi_dimension_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2552,15 +2544,15 @@ static void multi_dimension_rc_track_left_bank(
 
 /** rct2: 0x00792F68 */
 static void multi_dimension_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792F78 */
 static void multi_dimension_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -2875,7 +2867,7 @@ static void multi_dimension_rc_track_s_bend_left(
 
 /** rct2: 0x00792F88 */
 static void multi_dimension_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3190,7 +3182,7 @@ static void multi_dimension_rc_track_s_bend_right(
 
 /** rct2: 0x00792FC8 */
 static void multi_dimension_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3427,16 +3419,16 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00792FD8 */
 static void multi_dimension_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    multi_dimension_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    multi_dimension_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00792FE8 */
 static void multi_dimension_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -3679,17 +3671,16 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x00792FF8 */
 static void multi_dimension_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    multi_dimension_rc_track_left_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    multi_dimension_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793008 */
 static void multi_dimension_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3905,7 +3896,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x00793018 */
 static void multi_dimension_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4121,7 +4112,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x00793028 */
 static void multi_dimension_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -4131,12 +4122,12 @@ static void multi_dimension_rc_track_left_half_banked_helix_down_small(
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     multi_dimension_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793038 */
 static void multi_dimension_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -4146,12 +4137,12 @@ static void multi_dimension_rc_track_right_half_banked_helix_down_small(
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     multi_dimension_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793048 */
 static void multi_dimension_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4491,7 +4482,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x00793058 */
 static void multi_dimension_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4831,7 +4822,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x00793068 */
 static void multi_dimension_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4841,12 +4832,12 @@ static void multi_dimension_rc_track_left_half_banked_helix_down_large(
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     multi_dimension_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793078 */
 static void multi_dimension_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4856,12 +4847,12 @@ static void multi_dimension_rc_track_right_half_banked_helix_down_large(
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     multi_dimension_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793088 */
 static void multi_dimension_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -4921,7 +4912,7 @@ static void multi_dimension_rc_track_brakes(
 
 /** rct2: 0x00793098 */
 static void multi_dimension_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5032,7 +5023,7 @@ static void multi_dimension_rc_track_on_ride_photo(
 
 /** rct2: 0x00793328 */
 static void multi_dimension_rc_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5113,15 +5104,15 @@ static void multi_dimension_rc_track_90_deg_up(
 
 /** rct2: 0x00793338 */
 static void multi_dimension_rc_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_90_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793348 */
 static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5210,16 +5201,15 @@ static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x00793358 */
 static void multi_dimension_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    multi_dimension_rc_track_60_deg_up_to_90_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793368 */
 static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5300,7 +5290,7 @@ static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x00793378 */
 static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5387,7 +5377,7 @@ static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x007930B8 */
 static void multi_dimension_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5692,7 +5682,7 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007930C8 */
 static void multi_dimension_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -5997,25 +5987,25 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007930D8 */
 static void multi_dimension_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    multi_dimension_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x007930E8 */
 static void multi_dimension_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    multi_dimension_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    multi_dimension_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x007930F8 */
 static void multi_dimension_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6321,7 +6311,7 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x00793108 */
 static void multi_dimension_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6627,27 +6617,25 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x00793118 */
 static void multi_dimension_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    multi_dimension_rc_track_right_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    multi_dimension_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00793128 */
 static void multi_dimension_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    multi_dimension_rc_track_left_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    multi_dimension_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x007930A8 */
 static void multi_dimension_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -6939,7 +6927,7 @@ static void multi_dimension_rc_track_diag_flat(
 
 /** rct2: 0x00793158 */
 static void multi_dimension_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7231,7 +7219,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
 
 /** rct2: 0x007931B8 */
 static void multi_dimension_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7397,7 +7385,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
 
 /** rct2: 0x00793138 */
 static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7689,7 +7677,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00793198 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -7855,7 +7843,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007931A8 */
 static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8021,7 +8009,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00793148 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8313,7 +8301,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00793188 */
 static void multi_dimension_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8549,7 +8537,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
 
 /** rct2: 0x007931E8 */
 static void multi_dimension_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8715,7 +8703,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
 
 /** rct2: 0x00793168 */
 static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -8947,7 +8935,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x007931C8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9113,7 +9101,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007931D8 */
 static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9279,7 +9267,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00793178 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9515,7 +9503,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x00793218 */
 static void multi_dimension_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9685,7 +9673,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x00793228 */
 static void multi_dimension_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -9855,7 +9843,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x00793238 */
 static void multi_dimension_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10025,7 +10013,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x00793248 */
 static void multi_dimension_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10195,7 +10183,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x00793278 */
 static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10364,7 +10352,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x00793288 */
 static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10533,7 +10521,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x00793258 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10702,7 +10690,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x00793268 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -10871,7 +10859,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x00793298 */
 static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11033,7 +11021,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x007932A8 */
 static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11195,7 +11183,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x007932B8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11364,7 +11352,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x007932C8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11533,7 +11521,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x007931F8 */
 static void multi_dimension_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11700,7 +11688,7 @@ static void multi_dimension_rc_track_diag_left_bank(
 
 /** rct2: 0x00793208 */
 static void multi_dimension_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -11867,7 +11855,7 @@ static void multi_dimension_rc_track_diag_right_bank(
 
 /** rct2: 0x007932D8 */
 static void multi_dimension_rc_track_left_flyer_twist_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11979,7 +11967,7 @@ static void multi_dimension_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x007932E8 */
 static void multi_dimension_rc_track_right_flyer_twist_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -12089,7 +12077,7 @@ static void multi_dimension_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x007932F8 */
 static void multi_dimension_rc_track_left_flyer_twist_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -12201,7 +12189,7 @@ static void multi_dimension_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x00793308 */
 static void multi_dimension_rc_track_right_flyer_twist_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -12311,7 +12299,7 @@ static void multi_dimension_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x00793398 */
 static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12510,7 +12498,7 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
 
 /** rct2: 0x00793318 */
 static void multi_dimension_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();
@@ -12561,7 +12549,7 @@ static void multi_dimension_rc_track_block_brakes(
 
 /** rct2: 0x00793388 */
 static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12756,7 +12744,7 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
 
 /** rct2: 0x00793398 */
 static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())
@@ -12955,7 +12943,7 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
 
 /** rct2: 0x00793388 */
 static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (!tileElement->AsTrack()->IsInverted())

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -196,7 +196,7 @@ static constexpr const uint32_t reverse_freefall_rc_track_pieces_vertical_suppor
 };
 
 static void paint_reverse_freefall_rc_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction & 1)
@@ -218,7 +218,7 @@ static void paint_reverse_freefall_rc_flat(
 }
 
 static void paint_reverse_freefall_rc_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -252,7 +252,6 @@ static void paint_reverse_freefall_rc_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, tileElement);
 
@@ -261,7 +260,7 @@ static void paint_reverse_freefall_rc_station(
 }
 
 static void paint_reverse_freefall_rc_slope(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     TESTPAINT_IGNORE_ALL();
@@ -357,7 +356,7 @@ static void paint_reverse_freefall_rc_slope(
 }
 
 static void paint_reverse_freefall_rc_vertical(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t supportsImageId, trackImageId;
@@ -388,7 +387,7 @@ static void paint_reverse_freefall_rc_vertical(
 }
 
 static void paint_reverse_freefall_rc_onride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -47,7 +47,7 @@ void vehicle_visual_reverser(
 
 /** rct2: 0x0086E65C */
 static void reverser_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -92,7 +92,7 @@ static void reverser_rc_track_flat(
 }
 
 static void reverser_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -108,7 +108,7 @@ static void reverser_rc_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2,
         height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -116,7 +116,7 @@ static void reverser_rc_track_station(
 
 /** rct2: 0x0086E66C */
 static void reverser_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -185,7 +185,7 @@ static void reverser_rc_track_25_deg_up(
 
 /** rct2: 0x0086E67C */
 static void reverser_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -254,7 +254,7 @@ static void reverser_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0086E68C */
 static void reverser_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -323,31 +323,31 @@ static void reverser_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0086E69C */
 static void reverser_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    reverser_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    reverser_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0086E6AC */
 static void reverser_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    reverser_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    reverser_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0086E6BC */
 static void reverser_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    reverser_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    reverser_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0086E6CC */
 static void reverser_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -528,16 +528,16 @@ static void reverser_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0086E6DC */
 static void reverser_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    reverser_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    reverser_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0086E6EC */
 static void reverser_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -676,7 +676,7 @@ static void reverser_rc_track_s_bend_left(
 
 /** rct2: 0x0086E6FC */
 static void reverser_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -815,7 +815,7 @@ static void reverser_rc_track_s_bend_right(
 
 /** rct2: 0x0086E73C */
 static void reverser_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -922,16 +922,16 @@ static void reverser_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x0086E74C */
 static void reverser_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    reverser_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    reverser_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0086E75C */
 static void reverser_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -956,7 +956,7 @@ static void reverser_rc_track_brakes(
 
 /** rct2: 0x0086E76C */
 static void reverser_rc_track_left_reverser(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1141,7 +1141,7 @@ static void reverser_rc_track_left_reverser(
 
 /** rct2: 0x0086E77C */
 static void reverser_rc_track_right_reverser(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -67,7 +67,7 @@ constexpr int32_t SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_3_A = 21879;
 
 /** rct2: 0x0077839C */
 static void side_friction_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -139,7 +139,7 @@ static void side_friction_rc_track_flat(
 
 /** rct2: 0x007784AC, 0x007784BC, 0x007784CC */
 static void side_friction_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -152,7 +152,7 @@ static void side_friction_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2, height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -160,7 +160,7 @@ static void side_friction_rc_track_station(
 
 /** rct2: 0x007783AC */
 static void side_friction_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -245,7 +245,7 @@ static void side_friction_rc_track_25_deg_up(
 
 /** rct2: 0x007783CC */
 static void side_friction_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -330,7 +330,7 @@ static void side_friction_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x007783FC */
 static void side_friction_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -415,31 +415,31 @@ static void side_friction_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0077840C */
 static void side_friction_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    side_friction_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0077842C */
 static void side_friction_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    side_friction_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0077845C */
 static void side_friction_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    side_friction_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0077846C */
 static void side_friction_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -680,16 +680,16 @@ static void side_friction_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0077847C */
 static void side_friction_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    side_friction_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    side_friction_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0077848C */
 static void side_friction_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -876,7 +876,7 @@ static void side_friction_rc_track_s_bend_left(
 
 /** rct2: 0x0077849C */
 static void side_friction_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1063,7 +1063,7 @@ static void side_friction_rc_track_s_bend_right(
 
 /** rct2: 0x007784DC */
 static void side_friction_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1206,16 +1206,16 @@ static void side_friction_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x007784EC */
 static void side_friction_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    side_friction_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    side_friction_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x007784FC */
 static void side_friction_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1244,7 +1244,7 @@ static void side_friction_rc_track_brakes(
 
 /** rct2: 0x007785DC */
 static void side_friction_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1437,7 +1437,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007785EC */
 static void side_friction_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1629,25 +1629,25 @@ static void side_friction_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007785FC */
 static void side_friction_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    side_friction_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    side_friction_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0077860C */
 static void side_friction_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    side_friction_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    side_friction_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x0077850C */
 static void side_friction_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1813,7 +1813,7 @@ static void side_friction_rc_track_diag_flat(
 
 /** rct2: 0x0077853C */
 static void side_friction_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1995,7 +1995,7 @@ static void side_friction_rc_track_diag_25_deg_up(
 
 /** rct2: 0x0077851C */
 static void side_friction_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2161,7 +2161,7 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x0077852C */
 static void side_friction_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2343,7 +2343,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x0077859C */
 static void side_friction_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2525,7 +2525,7 @@ static void side_friction_rc_track_diag_25_deg_down(
 
 /** rct2: 0x0077857C */
 static void side_friction_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2702,7 +2702,7 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x0077858C */
 static void side_friction_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2867,7 +2867,7 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
 }
 
 static void side_friction_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -2926,14 +2926,14 @@ static void side_friction_rc_track_60_deg_up(
 }
 
 static void side_friction_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    side_friction_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void side_friction_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -2989,14 +2989,14 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
 }
 
 static void side_friction_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    side_friction_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void side_friction_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -3052,14 +3052,14 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
 }
 
 static void side_friction_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    side_friction_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void side_friction_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3144,14 +3144,14 @@ static void side_friction_rc_track_diag_60_deg_up(
 }
 
 static void side_friction_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    side_friction_rc_track_diag_60_deg_up(session, rideIndex, 3 - trackSequence, (direction + 2) % 4, height, tileElement);
+    side_friction_rc_track_diag_60_deg_up(session, ride, 3 - trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3240,15 +3240,15 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
 }
 
 static void side_friction_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
-        session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
 };
 
 static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3335,11 +3335,11 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
 }
 
 static void side_friction_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
-        session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
 };
 
 TRACK_PAINT_FUNCTION get_track_paint_function_side_friction_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
@@ -27,7 +27,7 @@
 namespace SingleRailRC
 {
     static void TrackFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -91,7 +91,7 @@ namespace SingleRailRC
     }
 
     static void TrackStation(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -117,14 +117,14 @@ namespace SingleRailRC
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 28, 2, height - 2, 0, 2,
             height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-        track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 4, 7);
+        track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 4, 7);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
     }
 
     static void Track25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -203,7 +203,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -282,7 +282,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -361,7 +361,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpTo60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -452,7 +452,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -543,7 +543,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -622,49 +622,49 @@ namespace SingleRailRC
     }
 
     static void Track25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownTo60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpTo60DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track90DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -704,14 +704,14 @@ namespace SingleRailRC
     }
 
     static void Track90DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track90DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegUpTo90DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -760,14 +760,14 @@ namespace SingleRailRC
     }
 
     static void Track90DegDownTo60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpTo90DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpTo90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track90DegUpTo60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -808,7 +808,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegDownTo90DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -851,7 +851,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -979,15 +979,15 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftQuarterTurn3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1188,15 +1188,15 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftQuarterTurn5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1361,7 +1361,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1526,23 +1526,23 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackRightEighthToDiag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightEighthToDiag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackLeftEighthToDiag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+        TrackLeftEighthToDiag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
     }
 
     static void TrackDiagFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1699,7 +1699,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -1856,7 +1856,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2013,7 +2013,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2170,7 +2170,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2327,7 +2327,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2482,7 +2482,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2639,7 +2639,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2796,7 +2796,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpTo60DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -2953,7 +2953,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3110,7 +3110,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3267,7 +3267,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownTo60DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3424,7 +3424,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -3581,7 +3581,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3624,7 +3624,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3667,21 +3667,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToRightBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBankToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToLeftBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3731,7 +3731,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3781,7 +3781,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3831,7 +3831,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3881,35 +3881,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToRightBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToLeftBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBankTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBankTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -3946,14 +3946,14 @@ namespace SingleRailRC
     }
 
     static void TrackRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4040,7 +4040,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4127,7 +4127,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4214,7 +4214,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4301,7 +4301,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4388,7 +4388,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4475,7 +4475,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4562,7 +4562,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4649,7 +4649,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4734,7 +4734,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4819,7 +4819,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4906,7 +4906,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -4993,7 +4993,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5076,7 +5076,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5159,7 +5159,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5295,15 +5295,15 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftQuarterTurn3Bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn3Bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5512,15 +5512,15 @@ namespace SingleRailRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackBankedLeftQuarterTurn5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackBankedLeftQuarterTurn5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5685,7 +5685,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5850,23 +5850,23 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackRightEighthBankToDiag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightEighthBankToDiag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-        TrackLeftEighthBankToDiag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+        TrackLeftEighthBankToDiag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -5964,7 +5964,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6068,23 +6068,23 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackRightQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn525DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6285,7 +6285,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn525DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6486,23 +6486,23 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn525DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackRightQuarterTurn525DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn525DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn525DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftQuarterTurn525DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn525DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn160DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6546,7 +6546,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn160DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6590,21 +6590,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn160DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightQuarterTurn160DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn160DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn160DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftQuarterTurn160DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn160DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftQuarterTurn190DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6656,7 +6656,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn190DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -6708,21 +6708,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn190DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightQuarterTurn190DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightQuarterTurn190DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightQuarterTurn190DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftQuarterTurn190DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftQuarterTurn190DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void Track25DegUpToLeftBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6774,7 +6774,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToRightBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6826,7 +6826,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6878,7 +6878,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpTo25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -6930,35 +6930,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToRightBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBanked25DegDownTo25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpToLeftBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToLeftBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBanked25DegUpTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownToRightBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBanked25DegUpTo25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7006,7 +7006,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedFlatToRightBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7054,7 +7054,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpToLeftBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7102,7 +7102,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpToRightBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7150,35 +7150,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBanked25DegUpToRightBankedFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBanked25DegUpToRightBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBankedFlatToRightBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBanked25DegUpToLeftBankedFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBanked25DegUpToLeftBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBanked25DegDownToLeftBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBankedFlatToRightBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBankedFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBanked25DegDownToRightBankedFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBankedFlatToLeftBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBankedFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegUpLeftBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7226,7 +7226,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpRightBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7274,21 +7274,21 @@ namespace SingleRailRC
     }
 
     static void Track25DegDownLeftBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpRightBanked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpRightBanked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track25DegDownRightBanked(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track25DegUpLeftBanked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track25DegUpLeftBanked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackFlatToLeftBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7340,7 +7340,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToRightBanked25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7392,7 +7392,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7444,7 +7444,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -7496,35 +7496,35 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToLeftBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBanked25DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackFlatToRightBanked25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBanked25DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBanked25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToRightBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBanked25DegDownToFlat(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatToLeftBanked25DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7622,7 +7622,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7726,23 +7726,23 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackRightBankedQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightBankedQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftBankedQuarterTurn3Tile25DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftBankedQuarterTurn3Tile25DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftBankedQuarterTurn525DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -7943,7 +7943,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn525DegUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8144,23 +8144,23 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn525DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackRightBankedQuarterTurn525DegUp(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightBankedQuarterTurn525DegUp(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightBankedQuarterTurn525DegDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftBankedQuarterTurn525DegUp(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftBankedQuarterTurn525DegUp(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackSBendLeft(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8314,7 +8314,7 @@ namespace SingleRailRC
     }
 
     static void TrackSBendRight(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8468,7 +8468,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -8735,7 +8735,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9002,7 +9002,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 4)
@@ -9011,11 +9011,11 @@ namespace SingleRailRC
             direction = (direction - 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackRightHalfBankedHelixUpSmall(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightHalfBankedHelixUpSmall(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 4)
@@ -9024,11 +9024,11 @@ namespace SingleRailRC
             direction = (direction + 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-        TrackLeftHalfBankedHelixUpSmall(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftHalfBankedHelixUpSmall(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9440,7 +9440,7 @@ namespace SingleRailRC
         }
     }
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -9865,7 +9865,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 7)
@@ -9874,11 +9874,11 @@ namespace SingleRailRC
             direction = (direction - 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackRightHalfBankedHelixUpLarge(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightHalfBankedHelixUpLarge(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (trackSequence >= 7)
@@ -9887,11 +9887,11 @@ namespace SingleRailRC
             direction = (direction + 1) & 3;
         }
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-        TrackLeftHalfBankedHelixUpLarge(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftHalfBankedHelixUpLarge(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void TrackLeftBarrelRollUpToDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10072,7 +10072,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBarrelRollUpToDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10253,21 +10253,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBarrelRollDownToUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftBarrelRollUpToDown(session, rideIndex, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackLeftBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackRightBarrelRollDownToUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightBarrelRollUpToDown(session, rideIndex, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackRightBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackHalfLoopUp(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10408,14 +10408,14 @@ namespace SingleRailRC
     }
 
     static void TrackHalfLoopDown(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackHalfLoopUp(session, rideIndex, 3 - trackSequence, direction, height, tileElement);
+        TrackHalfLoopUp(session, ride, 3 - trackSequence, direction, height, tileElement);
     }
 
     static void TrackBrakes(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -10444,7 +10444,7 @@ namespace SingleRailRC
     }
 
     static void TrackOnRidePhoto(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -10501,7 +10501,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegUpLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10670,7 +10670,7 @@ namespace SingleRailRC
         }
     }
     static void Track60DegUpToFlatLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -10840,21 +10840,21 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegDownLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpToFlatLongBase(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpToFlatLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDownToFlatLongBase(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatTo60DegUpLongBase(session, rideIndex, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatTo60DegUpLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackBlockBrakes(
-        paint_session* session, uint16_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (direction)
@@ -10883,7 +10883,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftCorkscrewUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11000,7 +11000,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightCorkscrewUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11115,21 +11115,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftCorkscrewDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightCorkscrewUp(session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
+        TrackRightCorkscrewUp(session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
     }
 
     static void TrackRightCorkscrewDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftCorkscrewUp(session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
+        TrackLeftCorkscrewUp(session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
     }
 
     static void Track90DegToInvertedFlatQuarterLoopUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11238,14 +11238,14 @@ namespace SingleRailRC
     }
 
     static void TrackInvertedFlatTo90DegQuarterLoopDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track90DegToInvertedFlatQuarterLoopUp(session, rideIndex, 2 - trackSequence, direction, height, tileElement);
+        Track90DegToInvertedFlatQuarterLoopUp(session, ride, 2 - trackSequence, direction, height, tileElement);
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11347,7 +11347,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11449,7 +11449,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11551,7 +11551,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11653,7 +11653,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftLargeHalfLoopUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -11925,7 +11925,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeHalfLoopUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -12197,21 +12197,21 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeHalfLoopDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackRightLargeHalfLoopUp(session, rideIndex, 6 - trackSequence, direction, height, tileElement);
+        TrackRightLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, tileElement);
     }
 
     static void TrackLeftLargeHalfLoopDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackLeftLargeHalfLoopUp(session, rideIndex, 6 - trackSequence, direction, height, tileElement);
+        TrackLeftLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, tileElement);
     }
 
     static void TrackFlatTo60DegUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -12320,7 +12320,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUpToFlat(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         if (tileElement->AsTrack()->HasChain())
@@ -12415,21 +12415,21 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        Track60DegUpToFlat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        Track60DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void Track60DegDownToFlat(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
-        TrackFlatTo60DegUp(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        TrackFlatTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
     }
 
     static void TrackDiagFlatTo60DegUp(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -12586,7 +12586,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUpToFlat(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -12743,7 +12743,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo60DegDown(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)
@@ -12900,7 +12900,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDownToFlat(
-        paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TileElement* tileElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _StandUpBlockBrakeImages[NumOrthogonalDirections
 
 /** rct2: 0x008A7114 */
 static void stand_up_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -89,7 +89,7 @@ static void stand_up_rc_track_flat(
 
 /** rct2: 0x008A7384, 0x008A7394, 0x008A73A4 */
 static void stand_up_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -115,7 +115,7 @@ static void stand_up_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -123,7 +123,7 @@ static void stand_up_rc_track_station(
 
 /** rct2: 0x008A7124 */
 static void stand_up_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -193,7 +193,7 @@ static void stand_up_rc_track_25_deg_up(
 
 /** rct2: 0x008A7134 */
 static void stand_up_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -263,7 +263,7 @@ static void stand_up_rc_track_60_deg_up(
 
 /** rct2: 0x008A7144 */
 static void stand_up_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -333,7 +333,7 @@ static void stand_up_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A7154 */
 static void stand_up_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -411,7 +411,7 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7164 */
 static void stand_up_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -489,7 +489,7 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7174 */
 static void stand_up_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -559,55 +559,55 @@ static void stand_up_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A7184 */
 static void stand_up_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7194 */
 static void stand_up_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A71A4 */
 static void stand_up_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A71B4 */
 static void stand_up_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A71C4 */
 static void stand_up_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A71D4 */
 static void stand_up_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A71E4 */
 static void stand_up_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -764,16 +764,16 @@ static void stand_up_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A71F4 */
 static void stand_up_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    stand_up_rc_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7204 */
 static void stand_up_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -807,7 +807,7 @@ static void stand_up_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A7214 */
 static void stand_up_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -841,7 +841,7 @@ static void stand_up_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A7224 */
 static void stand_up_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -875,7 +875,7 @@ static void stand_up_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A7234 */
 static void stand_up_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -909,7 +909,7 @@ static void stand_up_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A7244 */
 static void stand_up_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1083,16 +1083,16 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A7254 */
 static void stand_up_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    stand_up_rc_track_banked_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_banked_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7264 */
 static void stand_up_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1133,7 +1133,7 @@ static void stand_up_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7274 */
 static void stand_up_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1174,7 +1174,7 @@ static void stand_up_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7284 */
 static void stand_up_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1215,7 +1215,7 @@ static void stand_up_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7294 */
 static void stand_up_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1256,39 +1256,39 @@ static void stand_up_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A72A4 */
 static void stand_up_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A72B4 */
 static void stand_up_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A72C4 */
 static void stand_up_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A72D4 */
 static void stand_up_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A72E4 */
 static void stand_up_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1322,15 +1322,15 @@ static void stand_up_rc_track_left_bank(
 
 /** rct2: 0x008A72F4 */
 static void stand_up_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7304 */
 static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1618,7 +1618,7 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7314 */
 static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1906,27 +1906,25 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7324 */
 static void stand_up_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    stand_up_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    stand_up_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7334 */
 static void stand_up_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    stand_up_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7344 */
 static void stand_up_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2061,7 +2059,7 @@ static void stand_up_rc_track_s_bend_left(
 
 /** rct2: 0x008A7354 */
 static void stand_up_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2196,7 +2194,7 @@ static void stand_up_rc_track_s_bend_right(
 
 /** rct2: 0x008A7364 */
 static void stand_up_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2453,7 +2451,7 @@ static void stand_up_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A7374 */
 static void stand_up_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2678,7 +2676,7 @@ static void stand_up_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A73B4 */
 static void stand_up_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2778,16 +2776,16 @@ static void stand_up_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A73C4 */
 static void stand_up_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    stand_up_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A73D4 */
 static void stand_up_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2899,16 +2897,16 @@ static void stand_up_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A73E4 */
 static void stand_up_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    stand_up_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A73F4 */
 static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3043,7 +3041,7 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7404 */
 static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3190,27 +3188,25 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7414 */
 static void stand_up_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    stand_up_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    stand_up_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7424 */
 static void stand_up_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    stand_up_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7434 */
 static void stand_up_rc_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3336,15 +3332,15 @@ static void stand_up_rc_track_half_loop_up(
 
 /** rct2: 0x008A7444 */
 static void stand_up_rc_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_half_loop_up(session, rideIndex, 3 - trackSequence, direction, height, tileElement);
+    stand_up_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, tileElement);
 }
 
 /** rct2: 0x008A7454 */
 static void stand_up_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3456,7 +3452,7 @@ static void stand_up_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A7464 */
 static void stand_up_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3569,23 +3565,23 @@ static void stand_up_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A7474 */
 static void stand_up_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_right_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
+    stand_up_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7484 */
 static void stand_up_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    stand_up_rc_track_left_corkscrew_up(session, rideIndex, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7734 */
 static void stand_up_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3803,7 +3799,7 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A7744 */
 static void stand_up_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4021,7 +4017,7 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A7754 */
 static void stand_up_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -4030,13 +4026,12 @@ static void stand_up_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    stand_up_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    stand_up_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7764 */
 static void stand_up_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -4045,13 +4040,12 @@ static void stand_up_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    stand_up_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A76F4 */
 static void stand_up_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4393,7 +4387,7 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A7704 */
 static void stand_up_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4735,7 +4729,7 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A7714 */
 static void stand_up_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4744,13 +4738,12 @@ static void stand_up_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    stand_up_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    stand_up_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7724 */
 static void stand_up_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -4759,13 +4752,12 @@ static void stand_up_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    stand_up_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    stand_up_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A7494 */
 static void stand_up_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4793,7 +4785,7 @@ static void stand_up_rc_track_brakes(
 
 /** rct2: 0x008A74A4 */
 static void stand_up_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -4835,7 +4827,7 @@ static void stand_up_rc_track_on_ride_photo(
 
 /** rct2: 0x008A74B4 */
 static void stand_up_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4974,7 +4966,7 @@ static void stand_up_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A74C4 */
 static void stand_up_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5112,25 +5104,25 @@ static void stand_up_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A74D4 */
 static void stand_up_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    stand_up_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A74E4 */
 static void stand_up_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    stand_up_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    stand_up_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A76A4 */
 static void stand_up_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5272,7 +5264,7 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A76B4 */
 static void stand_up_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5413,25 +5405,25 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A76C4 */
 static void stand_up_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    stand_up_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    stand_up_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A76D4 */
 static void stand_up_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    stand_up_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    stand_up_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A74F4 */
 static void stand_up_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5577,7 +5569,7 @@ static void stand_up_rc_track_diag_flat(
 
 /** rct2: 0x008A7524 */
 static void stand_up_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5723,7 +5715,7 @@ static void stand_up_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A7584 */
 static void stand_up_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5869,7 +5861,7 @@ static void stand_up_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A7504 */
 static void stand_up_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6015,7 +6007,7 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A7564 */
 static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6161,7 +6153,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7574 */
 static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6307,7 +6299,7 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7514 */
 static void stand_up_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6453,7 +6445,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A7554 */
 static void stand_up_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6599,7 +6591,7 @@ static void stand_up_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A75B4 */
 static void stand_up_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6745,7 +6737,7 @@ static void stand_up_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A7534 */
 static void stand_up_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6889,7 +6881,7 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A7594 */
 static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7035,7 +7027,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A75A4 */
 static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7181,7 +7173,7 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A7544 */
 static void stand_up_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7327,7 +7319,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A75E4 */
 static void stand_up_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7406,7 +7398,7 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A75F4 */
 static void stand_up_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7485,7 +7477,7 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A7604 */
 static void stand_up_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7564,7 +7556,7 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A7614 */
 static void stand_up_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7643,7 +7635,7 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A7644 */
 static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7722,7 +7714,7 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7654 */
 static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7801,7 +7793,7 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7624 */
 static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7880,7 +7872,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7634 */
 static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7959,7 +7951,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A7664 */
 static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8036,7 +8028,7 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A7674 */
 static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8113,7 +8105,7 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A7684 */
 static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8192,7 +8184,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A7694 */
 static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8271,7 +8263,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A75C4 */
 static void stand_up_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8347,7 +8339,7 @@ static void stand_up_rc_track_diag_left_bank(
 
 /** rct2: 0x008A75D4 */
 static void stand_up_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8423,7 +8415,7 @@ static void stand_up_rc_track_diag_right_bank(
 
 /** rct2: 0x008A76E4 */
 static void stand_up_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A59A8 */
 static void steeplechase_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -70,7 +70,7 @@ static void steeplechase_track_flat(
 }
 
 static void steeplechase_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -87,7 +87,7 @@ static void steeplechase_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 3, height, 0, 0,
         height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -95,7 +95,7 @@ static void steeplechase_track_station(
 
 /** rct2: 0x008A59B8 */
 static void steeplechase_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -173,7 +173,7 @@ static void steeplechase_track_25_deg_up(
 
 /** rct2: 0x008A59C8 */
 static void steeplechase_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -251,7 +251,7 @@ static void steeplechase_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A59D8 */
 static void steeplechase_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -329,31 +329,31 @@ static void steeplechase_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A59E8 */
 static void steeplechase_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    steeplechase_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    steeplechase_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A59F8 */
 static void steeplechase_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    steeplechase_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    steeplechase_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5A08 */
 static void steeplechase_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    steeplechase_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    steeplechase_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5A18 */
 static void steeplechase_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -524,16 +524,16 @@ static void steeplechase_track_left_quarter_turn_5(
 
 /** rct2: 0x008A5A28 */
 static void steeplechase_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    steeplechase_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    steeplechase_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5A38 */
 static void steeplechase_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -682,7 +682,7 @@ static void steeplechase_track_s_bend_left(
 
 /** rct2: 0x008A5A48 */
 static void steeplechase_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -831,7 +831,7 @@ static void steeplechase_track_s_bend_right(
 
 /** rct2: 0x008A5A88 */
 static void steeplechase_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -945,16 +945,16 @@ static void steeplechase_track_left_quarter_turn_3(
 
 /** rct2: 0x008A5A98 */
 static void steeplechase_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    steeplechase_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    steeplechase_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5AA8 */
 static void steeplechase_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -981,7 +981,7 @@ static void steeplechase_track_brakes(
 
 /** rct2: 0x008A5AD8 */
 static void steeplechase_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1127,7 +1127,7 @@ static void steeplechase_track_left_eighth_to_diag(
 
 /** rct2: 0x008A5AE8 */
 static void steeplechase_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1272,25 +1272,25 @@ static void steeplechase_track_right_eighth_to_diag(
 
 /** rct2: 0x008A5AF8 */
 static void steeplechase_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    steeplechase_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    steeplechase_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5B08 */
 static void steeplechase_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    steeplechase_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    steeplechase_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5AC8 */
 static void steeplechase_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1436,7 +1436,7 @@ static void steeplechase_track_diag_flat(
 
 /** rct2: 0x008A5B38 */
 static void steeplechase_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1582,7 +1582,7 @@ static void steeplechase_track_diag_25_deg_up(
 
 /** rct2: 0x008A5B18 */
 static void steeplechase_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1728,7 +1728,7 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A5B28 */
 static void steeplechase_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1874,7 +1874,7 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A5B68 */
 static void steeplechase_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2020,7 +2020,7 @@ static void steeplechase_track_diag_25_deg_down(
 
 /** rct2: 0x008A5B48 */
 static void steeplechase_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2164,7 +2164,7 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A5B58 */
 static void steeplechase_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2310,7 +2310,7 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A5AB8 */
 static void steeplechase_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A8958 */
 static void suspended_swinging_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -73,7 +73,7 @@ static void suspended_swinging_rc_track_flat(
 
 /** rct2: 0x008A8AA8, 0x008A8AB8, 0x008A8AC8 */
 static void suspended_swinging_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -92,7 +92,7 @@ static void suspended_swinging_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -100,7 +100,7 @@ static void suspended_swinging_rc_track_station(
 
 /** rct2: 0x008A8968 */
 static void suspended_swinging_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -194,7 +194,7 @@ static void suspended_swinging_rc_track_25_deg_up(
 
 /** rct2: 0x008A8978 */
 static void suspended_swinging_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -235,7 +235,7 @@ static void suspended_swinging_rc_track_60_deg_up(
 
 /** rct2: 0x008A8988 */
 static void suspended_swinging_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -329,7 +329,7 @@ static void suspended_swinging_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A8998 */
 static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -376,7 +376,7 @@ static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A89A8 */
 static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -482,7 +482,7 @@ static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A89B8 */
 static void suspended_swinging_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (tileElement->AsTrack()->HasChain())
@@ -576,57 +576,55 @@ static void suspended_swinging_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A89C8 */
 static void suspended_swinging_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_swinging_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A89D8 */
 static void suspended_swinging_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_swinging_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A89E8 */
 static void suspended_swinging_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_swinging_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A89F8 */
 static void suspended_swinging_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8A08 */
 static void suspended_swinging_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8A18 */
 static void suspended_swinging_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_swinging_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8A28 */
 static void suspended_swinging_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -806,17 +804,16 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A8A38 */
 static void suspended_swinging_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    suspended_swinging_rc_track_left_quarter_turn_5(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    suspended_swinging_rc_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8A48 */
 static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -982,7 +979,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A8A58 */
 static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1148,27 +1145,27 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A8A68 */
 static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8A78 */
 static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8A88 */
 static void suspended_swinging_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1327,7 +1324,7 @@ static void suspended_swinging_rc_track_s_bend_left(
 
 /** rct2: 0x008A8A98 */
 static void suspended_swinging_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1486,7 +1483,7 @@ static void suspended_swinging_rc_track_s_bend_right(
 
 /** rct2: 0x008A8AD8 */
 static void suspended_swinging_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1605,17 +1602,16 @@ static void suspended_swinging_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A8AE8 */
 static void suspended_swinging_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    suspended_swinging_rc_track_left_quarter_turn_3(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    suspended_swinging_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8AF8 */
 static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1702,7 +1698,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A8B08 */
 static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1789,27 +1785,27 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A8B18 */
 static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8B28 */
 static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8B38 */
 static void suspended_swinging_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1841,7 +1837,7 @@ static void suspended_swinging_rc_track_brakes(
 
 /** rct2: 0x008A8B48 */
 static void suspended_swinging_rc_track_left_quarter_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2026,7 +2022,7 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
 
 /** rct2: 0x008A8B58 */
 static void suspended_swinging_rc_track_right_quarter_helix_large_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2211,7 +2207,7 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
 
 /** rct2: 0x008A8B68 */
 static void suspended_swinging_rc_track_left_quarter_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2396,7 +2392,7 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
 
 /** rct2: 0x008A8B78 */
 static void suspended_swinging_rc_track_right_quarter_helix_large_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2581,7 +2577,7 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
 
 /** rct2: 0x008A8B88 */
 static void suspended_swinging_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2744,7 +2740,7 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A8B98 */
 static void suspended_swinging_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2907,27 +2903,25 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A8BA8 */
 static void suspended_swinging_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    suspended_swinging_rc_track_right_eighth_to_diag(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_swinging_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8BB8 */
 static void suspended_swinging_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    suspended_swinging_rc_track_left_eighth_to_diag(
-        session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    suspended_swinging_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A8BC8 */
 static void suspended_swinging_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3066,7 +3060,7 @@ static void suspended_swinging_rc_track_diag_flat(
 
 /** rct2: 0x008A8BF8 */
 static void suspended_swinging_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3205,7 +3199,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A8C58 */
 static void suspended_swinging_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3288,7 +3282,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A8BD8 */
 static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3427,7 +3421,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A8C38 */
 static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3510,7 +3504,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A8C48 */
 static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3593,7 +3587,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A8BE8 */
 static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3732,7 +3726,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A8C28 */
 static void suspended_swinging_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3871,7 +3865,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A8C88 */
 static void suspended_swinging_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3933,7 +3927,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A8C08 */
 static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4069,7 +4063,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A8C68 */
 static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4152,7 +4146,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8C78 */
 static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4235,7 +4229,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8C18 */
 static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4374,7 +4368,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A8B38 */
 static void suspended_swinging_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/TwisterRollerCoaster.cpp
@@ -21,1596 +21,1581 @@
 
 /** rct2: 0x008AB6A4 */
 static void twister_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_flat(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_flat(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB8F4, 0x008AB904, 0x008AB914 */
 static void twister_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_station(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_station(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB6B4 */
 static void twister_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_25_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_25_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB6C4 */
 static void twister_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_60_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_60_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB6D4 */
 static void twister_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB6E4 */
 static void twister_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB6F4 */
 static void twister_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB704 */
 static void twister_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB714 */
 static void twister_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_25_deg_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB724 */
 static void twister_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_60_deg_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB734 */
 static void twister_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB744 */
 static void twister_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB754 */
 static void twister_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB764 */
 static void twister_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB774 */
 static void twister_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB784 */
 static void twister_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB794 */
 static void twister_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB7A4 */
 static void twister_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB7B4 */
 static void twister_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB7C4 */
 static void twister_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB7D4 */
 static void twister_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_banked_left_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB7E4 */
 static void twister_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_banked_right_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB7F4 */
 static void twister_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB804 */
 static void twister_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB814 */
 static void twister_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB824 */
 static void twister_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB834 */
 static void twister_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB844 */
 static void twister_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB854 */
 static void twister_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB864 */
 static void twister_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB874 */
 static void twister_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_left_bank(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_left_bank(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB884 */
 static void twister_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_right_bank(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB894 */
 static void twister_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB8A4 */
 static void twister_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB8B4 */
 static void twister_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB8C4 */
 static void twister_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB8D4 */
 static void twister_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_s_bend_left(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_s_bend_left(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB8E4 */
 static void twister_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_s_bend_right(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_s_bend_right(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA84 */
 static void twister_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_vertical_loop(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA94 */
 static void twister_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_vertical_loop(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB924 */
 static void twister_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB934 */
 static void twister_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB944 */
 static void twister_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB954 */
 static void twister_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB964 */
 static void twister_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB974 */
 static void twister_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB984 */
 static void twister_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB994 */
 static void twister_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB9A4 */
 static void twister_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB9B4 */
 static void twister_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB9C4 */
 static void twister_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_down_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB9D4 */
 static void twister_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_down_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB9E4 */
 static void twister_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AB9F4 */
 static void twister_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA04 */
 static void twister_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_down_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA14 */
 static void twister_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_down_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA44 */
 static void twister_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA24 */
 static void twister_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA34 */
 static void twister_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA54 */
 static void twister_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA64 */
 static void twister_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_brakes(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_brakes(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE04 */
 static void twister_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_left_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE14 */
 static void twister_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_right_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABA74 */
 static void twister_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_on_ride_photo(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_on_ride_photo(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE24 */
 static void twister_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_left_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE34 */
 static void twister_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_right_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE44 */
 static void twister_rc_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_90_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_90_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE54 */
 static void twister_rc_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_90_deg_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE64 */
 static void twister_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE74 */
 static void twister_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_90_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE84 */
 static void twister_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_90_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABE94 */
 static void twister_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_down_to_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABAB4 */
 static void twister_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABAC4 */
 static void twister_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABAD4 */
 static void twister_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABAE4 */
 static void twister_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABAF4 */
 static void twister_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB04 */
 static void twister_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB14 */
 static void twister_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB24 */
 static void twister_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABAA4 */
 static void twister_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_flat(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_diag_flat(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB54 */
 static void twister_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_diag_25_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABBB4 */
 static void twister_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_diag_60_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB34 */
 static void twister_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB94 */
 static void twister_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABBA4 */
 static void twister_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB44 */
 static void twister_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB84 */
 static void twister_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABBE4 */
 static void twister_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB64 */
 static void twister_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABBC4 */
 static void twister_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABBD4 */
 static void twister_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABB74 */
 static void twister_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC14 */
 static void twister_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC24 */
 static void twister_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC34 */
 static void twister_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_left_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC44 */
 static void twister_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC74 */
 static void twister_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC84 */
 static void twister_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC54 */
 static void twister_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC64 */
 static void twister_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC94 */
 static void twister_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABCA4 */
 static void twister_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABCB4 */
 static void twister_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABCC4 */
 static void twister_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABBF4 */
 static void twister_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_diag_left_bank(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABC04 */
 static void twister_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD74 */
 static void twister_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD84 */
 static void twister_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD94 */
 static void twister_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABDA4 */
 static void twister_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC0E4 */
 static void twister_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_block_brakes(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_block_brakes(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABEA4 */
 static void twister_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABEB4 */
 static void twister_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABEC4 */
 static void twister_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABED4 */
 static void twister_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABEE4 */
 static void twister_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABEF4 */
 static void twister_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF04 */
 static void twister_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF14 */
 static void twister_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF24 */
 static void twister_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF34 */
 static void twister_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF44 */
 static void twister_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF54 */
 static void twister_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF64 */
 static void twister_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF74 */
 static void twister_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF84 */
 static void twister_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABF94 */
 static void twister_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABFA4 */
 static void twister_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABFB4 */
 static void twister_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABFE4 */
 static void twister_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABFF4 */
 static void twister_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC004 */
 static void twister_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC014 */
 static void twister_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABFC4 */
 static void twister_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABFD4 */
 static void twister_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC024 */
 static void twister_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC034 */
 static void twister_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC044 */
 static void twister_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC054 */
 static void twister_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC064 */
 static void twister_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC074 */
 static void twister_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC084 */
 static void twister_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC094 */
 static void twister_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC0A4 */
 static void twister_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC0B4 */
 static void twister_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC0C4 */
 static void twister_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC0D4 */
 static void twister_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /* The following track elements used to be specific to the Vertical Roller Coaster */
 static void twister_rc_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_brake_for_drop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_brake_for_drop(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_brake_for_drop(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_diag_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_diag_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_diag_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_diag_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /* The following track elements used to be specific to the Steel Twister */
 /** rct2: 0x008ABCD4 */
 static void twister_rc_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_half_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_half_loop_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABCE4 */
 static void twister_rc_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_half_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_half_loop_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD34 */
 static void twister_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_corkscrew_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD44 */
 static void twister_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_corkscrew_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD54 */
 static void twister_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_corkscrew_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD64 */
 static void twister_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_corkscrew_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC0F4 */
 static void twister_rc_track_flat_to_60_deg_up_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC104 */
 static void twister_rc_track_60_deg_up_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC114 */
 static void twister_rc_track_60_deg_down_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_down_long_base(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC124 */
 static void twister_rc_track_flat_to_60_deg_down_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base122(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABCF4 */
 static void twister_rc_track_left_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_barrel_roll_up_to_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD04 */
 static void twister_rc_track_right_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_barrel_roll_up_to_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD14 */
 static void twister_rc_track_left_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_barrel_roll_down_to_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABD24 */
 static void twister_rc_track_right_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_barrel_roll_down_to_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABDB4 */
 static void twister_rc_track_powered_lift(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_powered_lift(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_powered_lift(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABDC4 */
 static void twister_rc_track_left_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_large_half_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABDD4 */
 static void twister_rc_track_right_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_large_half_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABDE4 */
 static void twister_rc_track_right_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_large_half_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008ABDF4 */
 static void twister_rc_track_left_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_large_half_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC134 */
 static void twister_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 /** rct2: 0x008AC144 */
 static void twister_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 static void twister_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_booster(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
+    bolliger_mabillard_track_booster(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_TUBES);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_twister_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/VerticalDropRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/VerticalDropRollerCoaster.cpp
@@ -14,1583 +14,1568 @@
 
 /** rct2: 0x008AA00C */
 static void vertical_drop_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_flat(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_flat(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_station(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_station(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA01C */
 static void vertical_drop_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_25_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_25_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA02C */
 static void vertical_drop_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_60_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_60_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA03C */
 static void vertical_drop_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA04C */
 static void vertical_drop_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA05C */
 static void vertical_drop_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA06C */
 static void vertical_drop_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA07C */
 static void vertical_drop_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_25_deg_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA08C */
 static void vertical_drop_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_60_deg_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA09C */
 static void vertical_drop_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA0AC */
 static void vertical_drop_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA0BC */
 static void vertical_drop_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA0CC */
 static void vertical_drop_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA0DC */
 static void vertical_drop_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA0EC */
 static void vertical_drop_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA0FC */
 static void vertical_drop_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA10C */
 static void vertical_drop_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA11C */
 static void vertical_drop_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA12C */
 static void vertical_drop_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA13C */
 static void vertical_drop_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_banked_left_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA14C */
 static void vertical_drop_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_banked_right_quarter_turn_5(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA15C */
 static void vertical_drop_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA16C */
 static void vertical_drop_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA17C */
 static void vertical_drop_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA18C */
 static void vertical_drop_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA19C */
 static void vertical_drop_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA1AC */
 static void vertical_drop_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA1BC */
 static void vertical_drop_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA1CC */
 static void vertical_drop_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA1DC */
 static void vertical_drop_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_left_bank(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_left_bank(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA1EC */
 static void vertical_drop_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_right_bank(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA1FC */
 static void vertical_drop_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA20C */
 static void vertical_drop_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA21C */
 static void vertical_drop_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA22C */
 static void vertical_drop_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA23C */
 static void vertical_drop_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_s_bend_left(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_s_bend_left(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA24C */
 static void vertical_drop_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_s_bend_right(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_s_bend_right(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA49C */
 static void vertical_drop_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_vertical_loop(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA4AC */
 static void vertical_drop_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_vertical_loop(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA28C */
 static void vertical_drop_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA29C */
 static void vertical_drop_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA2AC */
 static void vertical_drop_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA2BC */
 static void vertical_drop_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA2CC */
 static void vertical_drop_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA2DC */
 static void vertical_drop_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA2EC */
 static void vertical_drop_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA2FC */
 static void vertical_drop_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA30C */
 static void vertical_drop_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA31C */
 static void vertical_drop_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA32C */
 static void vertical_drop_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_down_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA33C */
 static void vertical_drop_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_down_small(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA34C */
 static void vertical_drop_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA35C */
 static void vertical_drop_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA36C */
 static void vertical_drop_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_half_banked_helix_down_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA37C */
 static void vertical_drop_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_half_banked_helix_down_large(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA3AC */
 static void vertical_drop_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA38C */
 static void vertical_drop_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA39C */
 static void vertical_drop_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA3BC */
 static void vertical_drop_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA40C */
 static void vertical_drop_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_brakes(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_brakes(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA7EC */
 static void vertical_drop_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_left_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA7FC */
 static void vertical_drop_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_right_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA41C */
 static void vertical_drop_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_on_ride_photo(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_on_ride_photo(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA80C */
 static void vertical_drop_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_left_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA81C */
 static void vertical_drop_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_right_banked(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA42C */
 static void vertical_drop_rc_track_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_90_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_90_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA43C */
 static void vertical_drop_rc_track_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_90_deg_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA44C */
 static void vertical_drop_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA45C */
 static void vertical_drop_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_90_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA46C */
 static void vertical_drop_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_90_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA47C */
 static void vertical_drop_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_down_to_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA4CC */
 static void vertical_drop_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA4DC */
 static void vertical_drop_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA4EC */
 static void vertical_drop_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA4FC */
 static void vertical_drop_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA50C */
 static void vertical_drop_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA51C */
 static void vertical_drop_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_bank_to_diag(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA52C */
 static void vertical_drop_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA53C */
 static void vertical_drop_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA4BC */
 static void vertical_drop_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_flat(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_diag_flat(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA56C */
 static void vertical_drop_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_diag_25_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA5CC */
 static void vertical_drop_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_diag_60_deg_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA54C */
 static void vertical_drop_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA5AC */
 static void vertical_drop_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA5BC */
 static void vertical_drop_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA55C */
 static void vertical_drop_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA59C */
 static void vertical_drop_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA5FC */
 static void vertical_drop_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA57C */
 static void vertical_drop_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA5DC */
 static void vertical_drop_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA5EC */
 static void vertical_drop_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA58C */
 static void vertical_drop_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA62C */
 static void vertical_drop_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA63C */
 static void vertical_drop_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA64C */
 static void vertical_drop_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_left_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA65C */
 static void vertical_drop_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA68C */
 static void vertical_drop_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA69C */
 static void vertical_drop_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA66C */
 static void vertical_drop_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA67C */
 static void vertical_drop_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA6AC */
 static void vertical_drop_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA6BC */
 static void vertical_drop_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA6CC */
 static void vertical_drop_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA6DC */
 static void vertical_drop_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA60C */
 static void vertical_drop_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_diag_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_diag_left_bank(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA61C */
 static void vertical_drop_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA72C */
 static void vertical_drop_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA73C */
 static void vertical_drop_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA74C */
 static void vertical_drop_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA75C */
 static void vertical_drop_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA9EC */
 static void vertical_drop_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_block_brakes(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_block_brakes(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA96C */
 static void vertical_drop_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA97C */
 static void vertical_drop_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA98C */
 static void vertical_drop_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA99C */
 static void vertical_drop_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA8AC */
 static void vertical_drop_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA8BC */
 static void vertical_drop_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA8CC */
 static void vertical_drop_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA8DC */
 static void vertical_drop_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA82C */
 static void vertical_drop_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA83C */
 static void vertical_drop_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA84C */
 static void vertical_drop_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA85C */
 static void vertical_drop_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA86C */
 static void vertical_drop_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA87C */
 static void vertical_drop_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA88C */
 static void vertical_drop_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA89C */
 static void vertical_drop_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA8EC */
 static void vertical_drop_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA8FC */
 static void vertical_drop_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA92C */
 static void vertical_drop_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA93C */
 static void vertical_drop_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA94C */
 static void vertical_drop_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA95C */
 static void vertical_drop_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA90C */
 static void vertical_drop_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA91C */
 static void vertical_drop_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA76C */
 static void vertical_drop_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA77C */
 static void vertical_drop_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA78C */
 static void vertical_drop_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA79C */
 static void vertical_drop_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA7AC */
 static void vertical_drop_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA7BC */
 static void vertical_drop_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA7CC */
 static void vertical_drop_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA7DC */
 static void vertical_drop_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA9AC */
 static void vertical_drop_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA9BC */
 static void vertical_drop_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA9CC */
 static void vertical_drop_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA9DC */
 static void vertical_drop_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /* The following elements used to be specific to the vertical_drop RC */
 /** rct2: 0x008AA3CC */
 static void vertical_drop_rc_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA3DC */
 static void vertical_drop_rc_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA3EC */
 static void vertical_drop_rc_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA3FC */
 static void vertical_drop_rc_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA48C */
 static void vertical_drop_rc_track_brake_for_drop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_brake_for_drop(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_brake_for_drop(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA6EC */
 static void vertical_drop_rc_track_diag_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA6FC */
 static void vertical_drop_rc_track_diag_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA70C */
 static void vertical_drop_rc_track_diag_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_flat_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /** rct2: 0x008AA71C */
 static void vertical_drop_rc_track_diag_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_diag_60_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 /* The following elements used to be specific to the steel twister RC */
 static void vertical_drop_rc_track_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_half_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_half_loop_up(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_half_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_half_loop_down(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_left_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_corkscrew_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_right_corkscrew_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_corkscrew_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_left_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_corkscrew_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_right_corkscrew_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_corkscrew_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_flat_to_60_deg_up_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_60_deg_up_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_60_deg_down_to_flat_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_down_long_base(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_flat_to_60_deg_down_long_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base122(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_left_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_barrel_roll_up_to_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_right_barrel_roll_up_to_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_barrel_roll_up_to_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_left_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_barrel_roll_down_to_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_right_barrel_roll_down_to_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_barrel_roll_down_to_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_powered_lift(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_powered_lift(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_powered_lift(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_left_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_large_half_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_right_large_half_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_large_half_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_right_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_right_large_half_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_left_large_half_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_left_large_half_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+        session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 static void vertical_drop_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    bolliger_mabillard_track_booster(session, rideIndex, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
+    bolliger_mabillard_track_booster(session, ride, trackSequence, direction, height, tileElement, METAL_SUPPORTS_BOXED);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_vertical_drop_rc(int32_t trackType)

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -209,7 +209,7 @@ void vehicle_visual_virginia_reel(
 
 /** rct2: 0x00811264 */
 static void paint_virginia_reel_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_flat;
@@ -238,7 +238,7 @@ static void paint_virginia_reel_track_flat(
 
 /** rct2: 0x00811274 */
 static void paint_virginia_reel_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_25_deg_up;
@@ -290,7 +290,7 @@ static void paint_virginia_reel_track_25_deg_up(
 
 /** rct2: 0x00811294 */
 static void paint_virginia_reel_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_flat_to_25_deg_up;
@@ -337,7 +337,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(
 
 /** rct2: 0x00811294 */
 static void paint_virginia_reel_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_25_deg_up_to_flat;
@@ -389,31 +389,31 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(
 
 /** rct2: 0x008112A4 */
 static void paint_virginia_reel_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_virginia_reel_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_virginia_reel_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008112B4 */
 static void paint_virginia_reel_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_virginia_reel_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_virginia_reel_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008112C4 */
 static void paint_virginia_reel_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_virginia_reel_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_virginia_reel_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008112D4, 0x008112E4, 0x008112F4 */
 static void paint_virginia_reel_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -440,7 +440,7 @@ static void paint_virginia_reel_station(
     }
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -450,7 +450,7 @@ static constexpr const uint8_t virginia_reel_left_quarter_turn_supports[] = { 5,
 
 /** rct2: 0x00811304 */
 static void paint_virginia_reel_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -480,17 +480,16 @@ static constexpr const uint8_t virginia_reel_right_quarter_turn_3_tiles_to_left_
 
 /** rct2: 0x00811314 */
 static void paint_virginia_reel_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = virginia_reel_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
-    paint_virginia_reel_track_left_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_virginia_reel_track_left_quarter_turn_3_tiles(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /** rct2: 0x00811324 */
 static void paint_virginia_reel_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -523,11 +522,10 @@ static void paint_virginia_reel_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00811334 */
 static void paint_virginia_reel_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_virginia_reel_track_left_quarter_turn_1_tile(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_virginia_reel_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /**

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -165,7 +165,7 @@ static constexpr const uint32_t _wild_mouse_block_brakes_image_ids[NumOrthogonal
 
 /** rct2: 0x0078B1E4 */
 static void wild_mouse_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -189,7 +189,7 @@ static void wild_mouse_track_flat(
 }
 
 static void wild_mouse_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t baseImageIds[4] = {
@@ -217,7 +217,7 @@ static void wild_mouse_track_station(
             height, 0, 0, height);
     }
     track_paint_util_draw_station_metal_supports(session, direction, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -225,7 +225,7 @@ static void wild_mouse_track_station(
 
 /** rct2: 0x0078B1F4 */
 static void wild_mouse_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -257,7 +257,7 @@ static void wild_mouse_track_25_deg_up(
 
 /** rct2: 0x0078B204 */
 static void wild_mouse_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -303,7 +303,7 @@ static void wild_mouse_track_60_deg_up(
 
 /** rct2: 0x0078B214 */
 static void wild_mouse_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -335,7 +335,7 @@ static void wild_mouse_track_flat_to_25_deg_up(
 
 /** rct2: 0x0078B224 */
 static void wild_mouse_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -382,7 +382,7 @@ static void wild_mouse_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0078B234 */
 static void wild_mouse_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -429,7 +429,7 @@ static void wild_mouse_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0078B244 */
 static void wild_mouse_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -461,54 +461,54 @@ static void wild_mouse_track_25_deg_up_to_flat(
 
 /** rct2: 0x0078B254 */
 static void wild_mouse_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B264 */
 static void wild_mouse_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B274 */
 static void wild_mouse_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B284 */
 static void wild_mouse_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B294 */
 static void wild_mouse_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B2A4 */
 static void wild_mouse_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void wild_mouse_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -564,7 +564,7 @@ static void wild_mouse_track_right_quarter_turn_3(
 }
 
 static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][2] = {
@@ -623,17 +623,16 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
 }
 
 static void wild_mouse_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wild_mouse_track_right_quarter_turn_3_25_deg_down(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    wild_mouse_track_right_quarter_turn_3_25_deg_down(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x0078B314 */
 static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][2] = {
@@ -703,25 +702,24 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0078B324 */
 static void wild_mouse_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wild_mouse_track_right_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    wild_mouse_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void wild_mouse_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wild_mouse_track_right_quarter_turn_3(session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    wild_mouse_track_right_quarter_turn_3(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x0078B394 */
 static void wild_mouse_track_left_quarter_turn_1(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -756,15 +754,15 @@ static void wild_mouse_track_left_quarter_turn_1(
 
 /** rct2: 0x0078B3A4 */
 static void wild_mouse_track_right_quarter_turn_1(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_left_quarter_turn_1(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wild_mouse_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B354 */
 static void wild_mouse_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -811,7 +809,7 @@ static void wild_mouse_track_flat_to_60_deg_up(
 
 /** rct2: 0x0078B364 */
 static void wild_mouse_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -865,23 +863,23 @@ static void wild_mouse_track_60_deg_up_to_flat(
 
 /** rct2: 0x0078B374 */
 static void wild_mouse_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_60_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B384 */
 static void wild_mouse_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wild_mouse_track_flat_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wild_mouse_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x0078B344 */
 static void wild_mouse_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = _wild_mouse_brakes_image_ids[direction] | session->TrackColours[SCHEME_TRACK];
@@ -898,7 +896,7 @@ static void wild_mouse_track_brakes(
 
 /** rct2: 0x0078B3C4 */
 static void wild_mouse_track_rotation_control_toggle(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -922,7 +920,7 @@ static void wild_mouse_track_rotation_control_toggle(
 
 /** rct2: 0x0078B3B4 */
 static void wild_mouse_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isClosed = tileElement->AsTrack()->BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -438,7 +438,7 @@ static void wooden_rc_track_paint_bb(paint_session* session, const sprite_bb_2* 
 
 /** rct2: 0x008AC568 */
 static void wooden_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -465,7 +465,7 @@ static void wooden_rc_track_flat(
 }
 
 static void wooden_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t stationImageIds[4][2] = {
@@ -491,7 +491,7 @@ static void wooden_rc_track_station(
             height);
     }
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station_2(session, rideIndex, direction, height, tileElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, tileElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -499,7 +499,7 @@ static void wooden_rc_track_station(
 
 /** rct2: 0x008AC578 */
 static void wooden_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -549,7 +549,7 @@ static void wooden_rc_track_25_deg_up(
 
 /** rct2: 0x008AC588 */
 static void wooden_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -587,7 +587,7 @@ static void wooden_rc_track_60_deg_up(
 
 /** rct2: 0x008AC598 */
 static void wooden_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -637,7 +637,7 @@ static void wooden_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AC5A8 */
 static void wooden_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -679,7 +679,7 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AC5B8 */
 static void wooden_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -721,7 +721,7 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AC5C8 */
 static void wooden_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -771,54 +771,54 @@ static void wooden_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AC5D8 */
 static void wooden_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC5E8 */
 static void wooden_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC5F8 */
 static void wooden_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC608 */
 static void wooden_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC618 */
 static void wooden_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC628 */
 static void wooden_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void wooden_rc_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb_2 imageIds[2][4][7] = {
@@ -1064,16 +1064,16 @@ static void wooden_rc_track_right_quarter_turn_5(
 }
 
 static void wooden_rc_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    wooden_rc_track_right_quarter_turn_5(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_right_quarter_turn_5(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC658 */
 static void wooden_rc_track_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1100,7 +1100,7 @@ static void wooden_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AC668 */
 static void wooden_rc_track_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1127,22 +1127,22 @@ static void wooden_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AC678 */
 static void wooden_rc_track_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_flat_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_flat_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC688 */
 static void wooden_rc_track_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_flat_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_flat_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void wooden_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb_2 imageIds[2][4][7] = {
@@ -1388,16 +1388,16 @@ static void wooden_rc_track_banked_right_quarter_turn_5(
 }
 
 static void wooden_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    wooden_rc_track_banked_right_quarter_turn_5(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_banked_right_quarter_turn_5(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC6B8 */
 static void wooden_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1432,7 +1432,7 @@ static void wooden_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AC6C8 */
 static void wooden_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1467,7 +1467,7 @@ static void wooden_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AC6D8 */
 static void wooden_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1502,7 +1502,7 @@ static void wooden_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AC6E8 */
 static void wooden_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1537,39 +1537,39 @@ static void wooden_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AC6F8 */
 static void wooden_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_to_right_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC708 */
 static void wooden_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_to_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC718 */
 static void wooden_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_right_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC728 */
 static void wooden_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_left_bank_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC738 */
 static void wooden_rc_track_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1589,15 +1589,15 @@ static void wooden_rc_track_left_bank(
 
 /** rct2: 0x008AC748 */
 static void wooden_rc_track_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_left_bank(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC758 */
 static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1898,7 +1898,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AC768 */
 static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2199,25 +2199,25 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AC778 */
 static void wooden_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    wooden_rc_track_right_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_right_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC788 */
 static void wooden_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    wooden_rc_track_left_quarter_turn_5_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_quarter_turn_5_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC798 */
 static void wooden_rc_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2436,7 +2436,7 @@ static void wooden_rc_track_s_bend_left(
 
 /** rct2: 0x008AC7A8 */
 static void wooden_rc_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2655,7 +2655,7 @@ static void wooden_rc_track_s_bend_right(
 
 /** rct2: 0x008ACE18 */
 static void wooden_rc_track_left_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -2912,7 +2912,7 @@ static void wooden_rc_track_left_vertical_loop(
 
 /** rct2: 0x008ACE28 */
 static void wooden_rc_track_right_vertical_loop(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3137,7 +3137,7 @@ static void wooden_rc_track_right_vertical_loop(
 
 /** rct2: 0x008AC7E8 */
 static void wooden_rc_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3307,16 +3307,16 @@ static void wooden_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AC7F8 */
 static void wooden_rc_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_rc_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC808 */
 static void wooden_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3486,16 +3486,16 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AC818 */
 static void wooden_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_rc_track_left_quarter_turn_3_bank(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_quarter_turn_3_bank(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC828 */
 static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3626,7 +3626,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AC838 */
 static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -3757,25 +3757,25 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AC848 */
 static void wooden_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_rc_track_right_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_right_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC858 */
 static void wooden_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_rc_track_left_quarter_turn_3_25_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_quarter_turn_3_25_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACAB8 */
 static void wooden_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4151,7 +4151,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008ACAC8 */
 static void wooden_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -4527,7 +4527,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008ACAD8 */
 static void wooden_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -4536,13 +4536,12 @@ static void wooden_rc_track_left_half_banked_helix_down_small(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_rc_track_right_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_right_half_banked_helix_up_small(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACAE8 */
 static void wooden_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 4)
@@ -4551,13 +4550,12 @@ static void wooden_rc_track_right_half_banked_helix_down_small(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_rc_track_left_half_banked_helix_up_small(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_half_banked_helix_up_small(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACAF8 */
 static void wooden_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5149,7 +5147,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008ACB08 */
 static void wooden_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -5741,7 +5739,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008ACB18 */
 static void wooden_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -5750,13 +5748,12 @@ static void wooden_rc_track_left_half_banked_helix_down_large(
         direction = (direction - 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    wooden_rc_track_right_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_right_half_banked_helix_up_large(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACB28 */
 static void wooden_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence >= 7)
@@ -5765,13 +5762,12 @@ static void wooden_rc_track_right_half_banked_helix_down_large(
         direction = (direction + 1) & 3;
     }
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    wooden_rc_track_left_half_banked_helix_up_large(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_half_banked_helix_up_large(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACB98 */
 static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5824,7 +5820,7 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ACB78 */
 static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5877,23 +5873,23 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ACB88 */
 static void wooden_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_right_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+    wooden_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACBA8 */
 static void wooden_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_left_quarter_turn_1_60_deg_up(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC868 */
 static void wooden_rc_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -5913,7 +5909,7 @@ static void wooden_rc_track_brakes(
 
 /** rct2: 0x008ACC78 */
 static void wooden_rc_track_25_deg_up_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -5969,7 +5965,7 @@ static void wooden_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008ACC88 */
 static void wooden_rc_track_25_deg_up_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -6025,7 +6021,7 @@ static void wooden_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008AC878 */
 static void wooden_rc_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -6064,23 +6060,23 @@ static void wooden_rc_track_on_ride_photo(
 
 /** rct2: 0x008ACC98 */
 static void wooden_rc_track_25_deg_down_left_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_right_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACCA8 */
 static void wooden_rc_track_25_deg_down_right_banked(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_left_banked(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACE08 */
 static void wooden_rc_track_water_splash(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const bool transparent = gConfigGeneral.transparent_water || (session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
@@ -6497,7 +6493,7 @@ static void wooden_rc_track_water_splash(
 
 /** rct2: 0x008AC958 */
 static void wooden_rc_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6730,7 +6726,7 @@ static void wooden_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AC968 */
 static void wooden_rc_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -6961,25 +6957,25 @@ static void wooden_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AC978 */
 static void wooden_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    wooden_rc_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC988 */
 static void wooden_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    wooden_rc_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    wooden_rc_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC998 */
 static void wooden_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7212,7 +7208,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008AC9A8 */
 static void wooden_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7443,25 +7439,25 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008AC9B8 */
 static void wooden_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    wooden_rc_track_right_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_right_eighth_bank_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC9C8 */
 static void wooden_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    wooden_rc_track_left_eighth_bank_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    wooden_rc_track_left_eighth_bank_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008AC888 */
 static void wooden_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7663,7 +7659,7 @@ static void wooden_rc_track_diag_flat(
 
 /** rct2: 0x008AC8B8 */
 static void wooden_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7881,7 +7877,7 @@ static void wooden_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AC8E8 */
 static void wooden_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -7983,7 +7979,7 @@ static void wooden_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008AC898 */
 static void wooden_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8185,7 +8181,7 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AC8C8 */
 static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8287,7 +8283,7 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AC8D8 */
 static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8389,7 +8385,7 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AC8A8 */
 static void wooden_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8607,7 +8603,7 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AC918 */
 static void wooden_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8825,7 +8821,7 @@ static void wooden_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008AC948 */
 static void wooden_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -8927,7 +8923,7 @@ static void wooden_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008AC8F8 */
 static void wooden_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9140,7 +9136,7 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AC928 */
 static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9242,7 +9238,7 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AC938 */
 static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9344,7 +9340,7 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AC908 */
 static void wooden_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9546,7 +9542,7 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008ACA18 */
 static void wooden_rc_track_diag_flat_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9648,7 +9644,7 @@ static void wooden_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008AC9F8 */
 static void wooden_rc_track_diag_flat_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9750,7 +9746,7 @@ static void wooden_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008ACA08 */
 static void wooden_rc_track_diag_left_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9852,7 +9848,7 @@ static void wooden_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008ACA28 */
 static void wooden_rc_track_diag_right_bank_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -9954,7 +9950,7 @@ static void wooden_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008ACA58 */
 static void wooden_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10056,7 +10052,7 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008ACA68 */
 static void wooden_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10158,7 +10154,7 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008ACA38 */
 static void wooden_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10260,7 +10256,7 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008ACA48 */
 static void wooden_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10362,7 +10358,7 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008ACA78 */
 static void wooden_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10459,7 +10455,7 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008ACA88 */
 static void wooden_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10556,7 +10552,7 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008ACA98 */
 static void wooden_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10658,7 +10654,7 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ACAA8 */
 static void wooden_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10760,7 +10756,7 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AC9D8 */
 static void wooden_rc_track_diag_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10862,7 +10858,7 @@ static void wooden_rc_track_diag_left_bank(
 
 /** rct2: 0x008AC9E8 */
 static void wooden_rc_track_diag_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -10964,7 +10960,7 @@ static void wooden_rc_track_diag_right_bank(
 
 /** rct2: 0x008ACB38 */
 static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11095,7 +11091,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACB48 */
 static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11226,7 +11222,7 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACB58 */
 static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11357,7 +11353,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ACB68 */
 static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11488,7 +11484,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
 
 /** rct2: 0x008ACDF8 */
 static void wooden_rc_track_block_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const auto brakeImg = tileElement->AsTrack()->BlockBrakeClosed() ? _wooden_rc_block_brakes_image_ids[direction][1]
@@ -11503,7 +11499,7 @@ static void wooden_rc_track_block_brakes(
 
 /** rct2: 0x008ACCB8 */
 static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11634,7 +11630,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACCC8 */
 static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -11765,27 +11761,27 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACCD8 */
 static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACCE8 */
 static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACC38 */
 static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -12086,7 +12082,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ACC48 */
 static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -12387,27 +12383,27 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ACC58 */
 static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACC68 */
 static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
-        session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+        session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACCF8 */
 static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12455,7 +12451,7 @@ static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ACD08 */
 static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12503,7 +12499,7 @@ static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ACD18 */
 static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12551,7 +12547,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ACD28 */
 static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12599,43 +12595,39 @@ static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ACD38 */
 static void wooden_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACD48 */
 static void wooden_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACD58 */
 static void wooden_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACD68 */
 static void wooden_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACD78 */
 static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12691,7 +12683,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ACD88 */
 static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12747,7 +12739,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ACD98 */
 static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12803,7 +12795,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008ACDA8 */
 static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12859,43 +12851,43 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008ACDB8 */
 static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACDC8 */
 static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACDD8 */
 static void wooden_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACDE8 */
 static void wooden_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+        session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACBB8 */
 static void wooden_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -12951,7 +12943,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ACBC8 */
 static void wooden_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -13007,7 +12999,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ACBD8 */
 static void wooden_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -13063,7 +13055,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ACBE8 */
 static void wooden_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -13119,38 +13111,38 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ACBF8 */
 static void wooden_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_right_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACC08 */
 static void wooden_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_left_banked_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACC18 */
 static void wooden_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_flat_to_right_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008ACC28 */
 static void wooden_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_rc_track_flat_to_left_banked_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void wooden_rc_track_booster(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -122,7 +122,7 @@ enum
 
 /** rct2: 0x008A5464 */
 static void wooden_wild_mouse_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -146,7 +146,7 @@ static void wooden_wild_mouse_track_flat(
 }
 
 static void wooden_wild_mouse_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -163,7 +163,7 @@ static void wooden_wild_mouse_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 1, height, 0, 0,
         height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -171,7 +171,7 @@ static void wooden_wild_mouse_track_station(
 
 /** rct2: 0x008A5474 */
 static void wooden_wild_mouse_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -211,7 +211,7 @@ static void wooden_wild_mouse_track_25_deg_up(
 
 /** rct2: 0x008A5484 */
 static void wooden_wild_mouse_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -259,7 +259,7 @@ static void wooden_wild_mouse_track_60_deg_up(
 
 /** rct2: 0x008A5494 */
 static void wooden_wild_mouse_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -299,7 +299,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A54A4 */
 static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -350,7 +350,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
 }
 
 static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -402,7 +402,7 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
 
 /** rct2: 0x008A54C4 */
 static void wooden_wild_mouse_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -442,54 +442,54 @@ static void wooden_wild_mouse_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A54D4 */
 static void wooden_wild_mouse_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A54E4 */
 static void wooden_wild_mouse_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A54F4 */
 static void wooden_wild_mouse_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5504 */
 static void wooden_wild_mouse_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_60_deg_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_60_deg_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5514 */
 static void wooden_wild_mouse_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5524 */
 static void wooden_wild_mouse_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void wooden_wild_mouse_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -547,15 +547,15 @@ static void wooden_wild_mouse_track_right_quarter_turn_3(
 }
 
 static void wooden_wild_mouse_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    wooden_wild_mouse_track_right_quarter_turn_3(session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    wooden_wild_mouse_track_right_quarter_turn_3(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void wooden_wild_mouse_track_left_quarter_turn_1(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -590,15 +590,15 @@ static void wooden_wild_mouse_track_left_quarter_turn_1(
 
 /** rct2: 0x008A55D4 */
 static void wooden_wild_mouse_track_right_quarter_turn_1(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_left_quarter_turn_1(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    wooden_wild_mouse_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A55E4 */
 static void wooden_wild_mouse_track_flat_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -649,7 +649,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_up(
 
 /** rct2: 0x008A55F4 */
 static void wooden_wild_mouse_track_60_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -700,18 +700,18 @@ static void wooden_wild_mouse_track_60_deg_up_to_flat(
 
 /** rct2: 0x008A5604 */
 static void wooden_wild_mouse_track_flat_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_60_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x008A5614 */
 static void wooden_wild_mouse_track_60_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    wooden_wild_mouse_track_flat_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    wooden_wild_mouse_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_wooden_wild_mouse(int32_t trackType)

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -145,7 +145,7 @@ static constexpr const uint32_t car_ride_track_pieces_quarter_turn_3_tiles[4][3]
 
 /** rct2: 0x006F72C8 */
 static void paint_car_ride_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -176,7 +176,7 @@ static void paint_car_ride_track_flat(
 
 /** rct2: 0x006F72D8 */
 static void paint_car_ride_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -214,7 +214,7 @@ static void paint_car_ride_track_25_deg_up(
 
 /** rct2: 0x006F72E8 */
 static void paint_car_ride_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_flat_to_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -252,7 +252,7 @@ static void paint_car_ride_track_flat_to_25_deg_up(
 
 /** rct2: 0x006F72F8 */
 static void paint_car_ride_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_25_deg_up_to_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -290,31 +290,31 @@ static void paint_car_ride_track_25_deg_up_to_flat(
 
 /** rct2: 0x006F7308 */
 static void paint_car_ride_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_car_ride_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F7318 */
 static void paint_car_ride_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_car_ride_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F7328 */
 static void paint_car_ride_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_car_ride_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F7338, 0x006F7348, 0x006F7358 */
 static void paint_car_ride_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -360,7 +360,7 @@ static void paint_car_ride_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -368,7 +368,7 @@ static void paint_car_ride_station(
 
 /** rct2: 0x006F7378 */
 static void paint_car_ride_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -405,17 +405,16 @@ static void paint_car_ride_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x006F7368 */
 static void paint_car_ride_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    paint_car_ride_track_right_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    paint_car_ride_track_right_quarter_turn_3_tiles(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F7388 */
 static void paint_car_ride_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_left_quarter_turn_1_tile[direction] | session->TrackColours[SCHEME_TRACK];
@@ -446,15 +445,15 @@ static void paint_car_ride_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x006F7398 */
 static void paint_car_ride_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_left_quarter_turn_1_tile(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_car_ride_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F73A8 */
 static void paint_car_ride_track_spinning_tunnel(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -487,7 +486,7 @@ static void paint_car_ride_track_spinning_tunnel(
 
 /** rct2: 0x006F73B8 */
 static void paint_car_ride_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_60_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -536,7 +535,7 @@ static void paint_car_ride_track_60_deg_up(
 
 /** rct2: 0x006F73C8 */
 static void paint_car_ride_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -592,7 +591,7 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x006F73D8 */
 static void paint_car_ride_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -648,31 +647,31 @@ static void paint_car_ride_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x006F73E8 */
 static void paint_car_ride_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_car_ride_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F73F8 */
 static void paint_car_ride_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_car_ride_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F7408 */
 static void paint_car_ride_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_car_ride_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_car_ride_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x006F7418 */
 static void paint_car_ride_track_log_bumps(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = car_ride_track_pieces_log_bumps[direction] | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -18,11 +18,10 @@
  * rct2: 0x0077084A
  */
 static void paint_circus_tent(
-    paint_session* session, ride_id_t rideIndex, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -53,7 +52,7 @@ static void paint_circus_tent(
  * rct2: 0x0076FAD4
  */
 static void paint_circus(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -62,7 +61,6 @@ static void paint_circus(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -79,22 +77,22 @@ static void paint_circus(
     switch (trackSequence)
     {
         case 1:
-            paint_circus_tent(session, rideIndex, direction, 32, 32, height);
+            paint_circus_tent(session, ride, direction, 32, 32, height);
             break;
         case 3:
-            paint_circus_tent(session, rideIndex, direction, 32, -32, height);
+            paint_circus_tent(session, ride, direction, 32, -32, height);
             break;
         case 5:
-            paint_circus_tent(session, rideIndex, direction, 0, -32, height);
+            paint_circus_tent(session, ride, direction, 0, -32, height);
             break;
         case 6:
-            paint_circus_tent(session, rideIndex, direction, -32, 32, height);
+            paint_circus_tent(session, ride, direction, -32, 32, height);
             break;
         case 7:
-            paint_circus_tent(session, rideIndex, direction, -32, -32, height);
+            paint_circus_tent(session, ride, direction, -32, -32, height);
             break;
         case 8:
-            paint_circus_tent(session, rideIndex, direction, -32, 0, height);
+            paint_circus_tent(session, ride, direction, -32, 0, height);
             break;
     }
 

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -63,7 +63,7 @@ static void paint_crooked_house_structure(
 }
 
 static void paint_crooked_house(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -72,7 +72,6 @@ static void paint_crooked_house(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -38,7 +38,7 @@ static void paint_dodgems_roof(paint_session* session, int32_t height, int32_t o
 }
 
 static void paint_dodgems(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];
@@ -50,7 +50,6 @@ static void paint_dodgems(
     uint32_t imageId = SPR_DODGEMS_FLOOR | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, 0, 0, 30, 30, 1, height, 1, 1, height);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -50,13 +50,12 @@ static ferris_wheel_bound_box ferris_wheel_data[] = {
  * rct2: 0x004C3874
  */
 static void paint_ferris_wheel_structure(
-    paint_session* session, ride_id_t rideIndex, uint8_t direction, int8_t axisOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     uint32_t imageId, baseImageId;
 
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -134,7 +133,7 @@ static void paint_ferris_wheel_structure(
  * rct2: 0x008A8EC4
  */
 static void paint_ferris_wheel(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
@@ -151,7 +150,6 @@ static void paint_ferris_wheel(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -189,16 +187,16 @@ static void paint_ferris_wheel(
     switch (relativeTrackSequence)
     {
         case 1:
-            paint_ferris_wheel_structure(session, rideIndex, direction, 48, height);
+            paint_ferris_wheel_structure(session, ride, direction, 48, height);
             break;
         case 2:
-            paint_ferris_wheel_structure(session, rideIndex, direction, 16, height);
+            paint_ferris_wheel_structure(session, ride, direction, 16, height);
             break;
         case 0:
-            paint_ferris_wheel_structure(session, rideIndex, direction, -16, height);
+            paint_ferris_wheel_structure(session, ride, direction, -16, height);
             break;
         case 3:
-            paint_ferris_wheel_structure(session, rideIndex, direction, -48, height);
+            paint_ferris_wheel_structure(session, ride, direction, -48, height);
             break;
     }
 

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -33,7 +33,7 @@ static constexpr const uint32_t flying_saucers_fence_sprites[] = {
  * rct2: 0x008873D8
  */
 static void paint_flying_saucers(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];
@@ -45,7 +45,6 @@ static void paint_flying_saucers(
     uint32_t imageId = SPR_FLYING_SAUCERS_FLOOR | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -165,7 +165,7 @@ static uint8_t get_tunnel_doors_image_straight_flat(const TrackElement* trackEle
 
 /** rct2: 0x00770BEC */
 static void paint_ghost_train_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = ghost_train_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -187,7 +187,7 @@ static void paint_ghost_train_track_flat(
 
 /** rct2: 0x00770BFC */
 static void paint_ghost_train_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = ghost_train_track_pieces_25_deg_up[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -224,7 +224,7 @@ static void paint_ghost_train_track_25_deg_up(
 
 /** rct2: 0x00770C0C */
 static void paint_ghost_train_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isBackwards = tileElement->AsTrack()->GetTrackType() == TrackElemType::Down25ToFlat;
@@ -271,7 +271,7 @@ static void paint_ghost_train_track_flat_to_25_deg_up(
 }
 
 static void paint_ghost_train_track_25_deg_up_to_flat_shared(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = ghost_train_track_pieces_25_deg_up_to_flat[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -292,10 +292,10 @@ static void paint_ghost_train_track_25_deg_up_to_flat_shared(
 
 /** rct2: 0x00770C1C */
 static void paint_ghost_train_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_ghost_train_track_25_deg_up_to_flat_shared(session, rideIndex, trackSequence, direction, height, tileElement);
+    paint_ghost_train_track_25_deg_up_to_flat_shared(session, ride, trackSequence, direction, height, tileElement);
 
     switch (direction)
     {
@@ -318,19 +318,18 @@ static void paint_ghost_train_track_25_deg_up_to_flat(
 
 /** rct2: 0x00770C2C */
 static void paint_ghost_train_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_ghost_train_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_ghost_train_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x00770C3C */
 static void paint_ghost_train_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_ghost_train_track_25_deg_up_to_flat_shared(
-        session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_ghost_train_track_25_deg_up_to_flat_shared(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 
     switch ((direction + 2) % 4)
     {
@@ -353,15 +352,15 @@ static void paint_ghost_train_track_flat_to_25_deg_down(
 
 /** rct2: 0x00770C4C */
 static void paint_ghost_train_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_ghost_train_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_ghost_train_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x00770C5C, 0x00770C6C, 0x00770C7C */
 static void paint_ghost_train_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -392,7 +391,7 @@ static void paint_ghost_train_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -400,7 +399,7 @@ static void paint_ghost_train_station(
 
 /** rct2: 0x00770C9C */
 static void paint_ghost_train_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -442,17 +441,16 @@ static void paint_ghost_train_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x00770CAC */
 static void paint_ghost_train_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    paint_ghost_train_track_right_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    paint_ghost_train_track_right_quarter_turn_3_tiles(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x00770CAC */
 static void paint_ghost_train_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isBackwards = tileElement->AsTrack()->GetTrackType() == TrackElemType::RightQuarterTurn1Tile;
@@ -479,16 +477,15 @@ static void paint_ghost_train_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00770CBC */
 static void paint_ghost_train_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_ghost_train_track_left_quarter_turn_1_tile(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_ghost_train_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /** rct2: 0x00770CCC */
 static void paint_ghost_train_track_spinning_tunnel(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = ghost_train_track_pieces_spinning_tunnel_track[direction] | session->TrackColours[SCHEME_TRACK];
@@ -508,7 +505,7 @@ static void paint_ghost_train_track_spinning_tunnel(
 
 /** rct2: 0x00770CDC */
 static void paint_ghost_train_track_brakes(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = ghost_train_track_pieces_brakes[direction] | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -32,14 +32,12 @@ static haunted_house_bound_box haunted_house_data[] = {
  * rct2: 0x0076F72C
  */
 static void paint_haunted_house_structure(
-    paint_session* session, ride_id_t rideIndex, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part,
-    uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
     uint8_t frameNum = 0;
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -95,7 +93,7 @@ static void paint_haunted_house_structure(
  * rct2: 0x0076E9B0
  */
 static void paint_haunted_house(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -104,7 +102,6 @@ static void paint_haunted_house(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -121,13 +118,13 @@ static void paint_haunted_house(
     switch (trackSequence)
     {
         case 3:
-            paint_haunted_house_structure(session, rideIndex, direction, 32, -32, 0, height + 3);
+            paint_haunted_house_structure(session, ride, direction, 32, -32, 0, height + 3);
             break;
         case 6:
-            paint_haunted_house_structure(session, rideIndex, direction, -32, 32, 4, height + 3);
+            paint_haunted_house_structure(session, ride, direction, -32, 32, 4, height + 3);
             break;
         case 7:
-            paint_haunted_house_structure(session, rideIndex, direction, -32, -32, 2, height + 3);
+            paint_haunted_house_structure(session, ride, direction, -32, -32, 2, height + 3);
             break;
     }
 

--- a/src/openrct2/ride/gentle/Maze.cpp
+++ b/src/openrct2/ride/gentle/Maze.cpp
@@ -45,7 +45,7 @@ enum
  * rct: 0x004ACF4A
  */
 static void maze_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint16_t maze_entry = tileElement->AsTrack()->GetMazeEntry();
@@ -61,7 +61,7 @@ static void maze_paint_setup(
     paint_util_set_segment_support_height(session, SEGMENTS_ALL & ~SEGMENT_C4, 0xFFFF, 0);
 
     int32_t base_image_id = 0;
-    switch (get_ride(rideIndex)->track_colour[0].supports)
+    switch (ride->track_colour[0].supports)
     {
         case 0:
             base_image_id = SPR_MAZE_BASE_BRICK;

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -25,12 +25,11 @@ static constexpr const uint16_t merry_go_round_breakdown_vibration[] = { 0, 1, 2
  * rct2: 0x0076287D
  */
 static void paint_merry_go_round_structure(
-    paint_session* session, ride_id_t rideIndex, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
     height += 7;
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -104,7 +103,7 @@ static void paint_merry_go_round_structure(
  * rct2: 0x00761B0C
  */
 static void paint_merry_go_round(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -113,7 +112,6 @@ static void paint_merry_go_round(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -130,22 +128,22 @@ static void paint_merry_go_round(
     switch (trackSequence)
     {
         case 1:
-            paint_merry_go_round_structure(session, rideIndex, direction, 32, 32, height);
+            paint_merry_go_round_structure(session, ride, direction, 32, 32, height);
             break;
         case 3:
-            paint_merry_go_round_structure(session, rideIndex, direction, 32, -32, height);
+            paint_merry_go_round_structure(session, ride, direction, 32, -32, height);
             break;
         case 5:
-            paint_merry_go_round_structure(session, rideIndex, direction, 0, -32, height);
+            paint_merry_go_round_structure(session, ride, direction, 0, -32, height);
             break;
         case 6:
-            paint_merry_go_round_structure(session, rideIndex, direction, -32, 32, height);
+            paint_merry_go_round_structure(session, ride, direction, -32, 32, height);
             break;
         case 7:
-            paint_merry_go_round_structure(session, rideIndex, direction, -32, -32, height);
+            paint_merry_go_round_structure(session, ride, direction, -32, -32, height);
             break;
         case 8:
-            paint_merry_go_round_structure(session, rideIndex, direction, -32, 0, height);
+            paint_merry_go_round_structure(session, ride, direction, -32, 0, height);
             break;
     }
 

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -484,7 +484,7 @@ static bool mini_golf_paint_util_should_draw_fence(paint_session* session, const
 
 /** rct2: 0x0087F10C */
 static void paint_mini_golf_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -531,7 +531,7 @@ static void paint_mini_golf_track_flat(
 
 /** rct2: 0x0087F11C */
 static void paint_mini_golf_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -570,7 +570,7 @@ static void paint_mini_golf_track_25_deg_up(
 
 /** rct2: 0x0087F12C */
 static void paint_mini_golf_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -609,7 +609,7 @@ static void paint_mini_golf_track_flat_to_25_deg_up(
 
 /** rct2: 0x0087F13C */
 static void paint_mini_golf_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -648,34 +648,33 @@ static void paint_mini_golf_track_25_deg_up_to_flat(
 
 /** rct2: 0x0087F14C */
 static void paint_mini_golf_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_golf_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_mini_golf_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0087F15C */
 static void paint_mini_golf_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_golf_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_mini_golf_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0087F16C */
 static void paint_mini_golf_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_golf_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_mini_golf_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0087F17C, 0x0087F18C, 0x0087F19C */
 static void paint_mini_golf_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -740,7 +739,7 @@ static void paint_mini_golf_station(
 
 /** rct2: 0x0087F1AC */
 static void paint_mini_golf_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -820,10 +819,10 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0087F1BC */
 static void paint_mini_golf_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_golf_track_left_quarter_turn_1_tile(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_mini_golf_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static void paint_mini_golf_hole_ab(
@@ -882,7 +881,7 @@ static void paint_mini_golf_hole_ab(
 
 /** rct2: 0x0087F1CC */
 static void paint_mini_golf_hole_a(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_mini_golf_hole_ab(session, trackSequence, direction, height, mini_golf_track_sprites_hole_a);
@@ -890,7 +889,7 @@ static void paint_mini_golf_hole_a(
 
 /** rct2: 0x0087F1DC */
 static void paint_mini_golf_hole_b(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_mini_golf_hole_ab(session, trackSequence, direction, height, mini_golf_track_sprites_hole_b);
@@ -898,7 +897,7 @@ static void paint_mini_golf_hole_b(
 
 /** rct2: 0x0087F1EC */
 static void paint_mini_golf_hole_c(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -968,7 +967,7 @@ static void paint_mini_golf_hole_c(
 
 /** rct2: 0x0087F1FC */
 static void paint_mini_golf_hole_d(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -1061,7 +1060,7 @@ static void paint_mini_golf_hole_d(
 
 /** rct2: 0x0087F1FC */
 static void paint_mini_golf_hole_e(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -18,7 +18,7 @@
 
 /** rct2: 0x */
 static void paint_mini_helicopters_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -48,7 +48,7 @@ static void paint_mini_helicopters_track_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -56,7 +56,7 @@ static void paint_mini_helicopters_track_station(
 
 /** rct2: 0x0081F348 */
 static void paint_mini_helicopters_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -88,7 +88,7 @@ static void paint_mini_helicopters_track_flat(
 
 /** rct2: 0x0081F368 */
 static void paint_mini_helicopters_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -129,7 +129,7 @@ static void paint_mini_helicopters_track_flat_to_25_deg_up(
 
 /** rct2: 0x0081F358 */
 static void paint_mini_helicopters_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -170,7 +170,7 @@ static void paint_mini_helicopters_track_25_deg_up(
 
 /** rct2: 0x0081F378 */
 static void paint_mini_helicopters_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -211,31 +211,31 @@ static void paint_mini_helicopters_track_25_deg_up_to_flat(
 
 /** rct2: 0x */
 static void paint_mini_helicopters_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_helicopters_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_mini_helicopters_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0081F388 */
 static void paint_mini_helicopters_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_helicopters_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_mini_helicopters_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0081F3A8 */
 static void paint_mini_helicopters_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_mini_helicopters_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_mini_helicopters_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0081F3E8 */
 static void paint_mini_helicopters_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -268,17 +268,17 @@ static constexpr const uint8_t mini_helicopters_right_quarter_turn_3_tiles_to_le
 
 /** rct2: 0x0081F3F8 */
 static void paint_mini_helicopters_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mini_helicopters_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
     paint_mini_helicopters_track_left_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /** rct2: 0x0081F408 */
 static void paint_mini_helicopters_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -293,11 +293,11 @@ static void paint_mini_helicopters_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0081F418 */
 static void paint_mini_helicopters_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_mini_helicopters_track_left_quarter_turn_1_tile(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /**

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -164,7 +164,7 @@ static paint_struct* paint_monorail_cycles_util_7c(
 
 /** rct2: 0x0088AD48 */
 static void paint_monorail_cycles_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = monorail_cycles_track_pieces_flat[(direction & 1)] | session->TrackColours[SCHEME_TRACK];
@@ -191,7 +191,7 @@ static void paint_monorail_cycles_track_flat(
 
 /** rct2: 0x0088ADD8 */
 static void paint_monorail_cycles_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -221,7 +221,7 @@ static void paint_monorail_cycles_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -229,7 +229,7 @@ static void paint_monorail_cycles_station(
 
 /** rct2: 0x0088AD88 */
 static void paint_monorail_cycles_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -262,12 +262,12 @@ static constexpr const uint8_t monorail_cycles_right_quarter_turn_3_tiles_to_lef
 
 /** rct2: 0x0088AD98 */
 static void paint_monorail_cycles_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = monorail_cycles_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
     paint_monorail_cycles_track_left_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static constexpr const int8_t monorail_cycles_track_right_quarter_turn_5_tiles_support_height_offset[][7] = {
@@ -286,7 +286,7 @@ static constexpr const int8_t monorail_cycles_track_right_quarter_turn_5_tiles_s
 
 /** rct2: 0x0088ADB8 */
 static void paint_monorail_cycles_track_right_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -402,17 +402,17 @@ static void paint_monorail_cycles_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x0088ADA8 */
 static void paint_monorail_cycles_track_left_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     paint_monorail_cycles_track_right_quarter_turn_5_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x0088ADC8 */
 static void paint_monorail_cycles_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -521,7 +521,7 @@ static void paint_monorail_cycles_track_s_bend_left(
 
 /** rct2: 0x*/
 static void paint_monorail_cycles_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -84,7 +84,7 @@ void vehicle_visual_observation_tower(
 
 /** rct2: 0x0070DD6C */
 static void paint_observation_tower_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -97,7 +97,6 @@ static void paint_observation_tower_base(
     uint32_t imageId = SPR_FLOOR_METAL_B | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, 0, 0, 32, 32, 1, height, 0, 0, height);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(
@@ -162,7 +161,7 @@ static void paint_observation_tower_base(
 
 /** rct2: 0x0070DD7C */
 static void paint_observation_tower_section(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -32,7 +32,8 @@ static constexpr const uint32_t space_rings_fence_sprites[] = {
 };
 
 /** rct2: 0x00768A3B */
-static void paint_space_rings_structure(paint_session* session, Ride* ride, uint8_t direction, uint32_t segment, int32_t height)
+static void paint_space_rings_structure(
+    paint_session* session, const Ride* ride, uint8_t direction, uint32_t segment, int32_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
@@ -86,10 +87,9 @@ static void paint_space_rings_structure(paint_session* session, Ride* ride, uint
 
 /** rct2: 0x00767C40 */
 static void paint_space_rings(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -46,7 +46,7 @@ enum
 };
 
 static void spiral_slide_paint_tile_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id = 0;
@@ -64,7 +64,7 @@ static void spiral_slide_paint_tile_right(
 }
 
 static void spiral_slide_paint_tile_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id = 0;
@@ -82,12 +82,11 @@ static void spiral_slide_paint_tile_left(
 }
 
 static void spiral_slide_paint_tile_front(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t image_id = 0;
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -192,7 +191,7 @@ static constexpr const uint32_t spiral_slide_fence_sprites[] = {
  * rct: 0x007485C8
  */
 static void paint_spiral_slide(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_2x2[direction][trackSequence];
@@ -205,7 +204,6 @@ static void paint_spiral_slide(
     uint32_t imageId = ((direction & 1) ? SPIRAL_SLIDE_BASE_B : SPIRAL_SLIDE_BASE_A) | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, 0, 0, 32, 32, 1, height, 0, 0, height);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(
@@ -216,13 +214,13 @@ static void paint_spiral_slide(
     switch (trackSequence)
     {
         case 1:
-            spiral_slide_paint_tile_right(session, rideIndex, trackSequence, direction, height, tileElement);
+            spiral_slide_paint_tile_right(session, ride, trackSequence, direction, height, tileElement);
             break;
         case 2:
-            spiral_slide_paint_tile_left(session, rideIndex, trackSequence, direction, height, tileElement);
+            spiral_slide_paint_tile_left(session, ride, trackSequence, direction, height, tileElement);
             break;
         case 3:
-            spiral_slide_paint_tile_front(session, rideIndex, trackSequence, direction, height, tileElement);
+            spiral_slide_paint_tile_front(session, ride, trackSequence, direction, height, tileElement);
             break;
     }
 

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -23,13 +23,12 @@
  *  rct2: 0x007630DE
  */
 static void facility_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool hasSupports = wooden_a_supports_paint_setup(
         session, direction & 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -23,13 +23,12 @@
  *  rct2: 0x007617A5
  */
 static void shop_paint_setup(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool hasSupports = wooden_a_supports_paint_setup(
         session, direction & 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -18,11 +18,10 @@
  * rct2: 0x007664C2
  */
 static void paint_3d_cinema_structure(
-    paint_session* session, ride_id_t rideIndex, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -53,7 +52,7 @@ static void paint_3d_cinema_structure(
  * rct2: 0x0076574C
  */
 static void paint_3d_cinema(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -62,7 +61,6 @@ static void paint_3d_cinema(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -79,22 +77,22 @@ static void paint_3d_cinema(
     switch (trackSequence)
     {
         case 1:
-            paint_3d_cinema_structure(session, rideIndex, direction, 32, 32, height);
+            paint_3d_cinema_structure(session, ride, direction, 32, 32, height);
             break;
         case 3:
-            paint_3d_cinema_structure(session, rideIndex, direction, 32, -32, height);
+            paint_3d_cinema_structure(session, ride, direction, 32, -32, height);
             break;
         case 5:
-            paint_3d_cinema_structure(session, rideIndex, direction, 0, -32, height);
+            paint_3d_cinema_structure(session, ride, direction, 0, -32, height);
             break;
         case 6:
-            paint_3d_cinema_structure(session, rideIndex, direction, -32, 32, height);
+            paint_3d_cinema_structure(session, ride, direction, -32, 32, height);
             break;
         case 7:
-            paint_3d_cinema_structure(session, rideIndex, direction, -32, -32, height);
+            paint_3d_cinema_structure(session, ride, direction, -32, -32, height);
             break;
         case 8:
-            paint_3d_cinema_structure(session, rideIndex, direction, -32, 0, height);
+            paint_3d_cinema_structure(session, ride, direction, -32, 0, height);
             break;
     }
 

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -18,7 +18,7 @@
 
 /** rct2: 0x008A2ABC */
 static void paint_enterprise_structure(
-    paint_session* session, Ride* ride, int8_t xOffset, int8_t yOffset, uint16_t height, const TileElement* tileElement)
+    paint_session* session, const Ride* ride, int8_t xOffset, int8_t yOffset, uint16_t height, const TileElement* tileElement)
 {
     height += 7;
 
@@ -79,10 +79,9 @@ static void paint_enterprise_structure(
 
 /** rct2: 0x008A1584 */
 static void paint_enterprise(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -125,7 +125,7 @@ static constexpr const uint32_t go_karts_track_pieces_25_deg_up_to_flat[4][2] = 
 
 /** rct2: 0x0074A748 */
 static void paint_go_karts_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -158,7 +158,7 @@ static void paint_go_karts_track_flat(
 
 /** rct2: 0x0074A758 */
 static void paint_go_karts_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -212,7 +212,7 @@ static void paint_go_karts_track_25_deg_up(
 
 /** rct2: 0x0074A768 */
 static void paint_go_karts_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -266,7 +266,7 @@ static void paint_go_karts_track_flat_to_25_deg_up(
 
 /** rct2: 0x */
 static void paint_go_karts_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -320,34 +320,33 @@ static void paint_go_karts_track_25_deg_up_to_flat(
 
 /** rct2: 0x0074A788 */
 static void paint_go_karts_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_go_karts_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_go_karts_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0074A798 */
 static void paint_go_karts_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_go_karts_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_go_karts_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x0074A7A8 */
 static void paint_go_karts_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_go_karts_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_go_karts_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x */
 static void paint_go_karts_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -457,7 +456,7 @@ static void paint_go_karts_station(
 
 /** rct2: 0x0074A7E8 */
 static void paint_go_karts_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -527,10 +526,10 @@ static void paint_go_karts_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0074A7F8 */
 static void paint_go_karts_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_go_karts_track_left_quarter_turn_1_tile(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_go_karts_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /**

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -87,7 +87,7 @@ void vehicle_visual_launched_freefall(
 
 /** rct2: 0x006FD1F8 */
 static void paint_launched_freefall_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -99,7 +99,6 @@ static void paint_launched_freefall_base(
     uint32_t imageId = SPR_FLOOR_METAL | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, 0, 0, 32, 32, 1, height, 0, 0, height);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(
@@ -163,7 +162,7 @@ static void paint_launched_freefall_base(
 
 /** rct2: 0x006FD208 */
 static void paint_launched_freefall_tower_section(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -55,7 +55,7 @@ static constexpr const bound_box MagicCarpetBounds[] = {
     { 0, 8, 32, 16 }, { 8, 0, 16, 32 }, { 0, 8, 32, 16 }, { 8, 0, 16, 32 }
 };
 
-static Vehicle* get_first_vehicle(Ride* ride)
+static const Vehicle* get_first_vehicle(const Ride* ride)
 {
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {
@@ -120,8 +120,8 @@ static void paint_magic_carpet_pendulum(
 }
 
 static void paint_magic_carpet_vehicle(
-    paint_session* session, Ride* ride, uint8_t direction, uint32_t swingImageId, CoordsXYZ offset, const CoordsXYZ& bbOffset,
-    const CoordsXYZ& bbSize)
+    paint_session* session, const Ride* ride, uint8_t direction, uint32_t swingImageId, CoordsXYZ offset,
+    const CoordsXYZ& bbOffset, const CoordsXYZ& bbSize)
 {
     rct_ride_entry* rideEntry = ride->GetRideEntry();
     uint32_t vehicleImageId = rideEntry->vehicles[0].base_image_id + direction;
@@ -159,7 +159,7 @@ static void paint_magic_carpet_vehicle(
     rct_drawpixelinfo* dpi = &session->DPI;
     if (dpi->zoom_level <= 1 && (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
     {
-        Vehicle* vehicle = get_first_vehicle(ride);
+        auto* vehicle = get_first_vehicle(ride);
         if (vehicle != nullptr)
         {
             uint32_t baseImageId = IMAGE_TYPE_REMAP | IMAGE_TYPE_REMAP_2_PLUS | (vehicleImageId + 4);
@@ -178,10 +178,10 @@ static void paint_magic_carpet_vehicle(
 
 /** rct2: 0x00899104 */
 static void paint_magic_carpet_structure(
-    paint_session* session, Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
-    Vehicle* vehicle = get_first_vehicle(ride);
+    auto* vehicle = get_first_vehicle(ride);
 
     uint32_t swingImageId = 0;
     if (vehicle != nullptr)
@@ -215,7 +215,7 @@ static void paint_magic_carpet_structure(
 
 /** rct2: 0x00898514 */
 static void paint_magic_carpet(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
@@ -245,7 +245,6 @@ static void paint_magic_carpet(
             break;
     }
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         switch (relativeTrackSequence)

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -32,9 +32,9 @@ enum
  *  rct2: 0x0076522A
  */
 static void paint_motionsimulator_vehicle(
-    paint_session* session, int8_t offsetX, int8_t offsetY, uint8_t direction, int32_t height, const TileElement* tileElement)
+    paint_session* session, const Ride* ride, int8_t offsetX, int8_t offsetY, uint8_t direction, int32_t height,
+    const TileElement* tileElement)
 {
-    auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
     if (ride == nullptr)
         return;
 
@@ -132,7 +132,7 @@ static void paint_motionsimulator_vehicle(
 
 /** rct2: 0x008A85C4 */
 static void paint_motionsimulator(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_2x2[direction][trackSequence];
@@ -141,7 +141,6 @@ static void paint_motionsimulator(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -158,13 +157,13 @@ static void paint_motionsimulator(
     switch (trackSequence)
     {
         case 1:
-            paint_motionsimulator_vehicle(session, 16, -16, direction, height, tileElement);
+            paint_motionsimulator_vehicle(session, ride, 16, -16, direction, height, tileElement);
             break;
         case 2:
-            paint_motionsimulator_vehicle(session, -16, 16, direction, height, tileElement);
+            paint_motionsimulator_vehicle(session, ride, -16, 16, direction, height, tileElement);
             break;
         case 3:
-            paint_motionsimulator_vehicle(session, -16, -16, direction, height, tileElement);
+            paint_motionsimulator_vehicle(session, ride, -16, -16, direction, height, tileElement);
             break;
     }
 

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -97,7 +97,7 @@ void vehicle_visual_roto_drop(
 
 /** rct2: 0x00886194 */
 static void paint_roto_drop_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -109,7 +109,6 @@ static void paint_roto_drop_base(
     uint32_t imageId = SPR_FLOOR_METAL_B | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, 0, 0, 32, 32, 1, height, 0, 0, height);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(
@@ -178,7 +177,7 @@ static void paint_roto_drop_base(
 
 /** rct2: 0x008861A4 */
 static void paint_roto_drop_tower_section(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -48,7 +48,7 @@ static constexpr const uint32_t swinging_inverter_ship_frame_sprites[] = { SPR_S
                                                                            SPR_SWINGING_INVERTER_SHIP_FRAME_3 };
 
 static void paint_swinging_inverter_ship_structure(
-    paint_session* session, Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
@@ -123,7 +123,7 @@ static void paint_swinging_inverter_ship_structure(
 
 /** rct2: 0x00760260 */
 static void paint_swinging_inverter_ship(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
@@ -166,7 +166,6 @@ static void paint_swinging_inverter_ship(
         }
     }
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         switch (relativeTrackSequence)

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -57,7 +57,7 @@ static constexpr const uint32_t swinging_ship_frame_sprites[][2] = {
 
 /** rct2: 0x4AF254 */
 static void paint_swinging_ship_structure(
-    paint_session* session, Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     uint32_t imageId, baseImageId;
 
@@ -173,10 +173,9 @@ static void paint_swinging_ship_structure(
 
 /** rct2: 0x008A85C4 */
 static void paint_swinging_ship(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -43,10 +43,9 @@ static int8_t TopSpinSeatPositionOffset[] = {
  *  rct2: 0x0076750D
  */
 static void top_spin_paint_vehicle(
-    paint_session* session, int8_t al, int8_t cl, ride_id_t rideIndex, uint8_t direction, int32_t height,
+    paint_session* session, int8_t al, int8_t cl, const Ride* ride, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -248,7 +247,7 @@ static void top_spin_paint_vehicle(
  * rct2: 0x0076679C
  */
 static void paint_top_spin(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -257,7 +256,6 @@ static void paint_top_spin(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
 
-    auto ride = get_ride(rideIndex);
     StationObject* stationObject = nullptr;
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
@@ -274,22 +272,22 @@ static void paint_top_spin(
     switch (trackSequence)
     {
         case 1:
-            top_spin_paint_vehicle(session, 32, 32, rideIndex, direction, height, tileElement);
+            top_spin_paint_vehicle(session, 32, 32, ride, direction, height, tileElement);
             break;
         case 3:
-            top_spin_paint_vehicle(session, 32, -32, rideIndex, direction, height, tileElement);
+            top_spin_paint_vehicle(session, 32, -32, ride, direction, height, tileElement);
             break;
         case 5:
-            top_spin_paint_vehicle(session, 0, -32, rideIndex, direction, height, tileElement);
+            top_spin_paint_vehicle(session, 0, -32, ride, direction, height, tileElement);
             break;
         case 6:
-            top_spin_paint_vehicle(session, -32, 32, rideIndex, direction, height, tileElement);
+            top_spin_paint_vehicle(session, -32, 32, ride, direction, height, tileElement);
             break;
         case 7:
-            top_spin_paint_vehicle(session, -32, -32, rideIndex, direction, height, tileElement);
+            top_spin_paint_vehicle(session, -32, -32, ride, direction, height, tileElement);
             break;
         case 8:
-            top_spin_paint_vehicle(session, -32, 0, rideIndex, direction, height, tileElement);
+            top_spin_paint_vehicle(session, -32, 0, ride, direction, height, tileElement);
             break;
     }
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -18,7 +18,7 @@
 
 /** rct2: 0x0076E5C9 */
 static void paint_twist_structure(
-    paint_session* session, Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
@@ -79,10 +79,9 @@ static void paint_twist_structure(
 
 /** rct2: 0x0076D858 */
 static void paint_twist(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -108,7 +108,7 @@ static void chairlift_paint_util_draw_supports(paint_session* session, int32_t s
 }
 
 static const TileElement* chairlift_paint_util_map_get_track_element_at_from_ride_fuzzy(
-    int32_t x, int32_t y, int32_t z, ride_id_t rideIndex)
+    int32_t x, int32_t y, int32_t z, const Ride* ride)
 {
     const TileElement* tileElement = map_get_first_element_at({ x, y });
     if (tileElement == nullptr)
@@ -120,7 +120,7 @@ static const TileElement* chairlift_paint_util_map_get_track_element_at_from_rid
     {
         if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
             continue;
-        if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
+        if (tileElement->AsTrack()->GetRideIndex() != ride->id)
             continue;
         if (tileElement->base_height != z && tileElement->base_height != z - 1)
             continue;
@@ -132,7 +132,7 @@ static const TileElement* chairlift_paint_util_map_get_track_element_at_from_rid
 };
 
 static bool chairlift_paint_util_is_first_track(
-    ride_id_t rideIndex, const TileElement* tileElement, const CoordsXY& pos, track_type_t trackType)
+    const Ride* ride, const TileElement* tileElement, const CoordsXY& pos, track_type_t trackType)
 {
     if (tileElement->AsTrack()->GetTrackType() != TrackElemType::BeginStation)
     {
@@ -146,13 +146,13 @@ static bool chairlift_paint_util_is_first_track(
     };
 
     const TileElement* nextTrack = chairlift_paint_util_map_get_track_element_at_from_ride_fuzzy(
-        newPos.x, newPos.y, tileElement->base_height, rideIndex);
+        newPos.x, newPos.y, tileElement->base_height, ride);
 
     return nextTrack == nullptr;
 }
 
 static bool chairlift_paint_util_is_last_track(
-    ride_id_t rideIndex, const TileElement* tileElement, const CoordsXY& pos, track_type_t trackType)
+    const Ride* ride, const TileElement* tileElement, const CoordsXY& pos, track_type_t trackType)
 {
     if (tileElement->AsTrack()->GetTrackType() != TrackElemType::EndStation)
     {
@@ -166,16 +166,15 @@ static bool chairlift_paint_util_is_last_track(
     };
 
     const TileElement* nextTrack = chairlift_paint_util_map_get_track_element_at_from_ride_fuzzy(
-        newPos.x, newPos.y, tileElement->base_height, rideIndex);
+        newPos.x, newPos.y, tileElement->base_height, ride);
 
     return nextTrack == nullptr;
 }
 
 static void chairlift_paint_station_ne_sw(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -183,8 +182,8 @@ static void chairlift_paint_station_ne_sw(
     auto trackType = tileElement->AsTrack()->GetTrackType();
     uint32_t imageId;
 
-    bool isStart = chairlift_paint_util_is_first_track(rideIndex, tileElement, pos, trackType);
-    bool isEnd = chairlift_paint_util_is_last_track(rideIndex, tileElement, pos, trackType);
+    bool isStart = chairlift_paint_util_is_first_track(ride, tileElement, pos, trackType);
+    bool isEnd = chairlift_paint_util_is_last_track(ride, tileElement, pos, trackType);
 
     auto stationObj = ride_get_station_object(ride);
 
@@ -266,10 +265,9 @@ static void chairlift_paint_station_ne_sw(
 }
 
 static void chairlift_paint_station_se_nw(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -277,8 +275,8 @@ static void chairlift_paint_station_se_nw(
     auto trackType = tileElement->AsTrack()->GetTrackType();
     uint32_t imageId;
 
-    bool isStart = chairlift_paint_util_is_first_track(rideIndex, tileElement, pos, trackType);
-    bool isEnd = chairlift_paint_util_is_last_track(rideIndex, tileElement, pos, trackType);
+    bool isStart = chairlift_paint_util_is_first_track(ride, tileElement, pos, trackType);
+    bool isEnd = chairlift_paint_util_is_last_track(ride, tileElement, pos, trackType);
 
     auto stationObj = ride_get_station_object(ride);
 
@@ -362,21 +360,21 @@ static void chairlift_paint_station_se_nw(
 
 /** rct2: 0x00744068 */
 static void chairlift_paint_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction % 2)
     {
-        chairlift_paint_station_se_nw(session, rideIndex, trackSequence, direction, height, tileElement);
+        chairlift_paint_station_se_nw(session, ride, trackSequence, direction, height, tileElement);
     }
     else
     {
-        chairlift_paint_station_ne_sw(session, rideIndex, trackSequence, direction, height, tileElement);
+        chairlift_paint_station_ne_sw(session, ride, trackSequence, direction, height, tileElement);
     }
 }
 
 static void chairlift_paint_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -399,7 +397,7 @@ static void chairlift_paint_flat(
 
 /** rct2: 0x00743FD8 */
 static void chairlift_paint_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -437,7 +435,7 @@ static void chairlift_paint_25_deg_up(
 
 /** rct2: 0x00743FD8 */
 static void chairlift_paint_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -492,7 +490,7 @@ static void chairlift_paint_flat_to_25_deg_up(
 
 /** rct2: 0x00743FF8 */
 static void chairlift_paint_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -547,31 +545,31 @@ static void chairlift_paint_25_deg_up_to_flat(
 
 /** rct2: 0x00744008 */
 static void chairlift_paint_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    chairlift_paint_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    chairlift_paint_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x00744018 */
 static void chairlift_paint_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    chairlift_paint_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    chairlift_paint_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x00744028 */
 static void chairlift_paint_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    chairlift_paint_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    chairlift_paint_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x00744038 */
 static void chairlift_paint_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -638,10 +636,10 @@ static void chairlift_paint_left_quarter_turn_1_tile(
 
 /** rct2: 0x00744048 */
 static void chairlift_paint_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    chairlift_paint_left_quarter_turn_1_tile(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    chairlift_paint_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /* 0x008AAA0C */

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -47,7 +47,7 @@ static void paint_lift_cage(paint_session* session, int8_t index, uint32_t colou
 
 /** rct2: 0x0076C6CC */
 static void paint_lift_base(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -77,7 +77,6 @@ static void paint_lift_base(
     uint32_t imageId = SPR_FLOOR_METAL_B | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, 0, 0, 32, 32, 1, height, 0, 0, height);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(
@@ -120,7 +119,7 @@ static void paint_lift_base(
 
 /** rct2: 0x0076C6DC */
 static void paint_lift_tower_section(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -588,7 +588,7 @@ static uint32_t miniature_railway_track_to_grooved_indent(
 
 /** rct2: 0x008AD0C0 */
 static void paint_miniature_railway_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool paintAsGravel = false;
@@ -668,7 +668,7 @@ static void paint_miniature_railway_track_flat(
 
 /** rct2: 0x008AD170, 0x008AD180, 0x008AD190 */
 static void paint_miniature_railway_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -683,7 +683,7 @@ static void paint_miniature_railway_station(
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
-    track_paint_util_draw_station_3(session, rideIndex, direction, height + 2, height, tileElement);
+    track_paint_util_draw_station_3(session, ride, direction, height + 2, height, tileElement);
     // covers shouldn't be offset by +2
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -692,7 +692,7 @@ static void paint_miniature_railway_station(
 
 /** rct2: 0x008AD0D0 */
 static void paint_miniature_railway_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = miniature_railway_track_pieces_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -724,7 +724,7 @@ static void paint_miniature_railway_track_25_deg_up(
 
 /** rct2: 0x008AD0E0 */
 static void paint_miniature_railway_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = miniature_railway_track_pieces_flat_to_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -756,7 +756,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AD0F0 */
 static void paint_miniature_railway_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = miniature_railway_track_pieces_25_deg_up_to_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -788,28 +788,26 @@ static void paint_miniature_railway_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AD100 */
 static void paint_miniature_railway_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_miniature_railway_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_miniature_railway_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AD110 */
 static void paint_miniature_railway_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_miniature_railway_track_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_miniature_railway_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AD120 */
 static void paint_miniature_railway_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_miniature_railway_track_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_miniature_railway_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 // clang-format off
@@ -920,7 +918,7 @@ static constexpr const int8_t miniature_railway_right_quarter_turn_5_tiles_sprit
 
 /** rct2: 0x008AD140 */
 static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (right_quarter_turn_5_supports_type[direction][trackSequence] != -1)
@@ -1009,12 +1007,12 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x008AD130 */
 static void paint_miniature_railway_track_left_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
     paint_miniature_railway_track_right_quarter_turn_5_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static constexpr const int8_t s_bend_left_supports_type[4][4] = {
@@ -1033,7 +1031,7 @@ static constexpr const uint32_t miniature_railway_s_bend_left_tiles_track_floor[
 
 /** rct2: 0x8AD150 */
 static void paint_miniature_railway_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -1135,7 +1133,7 @@ static constexpr const uint32_t miniature_railway_s_bend_right_tiles_track_floor
 
 /** rct2: 0x008AD160 */
 static void paint_miniature_railway_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -1267,7 +1265,7 @@ static constexpr const CoordsXYZ miniature_railway_right_quarter_turn_3_tile_bou
 
 /** rct2: 0x008AD1B0 */
 static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isSupported = false;
@@ -1333,12 +1331,12 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x008AD1A0 */
 static void paint_miniature_railway_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
     paint_miniature_railway_track_right_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static constexpr const int8_t paint_miniature_railway_eighth_to_diag_index[] = { 0, 1, 2, -1, 3 };
@@ -1416,7 +1414,7 @@ static constexpr const CoordsXY miniature_railway_track_floor_pieces_left_eight_
 
 /** rct2: 0x008AD1C0 */
 static void paint_miniature_railway_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t supportType[4][5] = { { 0, 0, 3, 5, 1 }, { 1, 1, 4, 2, 0 }, { 0, 0, 5, 3, 1 }, { 1, 1, 2, 4, 0 } };
@@ -1554,7 +1552,7 @@ static constexpr const CoordsXY miniature_railway_track_floor_pieces_right_eight
 
 /** rct2: 0x008AD1D0 */
 static void paint_miniature_railway_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t supportType[4][5] = { { 0, 0, 2, 4, 1 }, { 1, 1, 3, 5, 0 }, { 0, 0, 4, 2, 1 }, { 1, 1, 5, 3, 0 } };
@@ -1623,22 +1621,20 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
 
 /** rct2: 0x008AD1E0 */
 static void paint_miniature_railway_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    paint_miniature_railway_track_right_eighth_to_diag(
-        session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_miniature_railway_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AD1F0 */
 static void paint_miniature_railway_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    paint_miniature_railway_track_left_eighth_to_diag(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_miniature_railway_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static constexpr const bool miniature_railway_diag_image_segment[][4] = {
@@ -1683,7 +1679,7 @@ static constexpr const floor_desc floors[] = {
 
 /** rct2: 0x008AD200 */
 static void miniature_railway_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isSupported = false;
@@ -1756,7 +1752,7 @@ static bool wooden_supports_paint_setup(
 
 /** rct2: 0x008AD230 */
 static void miniature_railway_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     // TODO: The supports are inconsistent for different rotations
@@ -1831,7 +1827,7 @@ static void miniature_railway_track_diag_25_deg_up(
 
 /** rct2: 0x008AD210 */
 static void miniature_railway_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool hasSupports = false;
@@ -1882,7 +1878,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AD220 */
 static void miniature_railway_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t supportOffsets[][4] = {
@@ -1958,7 +1954,7 @@ static void miniature_railway_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AD260 */
 static void miniature_railway_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t supportOffsets[][4] = {
@@ -2033,7 +2029,7 @@ static void miniature_railway_track_diag_25_deg_down(
 
 /** rct2: 0x008AD240 */
 static void miniature_railway_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const int8_t supportOffsets[][4] = {
@@ -2106,7 +2102,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_down(
 }
 
 static void miniature_railway_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool hasSupports = false;

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -420,7 +420,7 @@ static constexpr const uint32_t monorail_track_pieces_diag_25_deg_up[4] = {
 
 /** rct2: 0x008AE1AC */
 static void paint_monorail_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = monorail_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -455,12 +455,12 @@ static void paint_monorail_track_flat(
 
 /** rct2: 0x008AE25C, 0x008AE26C, 0x008AE27C */
 static void paint_monorail_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
     const StationObject* stationObject = nullptr;
-    const auto* ride = get_ride(rideIndex);
+
     if (ride != nullptr)
         stationObject = ride_get_station_object(ride);
 
@@ -508,7 +508,7 @@ static void paint_monorail_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -516,7 +516,7 @@ static void paint_monorail_station(
 
 /** rct2: 0x008AE1BC */
 static void paint_monorail_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = monorail_track_pieces_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -558,7 +558,7 @@ static void paint_monorail_track_25_deg_up(
 
 /** rct2: 0x008AE1CC */
 static void paint_monorail_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = monorail_track_pieces_flat_to_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -600,7 +600,7 @@ static void paint_monorail_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AE1DC */
 static void paint_monorail_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = monorail_track_pieces_25_deg_up_to_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -642,31 +642,31 @@ static void paint_monorail_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AE1EC */
 static void paint_monorail_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_monorail_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_monorail_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AE1FC */
 static void paint_monorail_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_monorail_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_monorail_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AE20C */
 static void paint_monorail_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_monorail_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_monorail_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AE22C */
 static void paint_monorail_track_right_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -729,17 +729,16 @@ static void paint_monorail_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x008AE21C */
 static void paint_monorail_track_left_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    paint_monorail_track_right_quarter_turn_5_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    paint_monorail_track_right_quarter_turn_5_tiles(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 /** rct2: 0x */
 static void paint_monorail_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -845,7 +844,7 @@ static void paint_monorail_track_s_bend_left(
 
 /** rct2: 0x008AE24C */
 static void paint_monorail_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction == 2 || direction == 3)
@@ -951,7 +950,7 @@ static void paint_monorail_track_s_bend_right(
 
 /** rct2: 0x008AE29C */
 static void paint_monorail_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -988,19 +987,18 @@ static void paint_monorail_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x008AE28C */
 static void paint_monorail_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    paint_monorail_track_right_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    paint_monorail_track_right_quarter_turn_3_tiles(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static constexpr const int8_t paint_monorail_eighth_to_diag_index[] = { 0, 1, 2, -1, 3 };
 
 /** rct2: 0x008AE31C */
 static void paint_monorail_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
@@ -1068,7 +1066,7 @@ static void paint_monorail_track_left_eighth_to_diag(
 
 /** rct2: 0x008AE32C */
 static void paint_monorail_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
@@ -1136,22 +1134,22 @@ static void paint_monorail_track_right_eighth_to_diag(
 
 /** rct2: 0x008AE33C */
 static void paint_monorail_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
     trackSequence = map[trackSequence];
-    paint_monorail_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    paint_monorail_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 /** rct2: 0x008AE34C */
 static void paint_monorail_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
     trackSequence = map[trackSequence];
-    paint_monorail_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_monorail_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static constexpr const bool monorail_diag_image_segment[][4] = {
@@ -1170,7 +1168,7 @@ static constexpr const int32_t monorail_diag_blocked_segments[] = { SEGMENT_C4 |
 
 /** rct2: 0x008AE2AC */
 static void paint_monorail_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1193,7 +1191,7 @@ static void paint_monorail_track_diag_flat(
 
 /** rct2: 0x008AE2DC */
 static void paint_monorail_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1216,7 +1214,7 @@ static void paint_monorail_track_diag_25_deg_up(
 
 /** rct2: 0x008AE2BC */
 static void paint_monorail_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1239,7 +1237,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AE2CC */
 static void paint_monorail_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1262,7 +1260,7 @@ static void paint_monorail_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AE30C */
 static void paint_monorail_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1285,7 +1283,7 @@ static void paint_monorail_track_diag_25_deg_down(
 
 /** rct2: 0x008AE2EC */
 static void paint_monorail_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1309,7 +1307,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AE2FC */
 static void paint_monorail_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x008636F4 */
 static void suspended_monorail_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void suspended_monorail_track_flat(
 
 /** rct2: 0x008637A4, 0x008637B4, 0x008637C4 */
 static void suspended_monorail_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -72,7 +72,7 @@ static void suspended_monorail_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 32, 0, 6,
         height + 32);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, rideIndex, direction, height, tileElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, tileElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -80,7 +80,7 @@ static void suspended_monorail_track_station(
 
 /** rct2: 0x00863704 */
 static void suspended_monorail_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -145,7 +145,7 @@ static void suspended_monorail_track_25_deg_up(
 
 /** rct2: 0x00863714 */
 static void suspended_monorail_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -210,7 +210,7 @@ static void suspended_monorail_track_flat_to_25_deg_up(
 
 /** rct2: 0x00863724 */
 static void suspended_monorail_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -275,31 +275,31 @@ static void suspended_monorail_track_25_deg_up_to_flat(
 
 /** rct2: 0x00863734 */
 static void suspended_monorail_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_monorail_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_monorail_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00863744 */
 static void suspended_monorail_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_monorail_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_monorail_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00863754 */
 static void suspended_monorail_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    suspended_monorail_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_monorail_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00863764 */
 static void suspended_monorail_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -479,16 +479,16 @@ static void suspended_monorail_track_left_quarter_turn_5(
 
 /** rct2: 0x00863774 */
 static void suspended_monorail_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    suspended_monorail_track_left_quarter_turn_5(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    suspended_monorail_track_left_quarter_turn_5(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00863784 */
 static void suspended_monorail_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -659,7 +659,7 @@ static void suspended_monorail_track_s_bend_left(
 
 /** rct2: 0x00863794 */
 static void suspended_monorail_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -830,7 +830,7 @@ static void suspended_monorail_track_s_bend_right(
 
 /** rct2: 0x008637D4 */
 static void suspended_monorail_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -949,16 +949,16 @@ static void suspended_monorail_track_left_quarter_turn_3(
 
 /** rct2: 0x008637E4 */
 static void suspended_monorail_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    suspended_monorail_track_left_quarter_turn_3(session, rideIndex, trackSequence, (direction - 1) & 3, height, tileElement);
+    suspended_monorail_track_left_quarter_turn_3(session, ride, trackSequence, (direction - 1) & 3, height, tileElement);
 }
 
 /** rct2: 0x00863864 */
 static void suspended_monorail_track_left_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1121,7 +1121,7 @@ static void suspended_monorail_track_left_eighth_to_diag(
 
 /** rct2: 0x00863874 */
 static void suspended_monorail_track_right_eighth_to_diag(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1284,25 +1284,25 @@ static void suspended_monorail_track_right_eighth_to_diag(
 
 /** rct2: 0x00863884 */
 static void suspended_monorail_track_left_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    suspended_monorail_track_right_eighth_to_diag(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    suspended_monorail_track_right_eighth_to_diag(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 /** rct2: 0x00863894 */
 static void suspended_monorail_track_right_eighth_to_orthogonal(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    suspended_monorail_track_left_eighth_to_diag(session, rideIndex, trackSequence, (direction + 3) & 3, height, tileElement);
+    suspended_monorail_track_left_eighth_to_diag(session, ride, trackSequence, (direction + 3) & 3, height, tileElement);
 }
 
 /** rct2: 0x008637F4 */
 static void suspended_monorail_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1385,7 +1385,7 @@ static void suspended_monorail_track_diag_flat(
 
 /** rct2: 0x00863824 */
 static void suspended_monorail_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1468,7 +1468,7 @@ static void suspended_monorail_track_diag_25_deg_up(
 
 /** rct2: 0x00863804 */
 static void suspended_monorail_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1551,7 +1551,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00863814 */
 static void suspended_monorail_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1634,7 +1634,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00863854 */
 static void suspended_monorail_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1717,7 +1717,7 @@ static void suspended_monorail_track_diag_25_deg_down(
 
 /** rct2: 0x00863834 */
 static void suspended_monorail_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)
@@ -1797,7 +1797,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x00863844 */
 static void suspended_monorail_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -31,7 +31,7 @@ enum
 
 /** rct2: 0x008B0E40 */
 static void paint_boat_hire_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -61,10 +61,9 @@ static void paint_boat_hire_track_flat(
 
 /** rct2: 0x008B0E50 */
 static void paint_boat_hire_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -89,7 +88,7 @@ static void paint_boat_hire_station(
 
 /** rct2: 0x008B0E80 */
 static void paint_boat_hire_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -133,10 +132,10 @@ static void paint_boat_hire_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x008B0E90 */
 static void paint_boat_hire_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_boat_hire_track_left_quarter_turn_1_tile(session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    paint_boat_hire_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /**

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -349,7 +349,7 @@ enum
 };
 
 static void dinghy_slide_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -387,7 +387,7 @@ static void dinghy_slide_track_flat(
 }
 
 static void dinghy_slide_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -408,7 +408,7 @@ static void dinghy_slide_track_station(
     metal_a_supports_paint_setup(
         session, METAL_SUPPORTS_TUBES, 8 - (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    track_paint_util_draw_station(session, rideIndex, direction, height, tileElement);
+    track_paint_util_draw_station(session, ride, direction, height, tileElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -417,7 +417,7 @@ static void dinghy_slide_track_station(
 }
 
 static void dinghy_slide_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -462,7 +462,7 @@ static void dinghy_slide_track_25_deg_up(
 }
 
 static void dinghy_slide_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -498,7 +498,7 @@ static void dinghy_slide_track_60_deg_up(
 }
 
 static void dinghy_slide_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -543,7 +543,7 @@ static void dinghy_slide_track_flat_to_25_deg_up(
 }
 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -579,7 +579,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up(
 }
 
 static void dinghy_slide_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -615,7 +615,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up(
 }
 
 static void dinghy_slide_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -660,42 +660,42 @@ static void dinghy_slide_track_25_deg_up_to_flat(
 }
 
 static void dinghy_slide_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_right_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -823,22 +823,22 @@ static void dinghy_slide_track_right_quarter_turn_5(
 }
 
 static void dinghy_slide_track_left_quarter_turn_5(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    dinghy_slide_track_right_quarter_turn_5(session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    dinghy_slide_track_right_quarter_turn_5(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void dinghy_slide_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -933,7 +933,7 @@ static void dinghy_slide_track_s_bend_left(
 }
 
 static void dinghy_slide_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1026,7 +1026,7 @@ static void dinghy_slide_track_s_bend_right(
 }
 
 static void dinghy_slide_track_right_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -1107,15 +1107,15 @@ static void dinghy_slide_track_right_quarter_turn_3(
 }
 
 static void dinghy_slide_track_left_quarter_turn_3(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    dinghy_slide_track_right_quarter_turn_3(session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    dinghy_slide_track_right_quarter_turn_3(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void dinghy_slide_track_flat_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1144,7 +1144,7 @@ static void dinghy_slide_track_flat_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1180,7 +1180,7 @@ static void dinghy_slide_track_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_60_deg_up_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1216,7 +1216,7 @@ static void dinghy_slide_track_60_deg_up_covered(
 }
 
 static void dinghy_slide_track_flat_to_25_deg_up_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1252,7 +1252,7 @@ static void dinghy_slide_track_flat_to_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1288,7 +1288,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
 }
 
 static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1324,7 +1324,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_to_flat_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1360,43 +1360,42 @@ static void dinghy_slide_track_25_deg_up_to_flat_covered(
 }
 
 static void dinghy_slide_track_25_deg_down_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_25_deg_up_covered(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_60_deg_down_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_60_deg_up_covered(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_60_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_flat_to_25_deg_down_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_25_deg_up_to_flat_covered(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_25_deg_up_to_flat_covered(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_60_deg_down_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_60_deg_up_to_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_flat_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_flat_to_25_deg_up_covered(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_flat_to_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void dinghy_slide_track_right_quarter_turn_5_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -1524,16 +1523,15 @@ static void dinghy_slide_track_right_quarter_turn_5_covered(
 }
 
 static void dinghy_slide_track_left_quarter_turn_5_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    dinghy_slide_track_right_quarter_turn_5_covered(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    dinghy_slide_track_right_quarter_turn_5_covered(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void dinghy_slide_track_s_bend_left_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1628,7 +1626,7 @@ static void dinghy_slide_track_s_bend_left_covered(
 }
 
 static void dinghy_slide_track_s_bend_right_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1721,7 +1719,7 @@ static void dinghy_slide_track_s_bend_right_covered(
 }
 
 static void dinghy_slide_track_right_quarter_turn_3_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -1802,20 +1800,18 @@ static void dinghy_slide_track_right_quarter_turn_3_covered(
 }
 
 static void dinghy_slide_track_left_quarter_turn_3_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    dinghy_slide_track_right_quarter_turn_3_covered(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    dinghy_slide_track_right_quarter_turn_3_covered(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void dinghy_slide_track_60_deg_down_to_25_deg_down_covered(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    dinghy_slide_track_25_deg_up_to_60_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_dinghy_slide(int32_t trackType)

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -161,7 +161,7 @@ static constexpr const uint32_t LogFlumeTrackFlatImageIds[4][2] = {
 };
 
 static void paint_log_flume_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = LogFlumeTrackFlatImageIds[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -182,7 +182,7 @@ static void paint_log_flume_track_flat(
 }
 
 static void paint_log_flume_track_station(
-    paint_session* session, ride_id_t rideIndex, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = LogFlumeTrackFlatImageIds[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -209,7 +209,7 @@ static void paint_log_flume_track_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station_3(session, rideIndex, direction, height + 2, height, tileElement);
+    track_paint_util_draw_station_3(session, ride, direction, height + 2, height, tileElement);
     // Covers shouldn't be offset by +2
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -219,7 +219,7 @@ static void paint_log_flume_track_station(
 }
 
 static void paint_log_flume_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -254,7 +254,7 @@ static void paint_log_flume_track_25_deg_up(
 }
 
 static void paint_log_flume_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -289,7 +289,7 @@ static void paint_log_flume_track_flat_to_25_deg_up(
 }
 
 static void paint_log_flume_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -324,7 +324,7 @@ static void paint_log_flume_track_25_deg_up_to_flat(
 }
 
 static void paint_log_flume_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -359,7 +359,7 @@ static void paint_log_flume_track_25_deg_down(
 }
 
 static void paint_log_flume_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -394,7 +394,7 @@ static void paint_log_flume_track_flat_to_25_deg_down(
 }
 
 static void paint_log_flume_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -429,7 +429,7 @@ static void paint_log_flume_track_25_deg_down_to_flat(
 }
 
 static void paint_log_flume_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -524,7 +524,7 @@ static void paint_log_flume_track_s_bend_left(
 }
 
 static void paint_log_flume_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -617,7 +617,7 @@ static void paint_log_flume_track_s_bend_right(
 }
 
 static void paint_log_flume_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -684,7 +684,7 @@ static void paint_log_flume_track_left_quarter_turn_3_tiles(
 }
 
 static void paint_log_flume_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -751,7 +751,7 @@ static void paint_log_flume_track_right_quarter_turn_3_tiles(
 }
 
 static void paint_log_flume_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SPR_STATION_BASE_D | IMAGE_TYPE_REMAP;
@@ -782,7 +782,7 @@ static void paint_log_flume_track_on_ride_photo(
 }
 
 static void paint_log_flume_track_reverser(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -276,7 +276,7 @@ void vehicle_visual_river_rapids(
 
 /** rct2: 0x00757650 */
 static void paint_river_rapids_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -319,11 +319,10 @@ static void paint_river_rapids_track_flat(
 
 /** rct2: 0x007576C0 */
 static void paint_river_rapids_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_river_rapids_track_flat(session, rideIndex, trackSequence, direction, height, tileElement);
-    auto ride = get_ride(rideIndex);
+    paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, tileElement);
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 12, tileElement);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -508,7 +507,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
 
 /** rct2: 0x00757660 */
 static void paint_river_rapids_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_river_rapids_track_25_deg(session, direction, height, river_rapids_track_pieces_25_deg_up);
@@ -516,7 +515,7 @@ static void paint_river_rapids_track_25_deg_up(
 
 /** rct2: 0x00757670 */
 static void paint_river_rapids_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_river_rapids_track_25_deg_to_flat_b(session, direction, height, river_rapids_track_pieces_flat_to_25_deg_up);
@@ -524,7 +523,7 @@ static void paint_river_rapids_track_flat_to_25_deg_up(
 
 /** rct2: 0x00757680 */
 static void paint_river_rapids_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_river_rapids_track_25_deg_to_flat_a(session, direction, height, river_rapids_track_pieces_25_deg_up_to_flat);
@@ -532,7 +531,7 @@ static void paint_river_rapids_track_25_deg_up_to_flat(
 
 /** rct2: 0x00757690 */
 static void paint_river_rapids_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_river_rapids_track_25_deg(session, (direction + 2) % 4, height, river_rapids_track_pieces_25_deg_down);
@@ -540,7 +539,7 @@ static void paint_river_rapids_track_25_deg_down(
 
 /** rct2: 0x007576A0 */
 static void paint_river_rapids_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_river_rapids_track_25_deg_to_flat_a(
@@ -549,7 +548,7 @@ static void paint_river_rapids_track_flat_to_25_deg_down(
 
 /** rct2: 0x007576B0 */
 static void paint_river_rapids_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     paint_river_rapids_track_25_deg_to_flat_b(
@@ -558,7 +557,7 @@ static void paint_river_rapids_track_25_deg_down_to_flat(
 
 /** rct2: 0x007576F0 */
 static void paint_river_rapids_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -614,7 +613,7 @@ static void paint_river_rapids_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00757700 */
 static void paint_river_rapids_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -671,7 +670,7 @@ static void paint_river_rapids_track_right_quarter_turn_1_tile(
 
 /** rct2: 0x00757710 */
 static void paint_river_rapids_track_waterfall(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -734,7 +733,7 @@ static void paint_river_rapids_track_waterfall(
 
 /** rct2: 0x00757720 */
 static void paint_river_rapids_track_rapids(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -775,17 +774,17 @@ static void paint_river_rapids_track_rapids(
 
 /** rct2: 0x00757740 */
 static void paint_river_rapids_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_river_rapids_track_flat(session, rideIndex, trackSequence, direction, height, tileElement);
+    paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, tileElement);
     track_paint_util_onride_photo_paint(session, direction, height + 13, tileElement);
     paint_util_set_general_support_height(session, height + 48, 0x20);
 }
 
 /** rct2: 0x */
 static void paint_river_rapids_track_whirlpool(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -476,7 +476,7 @@ static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Side[4][5] = {
 };
 
 static void paint_splash_boats_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats25DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -501,7 +501,7 @@ static void paint_splash_boats_track_25_deg_up(
 }
 
 static void paint_splash_boats_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats60DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -527,7 +527,7 @@ static void paint_splash_boats_track_60_deg_up(
 }
 
 static void paint_splash_boats_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoatsFlatTo25DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -552,7 +552,7 @@ static void paint_splash_boats_track_flat_to_25_deg_up(
 }
 
 static void paint_splash_boats_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats25DegUpToFlatImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -577,7 +577,7 @@ static void paint_splash_boats_track_25_deg_up_to_flat(
 }
 
 static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats25DegUpTo60DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -603,7 +603,7 @@ static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
 }
 
 static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats60DegUpTo25DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -629,7 +629,7 @@ static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
 }
 
 static void paint_splash_boats_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats25DegDownImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -655,14 +655,14 @@ static void paint_splash_boats_track_25_deg_down(
 }
 
 static void paint_splash_boats_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_splash_boats_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    paint_splash_boats_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void paint_splash_boats_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoatsFlatTo25DegDownImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -688,23 +688,21 @@ static void paint_splash_boats_track_flat_to_25_deg_down(
 }
 
 static void paint_splash_boats_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_splash_boats_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    paint_splash_boats_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void paint_splash_boats_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    paint_splash_boats_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    paint_splash_boats_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void paint_splash_boats_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId = SplashBoats25DegDownToFlatImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -742,7 +740,7 @@ static void paint_splash_boats_track_25_deg_down_to_flat(
 /** Start of elements originally from River Rafts */
 /** rct2: 0x0089B170 */
 static void paint_splash_boats_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     uint32_t imageId;
@@ -785,7 +783,7 @@ static void paint_splash_boats_track_flat(
 
 /** rct2: 0x0089B1A0 */
 static void paint_splash_boats_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     if (direction & 1)
@@ -809,7 +807,6 @@ static void paint_splash_boats_station(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
 
-    auto ride = get_ride(rideIndex);
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 7, tileElement);
 
@@ -821,7 +818,7 @@ static void paint_splash_boats_station(
 
 /** rct2: 0x0089B1D0 */
 static void paint_splash_boats_track_left_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
@@ -902,7 +899,7 @@ static void paint_splash_boats_track_left_quarter_turn_5_tiles(
 
 /** rct2: 0x0089B1D0 */
 static void paint_splash_boats_track_right_quarter_turn_5_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
@@ -983,7 +980,7 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x0089B180 */
 static void paint_splash_boats_track_s_bend_left(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1075,7 +1072,7 @@ static void paint_splash_boats_track_s_bend_left(
 
 /** rct2: 0x0089B190 */
 static void paint_splash_boats_track_s_bend_right(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1166,7 +1163,7 @@ static void paint_splash_boats_track_s_bend_right(
 }
 
 static void paint_splash_boats_track_on_ride_photo(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     switch (direction)
@@ -1185,7 +1182,7 @@ static void paint_splash_boats_track_on_ride_photo(
             break;
     }
 
-    paint_splash_boats_track_flat(session, rideIndex, trackSequence, direction, height, tileElement);
+    paint_splash_boats_track_flat(session, ride, trackSequence, direction, height, tileElement);
 
     track_paint_util_onride_photo_paint(session, direction, height + 3, tileElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -81,10 +81,9 @@ void vehicle_visual_submarine(
 #endif
 
 static void submarine_ride_paint_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    auto ride = get_ride(rideIndex);
     if (ride == nullptr)
         return;
 
@@ -116,7 +115,7 @@ static void submarine_ride_paint_track_station(
 }
 
 static void submarine_ride_paint_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     int32_t heightLower = height - 16;
@@ -148,7 +147,7 @@ static void submarine_ride_paint_track_flat(
 }
 
 static void submarine_ride_paint_track_left_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -181,16 +180,16 @@ static void submarine_ride_paint_track_left_quarter_turn_3_tiles(
 
 static constexpr const uint8_t submarine_ride_right_quarter_turn_3_tiles_to_left_turn_map[] = { 3, 1, 2, 0 };
 static void submarine_ride_paint_track_right_quarter_turn_3_tiles(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = submarine_ride_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
     submarine_ride_paint_track_left_quarter_turn_3_tiles(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 static void submarine_ride_paint_track_left_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -204,11 +203,10 @@ static void submarine_ride_paint_track_left_quarter_turn_1_tile(
 }
 
 static void submarine_ride_paint_track_right_quarter_turn_1_tile(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    submarine_ride_paint_track_left_quarter_turn_1_tile(
-        session, rideIndex, trackSequence, (direction + 3) % 4, height, tileElement);
+    submarine_ride_paint_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, tileElement);
 }
 
 /**

--- a/src/openrct2/ride/water/WaterCoaster.cpp
+++ b/src/openrct2/ride/water/WaterCoaster.cpp
@@ -13,309 +13,307 @@
 #include "../coaster/JuniorRollerCoaster.h"
 
 static void water_rc_track_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    water_rc_track_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    water_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void water_rc_track_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    water_rc_track_25_deg_up_to_flat(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    water_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void water_rc_track_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    water_rc_track_flat_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) & 3, height, tileElement);
+    water_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, tileElement);
 }
 
 static void water_rc_track_diag_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_up_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_flat_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     bool isChained = tileElement->AsTrack()->HasChain();
     junior_rc_paint_track_diag_25_deg_down_to_flat(
-        session, rideIndex, trackSequence, direction, height, tileElement,
+        session, ride, trackSequence, direction, height, tileElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
 
 static void water_rc_track_station(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_paint_station(session, rideIndex, trackSequence, direction, height, tileElement, RIDE_TYPE_WATER_COASTER);
+    junior_rc_paint_station(session, ride, trackSequence, direction, height, tileElement, RIDE_TYPE_WATER_COASTER);
 }
 
 static void water_rc_track_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_paint_track_60_deg_up(session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+    junior_rc_paint_track_60_deg_up(session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    water_rc_track_60_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    water_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void water_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    water_rc_track_60_deg_up_to_25_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    water_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 static void water_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    water_rc_track_25_deg_up_to_60_deg_up(session, rideIndex, trackSequence, (direction + 2) % 4, height, tileElement);
+    water_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, tileElement);
 }
 
 // 5 tile turns
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static constexpr const uint8_t water_rc_left_quarter_turn_5_tiles_to_right_turn_map[] = { 6, 4, 5, 3, 1, 2, 0 };
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
-        session, rideIndex, water_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction + 1) % 4, height,
+        session, ride, water_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction + 1) % 4, height,
         tileElement);
 }
 
 static void water_rc_track_right_quarter_turn_5_tiles_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
-        session, rideIndex, water_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction + 3) % 4, height,
+        session, ride, water_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence], (direction + 3) % 4, height,
         tileElement);
 }
 
 // 3 tile turns
 
 static void water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static constexpr const uint8_t water_rc_left_quarter_turn_3_tiles_to_right_turn_map[] = { 3, 1, 2, 0 };
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = water_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
     water_rc_track_right_quarter_turn_3_tiles_25_deg_down(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+        session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     trackSequence = water_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
-    water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
-        session, rideIndex, trackSequence, (direction + 1) % 4, height, tileElement);
+    water_rc_track_right_quarter_turn_3_tiles_25_deg_up(session, ride, trackSequence, (direction + 1) % 4, height, tileElement);
 }
 
 static void water_rc_track_diag_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
-    junior_rc_paint_track_diag_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+    junior_rc_paint_track_diag_60_deg_up(session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_diag_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, ride_id_t rideIndex, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TileElement* tileElement)
 {
     junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-        session, rideIndex, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
+        session, ride, trackSequence, direction, height, tileElement, JuniorRcChainType::None);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_water_rc(int32_t trackType)


### PR DESCRIPTION
This eliminates useless calls to get_ride during rendering, also makes way more sense to pass the ride along so it can directly access it.

I added a basic counter in get_ride to measure the amount of times its called within viewport_paint for the main window.
develop: 
```(viewport_paint)]: ride_get access count: 22359```

PR:
```(viewport_paint)]: ride_get access count: 20975```

It does unfortunately still call it a lot since rendering is based on the tiles but thats not something one can easily change.

> openrct2 benchgfx parks/bpb.sv6
develop:
```
Engine: Software
Render Count: 60
Zoom[0] average: 0.075448s, 13 FPS
Zoom[1] average: 0.031700s, 32 FPS
Zoom[2] average: 0.014827s, 67 FPS
Total average: 0.040659s, 25 FPS
Time: 2.43952s
```

PR: 
```
Engine: Software
Render Count: 60
Zoom[0] average: 0.074150s, 13 FPS
Zoom[1] average: 0.032295s, 31 FPS
Zoom[2] average: 0.014713s, 68 FPS
Total average: 0.040386s, 25 FPS
Time: 2.42316s
```
Small gain only but I have only a single computer to test.