### PR TITLE
Fix #15148: Track Designs Manager delete confirmation window doesn't display properly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Fix: [#15142] ToonTowner's mine roofs were moved into the pirate theme scenery group instead of the mine theme scenery group.
+- Fix: [#15148] Track Designs Manager delete confirmation window doesn't display properly.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support
 blocking.

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -19,6 +19,8 @@
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRING;
 static constexpr const int32_t WH = 44;
 static constexpr const int32_t WW = 250;
+static constexpr const int32_t WH2 = 74;
+static constexpr const int32_t WW2 = 250;
 
 #pragma region Widgets
 
@@ -42,7 +44,7 @@ static rct_widget window_track_manage_widgets[] = {
 };
 
 static rct_widget window_track_delete_prompt_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW, WH),
+    WINDOW_SHIM(WINDOW_TITLE, WW2, WH2),
     MakeWidget({ 10, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
     MakeWidget({130, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL             ),
     { WIDGETS_END }
@@ -131,6 +133,7 @@ static void window_track_manage_mouseup(rct_window* w, rct_widgetindex widgetInd
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
+            window_close_by_class(WC_TRACK_DELETE_PROMPT);
             window_close(w);
             break;
         case WIDX_RENAME:
@@ -241,6 +244,10 @@ static void window_track_delete_prompt_mouseup(rct_window* w, rct_widgetindex wi
  */
 static void window_track_delete_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
+    char str_delete_file[256];
+    format_string(str_delete_file, 256, STR_DELETE_FILE, nullptr);
+    Formatter::Common().Add<char*>(str_delete_file);
+
     WindowDrawWidgets(w, dpi);
 
     DrawTextWrapped(

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -204,10 +204,8 @@ static void window_track_delete_prompt_open()
     int32_t screenHeight = context_get_height();
     rct_window* w = WindowCreate(
         ScreenCoordsXY(
-            std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - WW_DELETE_PROMPT) / 2),
-            (screenHeight - WH_DELETE_PROMPT) / 2),
-        WW_DELETE_PROMPT, WH_DELETE_PROMPT,
-        &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);
+            std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - WW_DELETE_PROMPT) / 2), (screenHeight - WH_DELETE_PROMPT) / 2),
+        WW_DELETE_PROMPT, WH_DELETE_PROMPT, &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_track_delete_prompt_widgets;
     w->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_RENAME) | (1ULL << WIDX_DELETE);
     WindowInitScrollWidgets(w);
@@ -250,11 +248,8 @@ static void window_track_delete_prompt_paint(rct_window* w, rct_drawpixelinfo* d
     WindowDrawWidgets(w, dpi);
 
     DrawTextWrapped(
-        dpi,
-        { w->windowPos.x + (WW_DELETE_PROMPT / 2), w->windowPos.y + ((WH_DELETE_PROMPT / 2) - 9) },
-        (WW_DELETE_PROMPT - 4),
-        STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK,
-        &_trackDesignFileReference->name, { TextAlignment::CENTRE });
+        dpi, { w->windowPos.x + (WW_DELETE_PROMPT / 2), w->windowPos.y + ((WH_DELETE_PROMPT / 2) - 9) }, (WW_DELETE_PROMPT - 4),
+        STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, &_trackDesignFileReference->name, { TextAlignment::CENTRE });
 }
 
 static void window_track_design_list_reload_tracks()

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -203,7 +203,10 @@ static void window_track_delete_prompt_open()
     int32_t screenWidth = context_get_width();
     int32_t screenHeight = context_get_height();
     rct_window* w = WindowCreate(
-        ScreenCoordsXY(std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - WW_DELETE_PROMPT) / 2), (screenHeight - WH_DELETE_PROMPT) / 2), WW_DELETE_PROMPT, WH_DELETE_PROMPT,
+        ScreenCoordsXY(
+            std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - WW_DELETE_PROMPT) / 2),
+            (screenHeight - WH_DELETE_PROMPT) / 2),
+        WW_DELETE_PROMPT, WH_DELETE_PROMPT,
         &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_track_delete_prompt_widgets;
     w->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_RENAME) | (1ULL << WIDX_DELETE);
