### PR TITLE
Fix #14316: Closing the Track Designs Manager window causes broken state

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -172,6 +172,7 @@ The following people are not part of the development team, but have been contrib
 * Emre Aydin (aemreaydin)
 * Daniel Karandikar (DKarandikar)
 * Struan Clark (xtruan)
+* Kane Shaw (seifer7)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,8 +1,8 @@
 0.3.4.1+ (in development)
 ------------------------------------------------------------------------
+- Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
-- Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 
 0.3.4.1 (2021-07-25)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
+- Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 
 0.3.4.1 (2021-07-25)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -456,6 +456,11 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             {
                 finish_object_selection();
             }
+            if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
+            {
+                auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::OpenSavePrompt, PromptMode::SaveBeforeQuit);
+                GameActions::Execute(&loadOrQuitAction);
+            }
             break;
         case WIDX_FILTER_RIDE_TAB_ALL:
             _filter_flags |= FILTER_RIDES;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -459,6 +459,7 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             }
             if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
             {
+                game_unload_scripts();
                 title_load();
             }
             break;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -32,6 +32,7 @@
 #include <openrct2/platform/platform.h>
 #include <openrct2/ride/RideData.h>
 #include <openrct2/scenario/Scenario.h>
+#include <openrct2/title/TitleScreen.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
@@ -458,8 +459,7 @@ static void window_editor_object_selection_mouseup(rct_window* w, rct_widgetinde
             }
             if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
             {
-                auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::OpenSavePrompt, PromptMode::SaveBeforeQuit);
-                GameActions::Execute(&loadOrQuitAction);
+                title_load();
             }
             break;
         case WIDX_FILTER_RIDE_TAB_ALL:


### PR DESCRIPTION
Fix #14316: Quiting track design manager broke editor
When exiting the Track Design Manager window the user was placed into
the scenario editor in a broken state.
User is now returned to the main menu when the window is closed.

PS. First contribution, hope it's right :)