### PR TITLE
Allow loading images from .pob files

### DIFF
--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -165,7 +165,7 @@ static bool TryClassifyAsTD4_TD6(OpenRCT2::IStream* stream, ClassifiedFileInfo* 
 uint32_t get_file_extension_type(const utf8* path)
 {
     auto extension = Path::GetExtension(path);
-    if (String::Equals(extension, ".dat", true))
+    if (String::Equals(extension, ".dat", true) || String::Equals(extension, ".pob", true))
         return FILE_EXTENSION_DAT;
     if (String::Equals(extension, ".sc4", true))
         return FILE_EXTENSION_SC4;

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -270,15 +270,32 @@ std::string ImageTable::FindLegacyObject(const std::string& name)
     const auto env = GetContext()->GetPlatformEnvironment();
     auto objectsPath = env->GetDirectoryPath(DIRBASE::RCT2, DIRID::OBJECT);
     auto objectPath = Path::Combine(objectsPath, name);
+    if (File::Exists(objectPath))
+    {
+        return objectPath;
+    }
+
+    std::string altName = std::string(name);
+    auto rangeStart = name.find(".DAT");
+    if (rangeStart != std::string::npos)
+    {
+        altName.replace(rangeStart, 4, ".POB");
+    }
+    objectPath = Path::Combine(objectsPath, altName);
+    if (File::Exists(objectPath))
+    {
+        return objectPath;
+    }
+
     if (!File::Exists(objectPath))
     {
         // Search recursively for any file with the target name (case insensitive)
-        auto filter = Path::Combine(objectsPath, "*.dat");
+        auto filter = Path::Combine(objectsPath, "*.dat;*.pob");
         auto scanner = Path::ScanDirectory(filter, true);
         while (scanner->Next())
         {
             auto currentName = Path::GetFileName(scanner->GetPathRelative());
-            if (String::Equals(currentName, name, true))
+            if (String::Equals(currentName, name, true) || String::Equals(currentName, altName, true))
             {
                 objectPath = scanner->GetPath();
                 break;

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -275,7 +275,7 @@ std::string ImageTable::FindLegacyObject(const std::string& name)
         return objectPath;
     }
 
-    std::string altName = std::string(name);
+    std::string altName = name;
     auto rangeStart = name.find(".DAT");
     if (rangeStart != std::string::npos)
     {


### PR DESCRIPTION
RCT Classic uses the same .DAT files as RCT2, but with a .POB extension. Ever since we introduced our own JSON objects for the RCT2/WW/TT objects, these have not worked correctly.