### PR TITLE
Feature: Add ride index to TrackRemoveAction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook.
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.
+- Feature: [#15188] Add ride index to TrackRemoveAction
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#14667] “Extreme Hawaiian Island” has unpurchaseable land tiles (original bug).

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1930,7 +1930,7 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
     }
 
     auto trackRemoveAction = TrackRemoveAction(
-        _currentTrackPieceType, 0,
+        _currentRideIndex, _currentTrackPieceType, 0,
         { _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z, _currentTrackPieceDirection });
 
     trackRemoveAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -294,7 +294,7 @@ money32 RideDemolishAction::DemolishTracks() const
 
         if (type != TrackElemType::Maze)
         {
-            auto trackRemoveAction = TrackRemoveAction(type, it.element->AsTrack()->GetSequenceIndex(), location);
+            auto trackRemoveAction = TrackRemoveAction(_rideIndex, type, it.element->AsTrack()->GetSequenceIndex(), location);
             trackRemoveAction.SetFlags(GAME_COMMAND_FLAG_NO_SPEND);
 
             auto removRes = GameActions::ExecuteNested(&trackRemoveAction);

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -19,8 +19,10 @@
 #include "../world/Surface.h"
 #include "RideSetSettingAction.h"
 
-TrackRemoveAction::TrackRemoveAction(track_type_t trackType, int32_t sequence, const CoordsXYZD& origin)
-    : _trackType(trackType)
+TrackRemoveAction::TrackRemoveAction(
+    NetworkRideId_t rideIndex, track_type_t trackType, int32_t sequence, const CoordsXYZD& origin)
+    : _rideIndex(rideIndex)
+    , _trackType(trackType)
     , _sequence(sequence)
     , _origin(origin)
 {
@@ -30,6 +32,7 @@ TrackRemoveAction::TrackRemoveAction(track_type_t trackType, int32_t sequence, c
 void TrackRemoveAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_origin);
+    visitor.Visit("ride", _rideIndex);
     visitor.Visit("trackType", _trackType);
     visitor.Visit("sequence", _sequence);
 }
@@ -43,7 +46,7 @@ void TrackRemoveAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
 
-    stream << DS_TAG(_trackType) << DS_TAG(_sequence) << DS_TAG(_origin);
+    stream << DS_TAG(_rideIndex) << DS_TAG(_trackType) << DS_TAG(_sequence) << DS_TAG(_origin);
 }
 
 GameActions::Result::Ptr TrackRemoveAction::Query() const
@@ -119,7 +122,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
             STR_YOU_ARE_NOT_ALLOWED_TO_REMOVE_THIS_SECTION);
     }
 
-    ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
+    ride_id_t rideIndex = _rideIndex;
     auto trackType = tileElement->AsTrack()->GetTrackType();
 
     auto ride = get_ride(rideIndex);
@@ -304,7 +307,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
         return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
     }
 
-    ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
+    ride_id_t rideIndex = _rideIndex;
     auto trackType = tileElement->AsTrack()->GetTrackType();
     bool isLiftHill = tileElement->AsTrack()->HasChain();
 

--- a/src/openrct2/actions/TrackRemoveAction.h
+++ b/src/openrct2/actions/TrackRemoveAction.h
@@ -14,13 +14,14 @@
 DEFINE_GAME_ACTION(TrackRemoveAction, GameCommand::RemoveTrack, GameActions::Result)
 {
 private:
+    NetworkRideId_t _rideIndex{ RIDE_ID_NULL };
     track_type_t _trackType{};
     int32_t _sequence{};
     CoordsXYZD _origin;
 
 public:
     TrackRemoveAction() = default;
-    TrackRemoveAction(track_type_t trackType, int32_t sequence, const CoordsXYZD& origin);
+    TrackRemoveAction(NetworkRideId_t rideIndex, track_type_t trackType, int32_t sequence, const CoordsXYZD& origin);
 
     void AcceptParameters(GameActionParameterVisitor & visitor) override;
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -37,7 +37,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -510,9 +510,9 @@ void ride_remove_provisional_track_piece()
         {
             auto trackType = next_track.element->AsTrack()->GetTrackType();
             int32_t trackSequence = next_track.element->AsTrack()->GetSequenceIndex();
-            auto trackRemoveAction = TrackRemoveAction{ trackType,
-                                                        trackSequence,
-                                                        { next_track.x, next_track.y, z, static_cast<Direction>(direction) } };
+            auto trackRemoveAction = TrackRemoveAction{
+                rideIndex, trackType, trackSequence, { next_track.x, next_track.y, z, static_cast<Direction>(direction) }
+            };
             trackRemoveAction.SetFlags(
                 GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND | GAME_COMMAND_FLAG_GHOST);
             GameActions::Execute(&trackRemoveAction);
@@ -1146,7 +1146,7 @@ int32_t ride_get_refund_price(const Ride* ride)
     do
     {
         auto trackRemoveAction = TrackRemoveAction(
-            trackElement.element->AsTrack()->GetTrackType(), trackElement.element->AsTrack()->GetSequenceIndex(),
+            ride->id, trackElement.element->AsTrack()->GetTrackType(), trackElement.element->AsTrack()->GetSequenceIndex(),
             { trackElement.x, trackElement.y, trackElement.element->GetBaseZ(), direction });
         trackRemoveAction.SetFlags(GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1540,7 +1540,7 @@ static bool track_design_place_ride(TrackDesign* td6, const CoordsXYZ& origin, R
                 const rct_preview_track* trackBlock = TrackBlocks[trackType];
                 int32_t tempZ = newCoords.z - trackCoordinates->z_begin + trackBlock->z;
                 auto trackRemoveAction = TrackRemoveAction(
-                    trackType, 0, { newCoords, tempZ, static_cast<Direction>(rotation & 3) });
+                    ride->id, trackType, 0, { newCoords, tempZ, static_cast<Direction>(rotation & 3) });
                 trackRemoveAction.SetFlags(
                     GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_NO_SPEND | GAME_COMMAND_FLAG_GHOST);
                 GameActions::ExecuteNested(&trackRemoveAction);


### PR DESCRIPTION
I only want "ride" to be an arg property for the GameActionEventArgs object in the plugin API. If there's a simpler and/or better way to accomplish that, I'm all ears 👂