### PR TITLE
Close #10624: Display GUI message when changing Scale Factor by hotkey

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3651,6 +3651,7 @@ STR_6450    :{BLACK}“{STRING}”
 STR_6451    :{BLACK}“{STRING}” - {STRING}
 STR_6452    :{WINDOW_COLOUR_2}Sells: {BLACK}{STRING}
 STR_6453    :Copy version info
+STR_6454    :Scale factor set to: {COMMA2DP32}
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.3.4.1+ (in development)
 ------------------------------------------------------------------------
+- Feature: [#10624] A GUI message is now displayed when changing Window Scale Factor by hotkey.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Improved: [#3417] Crash dumps are now placed in their own folder.

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -470,6 +470,9 @@ static void ShortcutScaleUp()
     gfx_invalidate_screen();
     context_trigger_resize();
     context_update_cursor_scale();
+    int32_t scale = static_cast<int32_t>(gConfigGeneral.window_scale * 100);
+    std::string scalestring = format_string(STR_UI_SCALING_SET, &scale);
+    chat_history_add(scalestring.c_str());
 }
 
 static void ShortcutScaleDown()
@@ -480,6 +483,9 @@ static void ShortcutScaleDown()
     gfx_invalidate_screen();
     context_trigger_resize();
     context_update_cursor_scale();
+    int32_t scale = static_cast<int32_t>(gConfigGeneral.window_scale * 100);
+    std::string scalestring = format_string(STR_UI_SCALING_SET, &scale);
+    chat_history_add(scalestring.c_str());
 }
 
 // Tile inspector shortcuts

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -90,12 +90,6 @@ void chat_draw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
 {
     thread_local std::string lineBuffer;
 
-    if (!chat_available())
-    {
-        gChatOpen = false;
-        return;
-    }
-
     _chatLeft = 10;
     _chatRight = std::min((context_get_width() - 10), CHAT_MAX_WINDOW_WIDTH);
     _chatWidth = _chatRight - _chatLeft;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3904,6 +3904,7 @@ enum
     STR_RIDE_OBJECT_SHOP_SELLS = 6452,
 
     STR_COPY_BUILD_HASH = 6453,
+    STR_UI_SCALING_SET = 6454,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings


### PR DESCRIPTION
- When changing the Window Scale Factor using a hotkey a GUI message is now displayed specifying the new scale factor using the Chat window.
- To ensure message is always visible, chat window is now drawn in single player games, title menu, and anywhere else.
- Chat window still cannot be manually toggle/brought up outside a mutiplayer game (intended.)