### PR TITLE
Issue #15225: Some scenarios show incorrect name/description in-game.

### DIFF
--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -366,8 +366,6 @@ public:
         // pad_01358842
         ImportResearchList();
         gMapBaseZ = _s6.map_base_z;
-        gScenarioName = std::string_view(_s6.scenario_name, sizeof(_s6.scenario_name));
-        gScenarioDetails = std::string_view(_s6.scenario_description, sizeof(_s6.scenario_description));
         gBankLoanInterestRate = _s6.current_interest_rate;
         // pad_0135934B
         // Preserve compatibility with vanilla RCT2's save format.


### PR DESCRIPTION
As some know, a number of the Scenarios created for the expansion packs by Frontier used the internal name "Six Flags Magic Mountain," why? I doubt God even knows. 

The S6Importer/SawyerChunkReader correctly decodes the scenario name and description and stores it under the `rct_s6_info` struct (`info.name` and `info.details`.)

The problem is that on lines 369-370 the name and description are replaced with the scenario internal name and description - which is sometimes incorrect - specifically a number of scenarios by Frontier in the expansion packs.