### PR TITLE
Add overloads to take CoordsXYZ

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -295,6 +295,15 @@ paint_struct* PaintAddImageAsChildRotated(
     paint_session* session, uint8_t direction, uint32_t image_id, int32_t x_offset, int32_t y_offset,
     int32_t bound_box_length_x, int32_t bound_box_length_y, int32_t bound_box_length_z, int32_t z_offset,
     int32_t bound_box_offset_x, int32_t bound_box_offset_y, int32_t bound_box_offset_z);
+paint_struct* PaintAddImageAsChildRotated(
+    paint_session* session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
+paint_struct* PaintAddImageAsParentRotated(
+    paint_session* session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize);
+paint_struct* PaintAddImageAsParentRotated(
+    paint_session* session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
 
 void paint_util_push_tunnel_rotated(paint_session* session, uint8_t direction, uint16_t height, uint8_t type);
 

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -48,6 +48,37 @@ paint_struct* PaintAddImageAsParentRotated(
     }
 }
 
+paint_struct* PaintAddImageAsParentRotated(
+    paint_session* session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
+{
+    if (direction & 1)
+    {
+        return PaintAddImageAsParent(
+            session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z },
+            { boundBoxOffset.y, boundBoxOffset.x, boundBoxOffset.z });
+    }
+    else
+    {
+        return PaintAddImageAsParent(session, image_id, offset, boundBoxSize, boundBoxOffset);
+    }
+}
+
+paint_struct* PaintAddImageAsParentRotated(
+    paint_session* session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize)
+{
+    if (direction & 1)
+    {
+        return PaintAddImageAsParent(
+            session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z });
+    }
+    else
+    {
+        return PaintAddImageAsParent(session, image_id, offset, boundBoxSize);
+    }
+}
+
 paint_struct* PaintAddImageAsChildRotated(
     paint_session* session, uint8_t direction, uint32_t image_id, int32_t x_offset, int32_t y_offset,
     int32_t bound_box_length_x, int32_t bound_box_length_y, int32_t bound_box_length_z, int32_t z_offset,
@@ -64,6 +95,22 @@ paint_struct* PaintAddImageAsChildRotated(
         return PaintAddImageAsChild(
             session, image_id, x_offset, y_offset, bound_box_length_x, bound_box_length_y, bound_box_length_z, z_offset,
             bound_box_offset_x, bound_box_offset_y, bound_box_offset_z);
+    }
+}
+
+paint_struct* PaintAddImageAsChildRotated(
+    paint_session* session, const uint8_t direction, const uint32_t image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
+{
+    if (direction & 1)
+    {
+        return PaintAddImageAsChild(
+            session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z },
+            { boundBoxOffset.y, boundBoxOffset.x, boundBoxOffset.z });
+    }
+    else
+    {
+        return PaintAddImageAsChild(session, image_id, offset, boundBoxSize, boundBoxOffset);
     }
 }
 


### PR DESCRIPTION
I tried to do the find and replace but my PC is really struggling to process the regex across all the paint track files as its so complex adding in all the new line checks.
```
PaintAddImageAsParentRotated\([\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^\{,]+),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*)\);

PaintAddImageAsParentRotated($1, $2, $3, {$4, $5, $9}, {$6, $7, $8});
```
```
PaintAddImageAsParentRotated\([\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^\{,]+),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*)\);

PaintAddImageAsParentRotated($1, $2, $3, {$4, $5, $9}, {$6, $7, $8}, {$10, $11, $12});
```
```
PaintAddImageAsChildRotated\([\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^\{,]+),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*),[\s\r]*?([^,]*)\);

PaintAddImageAsChildRotated($1, $2, $3, {$4, $5, $9}, {$6, $7, $8}, {$10, $11, $12});
```