### PR TITLE
Feature #7682: Lock camera to vehicle in main window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3655,6 +3655,7 @@ STR_6454    :Can’t rename banner…
 STR_6455    :Can’t rename sign…
 STR_6456    :Giant Screenshot
 STR_6457    :Report a bug on GitHub
+STR_6458    :Follow this on Main View
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.3.4.1+ (in development)
 ------------------------------------------------------------------------
 - Feature: [#3868] Initial support for using TTF in OpenGL mode (still contains bugs).
+- Feature: [#7682] Follow ride/guest/staff in main window viewport.
 - Feature: [#13407] Allow building chain lifts on enclosed dinghy slide pieces when cheats are on.
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook.
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -519,7 +519,8 @@ static void viewport_move(const ScreenCoordsXY& coords, rct_window* w, rct_viewp
 // rct2: 0x006E7A15
 static void viewport_set_underground_flag(int32_t underground, rct_window* window, rct_viewport* viewport)
 {
-    if (window->classification != WC_MAIN_WINDOW)
+    if (window->classification != WC_MAIN_WINDOW
+        || (window->classification == WC_MAIN_WINDOW && window->viewport_smart_follow_sprite != SPRITE_INDEX_NULL))
     {
         if (!underground)
         {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3911,6 +3911,8 @@ enum
 
     STR_FILE_BUG_ON_GITHUB = 6457,
 
+    STR_FOLLOW_SUBJECT_TIP = 6458,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
Pressing the "Locate" button in the Ride window when selected on a "Vehicle/Train" will now have the main viewport track the vehicle.

**Still to complete:**
- [x] Drop-down selection for Locate or Follow
- [x] While following, automatically toggle underground view on/off as required
- [x] Implement tracking for Staff & Guests
- [x] More testing