### PR TITLE
Fix #15176: Incorrect base height in tile inspector for track pieces

### DIFF
--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1991,6 +1991,7 @@ static void window_tile_inspector_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Current base height
                 screenCoords.x = w->windowPos.x + w->widgets[WIDX_TRACK_SPINNER_HEIGHT].left + 3;
+                ft = Formatter();
                 ft.Add<int32_t>(tileElement->base_height);
                 DrawTextBasic(dpi, screenCoords, STR_FORMAT_INTEGER, ft, { COLOUR_WHITE });
                 break;


### PR DESCRIPTION
Fix according to Duncan's instructions on Discord in #development.

Todo: download CI build and test it.