### PR TITLE
Move network instance to Context

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -654,12 +654,12 @@ namespace OpenRCT2
                 bool sendMap = false;
                 if (info.Type == FILE_TYPE::SAVED_GAME)
                 {
-                    if (network_get_mode() == NETWORK_MODE_CLIENT)
+                    if (_network.GetMode() == NETWORK_MODE_CLIENT)
                     {
-                        network_close();
+                        _network.Close();
                     }
                     game_load_init();
-                    if (network_get_mode() == NETWORK_MODE_SERVER)
+                    if (_network.GetMode() == NETWORK_MODE_SERVER)
                     {
                         sendMap = true;
                     }
@@ -667,13 +667,13 @@ namespace OpenRCT2
                 else
                 {
                     scenario_begin();
-                    if (network_get_mode() == NETWORK_MODE_SERVER)
+                    if (_network.GetMode() == NETWORK_MODE_SERVER)
                     {
                         sendMap = true;
                     }
-                    if (network_get_mode() == NETWORK_MODE_CLIENT)
+                    if (_network.GetMode() == NETWORK_MODE_CLIENT)
                     {
-                        network_close();
+                        _network.Close();
                     }
                 }
                 // This ensures that the newly loaded save reflects the user's
@@ -681,10 +681,10 @@ namespace OpenRCT2
                 peep_update_names(gConfigGeneral.show_real_names_of_guests);
                 if (sendMap)
                 {
-                    network_send_map();
+                    _network.Server_Send_MAP();
                 }
 #ifdef USE_BREAKPAD
-                if (network_get_mode() == NETWORK_MODE_NONE)
+                if (_network.GetMode() == NETWORK_MODE_NONE)
                 {
                     start_silent_record();
                 }
@@ -884,13 +884,13 @@ namespace OpenRCT2
 
                         if (String::IsNullOrEmpty(gCustomPassword))
                         {
-                            network_set_password(gConfigNetwork.default_password.c_str());
+                            _network.SetPassword(gConfigNetwork.default_password.c_str());
                         }
                         else
                         {
-                            network_set_password(gCustomPassword);
+                            _network.SetPassword(gCustomPassword);
                         }
-                        network_begin_server(gNetworkStartPort, gNetworkStartAddress);
+                        _network.BeginServer(gNetworkStartPort, gNetworkStartAddress);
                     }
                     else
 #endif // DISABLE_NETWORK
@@ -920,7 +920,7 @@ namespace OpenRCT2
                 {
                     gNetworkStartPort = gConfigNetwork.default_port;
                 }
-                network_begin_client(gNetworkStartHost, gNetworkStartPort);
+                _network.BeginClient(gNetworkStartHost, gNetworkStartPort);
             }
 #endif // DISABLE_NETWORK
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -46,6 +46,7 @@
 #include "localisation/Localisation.h"
 #include "localisation/LocalisationService.h"
 #include "network/DiscordService.h"
+#include "network/NetworkBase.h"
 #include "network/network.h"
 #include "object/ObjectManager.h"
 #include "object/ObjectRepository.h"
@@ -108,6 +109,9 @@ namespace OpenRCT2
 #ifdef ENABLE_SCRIPTING
         ScriptEngine _scriptEngine;
 #endif
+#ifndef DISABLE_NETWORK
+        NetworkBase _network;
+#endif
 
         // Game states
         std::unique_ptr<TitleScreen> _titleScreen;
@@ -150,6 +154,9 @@ namespace OpenRCT2
 #ifdef ENABLE_SCRIPTING
             , _scriptEngine(_stdInOutConsole, *env)
 #endif
+#ifndef DISABLE_NETWORK
+            , _network(*this)
+#endif
             , _painter(std::make_unique<Painter>(uiContext))
         {
             // Can't have more than one context currently.
@@ -164,7 +171,7 @@ namespace OpenRCT2
             //       If objects use GetContext() in their destructor things won't go well.
 
             GameActions::ClearQueue();
-            network_close();
+            _network.Close();
             window_close_all();
 
             // Unload objects after closing all windows, this is to overcome windows like
@@ -256,10 +263,17 @@ namespace OpenRCT2
             return _drawingEngine.get();
         }
 
-        virtual Paint::Painter* GetPainter() override
+        Paint::Painter* GetPainter() override
         {
             return _painter.get();
         }
