### PR TITLE
Fix refactor error in Paint.cpp assertions

### DIFF
--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -801,8 +801,8 @@ paint_struct* PaintAddImageAsParent(
     int32_t bound_box_length_y, int32_t bound_box_length_z, int32_t z_offset, int32_t bound_box_offset_x,
     int32_t bound_box_offset_y, int32_t bound_box_offset_z)
 {
-    assert(bound_box_length_x > 0);
-    assert(bound_box_length_y > 0);
+    assert(bound_box_length_x >= 0);
+    assert(bound_box_length_y >= 0);
 
     session->LastPS = nullptr;
     session->LastAttachedPS = nullptr;
@@ -863,8 +863,8 @@ paint_struct* PaintAddImageAsChild(
     int32_t bound_box_length_y, int32_t bound_box_length_z, int32_t z_offset, int32_t bound_box_offset_x,
     int32_t bound_box_offset_y, int32_t bound_box_offset_z)
 {
-    assert(bound_box_length_x > 0);
-    assert(bound_box_length_y > 0);
+    assert(bound_box_length_x >= 0);
+    assert(bound_box_length_y >= 0);
     return PaintAddImageAsChild(
         session, image_id, { x_offset, y_offset, z_offset }, { bound_box_length_x, bound_box_length_y, bound_box_length_z },
         { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -801,9 +801,6 @@ paint_struct* PaintAddImageAsParent(
     int32_t bound_box_length_y, int32_t bound_box_length_z, int32_t z_offset, int32_t bound_box_offset_x,
     int32_t bound_box_offset_y, int32_t bound_box_offset_z)
 {
-    assert(bound_box_length_x >= 0);
-    assert(bound_box_length_y >= 0);
-
     session->LastPS = nullptr;
     session->LastAttachedPS = nullptr;
 
@@ -863,8 +860,6 @@ paint_struct* PaintAddImageAsChild(
     int32_t bound_box_length_y, int32_t bound_box_length_z, int32_t z_offset, int32_t bound_box_offset_x,
     int32_t bound_box_offset_y, int32_t bound_box_offset_z)
 {
-    assert(bound_box_length_x >= 0);
-    assert(bound_box_length_y >= 0);
     return PaintAddImageAsChild(
         session, image_id, { x_offset, y_offset, z_offset }, { bound_box_length_x, bound_box_length_y, bound_box_length_z },
         { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });


### PR DESCRIPTION
Before the refactor, the assertion read like this:
```
assert(static_cast<uint16_t>(bound_box_length_x) == static_cast<int16_t>(bound_box_length_x));
```
which meant that bound_box_length_x = 0 was valid. The refactor (likely accidentally) changed this, which causes assertions to get hit within 2 seconds after opening on my machine.