### PR TITLE
Fix #15255: Wall banner index defaults to 0 instead of null type

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,7 @@
 - Fix: [#15170] Plugin: incorrect label text alignment.
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
 - Fix: [#15193] Crash when rides/stalls are demolished.
-- Fix: [#15255] Normal wall scenery would have the banner index 0 at all times.
+- Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#15170] Plugin: incorrect label text alignment.
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
 - Fix: [#15193] Crash when rides/stalls are demolished.
+- Fix: [#15255] Normal wall scenery would have the banner index 0 at all times.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -376,10 +376,7 @@ GameActions::Result::Ptr WallPlaceAction::Execute() const
     wallElement->SetAcrossTrack(wallAcrossTrack);
 
     wallElement->SetEntryIndex(_wallType);
-    if (banner != nullptr)
-    {
-        wallElement->SetBannerIndex(banner->id);
-    }
+    wallElement->SetBannerIndex(banner != nullptr ? banner->id : BANNER_INDEX_NULL);
 
     if (wallEntry->flags & WALL_SCENERY_HAS_TERNARY_COLOUR)
     {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -37,7 +37,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
No idea for how long this has been in, the side effect is only visible from the tile inspector as far as I can tell.

Closes #15255

Edit: Can reproduce this on 0.3.4.1 but not 0.3.3, so worth a changelog entry I guess.