+
+#ifndef DISABLE_NETWORK
+        NetworkBase& GetNetwork() override
+        {
+            return _network;
+        }
+#endif
 
         int32_t RunOpenRCT2(int argc, const char** argv) override
         {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -171,7 +171,9 @@ namespace OpenRCT2
             //       If objects use GetContext() in their destructor things won't go well.
 
             GameActions::ClearQueue();
+#ifndef DISABLE_NETWORK
             _network.Close();
+#endif
             window_close_all();
 
             // Unload objects after closing all windows, this is to overcome windows like
@@ -651,22 +653,29 @@ namespace OpenRCT2
                 gScreenAge = 0;
                 gLastAutoSaveUpdate = AUTOSAVE_PAUSE;
 
+#ifndef DISABLE_NETWORK
                 bool sendMap = false;
+#endif
                 if (info.Type == FILE_TYPE::SAVED_GAME)
                 {
+#ifndef DISABLE_NETWORK
                     if (_network.GetMode() == NETWORK_MODE_CLIENT)
                     {
                         _network.Close();
                     }
+#endif
                     game_load_init();
+#ifndef DISABLE_NETWORK
                     if (_network.GetMode() == NETWORK_MODE_SERVER)
                     {
                         sendMap = true;
                     }
+#endif
                 }
                 else
                 {
                     scenario_begin();
+#ifndef DISABLE_NETWORK
                     if (_network.GetMode() == NETWORK_MODE_SERVER)
                     {
                         sendMap = true;
@@ -675,14 +684,18 @@ namespace OpenRCT2
                     {
                         _network.Close();
                     }
+#endif
                 }
                 // This ensures that the newly loaded save reflects the user's
                 // 'show real names of guests' option, now that it's a global setting
                 peep_update_names(gConfigGeneral.show_real_names_of_guests);
+#ifndef DISABLE_NETWORK
                 if (sendMap)
                 {
                     _network.Server_Send_MAP();
                 }
+#endif
+
 #ifdef USE_BREAKPAD
                 if (_network.GetMode() == NETWORK_MODE_NONE)
                 {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -477,7 +477,6 @@ namespace OpenRCT2
                 gGameSoundsOff = !gConfigSound.master_sound_enabled;
             }
 
-            network_set_env(_env);
             chat_init();
             CopyOriginalUserFilesOver();
 

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
@@ -70,6 +70,8 @@ enum
     CURSOR_PRESSED = CURSOR_DOWN | CURSOR_CHANGED,
 };
 
+class NetworkBase;
+
 namespace OpenRCT2
 {
     class GameState;
@@ -131,7 +133,9 @@ namespace OpenRCT2
         virtual DrawingEngine GetDrawingEngineType() abstract;
         virtual Drawing::IDrawingEngine* GetDrawingEngine() abstract;
         virtual Paint::Painter* GetPainter() abstract;
-
+#ifndef DISABLE_NETWORK
+        virtual NetworkBase& GetNetwork() abstract;
+#endif
         virtual int32_t RunOpenRCT2(int argc, const char** argv) abstract;
 
         virtual bool Initialise() abstract;

--- a/src/openrct2/System.hpp
+++ b/src/openrct2/System.hpp
@@ -1,0 +1,60 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+namespace OpenRCT2
+{
+    struct IContext;
+
+    // Base class for systems that are hosted in the Context.
+    class System
+    {
+        IContext& _context;
+
+    public:
+        System(IContext& owner)
+            : _context(owner)
+        {
+        }
+
+        virtual ~System() = default;
+
+        // Called before a tick.
+        virtual void PreTick()
+        {
+        }
+
+        // Called every game tick, which by default is 40hz.
+        virtual void Tick()
+        {
+        }
+
+        // Called after a tick.
+        virtual void PostTick()
+        {
+        }
+
+        // Called every frame.
+        virtual void Update()
+        {
+        }
+
+        IContext& GetContext()
+        {
+            return _context;
+        }
+
+        const IContext& GetContext() const
+        {
+            return _context;
+        }
+    };
+
+} // namespace OpenRCT2

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -436,6 +436,7 @@
     <ClInclude Include="scripting\bindings\network\ScSocket.hpp" />
     <ClInclude Include="scripting\bindings\world\ScTile.hpp" />
     <ClInclude Include="sprites.h" />
+    <ClInclude Include="System.hpp" />
     <ClInclude Include="title\TitleScreen.h" />
     <ClInclude Include="title\TitleSequence.h" />
     <ClInclude Include="title\TitleSequenceManager.h" />

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -3214,11 +3214,6 @@ void NetworkBase::Client_Handle_GAMEINFO([[maybe_unused]] NetworkConnection& con
     network_chat_show_server_greeting();
 }
 
-void network_close()
-{
-    OpenRCT2::GetContext()->GetNetwork().Close();
-}
-
 void network_reconnect()
 {
     OpenRCT2::GetContext()->GetNetwork().Reconnect();
@@ -4212,9 +4207,6 @@ void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds)
 {
 }
 void network_send_password(const std::string& password)
-{
-}
-void network_close()
 {
 }
 void network_reconnect()

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -147,11 +147,6 @@ NetworkBase::NetworkBase(OpenRCT2::IContext& context)
     _server_log_fs << std::unitbuf;
 }
 
-void NetworkBase::SetEnvironment(const std::shared_ptr<IPlatformEnvironment>& env)
-{
-    _env = env;
-}
-
 bool NetworkBase::Init()
 {
     status = NETWORK_STATUS_READY;
@@ -1101,7 +1096,8 @@ void NetworkBase::AppendLog(std::ostream& fs, const std::string& s)
 
 void NetworkBase::BeginChatLog()
 {
-    auto directory = _env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_CHAT);
+    auto env = _context.GetPlatformEnvironment();
+    auto directory = env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_CHAT);
     _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
 
 #    if defined(_WIN32) && !defined(__MINGW32__)
@@ -1127,7 +1123,8 @@ void NetworkBase::CloseChatLog()
 
 void NetworkBase::BeginServerLog()
 {
-    auto directory = _env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_SERVER);
+    auto env = _context.GetPlatformEnvironment();
+    auto directory = env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_SERVER);
     _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
 
 #    if defined(_WIN32) && !defined(__MINGW32__)
