### PR TITLE
Fix issue #15211: Rename RideConstructionState::Build to RideConstructionState::MazeBuild

### DIFF
--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -274,7 +274,7 @@ static void window_maze_construction_mousedown(rct_window* w, rct_widgetindex wi
     switch (widgetIndex)
     {
         case WIDX_MAZE_BUILD_MODE:
-            window_maze_construction_build_mode_mousedown(RideConstructionState::Build);
+            window_maze_construction_build_mode_mousedown(RideConstructionState::MazeBuild);
             break;
         case WIDX_MAZE_MOVE_MODE:
             window_maze_construction_build_mode_mousedown(RideConstructionState::MazeMove);
@@ -484,7 +484,7 @@ void window_maze_construction_update_pressed_widgets()
                 pressedWidgets |= EnumToFlag(WIDX_MAZE_EXIT);
             }
             break;
-        case RideConstructionState::Build:
+        case RideConstructionState::MazeBuild:
             pressedWidgets |= EnumToFlag(WIDX_MAZE_BUILD_MODE);
             break;
         case RideConstructionState::MazeMove:
@@ -519,7 +519,7 @@ static void window_maze_construction_construct(int32_t direction)
     z = _currentTrackBegin.z;
     switch (_rideConstructionState)
     {
-        case RideConstructionState::Build:
+        case RideConstructionState::MazeBuild:
             mode = GC_SET_MAZE_TRACK_BUILD;
             flags = GAME_COMMAND_FLAG_APPLY;
             break;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2610,7 +2610,7 @@ void sub_6C94D8()
             }
             break;
         }
-        case RideConstructionState::Build:
+        case RideConstructionState::MazeBuild:
         case RideConstructionState::MazeMove:
         case RideConstructionState::MazeFill:
         {
@@ -3735,7 +3735,7 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
     {
         for (int32_t zAttempts = 0; zAttempts < numAttempts; ++zAttempts)
         {
-            _rideConstructionState = RideConstructionState::Build;
+            _rideConstructionState = RideConstructionState::MazeBuild;
             _currentTrackBegin.x = mapCoords.x;
             _currentTrackBegin.y = mapCoords.y;
             _currentTrackBegin.z = z;

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -889,7 +889,7 @@ enum class RideConstructionState : uint8_t
     Selected,
     Place,
     EntranceExit,
-    Build,
+    MazeBuild,
     MazeMove,
     MazeFill
 };

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -550,7 +550,7 @@ void ride_construction_invalidate_current_track()
                 { _currentTrackBegin, static_cast<Direction>(_currentTrackPieceDirection & 3) }, _currentTrackPieceType, 0,
                 nullptr, TRACK_ELEMENT_SET_HIGHLIGHT_FALSE);
             break;
-        case RideConstructionState::Build:
+        case RideConstructionState::MazeBuild:
         case RideConstructionState::MazeMove:
         case RideConstructionState::MazeFill:
         case RideConstructionState::Front:
@@ -950,7 +950,7 @@ static bool ride_modify_maze(const CoordsXYE& tileElement)
         if (trackElement != nullptr)
         {
             _currentRideIndex = trackElement->GetRideIndex();
-            _rideConstructionState = RideConstructionState::Build;
+            _rideConstructionState = RideConstructionState::MazeBuild;
             _currentTrackBegin.x = tileElement.x;
             _currentTrackBegin.y = tileElement.y;
             _currentTrackBegin.z = trackElement->GetBaseZ();


### PR DESCRIPTION
Fix issue #15211: Rename RideConstructionState::Build to RideConstructionState::MazeBuild

Pull #15203 commited enum RideConstructionState missing the "Maze" part in "MazeBuild"