### PR TITLE
Feature: Highlight selected Tile Inspector element

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook.
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.
+- Feature: [#15164] Highlight elements selected by the Tile Inspector, tracks are currently not supported.
 - Feature: [#15165] [Plugin] Add the ability to create entities using "map.createEntity".
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -32,6 +32,7 @@
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/SmallScenery.h>
 #include <openrct2/world/Surface.h>
+#include <openrct2/world/TileInspector.h>
 
 // clang-format off
 static constexpr const rct_string_id EntranceTypeStringIds[] = {
@@ -438,6 +439,7 @@ static void window_tile_inspector_invalidate(rct_window* w);
 static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi);
 static void window_tile_inspector_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
 static void window_tile_inspector_set_page(rct_window* w, const TileInspectorPage page);
+static void window_tile_inspector_close(rct_window* w);
 
 // clang-format off
 static rct_window_event_list TileInspectorWindowEvents([](auto& events)
@@ -456,6 +458,7 @@ static rct_window_event_list TileInspectorWindowEvents([](auto& events)
     events.invalidate = &window_tile_inspector_invalidate;
     events.paint = &window_tile_inspector_paint;
     events.scroll_paint = &window_tile_inspector_scrollpaint;
+    events.close = &window_tile_inspector_close;
 });
 
 static uint64_t PageEnabledWidgets[] = {
@@ -542,10 +545,14 @@ static void window_tile_inspector_select_element_from_list(rct_window* w, int32_
     if (index < 0 || index >= windowTileInspectorElementCount)
     {
         windowTileInspectorSelectedIndex = -1;
+        OpenRCT2::TileInspector::SetSelectedElement(nullptr);
     }
     else
     {
         windowTileInspectorSelectedIndex = index;
+
+        const TileElement* const tileElement = window_tile_inspector_get_selected_element(w);
+        OpenRCT2::TileInspector::SetSelectedElement(tileElement);
     }
 
     w->Invalidate();
@@ -759,6 +766,11 @@ static void window_tile_inspector_clamp_corrupt(int32_t elementIndex)
 {
     auto modifyTile = TileModifyAction(windowTileInspectorToolMap, TileModifyType::CorruptClamp, elementIndex);
     GameActions::Execute(&modifyTile);
+}
+
+static void window_tile_inspector_close(rct_window* w)
+{
+    OpenRCT2::TileInspector::SetSelectedElement(nullptr);
 }
 
 static void window_tile_inspector_mouseup(rct_window* w, rct_widgetindex widgetIndex)
@@ -1286,6 +1298,8 @@ static void window_tile_inspector_update_selected_tile(rct_window* w, const Scre
     windowTileInspectorTileSelected = true;
     windowTileInspectorToolMap = mapCoords;
     windowTileInspectorTile = TileCoordsXY(mapCoords);
+
+    OpenRCT2::TileInspector::SetSelectedElement(clickedElement);
 
     window_tile_inspector_load_tile(w, clickedElement);
 }

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -15,6 +15,7 @@
 #include "../../sprites.h"
 #include "../../world/Banner.h"
 #include "../../world/Scenery.h"
+#include "../../world/TileInspector.h"
 #include "../Paint.h"
 #include "Paint.TileElement.h"
 
@@ -72,6 +73,10 @@ void banner_paint(paint_session* session, uint8_t direction, int32_t height, con
     if (tile_element->IsGhost()) // if being placed
     {
         session->InteractionType = ViewportInteractionItem::None;
+        image_id |= CONSTRUCTION_MARKER;
+    }
+    else if (OpenRCT2::TileInspector::IsElementSelected(tile_element))
+    {
         image_id |= CONSTRUCTION_MARKER;
     }
     else

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -21,6 +21,7 @@
 #include "../../world/Entrance.h"
 #include "../../world/Footpath.h"
 #include "../../world/Park.h"
+#include "../../world/TileInspector.h"
 #include "../Paint.h"
 #include "../Supports.h"
 #include "Paint.TileElement.h"
@@ -95,6 +96,13 @@ static void ride_entrance_exit_paint(paint_session* session, uint8_t direction, 
     if (tile_element->IsGhost())
     {
         session->InteractionType = ViewportInteractionItem::None;
+        image_id = CONSTRUCTION_MARKER;
+        entranceImageId = image_id;
+        if (transparant_image_id)
+            transparant_image_id = image_id;
+    }
+    else if (OpenRCT2::TileInspector::IsElementSelected(tile_element))
+    {
         image_id = CONSTRUCTION_MARKER;
         entranceImageId = image_id;
         if (transparant_image_id)
@@ -225,6 +233,10 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
     if (tile_element->IsGhost())
     {
         session->InteractionType = ViewportInteractionItem::None;
+        ghost_id = CONSTRUCTION_MARKER;
+    }
+    else if (OpenRCT2::TileInspector::IsElementSelected(tile_element))
+    {
         ghost_id = CONSTRUCTION_MARKER;
     }
 

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -19,6 +19,7 @@
 #include "../../world/LargeScenery.h"
 #include "../../world/Map.h"
 #include "../../world/Scenery.h"
+#include "../../world/TileInspector.h"
 #include "../Paint.h"
 #include "../Supports.h"
 #include "Paint.TileElement.h"
@@ -227,7 +228,7 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
         return;
     }
     session->InteractionType = ViewportInteractionItem::LargeScenery;
-    uint32_t sequenceNum = tileElement->AsLargeScenery()->GetSequenceIndex();
+    const uint32_t sequenceNum = tileElement->AsLargeScenery()->GetSequenceIndex();
     const LargeSceneryObject* object = tileElement->AsLargeScenery()->GetObject();
     if (object == nullptr)
         return;
@@ -250,20 +251,25 @@ void large_scenery_paint(paint_session* session, uint8_t direction, uint16_t hei
     {
         if (!track_design_save_contains_tile_element(tileElement))
         {
-            sequenceNum = SPRITE_ID_PALETTE_COLOUR_1(EnumValue(FilterPaletteID::Palette46));
             image_id &= 0x7FFFF;
-            dword_F4387C = sequenceNum;
+            dword_F4387C = SPRITE_ID_PALETTE_COLOUR_1(EnumValue(FilterPaletteID::Palette46));
             image_id |= dword_F4387C;
         }
     }
     if (tileElement->IsGhost())
     {
         session->InteractionType = ViewportInteractionItem::None;
-        sequenceNum = CONSTRUCTION_MARKER;
         image_id &= 0x7FFFF;
-        dword_F4387C = sequenceNum;
+        dword_F4387C = CONSTRUCTION_MARKER;
         image_id |= dword_F4387C;
     }
+    else if (OpenRCT2::TileInspector::IsElementSelected(tileElement))
+    {
+        image_id &= 0x7FFFF;
+        dword_F4387C = CONSTRUCTION_MARKER;
+        image_id |= dword_F4387C;
+    }
+
     int32_t boxlengthZ = tile->z_clearance;
     if (boxlengthZ > 0x80)
     {

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -23,10 +23,13 @@
 #include "../../world/Map.h"
 #include "../../world/Scenery.h"
 #include "../../world/Surface.h"
+#include "../../world/TileInspector.h"
 #include "../Paint.h"
 #include "../Supports.h"
 #include "Paint.Surface.h"
 #include "Paint.TileElement.h"
+
+using namespace OpenRCT2;
 
 bool gPaintWidePathsAsGhost = false;
 
@@ -843,6 +846,11 @@ void path_paint(paint_session* session, uint16_t height, const TileElement* tile
     {
         session->InteractionType = ViewportInteractionItem::None;
         imageFlags = CONSTRUCTION_MARKER;
+    }
+    else if (TileInspector::IsElementSelected(tile_element))
+    {
+        imageFlags |= CONSTRUCTION_MARKER;
+        sceneryImageFlags = CONSTRUCTION_MARKER;
     }
 
     // For debugging purpose, show blocked tiles with a colour

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -16,6 +16,7 @@
 #include "../../world/Map.h"
 #include "../../world/Scenery.h"
 #include "../../world/SmallScenery.h"
+#include "../../world/TileInspector.h"
 #include "../Paint.h"
 #include "../Supports.h"
 #include "Paint.TileElement.h"
@@ -56,6 +57,10 @@ void scenery_paint(paint_session* session, uint8_t direction, int32_t height, co
     if (tileElement->IsGhost())
     {
         session->InteractionType = ViewportInteractionItem::None;
+        marker = CONSTRUCTION_MARKER;
+    }
+    else if (OpenRCT2::TileInspector::IsElementSelected(tileElement))
+    {
         marker = CONSTRUCTION_MARKER;
     }
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -27,6 +27,7 @@
 #include "../../sprites.h"
 #include "../../world/Entity.h"
 #include "../../world/Surface.h"
+#include "../../world/TileInspector.h"
 #include "Paint.TileElement.h"
 
 #include <algorithm>
@@ -1073,6 +1074,11 @@ void surface_paint(paint_session* session, uint8_t direction, uint16_t height, c
         {
             imageId &= 0xDC07FFFF; // remove colour
             imageId |= 0x41880000;
+        }
+
+        if (OpenRCT2::TileInspector::IsElementSelected(tileElement))
+        {
+            imageId |= CONSTRUCTION_MARKER;
         }
 
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, -1 });

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -19,6 +19,7 @@
 #include "../../world/Banner.h"
 #include "../../world/Map.h"
 #include "../../world/Scenery.h"
+#include "../../world/TileInspector.h"
 #include "../../world/Wall.h"
 #include "../Paint.h"
 #include "Paint.TileElement.h"
@@ -201,6 +202,10 @@ void fence_paint(paint_session* session, uint8_t direction, int32_t height, cons
     if (tile_element->IsGhost())
     {
         session->InteractionType = ViewportInteractionItem::None;
+        dword_141F710 = CONSTRUCTION_MARKER;
+    }
+    else if (OpenRCT2::TileInspector::IsElementSelected(tile_element))
+    {
         dword_141F710 = CONSTRUCTION_MARKER;
     }
 

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -1131,4 +1131,18 @@ namespace OpenRCT2::TileInspector
         return std::make_unique<GameActions::Result>();
     }
 
+    // NOTE: The pointer is exclusively used to determine the  current selection,
+    // do not access the data, points to potentially invalid memory.
+    static const TileElement* _highlightedElement = nullptr;
+
+    void SetSelectedElement(const TileElement* elem)
+    {
+        _highlightedElement = elem;
+    }
+
+    bool IsElementSelected(const TileElement* elem)
+    {
+        return _highlightedElement == elem;
+    }
+
 } // namespace OpenRCT2::TileInspector

--- a/src/openrct2/world/TileInspector.h
+++ b/src/openrct2/world/TileInspector.h
@@ -21,6 +21,9 @@ namespace OpenRCT2::TileInspector
 {
     using GameActionResultPtr = std::unique_ptr<GameActions::Result>;
 
+    void SetSelectedElement(const TileElement* elem);
+    bool IsElementSelected(const TileElement* elem);
+
     GameActionResultPtr InsertCorruptElementAt(const CoordsXY& loc, int16_t elementIndex, bool isExecuting);
     GameActionResultPtr RemoveElementAt(const CoordsXY& loc, int16_t elementIndex, bool isExecuting);
     GameActionResultPtr SwapElementsAt(const CoordsXY& loc, int16_t first, int16_t second, bool isExecuting);


### PR DESCRIPTION
![2021-08-01_23-15-40](https://user-images.githubusercontent.com/5415177/127784227-d984080c-6110-400f-a9bf-384091cedbd3.gif)

The tile inspector will highlight the selected element the same way its done with construction. Unfortunately the way tracks are drawn I did not implement this for tracks, this would add a huge amount of code into quite a few files.