@@ -3217,11 +3214,6 @@ void NetworkBase::Client_Handle_GAMEINFO([[maybe_unused]] NetworkConnection& con
     network_chat_show_server_greeting();
 }
 
-void network_set_env(const std::shared_ptr<IPlatformEnvironment>& env)
-{
-    OpenRCT2::GetContext()->GetNetwork().SetEnvironment(env);
-}
-
 void network_close()
 {
     OpenRCT2::GetContext()->GetNetwork().Close();
@@ -4235,9 +4227,6 @@ void network_close()
 {
 }
 void network_reconnect()
-{
-}
-void network_set_env(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>&)
 {
 }
 void network_shutdown_client()

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -3852,12 +3852,6 @@ int32_t network_get_current_player_group_index()
     return -1;
 }
 
-void network_send_map()
-{
-    auto& network = OpenRCT2::GetContext()->GetNetwork();
-    network.Server_Send_MAP();
-}
-
 void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds)
 {
     auto& network = OpenRCT2::GetContext()->GetNetwork();
@@ -4066,9 +4060,6 @@ void network_request_gamestate_snapshot()
 {
 }
 void network_send_game_action(const GameAction* action)
-{
-}
-void network_send_map()
 {
 }
 void network_update()

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -12,10 +12,17 @@
 
 #ifndef DISABLE_NETWORK
 
+namespace OpenRCT2
+{
+    struct IContext;
+}
+
 class NetworkBase
 {
+    OpenRCT2::IContext& _context;
+
 public:
-    NetworkBase();
+    NetworkBase(OpenRCT2::IContext& context);
 
 public: // Uncategorized
     bool BeginServer(uint16_t port, const std::string& address);

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../System.hpp"
 #include "../actions/GameAction.h"
 #include "NetworkConnection.h"
 #include "NetworkGroup.h"
@@ -17,10 +18,8 @@ namespace OpenRCT2
     struct IContext;
 }
 
-class NetworkBase
+class NetworkBase : public OpenRCT2::System
 {
-    OpenRCT2::IContext& _context;
-
 public:
     NetworkBase(OpenRCT2::IContext& context);
 
@@ -32,7 +31,8 @@ public: // Common
     bool Init();
     void Close();
     uint32_t GetServerTick();
-    void Update();
+    // FIXME: This is currently the wrong function to override in System, will be refactored later.
+    void Update() override final;
     void Flush();
     void ProcessPending();
     void ProcessPlayerList();
@@ -96,7 +96,7 @@ public: // Server
     void Server_Send_EVENT_PLAYER_JOINED(const char* playerName);
     void Server_Send_EVENT_PLAYER_DISCONNECTED(const char* playerName, const char* reason);
     void Server_Send_OBJECTS_LIST(NetworkConnection& connection, const std::vector<const ObjectRepositoryItem*>& objects) const;
-    void Server_Send_SCRIPTS(NetworkConnection& connection) const;
+    void Server_Send_SCRIPTS(NetworkConnection& connection);
 
     // Handlers
     void Server_Handle_REQUEST_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet);

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -29,7 +29,6 @@ public: // Uncategorized
     bool BeginClient(const std::string& host, uint16_t port);
 
 public: // Common
-    void SetEnvironment(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);
     bool Init();
     void Close();
     uint32_t GetServerTick();
@@ -180,7 +179,6 @@ public: // Public common
 private: // Common Data
     using CommandHandler = void (NetworkBase::*)(NetworkConnection& connection, NetworkPacket& packet);
 
-    std::shared_ptr<OpenRCT2::IPlatformEnvironment> _env;
     std::vector<uint8_t> chunk_buffer;
     std::ofstream _chat_log_fs;
     uint32_t _lastUpdateTime = 0;

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -96,12 +96,10 @@ int32_t network_get_pickup_peep_old_x(uint8_t playerid);
 void network_send_map();
 void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds = {});
 void network_send_game_action(const GameAction* action);
