### PR TITLE
Enable blank issue template [ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
 - name: Translation / Localisation
   url: https://github.com/OpenRCT2/Localisation


### PR DESCRIPTION
This enables the blank issue template, the link appears on the bottom of the list.

> ![](https://cdn.discordapp.com/attachments/264137540670324737/874370707394555934/unknown.png)