### PR TITLE
Fix: #15199 Construction window not being closed when a ride gets demolished

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#15170] Plugin: incorrect label text alignment.
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
 - Fix: [#15193] Crash when rides/stalls are demolished.
+- Fix: [#15199] Construction window not being closed when a ride gets demolished.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,7 @@
 - Fix: [#15170] Plugin: incorrect label text alignment.
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
 - Fix: [#15193] Crash when rides/stalls are demolished.
-- Fix: [#15199] Construction window not being closed when a ride gets demolished.
+- Fix: [#15199] Construction window is not closed when a ride gets demolished.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -157,10 +157,7 @@ GameActions::Result::Ptr RideDemolishAction::DemolishRide(Ride* ride) const
     gParkValue = GetContext()->GetGameState()->GetPark().CalculateParkValue();
 
     // Close windows related to the demolished ride
-    if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED))
-    {
-        window_close_by_number(WC_RIDE_CONSTRUCTION, _rideIndex);
-    }
+    window_close_by_number(WC_RIDE_CONSTRUCTION, _rideIndex);
     window_close_by_number(WC_RIDE, _rideIndex);
     window_close_by_number(WC_DEMOLISH_RIDE_PROMPT, _rideIndex);
     window_close_by_class(WC_NEW_CAMPAIGN);


### PR DESCRIPTION
That condition made no sense, when the ride is gone no construction can happen.

Closes #15199