### PR TITLE
Add new plugin api properties to entity, ride and park

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -91,7 +91,7 @@ The following people are not part of the development team, but have been contrib
 * Jim Verheijde (Jimver) - Make handymen less likely to get stuck in queue lines, misc.
 * Helio Batimarqui (batimarqui) - Misc.
 * Keith Stellyes (keithstellyes) - Misc.
-* Bas Cantrijn (Basssiiie) - Misc.
+* Bas Cantrijn (Basssiiie) - Various plugin additions, misc.
 * Adrian Zdanowicz (CookiePLMonster) - Misc.
 * Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#15084] [Plugin] Add "vehicle.crash" hook.
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.
 - Feature: [#15165] [Plugin] Add the ability to create entities using "map.createEntity".
+- Feature: [#15194] [Plugin] Add guest properties, ride downtime and park casualty penalty.
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#14667] “Extreme Hawaiian Island” has unpurchaseable land tiles (original bug).

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -516,9 +516,9 @@ declare global {
         readonly isClientOnly: boolean;
         result: boolean;
     }
-    
+
     type VehicleCrashIntoType = "another_vehicle" | "land" | "water";
-    
+
     interface VehicleCrashArgs {
         readonly id: number;
         readonly crashIntoType: VehicleCrashIntoType;
@@ -577,6 +577,8 @@ declare global {
         getAllEntities(type: "peep"): Peep[];
         getAllEntities(type: "guest"): Guest[];
         getAllEntities(type: "staff"): Staff[];
+        getAllEntities(type: "car"): Car[];
+        getAllEntities(type: "litter"): Litter[];
         createEntity(type: EntityType, initializer: object): Entity;
     }
 
@@ -1034,6 +1036,11 @@ declare global {
          * The value of the ride.
          */
         value: number;
+
+        /**
+         * The percentage of downtime for this ride from 0 to 100.
+         */
+        readonly downtime: number;
     }
 
     type RideClassification = "ride" | "stall" | "facility";
@@ -1441,6 +1448,21 @@ declare global {
          * Amount of cash in the guest's pocket.
          */
         cash: number;
+
+        /**
+         * Whether the guest is within the boundaries of the park.
+         */
+        readonly isInPark: boolean;
+
+        /**
+         * Whether the guest is lost or not. The guest is lost when the countdown is below 90.
+         */
+        readonly isLost: boolean;
+
+        /**
+         * Countdown between 0 and 255 that keeps track of how long the guest has been looking for its current destination.
+         */
+        lostCountdown: number;
     }
 
     /**
@@ -1485,17 +1507,17 @@ declare global {
         creationTime: number;
     }
 
-    type LitterType = "vomit" | 
-        "vomit_alt" | 
-        "empty_can" |  
-        "rubbish" | 
-        "burger_box" | 
-        "empty_cup" | 
-        "empty_box" | 
-        "empty_bottle" | 
-        "empty_bowl_red" | 
-        "empty_drink_carton" |  
-        "empty_juice_cup" | 
+    type LitterType = "vomit" |
+        "vomit_alt" |
+        "empty_can" |
+        "rubbish" |
+        "burger_box" |
+        "empty_cup" |
+        "empty_box" |
+        "empty_bottle" |
+        "empty_bowl_red" |
+        "empty_drink_carton" |
+        "empty_juice_cup" |
         "empty_bowl_blue";
 
     /**
@@ -1749,6 +1771,12 @@ declare global {
          * The purchase price of one tile for construction rights.
          */
         constructionRightsPrice: number;
+
+        /**
+         * The amount of penalty points currentlty applied to the park rating for
+         * drowned guests and crashed coaster cars.
+         */
+        casualtyPenalty: number;
 
         /**
          * The number of tiles on the map with park ownership or construction rights.

--- a/src/openrct2/scripting/ScEntity.hpp
+++ b/src/openrct2/scripting/ScEntity.hpp
@@ -848,6 +848,9 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScGuest::maxIntensity_get, &ScGuest::maxIntensity_set, "maxIntensity");
             dukglue_register_property(ctx, &ScGuest::nauseaTolerance_get, &ScGuest::nauseaTolerance_set, "nauseaTolerance");
             dukglue_register_property(ctx, &ScGuest::cash_get, &ScGuest::cash_set, "cash");
+            dukglue_register_property(ctx, &ScGuest::isInPark_get, nullptr, "isInPark");
+            dukglue_register_property(ctx, &ScGuest::isLost_get, nullptr, "isLost");
+            dukglue_register_property(ctx, &ScGuest::lostCountdown_get, &ScGuest::lostCountdown_set, "lostCountdown");
         }
 
     private:
@@ -1113,6 +1116,33 @@ namespace OpenRCT2::Scripting
             if (peep != nullptr)
             {
                 peep->CashInPocket = std::max(0, value);
+            }
+        }
+
+        bool isInPark_get() const
+        {
+            auto peep = GetGuest();
+            return (peep != nullptr && !peep->OutsideOfPark);
+        }
+
+        bool isLost_get() const
+        {
+            auto peep = GetGuest();
+            return (peep != nullptr && peep->GuestIsLostCountdown < 90);
+        }
+
+        uint8_t lostCountdown_get() const
+        {
+            auto peep = GetGuest();
+            return peep != nullptr ? peep->GuestIsLostCountdown : 0;
+        }
+        void lostCountdown_set(uint8_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            auto peep = GetGuest();
+            if (peep != nullptr)
+            {
+                peep->GuestIsLostCountdown = value;
             }
         }
     };

--- a/src/openrct2/scripting/ScPark.hpp
+++ b/src/openrct2/scripting/ScPark.hpp
@@ -449,6 +449,16 @@ namespace OpenRCT2::Scripting
             gConstructionRightsPrice = value;
         }
 
+        int16_t casualtyPenalty_get() const
+        {
+            return gParkRatingCasualtyPenalty;
+        }
+        void casualtyPenalty_set(int16_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            gParkRatingCasualtyPenalty = value;
+        }
+
         uint16_t parkSize_get() const
         {
             return gParkSize;
@@ -600,6 +610,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(ctx, &ScPark::parkSize_get, nullptr, "parkSize");
             dukglue_register_property(ctx, &ScPark::name_get, &ScPark::name_set, "name");
             dukglue_register_property(ctx, &ScPark::messages_get, &ScPark::messages_set, "messages");
+            dukglue_register_property(ctx, &ScPark::casualtyPenalty_get, &ScPark::casualtyPenalty_set, "casualtyPenalty");
             dukglue_register_method(ctx, &ScPark::getFlag, "getFlag");
             dukglue_register_method(ctx, &ScPark::setFlag, "setFlag");
             dukglue_register_method(ctx, &ScPark::postMessage, "postMessage");

--- a/src/openrct2/scripting/ScRide.hpp
+++ b/src/openrct2/scripting/ScRide.hpp
@@ -642,6 +642,12 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        uint8_t downtime_get() const
+        {
+            auto ride = GetRide();
+            return ride != nullptr ? ride->downtime : 0;
+        }
+
         Ride* GetRide() const
         {
             return get_ride(_rideId);
@@ -681,6 +687,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_property(
                 ctx, &ScRide::inspectionInterval_get, &ScRide::inspectionInterval_set, "inspectionInterval");
             dukglue_register_property(ctx, &ScRide::value_get, &ScRide::value_set, "value");
+            dukglue_register_property(ctx, &ScRide::downtime_get, nullptr, "downtime");
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 35;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 36;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;


### PR DESCRIPTION
Hey all,

On the side I've been experimenting with a new plugin that helps users figure out what impacts their park rating. The added properties are all related to calculating the park rating, though I've made a few settable as well (which might be useful for other plugin developers).

The changes:
1. Added `isInPark`, `isLost` and `lostCountdown` properties to `Guest`.
2. Added `downtime` property to `Ride`.
3. Added `casualtyPenalty` to `Park`.
4. Added overload to `getAllEntities` for `Car` and `Litter` since these interfaces exist too.
5. Auto-formatted `openrct2.d.ts` according to the rules in the project, which changed some incorrect whitespace too.
6. Updated my contribution description in `contributers.md` because someone mentioned `Misc.` is too plain and boring. 😛 
7. Incremented the plugin api version and added a changelog.

Love to hear if there's any feedback. 😄 If I should split the changes into multiple PR's, please let me know.