### PR TITLE
Move ToonTowner mine roofs to mine theme instead of pirate theme

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
+- Fix: [#15142] ToonTowner's mine roofs were moved into the pirate theme scenery group instead of the mine theme scenery group.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 
 0.3.4.1 (2021-07-25)

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -215,7 +215,7 @@ ObjectEntryDescriptor SmallSceneryObject::GetScgPiratHeader() const
 
 ObjectEntryDescriptor SmallSceneryObject::GetScgMineHeader() const
 {
-    return ObjectEntryDescriptor("rct2.scgpirat");
+    return ObjectEntryDescriptor("rct2.scgmine");
 }
 
 ObjectEntryDescriptor SmallSceneryObject::GetScgAbstrHeader() const


### PR DESCRIPTION
A small copy/paste error seemed to have put the ToonTowner Mine Roofs in the game's pirate theme scenery group, while the intended scenery group was the mine theme scenery group (as indicated by the function's name and comments). This PR intends to fix that.

Result of the fix ingame:
![afbeelding](https://user-images.githubusercontent.com/20048660/127734691-92263e37-4233-4dbc-a5c4-8060daabc4bf.png)