-void network_enqueue_game_action(const GameAction* action);
 void network_send_password(const std::string& password);
 
 void network_set_password(const char* password);
 
-void network_print_error();
 void network_append_chat_log(const utf8* text);
 void network_append_server_log(const utf8* text);
 const utf8* network_get_server_name();

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -35,12 +35,6 @@ enum class ModifyGroupType : uint8_t;
 enum class PermissionState : uint8_t;
 enum class NetworkPermission : uint32_t;
 
-namespace OpenRCT2
-{
-    struct IPlatformEnvironment;
-}
-
-void network_set_env(const std::shared_ptr<OpenRCT2::IPlatformEnvironment>& env);
 void network_close();
 void network_reconnect();
 void network_shutdown_client();

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -93,7 +93,6 @@ Peep* network_get_pickup_peep(uint8_t playerid);
 void network_set_pickup_peep_old_x(uint8_t playerid, int32_t x);
 int32_t network_get_pickup_peep_old_x(uint8_t playerid);
 
-void network_send_map();
 void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds = {});
 void network_send_game_action(const GameAction* action);
 void network_send_password(const std::string& password);

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -35,7 +35,6 @@ enum class ModifyGroupType : uint8_t;
 enum class PermissionState : uint8_t;
 enum class NetworkPermission : uint32_t;
 
-void network_close();
 void network_reconnect();
 void network_shutdown_client();
 int32_t network_begin_client(const std::string& host, int32_t port);

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -23,6 +23,7 @@
 #include "../interface/Viewport.h"
 #include "../interface/Window.h"
 #include "../localisation/Localisation.h"
+#include "../network/NetworkBase.h"
 #include "../network/network.h"
 #include "../scenario/Scenario.h"
 #include "../scenario/ScenarioRepository.h"
@@ -124,7 +125,7 @@ void TitleScreen::Load()
     gScreenAge = 0;
     gCurrentLoadedPath = "";
 
-    network_close();
+    GetContext()->GetNetwork().Close();
     OpenRCT2::Audio::StopAll();
     GetContext()->GetGameState()->InitAll(150);
     viewport_init_all();

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -125,7 +125,9 @@ void TitleScreen::Load()
     gScreenAge = 0;
     gCurrentLoadedPath = "";
 
+#ifndef DISABLE_NETWORK
     GetContext()->GetNetwork().Close();
+#endif
     OpenRCT2::Audio::StopAll();
     GetContext()->GetGameState()->InitAll(150);
     viewport_init_all();


### PR DESCRIPTION
This PR also introduces a System model that other classes can use, more refactor work is needed to get this right but this will also help eliminate global variables since all systems will always have a reference to IContext and IContext always has the full game state.