@@ -247,7 +250,10 @@ static void window_track_delete_prompt_paint(rct_window* w, rct_drawpixelinfo* d
     WindowDrawWidgets(w, dpi);
 
     DrawTextWrapped(
-        dpi, { w->windowPos.x + 125, w->windowPos.y + 28 }, 246, STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK,
+        dpi,
+        { w->windowPos.x + (WW_DELETE_PROMPT / 2), w->windowPos.y + ((WH_DELETE_PROMPT / 2) - 9) },
+        (WW_DELETE_PROMPT - 4),
+        STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK,
         &_trackDesignFileReference->name, { TextAlignment::CENTRE });
 }
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -19,8 +19,8 @@
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRING;
 static constexpr const int32_t WH = 44;
 static constexpr const int32_t WW = 250;
-static constexpr const int32_t WH2 = 74;
-static constexpr const int32_t WW2 = 250;
+static constexpr const int32_t WH_DELETE_PROMPT = 74;
+static constexpr const int32_t WW_DELETE_PROMPT = 250;
 
 #pragma region Widgets
 
@@ -44,7 +44,7 @@ static rct_widget window_track_manage_widgets[] = {
 };
 
 static rct_widget window_track_delete_prompt_widgets[] = {
-    WINDOW_SHIM(WINDOW_TITLE, WW2, WH2),
+    WINDOW_SHIM(STR_DELETE_FILE, WW_DELETE_PROMPT, WH_DELETE_PROMPT),
     MakeWidget({ 10, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_TRACK_MANAGE_DELETE),
     MakeWidget({130, 54}, {110, 12}, WindowWidgetType::Button, WindowColour::Primary, STR_CANCEL             ),
     { WIDGETS_END }
@@ -95,7 +95,7 @@ rct_window* window_track_manage_open(track_design_file_ref* tdFileRef)
     window_close_by_class(WC_MANAGE_TRACK_DESIGN);
 
     rct_window* w = WindowCreateCentred(
-        250, 44, &window_track_manage_events, WC_MANAGE_TRACK_DESIGN, WF_STICK_TO_FRONT | WF_TRANSPARENT);
+        WW, WH, &window_track_manage_events, WC_MANAGE_TRACK_DESIGN, WF_STICK_TO_FRONT | WF_TRANSPARENT);
     w->widgets = window_track_manage_widgets;
     w->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_RENAME) | (1ULL << WIDX_DELETE);
     WindowInitScrollWidgets(w);
@@ -203,7 +203,7 @@ static void window_track_delete_prompt_open()
     int32_t screenWidth = context_get_width();
     int32_t screenHeight = context_get_height();
     rct_window* w = WindowCreate(
-        ScreenCoordsXY(std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - 250) / 2), (screenHeight - 44) / 2), 250, 74,
+        ScreenCoordsXY(std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - WW_DELETE_PROMPT) / 2), (screenHeight - WH_DELETE_PROMPT) / 2), WW_DELETE_PROMPT, WH_DELETE_PROMPT,
         &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_track_delete_prompt_widgets;
     w->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_RENAME) | (1ULL << WIDX_DELETE);
@@ -244,10 +244,6 @@ static void window_track_delete_prompt_mouseup(rct_window* w, rct_widgetindex wi
  */
 static void window_track_delete_prompt_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    char str_delete_file[256];
-    format_string(str_delete_file, 256, STR_DELETE_FILE, nullptr);
-    Formatter::Common().Add<char*>(str_delete_file);
-
     WindowDrawWidgets(w, dpi);
 
     DrawTextWrapped(


### PR DESCRIPTION
- Increased the height of the "Delete Confirmation" window in the Track Designs Manager to fit the content.
- Changed the title of the "Delete Confirmation" window to "Delete File" (as per RCT2 vanilla) instead of the track design name.
- "Delete Confirmation" window automatically closes when parent window is closed (Rename / Delete choice window.

**Before Fix**
![Before Fix](https://user-images.githubusercontent.com/13601073/127765207-2d6c24d5-a073-47ed-b396-988419cc39f7.png)


**After Fix**
![After Fix](https://user-images.githubusercontent.com/13601073/127765194-b21521e7-c075-4abe-9c2d-412297dc2e46.png)



PS. Please ignore unrelated issue of character corruption (lowercase "L" displays as "ğ")