### PR TITLE
Track Element Descriptor refactor (issue #13874)

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -946,7 +946,7 @@ static void window_new_ride_paint_ride_information(
         int32_t startPieceId = GetRideTypeDescriptor(item.Type).StartTrackPiece;
         money64 price = GetRideTypeDescriptor(item.Type).BuildCosts.TrackPrice;
         const auto& ted = GetTrackElementDescriptor(startPieceId);
-        price *= ted.Pricing;
+        price *= ted.Price;
         price = (price >> 17) * 10 * GetRideTypeDescriptor(item.Type).BuildCosts.PriceEstimateMultiplier;
 
         //

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -33,6 +33,8 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Park.h>
 
+using namespace OpenRCT2::TrackMetaData;
+
 static constexpr const rct_string_id WINDOW_TITLE = STR_NONE;
 constexpr size_t AVAILABILITY_STRING_SIZE = 256;
 static constexpr const int32_t WH = 382;
@@ -943,7 +945,8 @@ static void window_new_ride_paint_ride_information(
         // Get price of ride
         int32_t unk2 = GetRideTypeDescriptor(item.Type).StartTrackPiece;
         money64 price = GetRideTypeDescriptor(item.Type).BuildCosts.TrackPrice;
-        price *= TrackPricing[unk2];
+        const auto& teDescriptor = GetTrackElementDescriptor(unk2);
+        price *= teDescriptor.Pricing;
         price = (price >> 17) * 10 * GetRideTypeDescriptor(item.Type).BuildCosts.PriceEstimateMultiplier;
 
         //

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -943,10 +943,10 @@ static void window_new_ride_paint_ride_information(
     if (!(gParkFlags & PARK_FLAGS_NO_MONEY))
     {
         // Get price of ride
-        int32_t unk2 = GetRideTypeDescriptor(item.Type).StartTrackPiece;
+        int32_t startPieceId = GetRideTypeDescriptor(item.Type).StartTrackPiece;
         money64 price = GetRideTypeDescriptor(item.Type).BuildCosts.TrackPrice;
-        const auto& teDescriptor = GetTrackElementDescriptor(unk2);
-        price *= teDescriptor.Pricing;
+        const auto& ted = GetTrackElementDescriptor(startPieceId);
+        price *= ted.Pricing;
         price = (price >> 17) * 10 * GetRideTypeDescriptor(item.Type).BuildCosts.PriceEstimateMultiplier;
 
         //

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1370,7 +1370,7 @@ rct_window* window_ride_open_track(TileElement* tileElement)
                     auto trackElement = tileElement->AsTrack();
                     auto trackType = trackElement->GetTrackType();
                     const auto& ted = GetTrackElementDescriptor(trackType);
-                    if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                    if (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                     {
                         auto stationIndex = trackElement->GetStationIndex();
                         return window_ride_open_station(ride, stationIndex);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1369,8 +1369,8 @@ rct_window* window_ride_open_track(TileElement* tileElement)
                     // Open ride window in station view
                     auto trackElement = tileElement->AsTrack();
                     auto trackType = trackElement->GetTrackType();
-                    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-                    if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                    const auto& ted = GetTrackElementDescriptor(trackType);
+                    if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                     {
                         auto stationIndex = trackElement->GetStationIndex();
                         return window_ride_open_station(ride, stationIndex);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -59,6 +59,7 @@
 #include <vector>
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::TrackMetaData;
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_RIDE_WINDOW_TITLE;
 static constexpr const int32_t WH = 207;
@@ -1368,7 +1369,8 @@ rct_window* window_ride_open_track(TileElement* tileElement)
                     // Open ride window in station view
                     auto trackElement = tileElement->AsTrack();
                     auto trackType = trackElement->GetTrackType();
-                    if (TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+                    if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                     {
                         auto stationIndex = trackElement->GetStationIndex();
                         return window_ride_open_station(ride, stationIndex);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2349,7 +2349,7 @@ static void window_ride_construction_draw_track_piece(
         return;
 
     const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    auto trackBlock = teDescriptor.Block;
+    const auto* trackBlock = teDescriptor.Block;
     while ((trackBlock + 1)->index != 0xFF)
         trackBlock++;
 
@@ -2404,7 +2404,7 @@ static void sub_6CBCE2(
     gMapSize = MAXIMUM_MAP_SIZE_TECHNICAL;
 
     const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    auto trackBlock = teDescriptor.Block;
+    const auto* trackBlock = teDescriptor.Block;
     while (trackBlock->index != 255)
     {
         auto quarterTile = trackBlock->var_08.Rotate(trackDirection);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -42,6 +42,8 @@ static constexpr const int32_t WH = 394;
 static constexpr const int32_t WW = 166;
 static constexpr const uint16_t ARROW_PULSE_DURATION = 200;
 
+using namespace OpenRCT2::TrackMetaData;
+
 #pragma region Widgets
 
 // clang-format off
@@ -1924,7 +1926,8 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
             return;
         }
 
-        const rct_preview_track* trackBlock = TrackBlocks[tileElement->AsTrack()->GetTrackType()];
+        const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+        const rct_preview_track* trackBlock = teDescriptor.Block;
         newCoords->z = (tileElement->GetBaseZ()) - trackBlock->z;
         gGotoStartPlacementMode = true;
     }
@@ -2345,7 +2348,8 @@ static void window_ride_construction_draw_track_piece(
     if (ride == nullptr)
         return;
 
-    auto trackBlock = TrackBlocks[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    auto trackBlock = teDescriptor.Block;
     while ((trackBlock + 1)->index != 0xFF)
         trackBlock++;
 
@@ -2399,7 +2403,8 @@ static void sub_6CBCE2(
 
     gMapSize = MAXIMUM_MAP_SIZE_TECHNICAL;
 
-    auto trackBlock = TrackBlocks[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    auto trackBlock = teDescriptor.Block;
     while (trackBlock->index != 255)
     {
         auto quarterTile = trackBlock->var_08.Rotate(trackDirection);
@@ -3292,7 +3297,8 @@ static void window_ride_construction_select_map_tiles(
 
     const rct_preview_track* trackBlock;
 
-    trackBlock = TrackBlocks[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    trackBlock = teDescriptor.Block;
     trackDirection &= 3;
     gMapSelectionTiles.clear();
     while (trackBlock->index != 255)
@@ -3469,7 +3475,8 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
         // z = map_get_highest_z(x >> 5, y >> 5);
     }
     // loc_6CC91B:
-    trackBlock = TrackBlocks[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    trackBlock = teDescriptor.Block;
     int32_t bx = 0;
     do
     {
@@ -3699,7 +3706,8 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 
     if (_trackPlaceZ == 0)
     {
-        const rct_preview_track* trackBlock = TrackBlocks[_currentTrackPieceType];
+        const auto& teDescriptor = GetTrackElementDescriptor(_currentTrackPieceType);
+        const rct_preview_track* trackBlock = teDescriptor.Block;
         int32_t bx = 0;
         do
         {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1926,8 +1926,8 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
             return;
         }
 
-        const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-        const rct_preview_track* trackBlock = teDescriptor.Block;
+        const auto& ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+        const rct_preview_track* trackBlock = ted.Block;
         newCoords->z = (tileElement->GetBaseZ()) - trackBlock->z;
         gGotoStartPlacementMode = true;
     }
@@ -2348,8 +2348,8 @@ static void window_ride_construction_draw_track_piece(
     if (ride == nullptr)
         return;
 
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const auto* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const auto* trackBlock = ted.Block;
     while ((trackBlock + 1)->index != 0xFF)
         trackBlock++;
 
@@ -2403,8 +2403,8 @@ static void sub_6CBCE2(
 
     gMapSize = MAXIMUM_MAP_SIZE_TECHNICAL;
 
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const auto* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const auto* trackBlock = ted.Block;
     while (trackBlock->index != 255)
     {
         auto quarterTile = trackBlock->var_08.Rotate(trackDirection);
@@ -3297,8 +3297,8 @@ static void window_ride_construction_select_map_tiles(
 
     const rct_preview_track* trackBlock;
 
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    trackBlock = ted.Block;
     trackDirection &= 3;
     gMapSelectionTiles.clear();
     while (trackBlock->index != 255)
@@ -3475,8 +3475,8 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
         // z = map_get_highest_z(x >> 5, y >> 5);
     }
     // loc_6CC91B:
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    trackBlock = ted.Block;
     int32_t bx = 0;
     do
     {
@@ -3706,8 +3706,8 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 
     if (_trackPlaceZ == 0)
     {
-        const auto& teDescriptor = GetTrackElementDescriptor(_currentTrackPieceType);
-        const rct_preview_track* trackBlock = teDescriptor.Block;
+        const auto& ted = GetTrackElementDescriptor(_currentTrackPieceType);
+        const rct_preview_track* trackBlock = ted.Block;
         int32_t bx = 0;
         do
         {

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::TrackMetaData;
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRING;
 static constexpr const int32_t WH = 124;
@@ -550,7 +551,8 @@ static void window_track_place_draw_mini_preview_track(
         }
 
         // Follow a single track piece shape
-        const rct_preview_track* trackBlock = TrackBlocks[trackType];
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        const rct_preview_track* trackBlock = teDescriptor.Block;
         while (trackBlock->index != 255)
         {
             auto rotatedAndOffsetTrackBlock = curTrackStart + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(curTrackRotation);
@@ -594,8 +596,7 @@ static void window_track_place_draw_mini_preview_track(
 
         // Change rotation and next position based on track curvature
         curTrackRotation &= 3;
-        using namespace OpenRCT2::TrackMetaData;
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+
         const rct_track_coordinates* track_coordinate = &teDescriptor.Coordinates;
 
         curTrackStart += CoordsXY{ track_coordinate->x, track_coordinate->y }.Rotate(curTrackRotation);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -594,7 +594,9 @@ static void window_track_place_draw_mini_preview_track(
 
         // Change rotation and next position based on track curvature
         curTrackRotation &= 3;
-        const rct_track_coordinates* track_coordinate = &TrackCoordinates[trackType];
+        using namespace OpenRCT2::TrackMetaData;
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        const rct_track_coordinates* track_coordinate = &teDescriptor.Coordinates;
 
         curTrackStart += CoordsXY{ track_coordinate->x, track_coordinate->y }.Rotate(curTrackRotation);
         curTrackRotation += track_coordinate->rotation_end - track_coordinate->rotation_begin;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -551,8 +551,8 @@ static void window_track_place_draw_mini_preview_track(
         }
 
         // Follow a single track piece shape
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        const rct_preview_track* trackBlock = teDescriptor.Block;
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        const rct_preview_track* trackBlock = ted.Block;
         while (trackBlock->index != 255)
         {
             auto rotatedAndOffsetTrackBlock = curTrackStart + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(curTrackRotation);
@@ -574,9 +574,8 @@ static void window_track_place_draw_mini_preview_track(
                     auto bits = trackBlock->var_08.Rotate(curTrackRotation & 3).GetBaseQuarterOccupied();
 
                     // Station track is a lighter colour
-                    uint8_t colour = (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
-                        ? _PaletteIndexColourStation
-                        : _PaletteIndexColourTrack;
+                    uint8_t colour = (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN) ? _PaletteIndexColourStation
+                                                                                                   : _PaletteIndexColourTrack;
 
                     for (int32_t i = 0; i < 4; i++)
                     {
@@ -597,7 +596,7 @@ static void window_track_place_draw_mini_preview_track(
         // Change rotation and next position based on track curvature
         curTrackRotation &= 3;
 
-        const rct_track_coordinates* track_coordinate = &teDescriptor.Coordinates;
+        const rct_track_coordinates* track_coordinate = &ted.Coordinates;
 
         curTrackStart += CoordsXY{ track_coordinate->x, track_coordinate->y }.Rotate(curTrackRotation);
         curTrackRotation += track_coordinate->rotation_end - track_coordinate->rotation_begin;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -574,8 +574,8 @@ static void window_track_place_draw_mini_preview_track(
                     auto bits = trackBlock->var_08.Rotate(curTrackRotation & 3).GetBaseQuarterOccupied();
 
                     // Station track is a lighter colour
-                    uint8_t colour = (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN) ? _PaletteIndexColourStation
-                                                                                                   : _PaletteIndexColourTrack;
+                    uint8_t colour = (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN) ? _PaletteIndexColourStation
+                                                                                              : _PaletteIndexColourTrack;
 
                     for (int32_t i = 0; i < 4; i++)
                     {

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -574,7 +574,7 @@ static void window_track_place_draw_mini_preview_track(
                     auto bits = trackBlock->var_08.Rotate(curTrackRotation & 3).GetBaseQuarterOccupied();
 
                     // Station track is a lighter colour
-                    uint8_t colour = (TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                    uint8_t colour = (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                         ? _PaletteIndexColourStation
                         : _PaletteIndexColourTrack;
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -53,6 +53,7 @@
 #include "platform/Crash.h"
 #include "platform/Platform2.h"
 #include "platform/platform.h"
+#include "ride/TrackData.h"
 #include "ride/TrackDesignRepository.h"
 #include "scenario/Scenario.h"
 #include "scenario/ScenarioRepository.h"
@@ -395,6 +396,7 @@ namespace OpenRCT2
                 }
                 _env->SetBasePath(DIRBASE::RCT2, rct2InstallPath);
             }
+            TrackMetaData::Init();
 
             _objectRepository = CreateObjectRepository(_env);
             _objectManager = CreateObjectManager(*_objectRepository);

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -115,8 +115,8 @@ GameActions::Result::Ptr MazePlaceTrackAction::Query() const
         return res;
     }
 
-    const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
-    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
+    const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
+    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
     res->Cost = canBuild->Cost + price / 2 * 10;
 
     return res;
@@ -157,8 +157,8 @@ GameActions::Result::Ptr MazePlaceTrackAction::Execute() const
         return canBuild;
     }
 
-    const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
-    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
+    const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
+    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
     res->Cost = canBuild->Cost + price / 2 * 10;
 
     auto startLoc = _loc.ToTileStart();

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -12,6 +12,8 @@
 #include "../ride/RideData.h"
 #include "../ride/TrackData.h"
 
+using namespace OpenRCT2::TrackMetaData;
+
 MazePlaceTrackAction::MazePlaceTrackAction(const CoordsXYZ& location, NetworkRideId_t rideIndex, uint16_t mazeEntry)
     : _loc(location)
     , _rideIndex(rideIndex)
@@ -113,7 +115,8 @@ GameActions::Result::Ptr MazePlaceTrackAction::Query() const
         return res;
     }
 
-    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * TrackPricing[TrackElemType::Maze]) >> 16));
+    const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
+    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
     res->Cost = canBuild->Cost + price / 2 * 10;
 
     return res;
@@ -154,7 +157,8 @@ GameActions::Result::Ptr MazePlaceTrackAction::Execute() const
         return canBuild;
     }
 
-    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * TrackPricing[TrackElemType::Maze]) >> 16));
+    const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
+    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
     res->Cost = canBuild->Cost + price / 2 * 10;
 
     auto startLoc = _loc.ToTileStart();

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -116,7 +116,7 @@ GameActions::Result::Ptr MazePlaceTrackAction::Query() const
     }
 
     const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
-    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
+    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
     res->Cost = canBuild->Cost + price / 2 * 10;
 
     return res;
@@ -158,7 +158,7 @@ GameActions::Result::Ptr MazePlaceTrackAction::Execute() const
     }
 
     const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
-    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
+    money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
     res->Cost = canBuild->Cost + price / 2 * 10;
 
     auto startLoc = _loc.ToTileStart();

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -21,6 +21,8 @@
 #include "../world/Footpath.h"
 #include "../world/Park.h"
 
+using namespace OpenRCT2::TrackMetaData;
+
 MazeSetTrackAction::MazeSetTrackAction(
     const CoordsXYZD& location, bool initialPlacement, NetworkRideId_t rideIndex, uint8_t mode)
     : _loc(location)
@@ -134,7 +136,8 @@ GameActions::Result::Ptr MazeSetTrackAction::Query() const
             return res;
         }
 
-        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * TrackPricing[TrackElemType::Maze]) >> 16));
+        const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
+        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
         res->Cost = price / 2 * 10;
 
         return res;
@@ -169,7 +172,8 @@ GameActions::Result::Ptr MazeSetTrackAction::Execute() const
     auto tileElement = map_get_track_element_at_of_type_from_ride(_loc, TrackElemType::Maze, _rideIndex);
     if (tileElement == nullptr)
     {
-        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * TrackPricing[TrackElemType::Maze]) >> 16));
+        const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
+        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
         res->Cost = price / 2 * 10;
 
         auto startLoc = _loc.ToTileStart();

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -137,7 +137,7 @@ GameActions::Result::Ptr MazeSetTrackAction::Query() const
         }
 
         const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
-        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
+        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
         res->Cost = price / 2 * 10;
 
         return res;
@@ -173,7 +173,7 @@ GameActions::Result::Ptr MazeSetTrackAction::Execute() const
     if (tileElement == nullptr)
     {
         const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
-        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
+        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
         res->Cost = price / 2 * 10;
 
         auto startLoc = _loc.ToTileStart();

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -136,8 +136,8 @@ GameActions::Result::Ptr MazeSetTrackAction::Query() const
             return res;
         }
 
-        const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
-        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
+        const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
+        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
         res->Cost = price / 2 * 10;
 
         return res;
@@ -172,8 +172,8 @@ GameActions::Result::Ptr MazeSetTrackAction::Execute() const
     auto tileElement = map_get_track_element_at_of_type_from_ride(_loc, TrackElemType::Maze, _rideIndex);
     if (tileElement == nullptr)
     {
-        const auto& teDescriptor = GetTrackElementDescriptor(TrackElemType::Maze);
-        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * teDescriptor.Pricing) >> 16));
+        const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
+        money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Pricing) >> 16));
         res->Cost = price / 2 * 10;
 
         auto startLoc = _loc.ToTileStart();

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -318,7 +318,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
             }
         }
 
-        int32_t entranceDirections = ted.TrackSequenceProperties[0];
+        int32_t entranceDirections = ted.SequenceProperties[0];
         if ((entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN) && trackBlock->index == 0)
         {
             if (!track_add_station_element({ mapLoc, baseZ, _origin.direction }, _rideIndex, 0, _fromTrackDesign))
@@ -367,7 +367,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= ted.Pricing;
+    price *= ted.Price;
 
     price >>= 16;
     res->Cost = cost + ((price / 2) * 10);
@@ -538,7 +538,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         {
             if (!(GetFlags() & GAME_COMMAND_FLAG_NO_SPEND))
             {
-                entranceDirections = ted.TrackSequenceProperties[0];
+                entranceDirections = ted.SequenceProperties[0];
             }
         }
 
@@ -597,7 +597,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         }
         trackElement->SetColourScheme(_colour);
 
-        entranceDirections = ted.TrackSequenceProperties[0];
+        entranceDirections = ted.SequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
         {
             uint8_t availableDirections = entranceDirections & 0x0F;
@@ -653,7 +653,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= ted.Pricing;
+    price *= ted.Price;
 
     price >>= 16;
     res->Cost = cost + ((price / 2) * 10);

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -368,7 +368,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= TrackPricing[_trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+    price *= teDescriptor.Pricing;
 
     price >>= 16;
     res->Cost = cost + ((price / 2) * 10);
@@ -656,7 +657,8 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= TrackPricing[_trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+    price *= teDescriptor.Pricing;
 
     price >>= 16;
     res->Cost = cost + ((price / 2) * 10);

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -147,8 +147,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
         if ((_trackPlaceFlags & CONSTRUCTION_LIFT_HILL_SELECTED)
             && !ride->GetRideTypeDescriptor().SupportsTrackPiece(TRACK_LIFT_HILL_STEEP) && !gCheatsEnableChainLiftOnAllTrack)
         {
-            const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
-            if (teDescriptor.Flags & TRACK_ELEM_FLAG_IS_STEEP_UP)
+            const auto& ted = GetTrackElementDescriptor(_trackType);
+            if (ted.Flags & TRACK_ELEM_FLAG_IS_STEEP_UP)
             {
                 return std::make_unique<TrackPlaceActionResult>(GameActions::Status::Disallowed, STR_TOO_STEEP_FOR_LIFT_HILL);
             }
@@ -156,8 +156,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     money32 cost = 0;
-    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
-    const rct_preview_track* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(_trackType);
+    const rct_preview_track* trackBlock = ted.Block;
     uint32_t numElements = 0;
     // First check if any of the track pieces are outside the park
     for (; trackBlock->index != 0xFF; trackBlock++)
@@ -180,7 +180,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
 
     if (!gCheatsAllowTrackPlaceInvalidHeights)
     {
-        if (teDescriptor.Flags & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
+        if (ted.Flags & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
         {
             if ((_origin.z & 0x0F) != 8)
             {
@@ -199,7 +199,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     // If that is not the case, then perform the remaining checks
-    trackBlock = teDescriptor.Block;
+    trackBlock = ted.Block;
 
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
@@ -263,7 +263,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
         }
 
         res->GroundFlags = mapGroundFlags;
-        if (teDescriptor.Flags & TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND)
+        if (ted.Flags & TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND)
         {
             if (res->GroundFlags & ELEMENT_IS_UNDERGROUND)
             {
@@ -272,7 +272,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
             }
         }
 
-        if (teDescriptor.Flags & TRACK_ELEM_FLAG_ONLY_UNDERWATER)
+        if (ted.Flags & TRACK_ELEM_FLAG_ONLY_UNDERWATER)
         { // No element has this flag
             if (canBuild->GroundFlags & ELEMENT_IS_UNDERWATER)
             {
@@ -318,7 +318,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
             }
         }
 
-        int32_t entranceDirections = teDescriptor.TrackSequenceProperties[0];
+        int32_t entranceDirections = ted.TrackSequenceProperties[0];
         if ((entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN) && trackBlock->index == 0)
         {
             if (!track_add_station_element({ mapLoc, baseZ, _origin.direction }, _rideIndex, 0, _fromTrackDesign))
@@ -367,7 +367,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= teDescriptor.Pricing;
+    price *= ted.Pricing;
 
     price >>= 16;
     res->Cost = cost + ((price / 2) * 10);
@@ -400,11 +400,11 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
 
     uint32_t rideTypeFlags = ride->GetRideTypeDescriptor().Flags;
 
-    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
-    auto wallEdges = teDescriptor.SequenceElementAllowedWallEdges;
+    const auto& ted = GetTrackElementDescriptor(_trackType);
+    auto wallEdges = ted.SequenceElementAllowedWallEdges;
 
     money32 cost = 0;
-    const rct_preview_track* trackBlock = teDescriptor.Block;
+    const rct_preview_track* trackBlock = ted.Block;
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
         auto rotatedTrack = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(_origin.direction), trackBlock->z };
@@ -538,7 +538,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         {
             if (!(GetFlags() & GAME_COMMAND_FLAG_NO_SPEND))
             {
-                entranceDirections = teDescriptor.TrackSequenceProperties[0];
+                entranceDirections = ted.TrackSequenceProperties[0];
             }
         }
 
@@ -597,7 +597,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         }
         trackElement->SetColourScheme(_colour);
 
-        entranceDirections = teDescriptor.TrackSequenceProperties[0];
+        entranceDirections = ted.TrackSequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
         {
             uint8_t availableDirections = entranceDirections & 0x0F;
@@ -653,7 +653,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= teDescriptor.Pricing;
+    price *= ted.Pricing;
 
     price >>= 16;
     res->Cost = cost + ((price / 2) * 10);
@@ -662,8 +662,8 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
 
 bool TrackPlaceAction::CheckMapCapacity(int16_t numTiles) const
 {
-    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
-    for (const rct_preview_track* trackBlock = teDescriptor.Block; trackBlock->index != 0xFF; trackBlock++)
+    const auto& ted = GetTrackElementDescriptor(_trackType);
+    for (const rct_preview_track* trackBlock = ted.Block; trackBlock->index != 0xFF; trackBlock++)
     {
         auto rotatedTrack = CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(_origin.direction);
 

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -400,11 +400,10 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
 
     uint32_t rideTypeFlags = ride->GetRideTypeDescriptor().Flags;
 
-    const uint8_t(*wallEdges)[16];
-    wallEdges = &TrackSequenceElementAllowedWallEdges[_trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+    auto wallEdges = teDescriptor.SequenceElementAllowedWallEdges;
 
     money32 cost = 0;
-    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
     const rct_preview_track* trackBlock = teDescriptor.Block;
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
@@ -452,7 +451,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
             else
             {
                 // Remove walls in the directions this track intersects
-                uint8_t intersectingDirections = (*wallEdges)[blockIndex];
+                uint8_t intersectingDirections = wallEdges[blockIndex];
                 intersectingDirections ^= 0x0F;
                 intersectingDirections = rol4(intersectingDirections, _origin.direction);
                 for (int32_t i = 0; i < NumOrthogonalDirections; i++)

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -318,7 +318,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
             }
         }
 
-        int32_t entranceDirections = TrackSequenceProperties[_trackType][0];
+        int32_t entranceDirections = teDescriptor.TrackSequenceProperties[0];
         if ((entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN) && trackBlock->index == 0)
         {
             if (!track_add_station_element({ mapLoc, baseZ, _origin.direction }, _rideIndex, 0, _fromTrackDesign))
@@ -538,7 +538,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         {
             if (!(GetFlags() & GAME_COMMAND_FLAG_NO_SPEND))
             {
-                entranceDirections = TrackSequenceProperties[_trackType][0];
+                entranceDirections = teDescriptor.TrackSequenceProperties[0];
             }
         }
 
@@ -597,7 +597,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         }
         trackElement->SetColourScheme(_colour);
 
-        entranceDirections = TrackSequenceProperties[_trackType][0];
+        entranceDirections = teDescriptor.TrackSequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
         {
             uint8_t availableDirections = entranceDirections & 0x0F;

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -19,6 +19,7 @@
 #include "../world/Surface.h"
 #include "RideSetSettingAction.h"
 
+using namespace OpenRCT2::TrackMetaData;
 TrackPlaceActionResult::TrackPlaceActionResult()
     : GameActions::Result(GameActions::Status::Ok, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE)
 {
@@ -146,7 +147,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
         if ((_trackPlaceFlags & CONSTRUCTION_LIFT_HILL_SELECTED)
             && !ride->GetRideTypeDescriptor().SupportsTrackPiece(TRACK_LIFT_HILL_STEEP) && !gCheatsEnableChainLiftOnAllTrack)
         {
-            if (TrackFlags[_trackType] & TRACK_ELEM_FLAG_IS_STEEP_UP)
+            const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+            if (teDescriptor.Flags & TRACK_ELEM_FLAG_IS_STEEP_UP)
             {
                 return std::make_unique<TrackPlaceActionResult>(GameActions::Status::Disallowed, STR_TOO_STEEP_FOR_LIFT_HILL);
             }
@@ -176,7 +178,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
     if (!gCheatsAllowTrackPlaceInvalidHeights)
     {
-        if (TrackFlags[_trackType] & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
+        const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+        if (teDescriptor.Flags & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
         {
             if ((_origin.z & 0x0F) != 8)
             {
@@ -260,7 +263,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
 
         res->GroundFlags = mapGroundFlags;
 
-        if (TrackFlags[_trackType] & TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND)
+        const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+        if (teDescriptor.Flags & TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND)
         {
             if (res->GroundFlags & ELEMENT_IS_UNDERGROUND)
             {
@@ -269,7 +273,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
             }
         }
 
-        if (TrackFlags[_trackType] & TRACK_ELEM_FLAG_ONLY_UNDERWATER)
+        if (teDescriptor.Flags & TRACK_ELEM_FLAG_ONLY_UNDERWATER)
         { // No element has this flag
             if (canBuild->GroundFlags & ELEMENT_IS_UNDERWATER)
             {

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -401,7 +401,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
     uint32_t rideTypeFlags = ride->GetRideTypeDescriptor().Flags;
 
     const auto& ted = GetTrackElementDescriptor(_trackType);
-    auto wallEdges = ted.SequenceElementAllowedWallEdges;
+    const auto& wallEdges = ted.SequenceElementAllowedWallEdges;
 
     money32 cost = 0;
     const rct_preview_track* trackBlock = ted.Block;

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -156,7 +156,8 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     money32 cost = 0;
-    const rct_preview_track* trackBlock = TrackBlocks[_trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+    const rct_preview_track* trackBlock = teDescriptor.Block;
     uint32_t numElements = 0;
     // First check if any of the track pieces are outside the park
     for (; trackBlock->index != 0xFF; trackBlock++)
@@ -176,9 +177,9 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
         log_warning("Not enough free map elements to place track.");
         return std::make_unique<TrackPlaceActionResult>(GameActions::Status::NoFreeElements, STR_TILE_ELEMENT_LIMIT_REACHED);
     }
+
     if (!gCheatsAllowTrackPlaceInvalidHeights)
     {
-        const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
         if (teDescriptor.Flags & TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT)
         {
             if ((_origin.z & 0x0F) != 8)
@@ -198,7 +199,7 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     // If that is not the case, then perform the remaining checks
-    trackBlock = TrackBlocks[_trackType];
+    trackBlock = teDescriptor.Block;
 
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
@@ -262,8 +263,6 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
         }
 
         res->GroundFlags = mapGroundFlags;
-
-        const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
         if (teDescriptor.Flags & TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND)
         {
             if (res->GroundFlags & ELEMENT_IS_UNDERGROUND)
@@ -368,7 +367,6 @@ GameActions::Result::Ptr TrackPlaceAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
     price *= teDescriptor.Pricing;
 
     price >>= 16;
@@ -406,9 +404,8 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
     wallEdges = &TrackSequenceElementAllowedWallEdges[_trackType];
 
     money32 cost = 0;
-    const rct_preview_track* trackBlock = TrackBlocks[_trackType];
-
-    trackBlock = TrackBlocks[_trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+    const rct_preview_track* trackBlock = teDescriptor.Block;
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
         auto rotatedTrack = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(_origin.direction), trackBlock->z };
@@ -657,7 +654,6 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
     price *= teDescriptor.Pricing;
 
     price >>= 16;
@@ -667,7 +663,8 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
 
 bool TrackPlaceAction::CheckMapCapacity(int16_t numTiles) const
 {
-    for (const rct_preview_track* trackBlock = TrackBlocks[_trackType]; trackBlock->index != 0xFF; trackBlock++)
+    const auto& teDescriptor = GetTrackElementDescriptor(_trackType);
+    for (const rct_preview_track* trackBlock = teDescriptor.Block; trackBlock->index != 0xFF; trackBlock++)
     {
         auto rotatedTrack = CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(_origin.direction);
 

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -203,7 +203,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
             return MakeResult(GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
 
-        int32_t entranceDirections = TrackSequenceProperties[trackType][0];
+        int32_t entranceDirections = teDescriptor.TrackSequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
         {
             if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, 0))
@@ -378,7 +378,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
             return MakeResult(GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
 
-        int32_t entranceDirections = TrackSequenceProperties[trackType][0];
+        int32_t entranceDirections = teDescriptor.TrackSequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
         {
             if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, 0))

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -136,8 +136,8 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
         log_warning("Ride type not found. ride type = %d.", ride->type);
         return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
     }
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_preview_track* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const rct_preview_track* trackBlock = ted.Block;
     trackBlock += tileElement->AsTrack()->GetSequenceIndex();
 
     auto startLoc = _origin;
@@ -153,7 +153,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
 
     money32 cost = 0;
 
-    trackBlock = teDescriptor.Block;
+    trackBlock = ted.Block;
     for (; trackBlock->index != 255; trackBlock++)
     {
         rotatedTrack = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(startLoc.direction), trackBlock->z };
@@ -203,7 +203,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
             return MakeResult(GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
 
-        int32_t entranceDirections = teDescriptor.TrackSequenceProperties[0];
+        int32_t entranceDirections = ted.TrackSequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
         {
             if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, 0))
@@ -229,7 +229,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= teDescriptor.Pricing;
+    price *= ted.Pricing;
     price >>= 16;
     price = (price + cost) / 2;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
@@ -317,8 +317,8 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
         log_warning("Ride not found. ride index = %d.", rideIndex);
         return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
     }
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_preview_track* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const rct_preview_track* trackBlock = ted.Block;
     trackBlock += tileElement->AsTrack()->GetSequenceIndex();
 
     auto startLoc = _origin;
@@ -333,7 +333,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     res->Position.z = startLoc.z;
     money32 cost = 0;
 
-    trackBlock = teDescriptor.Block;
+    trackBlock = ted.Block;
     for (; trackBlock->index != 255; trackBlock++)
     {
         rotatedTrackLoc = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(startLoc.direction), trackBlock->z };
@@ -378,7 +378,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
             return MakeResult(GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
 
-        int32_t entranceDirections = teDescriptor.TrackSequenceProperties[0];
+        int32_t entranceDirections = ted.TrackSequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
         {
             if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, 0))
@@ -477,7 +477,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= teDescriptor.Pricing;
+    price *= ted.Pricing;
     price >>= 16;
     price = (price + cost) / 2;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -203,7 +203,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
             return MakeResult(GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
 
-        int32_t entranceDirections = ted.TrackSequenceProperties[0];
+        int32_t entranceDirections = ted.SequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
         {
             if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, 0))
@@ -229,7 +229,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= ted.Pricing;
+    price *= ted.Price;
     price >>= 16;
     price = (price + cost) / 2;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
@@ -378,7 +378,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
             return MakeResult(GameActions::Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
         }
 
-        int32_t entranceDirections = ted.TrackSequenceProperties[0];
+        int32_t entranceDirections = ted.SequenceProperties[0];
         if (entranceDirections & TRACK_SEQUENCE_FLAG_ORIGIN && (tileElement->AsTrack()->GetSequenceIndex() == 0))
         {
             if (!track_remove_station_element({ mapLoc, _origin.direction }, rideIndex, 0))
@@ -477,7 +477,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= ted.Pricing;
+    price *= ted.Price;
     price >>= 16;
     price = (price + cost) / 2;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -122,7 +122,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
     }
 
     ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
-    auto trackType = tileElement->AsTrack()->GetTrackType();
+    const auto trackType = tileElement->AsTrack()->GetTrackType();
 
     auto ride = get_ride(rideIndex);
     if (ride == nullptr)
@@ -136,7 +136,8 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
         log_warning("Ride type not found. ride type = %d.", ride->type);
         return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
     }
-    const rct_preview_track* trackBlock = TrackBlocks[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    const rct_preview_track* trackBlock = teDescriptor.Block;
     trackBlock += tileElement->AsTrack()->GetSequenceIndex();
 
     auto startLoc = _origin;
@@ -152,7 +153,7 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
 
     money32 cost = 0;
 
-    trackBlock = TrackBlocks[trackType];
+    trackBlock = teDescriptor.Block;
     for (; trackBlock->index != 255; trackBlock++)
     {
         rotatedTrack = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(startLoc.direction), trackBlock->z };
@@ -228,7 +229,6 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
     price *= teDescriptor.Pricing;
     price >>= 16;
     price = (price + cost) / 2;
@@ -308,7 +308,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     }
 
     ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();
-    auto trackType = tileElement->AsTrack()->GetTrackType();
+    const auto trackType = tileElement->AsTrack()->GetTrackType();
     bool isLiftHill = tileElement->AsTrack()->HasChain();
 
     auto ride = get_ride(rideIndex);
@@ -317,7 +317,8 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
         log_warning("Ride not found. ride index = %d.", rideIndex);
         return MakeResult(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS);
     }
-    const rct_preview_track* trackBlock = TrackBlocks[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    const rct_preview_track* trackBlock = teDescriptor.Block;
     trackBlock += tileElement->AsTrack()->GetSequenceIndex();
 
     auto startLoc = _origin;
@@ -332,7 +333,7 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     res->Position.z = startLoc.z;
     money32 cost = 0;
 
-    trackBlock = TrackBlocks[trackType];
+    trackBlock = teDescriptor.Block;
     for (; trackBlock->index != 255; trackBlock++)
     {
         rotatedTrackLoc = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(startLoc.direction), trackBlock->z };
@@ -476,7 +477,6 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
     price *= teDescriptor.Pricing;
     price >>= 16;
     price = (price + cost) / 2;

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -19,6 +19,8 @@
 #include "../world/Surface.h"
 #include "RideSetSettingAction.h"
 
+using namespace OpenRCT2::TrackMetaData;
+
 TrackRemoveAction::TrackRemoveAction(track_type_t trackType, int32_t sequence, const CoordsXYZD& origin)
     : _trackType(trackType)
     , _sequence(sequence)
@@ -226,7 +228,8 @@ GameActions::Result::Ptr TrackRemoveAction::Query() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= TrackPricing[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    price *= teDescriptor.Pricing;
     price >>= 16;
     price = (price + cost) / 2;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
@@ -473,7 +476,8 @@ GameActions::Result::Ptr TrackRemoveAction::Execute() const
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
-    price *= TrackPricing[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    price *= teDescriptor.Pricing;
     price >>= 16;
     price = (price + cost) / 2;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -452,7 +452,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
                 direction = direction_reverse(trackElement->GetDirection());
                 if (direction == _edge)
                 {
-                    const rct_preview_track* trackBlock = &TrackBlocks[trackType][sequence];
+                    const rct_preview_track* trackBlock = &teDescriptor.Block[sequence];
                     z = teDescriptor.Coordinates.z_begin;
                     z = trackElement->base_height + ((z - trackBlock->z) * 8);
                     if (z == z0)
@@ -464,7 +464,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
         }
     }
 
-    const rct_preview_track* trackBlock = &TrackBlocks[trackType][sequence + 1];
+    const rct_preview_track* trackBlock = &teDescriptor.Block[sequence + 1];
     if (trackBlock->index != 0xFF)
     {
         return false;
@@ -487,7 +487,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
         return false;
     }
 
-    trackBlock = &TrackBlocks[trackType][sequence];
+    trackBlock = &teDescriptor.Block[sequence];
     z = teDescriptor.Coordinates.z_end;
     z = trackElement->base_height + ((z - trackBlock->z) * 8);
     return z == z0;

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -405,6 +405,9 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
     WallSceneryEntry* wall, int32_t z0, TrackElement* trackElement, bool* wallAcrossTrack) const
 {
     track_type_t trackType = trackElement->GetTrackType();
+
+    using namespace OpenRCT2::TrackMetaData;
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
     int32_t sequence = trackElement->GetSequenceIndex();
     int32_t direction = (_edge - trackElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK;
     auto ride = get_ride(trackElement->GetRideIndex());
@@ -444,13 +447,13 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
 
         if (TrackDefinitions[trackType].bank_start == 0)
         {
-            if (!(TrackCoordinates[trackType].rotation_begin & 4))
+            if (!(teDescriptor.Coordinates.rotation_begin & 4))
             {
                 direction = direction_reverse(trackElement->GetDirection());
                 if (direction == _edge)
                 {
                     const rct_preview_track* trackBlock = &TrackBlocks[trackType][sequence];
-                    z = TrackCoordinates[trackType].z_begin;
+                    z = teDescriptor.Coordinates.z_begin;
                     z = trackElement->base_height + ((z - trackBlock->z) * 8);
                     if (z == z0)
                     {
@@ -472,20 +475,20 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
         return false;
     }
 
-    direction = TrackCoordinates[trackType].rotation_end;
+    direction = teDescriptor.Coordinates.rotation_end;
     if (direction & 4)
     {
         return false;
     }
 
-    direction = (trackElement->GetDirection() + TrackCoordinates[trackType].rotation_end) & TILE_ELEMENT_DIRECTION_MASK;
+    direction = (trackElement->GetDirection() + teDescriptor.Coordinates.rotation_end) & TILE_ELEMENT_DIRECTION_MASK;
     if (direction != _edge)
     {
         return false;
     }
 
     trackBlock = &TrackBlocks[trackType][sequence];
-    z = TrackCoordinates[trackType].z_end;
+    z = teDescriptor.Coordinates.z_end;
     z = trackElement->base_height + ((z - trackBlock->z) * 8);
     return z == z0;
 }

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -441,7 +441,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
     int32_t z;
     if (sequence == 0)
     {
-        if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_DISALLOW_DOORS)
+        if (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_DISALLOW_DOORS)
         {
             return false;
         }

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -20,6 +20,7 @@
 #include "../world/Surface.h"
 #include "../world/Wall.h"
 
+using namespace OpenRCT2::TrackMetaData;
 WallPlaceActionResult::WallPlaceActionResult()
     : GameActions::Result(GameActions::Status::Ok, STR_CANT_BUILD_THIS_HERE)
 {
@@ -592,7 +593,8 @@ bool WallPlaceAction::TrackIsAllowedWallEdges(
 {
     if (!GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_TRACK_NO_WALLS))
     {
-        if (TrackSequenceElementAllowedWallEdges[trackType][trackSequence] & (1 << direction))
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        if (teDescriptor.SequenceElementAllowedWallEdges[trackSequence] & (1 << direction))
         {
             return true;
         }

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -408,7 +408,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
     track_type_t trackType = trackElement->GetTrackType();
 
     using namespace OpenRCT2::TrackMetaData;
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    const auto& ted = GetTrackElementDescriptor(trackType);
     int32_t sequence = trackElement->GetSequenceIndex();
     int32_t direction = (_edge - trackElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK;
     auto ride = get_ride(trackElement->GetRideIndex());
@@ -441,20 +441,20 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
     int32_t z;
     if (sequence == 0)
     {
-        if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_DISALLOW_DOORS)
+        if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_DISALLOW_DOORS)
         {
             return false;
         }
 
         if (TrackDefinitions[trackType].bank_start == 0)
         {
-            if (!(teDescriptor.Coordinates.rotation_begin & 4))
+            if (!(ted.Coordinates.rotation_begin & 4))
             {
                 direction = direction_reverse(trackElement->GetDirection());
                 if (direction == _edge)
                 {
-                    const rct_preview_track* trackBlock = &teDescriptor.Block[sequence];
-                    z = teDescriptor.Coordinates.z_begin;
+                    const rct_preview_track* trackBlock = &ted.Block[sequence];
+                    z = ted.Coordinates.z_begin;
                     z = trackElement->base_height + ((z - trackBlock->z) * 8);
                     if (z == z0)
                     {
@@ -465,7 +465,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
         }
     }
 
-    const rct_preview_track* trackBlock = &teDescriptor.Block[sequence + 1];
+    const rct_preview_track* trackBlock = &ted.Block[sequence + 1];
     if (trackBlock->index != 0xFF)
     {
         return false;
@@ -476,20 +476,20 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
         return false;
     }
 
-    direction = teDescriptor.Coordinates.rotation_end;
+    direction = ted.Coordinates.rotation_end;
     if (direction & 4)
     {
         return false;
     }
 
-    direction = (trackElement->GetDirection() + teDescriptor.Coordinates.rotation_end) & TILE_ELEMENT_DIRECTION_MASK;
+    direction = (trackElement->GetDirection() + ted.Coordinates.rotation_end) & TILE_ELEMENT_DIRECTION_MASK;
     if (direction != _edge)
     {
         return false;
     }
 
-    trackBlock = &teDescriptor.Block[sequence];
-    z = teDescriptor.Coordinates.z_end;
+    trackBlock = &ted.Block[sequence];
+    z = ted.Coordinates.z_end;
     z = trackElement->base_height + ((z - trackBlock->z) * 8);
     return z == z0;
 }
@@ -593,8 +593,8 @@ bool WallPlaceAction::TrackIsAllowedWallEdges(
 {
     if (!GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_TRACK_NO_WALLS))
     {
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        if (teDescriptor.SequenceElementAllowedWallEdges[trackSequence] & (1 << direction))
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        if (ted.SequenceElementAllowedWallEdges[trackSequence] & (1 << direction))
         {
             return true;
         }

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -441,7 +441,7 @@ bool WallPlaceAction::WallCheckObstructionWithTrack(
     int32_t z;
     if (sequence == 0)
     {
-        if (TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_DISALLOW_DOORS)
+        if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_DISALLOW_DOORS)
         {
             return false;
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -480,7 +480,7 @@ bool track_block_get_next_from_zero(
             continue;
 
         const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
-        auto nextTrackBlock = TrackBlocks[trackElement->GetTrackType()];
+        auto nextTrackBlock = teDescriptor.Block;
         if (nextTrackBlock == nullptr)
             continue;
 
@@ -530,7 +530,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
     if (ride == nullptr)
         return false;
 
-    auto trackBlock = TrackBlocks[inputElement->GetTrackType()];
+    auto trackBlock = teDescriptor.Block;
     if (trackBlock == nullptr)
         return false;
 
@@ -598,11 +598,10 @@ bool track_block_get_previous_from_zero(
         if (trackElement->GetRideIndex() != ride->id)
             continue;
 
-        auto nextTrackBlock = TrackBlocks[trackElement->GetTrackType()];
+        const auto& teDesc = GetTrackElementDescriptor(trackElement->GetTrackType());
+        auto nextTrackBlock = teDesc.Block;
         if (nextTrackBlock == nullptr)
             continue;
-
-        const auto& teDesc = GetTrackElementDescriptor(trackElement->GetTrackType());
         auto nextTrackCoordinate = teDesc.Coordinates;
 
         nextTrackBlock += trackElement->GetSequenceIndex();
@@ -635,7 +634,8 @@ bool track_block_get_previous_from_zero(
 
         outTrackBeginEnd->begin_z = tileElement->GetBaseZ();
 
-        auto nextTrackBlock2 = TrackBlocks[trackElement->GetTrackType()];
+        const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
+        auto nextTrackBlock2 = teDescriptor.Block;
         if (nextTrackBlock2 == nullptr)
             continue;
 
@@ -676,7 +676,7 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
     if (ride == nullptr)
         return false;
 
-    auto trackBlock = TrackBlocks[trackElement->GetTrackType()];
+    auto trackBlock = teDescriptor.Block;
     if (trackBlock == nullptr)
         return false;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -531,7 +531,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
     if (ride == nullptr)
         return false;
 
-    auto trackBlock = teDescriptor.Block;
+    const auto* trackBlock = teDescriptor.Block;
     if (trackBlock == nullptr)
         return false;
 
@@ -600,7 +600,7 @@ bool track_block_get_previous_from_zero(
             continue;
 
         const auto& teDesc = GetTrackElementDescriptor(trackElement->GetTrackType());
-        auto nextTrackBlock = teDesc.Block;
+        const auto* nextTrackBlock = teDesc.Block;
         if (nextTrackBlock == nullptr)
             continue;
         auto nextTrackCoordinate = teDesc.Coordinates;
@@ -636,7 +636,7 @@ bool track_block_get_previous_from_zero(
         outTrackBeginEnd->begin_z = tileElement->GetBaseZ();
 
         const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
-        auto nextTrackBlock2 = teDescriptor.Block;
+        const auto* nextTrackBlock2 = teDescriptor.Block;
         if (nextTrackBlock2 == nullptr)
             continue;
 
@@ -677,7 +677,7 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
     if (ride == nullptr)
         return false;
 
-    auto trackBlock = teDescriptor.Block;
+    const auto* trackBlock = teDescriptor.Block;
     if (trackBlock == nullptr)
         return false;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -410,11 +410,11 @@ bool ride_try_get_origin_element(const Ride* ride, CoordsXYE* output)
         // Found a track piece for target ride
 
         // Check if it's not the station or ??? (but allow end piece of station)
-        const auto& teDescriptor = GetTrackElementDescriptor(it.element->AsTrack()->GetTrackType());
+        const auto& ted = GetTrackElementDescriptor(it.element->AsTrack()->GetTrackType());
         bool specialTrackPiece
             = (it.element->AsTrack()->GetTrackType() != TrackElemType::BeginStation
                && it.element->AsTrack()->GetTrackType() != TrackElemType::MiddleStation
-               && (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN));
+               && (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN));
 
         // Set result tile to this track piece if first found track or a ???
         if (resultTileElement == nullptr || specialTrackPiece)
@@ -480,12 +480,12 @@ bool track_block_get_next_from_zero(
         if (tileElement->IsGhost() != isGhost)
             continue;
 
-        const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
-        auto nextTrackBlock = teDescriptor.Block;
+        const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
+        auto nextTrackBlock = ted.Block;
         if (nextTrackBlock == nullptr)
             continue;
 
-        auto nextTrackCoordinate = teDescriptor.Coordinates;
+        auto nextTrackCoordinate = ted.Coordinates;
         uint8_t nextRotation = tileElement->GetDirectionWithOffset(nextTrackCoordinate.rotation_begin)
             | (nextTrackCoordinate.rotation_begin & TRACK_BLOCK_2);
 
@@ -522,7 +522,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
         return false;
 
     auto inputElement = input->element->AsTrack();
-    const auto& teDescriptor = GetTrackElementDescriptor(inputElement->GetTrackType());
+    const auto& ted = GetTrackElementDescriptor(inputElement->GetTrackType());
     if (inputElement == nullptr)
         return false;
 
@@ -531,13 +531,13 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
     if (ride == nullptr)
         return false;
 
-    const auto* trackBlock = teDescriptor.Block;
+    const auto* trackBlock = ted.Block;
     if (trackBlock == nullptr)
         return false;
 
     trackBlock += inputElement->GetSequenceIndex();
 
-    auto trackCoordinate = teDescriptor.Coordinates;
+    auto trackCoordinate = ted.Coordinates;
 
     int32_t x = input->x;
     int32_t y = input->y;
@@ -635,8 +635,8 @@ bool track_block_get_previous_from_zero(
 
         outTrackBeginEnd->begin_z = tileElement->GetBaseZ();
 
-        const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
-        const auto* nextTrackBlock2 = teDescriptor.Block;
+        const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
+        const auto* nextTrackBlock2 = ted.Block;
         if (nextTrackBlock2 == nullptr)
             continue;
 
@@ -668,7 +668,7 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
         return false;
 
     auto trackElement = trackPos.element->AsTrack();
-    const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
+    const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
     if (trackElement == nullptr)
         return false;
 
@@ -677,13 +677,13 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
     if (ride == nullptr)
         return false;
 
-    const auto* trackBlock = teDescriptor.Block;
+    const auto* trackBlock = ted.Block;
     if (trackBlock == nullptr)
         return false;
 
     trackBlock += trackElement->GetSequenceIndex();
 
-    auto trackCoordinate = teDescriptor.Coordinates;
+    auto trackCoordinate = ted.Coordinates;
 
     int32_t z = trackElement->GetBaseZ();
 
@@ -2229,8 +2229,8 @@ static void ride_shop_connected(Ride* ride)
         return;
     }
 
-    const auto& teDescriptor = GetTrackElementDescriptor(track_type);
-    uint8_t entrance_directions = teDescriptor.TrackSequenceProperties[0] & 0xF;
+    const auto& ted = GetTrackElementDescriptor(track_type);
+    uint8_t entrance_directions = ted.TrackSequenceProperties[0] & 0xF;
     uint8_t tile_direction = trackElement->GetDirection();
     entrance_directions = rol4(entrance_directions, tile_direction);
 
@@ -2665,8 +2665,8 @@ static bool ride_check_track_contains_inversions(CoordsXYE* input, CoordsXYE* ou
     while (track_circuit_iterator_next(&it))
     {
         auto trackType = it.current.element->AsTrack()->GetTrackType();
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        if (teDescriptor.Flags & TRACK_ELEM_FLAG_INVERSION_TO_NORMAL)
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        if (ted.Flags & TRACK_ELEM_FLAG_INVERSION_TO_NORMAL)
         {
             *output = it.current;
             return true;
@@ -2724,8 +2724,8 @@ static bool ride_check_track_contains_banked(CoordsXYE* input, CoordsXYE* output
     while (track_circuit_iterator_next(&it))
     {
         auto trackType = output->element->AsTrack()->GetTrackType();
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        if (teDescriptor.Flags & TRACK_ELEM_FLAG_BANKED)
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        if (ted.Flags & TRACK_ELEM_FLAG_BANKED)
         {
             *output = it.current;
             return true;
@@ -2774,8 +2774,8 @@ static int32_t ride_check_station_length(CoordsXYE* input, CoordsXYE* output)
 
     do
     {
-        const auto& teDescriptor = GetTrackElementDescriptor(output->element->AsTrack()->GetTrackType());
-        if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+        const auto& ted = GetTrackElementDescriptor(output->element->AsTrack()->GetTrackType());
+        if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
         {
             num_station_elements++;
             last_good_station = *output;
@@ -2822,8 +2822,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     // Check back of the track
     track_get_back(input, &trackBack);
     auto trackType = trackBack.element->AsTrack()->GetTrackType();
-    auto teDescriptor = GetTrackElementDescriptor(trackType);
-    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    auto ted = GetTrackElementDescriptor(trackType);
+    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -2832,8 +2832,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     // Check front of the track
     track_get_front(input, &trackFront);
     trackType = trackFront.element->AsTrack()->GetTrackType();
-    teDescriptor = GetTrackElementDescriptor(trackType);
-    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    ted = GetTrackElementDescriptor(trackType);
+    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -2869,8 +2869,8 @@ static void ride_set_boat_hire_return_point(Ride* ride, CoordsXYE* startElement)
     };
 
     trackType = returnPos.element->AsTrack()->GetTrackType();
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    int32_t elementReturnDirection = teDescriptor.Coordinates.rotation_begin;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    int32_t elementReturnDirection = ted.Coordinates.rotation_begin;
     ride->boat_hire_return_direction = returnPos.element->GetDirectionWithOffset(elementReturnDirection);
     ride->boat_hire_return_position = TileCoordsXY{ returnPos };
 }
@@ -3544,8 +3544,8 @@ static bool ride_initialise_cable_lift_track(Ride* ride, bool isApplying)
         if (tileElement->GetBaseZ() != location.z)
             continue;
 
-        const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-        if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        const auto& ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+        if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
         {
             continue;
         }
@@ -3777,8 +3777,8 @@ TrackElement* Ride::GetOriginElement(StationIndex stationIndex) const
             continue;
 
         auto* trackElement = tileElement->AsTrack();
-        const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
-        if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
+        if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
             continue;
 
         if (trackElement->GetRideIndex() == id)
@@ -4884,8 +4884,8 @@ static int32_t ride_get_track_length(Ride* ride)
                 continue;
 
             trackType = tileElement->AsTrack()->GetTrackType();
-            const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-            if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+            const auto& ted = GetTrackElementDescriptor(trackType);
+            if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                 continue;
 
             if (tileElement->GetBaseZ() != trackStart.z)
@@ -4916,8 +4916,8 @@ static int32_t ride_get_track_length(Ride* ride)
     while (track_circuit_iterator_next(&it))
     {
         trackType = it.current.element->AsTrack()->GetTrackType();
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        result += teDescriptor.PieceLength;
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        result += ted.PieceLength;
 
         moveSlowIt = !moveSlowIt;
         if (moveSlowIt)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -410,10 +410,11 @@ bool ride_try_get_origin_element(const Ride* ride, CoordsXYE* output)
         // Found a track piece for target ride
 
         // Check if it's not the station or ??? (but allow end piece of station)
+        const auto& teDescriptor = GetTrackElementDescriptor(it.element->AsTrack()->GetTrackType());
         bool specialTrackPiece
             = (it.element->AsTrack()->GetTrackType() != TrackElemType::BeginStation
                && it.element->AsTrack()->GetTrackType() != TrackElemType::MiddleStation
-               && (TrackSequenceProperties[it.element->AsTrack()->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN));
+               && (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN));
 
         // Set result tile to this track piece if first found track or a ???
         if (resultTileElement == nullptr || specialTrackPiece)
@@ -2228,7 +2229,8 @@ static void ride_shop_connected(Ride* ride)
         return;
     }
 
-    uint8_t entrance_directions = TrackSequenceProperties[track_type][0] & 0xF;
+    const auto& teDescriptor = GetTrackElementDescriptor(track_type);
+    uint8_t entrance_directions = teDescriptor.TrackSequenceProperties[0] & 0xF;
     uint8_t tile_direction = trackElement->GetDirection();
     entrance_directions = rol4(entrance_directions, tile_direction);
 
@@ -2772,7 +2774,8 @@ static int32_t ride_check_station_length(CoordsXYE* input, CoordsXYE* output)
 
     do
     {
-        if (TrackSequenceProperties[output->element->AsTrack()->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+        const auto& teDescriptor = GetTrackElementDescriptor(output->element->AsTrack()->GetTrackType());
+        if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
         {
             num_station_elements++;
             last_good_station = *output;
@@ -2819,7 +2822,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     // Check back of the track
     track_get_back(input, &trackBack);
     auto trackType = trackBack.element->AsTrack()->GetTrackType();
-    if (!(TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    auto teDescriptor = GetTrackElementDescriptor(trackType);
+    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -2828,7 +2832,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     // Check front of the track
     track_get_front(input, &trackFront);
     trackType = trackFront.element->AsTrack()->GetTrackType();
-    if (!(TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    teDescriptor = GetTrackElementDescriptor(trackType);
+    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -3539,7 +3544,8 @@ static bool ride_initialise_cable_lift_track(Ride* ride, bool isApplying)
         if (tileElement->GetBaseZ() != location.z)
             continue;
 
-        if (!(TrackSequenceProperties[tileElement->AsTrack()->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+        if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
         {
             continue;
         }
@@ -3771,8 +3777,8 @@ TrackElement* Ride::GetOriginElement(StationIndex stationIndex) const
             continue;
 
         auto* trackElement = tileElement->AsTrack();
-
-        if (!(TrackSequenceProperties[trackElement->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
+        if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
             continue;
 
         if (trackElement->GetRideIndex() == id)
@@ -4878,7 +4884,8 @@ static int32_t ride_get_track_length(Ride* ride)
                 continue;
 
             trackType = tileElement->AsTrack()->GetTrackType();
-            if (!(TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+            const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+            if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                 continue;
 
             if (tileElement->GetBaseZ() != trackStart.z)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -73,6 +73,7 @@
 #include <optional>
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::TrackMetaData;
 
 RideMode& operator++(RideMode& d, int)
 {
@@ -478,11 +479,12 @@ bool track_block_get_next_from_zero(
         if (tileElement->IsGhost() != isGhost)
             continue;
 
+        const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
         auto nextTrackBlock = TrackBlocks[trackElement->GetTrackType()];
         if (nextTrackBlock == nullptr)
             continue;
 
-        auto nextTrackCoordinate = TrackCoordinates[trackElement->GetTrackType()];
+        auto nextTrackCoordinate = teDescriptor.Coordinates;
         uint8_t nextRotation = tileElement->GetDirectionWithOffset(nextTrackCoordinate.rotation_begin)
             | (nextTrackCoordinate.rotation_begin & TRACK_BLOCK_2);
 
@@ -519,6 +521,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
         return false;
 
     auto inputElement = input->element->AsTrack();
+    const auto& teDescriptor = GetTrackElementDescriptor(inputElement->GetTrackType());
     if (inputElement == nullptr)
         return false;
 
@@ -533,7 +536,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
 
     trackBlock += inputElement->GetSequenceIndex();
 
-    auto trackCoordinate = TrackCoordinates[inputElement->GetTrackType()];
+    auto trackCoordinate = teDescriptor.Coordinates;
 
     int32_t x = input->x;
     int32_t y = input->y;
@@ -599,7 +602,8 @@ bool track_block_get_previous_from_zero(
         if (nextTrackBlock == nullptr)
             continue;
 
-        auto nextTrackCoordinate = TrackCoordinates[trackElement->GetTrackType()];
+        const auto& teDesc = GetTrackElementDescriptor(trackElement->GetTrackType());
+        auto nextTrackCoordinate = teDesc.Coordinates;
 
         nextTrackBlock += trackElement->GetSequenceIndex();
         if ((nextTrackBlock + 1)->index != 255)
@@ -663,6 +667,7 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
         return false;
 
     auto trackElement = trackPos.element->AsTrack();
+    const auto& teDescriptor = GetTrackElementDescriptor(trackElement->GetTrackType());
     if (trackElement == nullptr)
         return false;
 
@@ -677,7 +682,7 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
 
     trackBlock += trackElement->GetSequenceIndex();
 
-    auto trackCoordinate = TrackCoordinates[trackElement->GetTrackType()];
+    auto trackCoordinate = teDescriptor.Coordinates;
 
     int32_t z = trackElement->GetBaseZ();
 
@@ -2857,7 +2862,8 @@ static void ride_set_boat_hire_return_point(Ride* ride, CoordsXYE* startElement)
     };
 
     trackType = returnPos.element->AsTrack()->GetTrackType();
-    int32_t elementReturnDirection = TrackCoordinates[trackType].rotation_begin;
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    int32_t elementReturnDirection = teDescriptor.Coordinates.rotation_begin;
     ride->boat_hire_return_direction = returnPos.element->GetDirectionWithOffset(elementReturnDirection);
     ride->boat_hire_return_position = TileCoordsXY{ returnPos };
 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2663,7 +2663,8 @@ static bool ride_check_track_contains_inversions(CoordsXYE* input, CoordsXYE* ou
     while (track_circuit_iterator_next(&it))
     {
         auto trackType = it.current.element->AsTrack()->GetTrackType();
-        if (TrackFlags[trackType] & TRACK_ELEM_FLAG_INVERSION_TO_NORMAL)
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        if (teDescriptor.Flags & TRACK_ELEM_FLAG_INVERSION_TO_NORMAL)
         {
             *output = it.current;
             return true;
@@ -2721,7 +2722,8 @@ static bool ride_check_track_contains_banked(CoordsXYE* input, CoordsXYE* output
     while (track_circuit_iterator_next(&it))
     {
         auto trackType = output->element->AsTrack()->GetTrackType();
-        if (TrackFlags[trackType] & TRACK_ELEM_FLAG_BANKED)
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        if (teDescriptor.Flags & TRACK_ELEM_FLAG_BANKED)
         {
             *output = it.current;
             return true;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -481,11 +481,11 @@ bool track_block_get_next_from_zero(
             continue;
 
         const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
-        auto nextTrackBlock = ted.Block;
+        const auto* nextTrackBlock = ted.Block;
         if (nextTrackBlock == nullptr)
             continue;
 
-        auto nextTrackCoordinate = ted.Coordinates;
+        const auto& nextTrackCoordinate = ted.Coordinates;
         uint8_t nextRotation = tileElement->GetDirectionWithOffset(nextTrackCoordinate.rotation_begin)
             | (nextTrackCoordinate.rotation_begin & TRACK_BLOCK_2);
 
@@ -537,7 +537,7 @@ bool track_block_get_next(CoordsXYE* input, CoordsXYE* output, int32_t* z, int32
 
     trackBlock += inputElement->GetSequenceIndex();
 
-    auto trackCoordinate = ted.Coordinates;
+    const auto& trackCoordinate = ted.Coordinates;
 
     int32_t x = input->x;
     int32_t y = input->y;
@@ -599,11 +599,11 @@ bool track_block_get_previous_from_zero(
         if (trackElement->GetRideIndex() != ride->id)
             continue;
 
-        const auto& teDesc = GetTrackElementDescriptor(trackElement->GetTrackType());
-        const auto* nextTrackBlock = teDesc.Block;
+        const auto* ted = &GetTrackElementDescriptor(trackElement->GetTrackType());
+        const auto* nextTrackBlock = ted->Block;
         if (nextTrackBlock == nullptr)
             continue;
-        auto nextTrackCoordinate = teDesc.Coordinates;
+        const auto& nextTrackCoordinate = ted->Coordinates;
 
         nextTrackBlock += trackElement->GetSequenceIndex();
         if ((nextTrackBlock + 1)->index != 255)
@@ -635,8 +635,8 @@ bool track_block_get_previous_from_zero(
 
         outTrackBeginEnd->begin_z = tileElement->GetBaseZ();
 
-        const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
-        const auto* nextTrackBlock2 = ted.Block;
+        ted = &GetTrackElementDescriptor(trackElement->GetTrackType());
+        const auto* nextTrackBlock2 = ted->Block;
         if (nextTrackBlock2 == nullptr)
             continue;
 
@@ -2822,8 +2822,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     // Check back of the track
     track_get_back(input, &trackBack);
     auto trackType = trackBack.element->AsTrack()->GetTrackType();
-    auto ted = GetTrackElementDescriptor(trackType);
-    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    const auto* ted = &GetTrackElementDescriptor(trackType);
+    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -2832,8 +2832,8 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     // Check front of the track
     track_get_front(input, &trackFront);
     trackType = trackFront.element->AsTrack()->GetTrackType();
-    ted = GetTrackElementDescriptor(trackType);
-    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    ted = &GetTrackElementDescriptor(trackType);
+    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -414,7 +414,7 @@ bool ride_try_get_origin_element(const Ride* ride, CoordsXYE* output)
         bool specialTrackPiece
             = (it.element->AsTrack()->GetTrackType() != TrackElemType::BeginStation
                && it.element->AsTrack()->GetTrackType() != TrackElemType::MiddleStation
-               && (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN));
+               && (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN));
 
         // Set result tile to this track piece if first found track or a ???
         if (resultTileElement == nullptr || specialTrackPiece)
@@ -2230,7 +2230,7 @@ static void ride_shop_connected(Ride* ride)
     }
 
     const auto& ted = GetTrackElementDescriptor(track_type);
-    uint8_t entrance_directions = ted.TrackSequenceProperties[0] & 0xF;
+    uint8_t entrance_directions = ted.SequenceProperties[0] & 0xF;
     uint8_t tile_direction = trackElement->GetDirection();
     entrance_directions = rol4(entrance_directions, tile_direction);
 
@@ -2775,7 +2775,7 @@ static int32_t ride_check_station_length(CoordsXYE* input, CoordsXYE* output)
     do
     {
         const auto& ted = GetTrackElementDescriptor(output->element->AsTrack()->GetTrackType());
-        if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+        if (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
         {
             num_station_elements++;
             last_good_station = *output;
@@ -2823,7 +2823,7 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     track_get_back(input, &trackBack);
     auto trackType = trackBack.element->AsTrack()->GetTrackType();
     const auto* ted = &GetTrackElementDescriptor(trackType);
-    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    if (!(ted->SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -2833,7 +2833,7 @@ static bool ride_check_start_and_end_is_station(CoordsXYE* input)
     track_get_front(input, &trackFront);
     trackType = trackFront.element->AsTrack()->GetTrackType();
     ted = &GetTrackElementDescriptor(trackType);
-    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    if (!(ted->SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return false;
     }
@@ -3545,7 +3545,7 @@ static bool ride_initialise_cable_lift_track(Ride* ride, bool isApplying)
             continue;
 
         const auto& ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-        if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        if (!(ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
         {
             continue;
         }
@@ -3778,7 +3778,7 @@ TrackElement* Ride::GetOriginElement(StationIndex stationIndex) const
 
         auto* trackElement = tileElement->AsTrack();
         const auto& ted = GetTrackElementDescriptor(trackElement->GetTrackType());
-        if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        if (!(ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
             continue;
 
         if (trackElement->GetRideIndex() == id)
@@ -4885,7 +4885,7 @@ static int32_t ride_get_track_length(Ride* ride)
 
             trackType = tileElement->AsTrack()->GetTrackType();
             const auto& ted = GetTrackElementDescriptor(trackType);
-            if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+            if (!(ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                 continue;
 
             if (tileElement->GetBaseZ() != trackStart.z)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4909,7 +4909,8 @@ static int32_t ride_get_track_length(Ride* ride)
     while (track_circuit_iterator_next(&it))
     {
         trackType = it.current.element->AsTrack()->GetTrackType();
-        result += TrackPieceLengths[trackType];
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        result += teDescriptor.PieceLength;
 
         moveSlowIt = !moveSlowIt;
         if (moveSlowIt)

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -393,7 +393,8 @@ std::optional<CoordsXYZ> sub_6C683D(
     }
 
     // Possibly z should be & 0xF8
-    auto trackBlock = TrackBlocks[type];
+    const auto& teDescriptor = GetTrackElementDescriptor(type);
+    auto trackBlock = teDescriptor.Block;
     if (trackBlock == nullptr)
         return std::nullopt;
 
@@ -1499,7 +1500,8 @@ void sub_6CB945(Ride* ride)
                 continue;
             }
 
-            const rct_preview_track* trackBlock = TrackBlocks[tileElement->AsTrack()->GetTrackType()];
+            const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+            const rct_preview_track* trackBlock = teDescriptor.Block;
             while ((++trackBlock)->index != 0xFF)
             {
                 CoordsXYZ blockLocation = location + CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(direction), 0 };

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -394,8 +394,8 @@ std::optional<CoordsXYZ> sub_6C683D(
     }
 
     // Possibly z should be & 0xF8
-    const auto& teDescriptor = GetTrackElementDescriptor(type);
-    const auto* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(type);
+    const auto* trackBlock = ted.Block;
     if (trackBlock == nullptr)
         return std::nullopt;
 
@@ -630,7 +630,7 @@ void ride_construction_set_default_next_piece()
     TileElement* tileElement;
     _currentTrackPrice = MONEY32_UNDEFINED;
 
-    TrackElementDescriptor teDescriptor;
+    TrackElementDescriptor ted;
     switch (_rideConstructionState)
     {
         case RideConstructionState::Front:
@@ -659,8 +659,8 @@ void ride_construction_set_default_next_piece()
                 }
             }
 
-            teDescriptor = GetTrackElementDescriptor(trackType);
-            curve = teDescriptor.CurveChain.next;
+            ted = GetTrackElementDescriptor(trackType);
+            curve = ted.CurveChain.next;
             bank = TrackDefinitions[trackType].bank_end;
             slope = TrackDefinitions[trackType].vangle_end;
 
@@ -705,8 +705,8 @@ void ride_construction_set_default_next_piece()
                 }
             }
 
-            teDescriptor = GetTrackElementDescriptor(trackType);
-            curve = teDescriptor.CurveChain.previous;
+            ted = GetTrackElementDescriptor(trackType);
+            curve = ted.CurveChain.previous;
             bank = TrackDefinitions[trackType].bank_start;
             slope = TrackDefinitions[trackType].vangle_start;
 
@@ -1254,8 +1254,8 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
         {
             if (info.Element->AsTrack()->GetRideIndex() == gRideEntranceExitPlaceRideIndex)
             {
-                const auto& teDescriptor = GetTrackElementDescriptor(info.Element->AsTrack()->GetTrackType());
-                if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                const auto& ted = GetTrackElementDescriptor(info.Element->AsTrack()->GetTrackType());
+                if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                 {
                     if (info.Element->AsTrack()->GetTrackType() == TrackElemType::Maze)
                     {
@@ -1345,8 +1345,8 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
 
                     int32_t eax = (entranceExitCoords.direction + 2 - tileElement->GetDirection())
                         & TILE_ELEMENT_DIRECTION_MASK;
-                    const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (teDescriptor.TrackSequenceProperties[tileElement->AsTrack()->GetSequenceIndex()] & (1 << eax))
+                    const auto& ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (ted.TrackSequenceProperties[tileElement->AsTrack()->GetSequenceIndex()] & (1 << eax))
                     {
                         entranceExitCoords.direction = direction_reverse(entranceExitCoords.direction);
                         gRideEntranceExitPlaceDirection = entranceExitCoords.direction;
@@ -1439,7 +1439,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
  */
 void sub_6CB945(Ride* ride)
 {
-    TrackElementDescriptor teDescriptor;
+    TrackElementDescriptor ted;
     if (ride->type != RIDE_TYPE_MAZE)
     {
         for (StationIndex stationId = 0; stationId < MAX_STATIONS; ++stationId)
@@ -1475,8 +1475,8 @@ void sub_6CB945(Ride* ride)
                     if (tileElement->AsTrack()->GetSequenceIndex() != 0)
                         continue;
 
-                    teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+                    ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1503,8 +1503,8 @@ void sub_6CB945(Ride* ride)
                 continue;
             }
 
-            teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-            const rct_preview_track* trackBlock = teDescriptor.Block;
+            ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+            const rct_preview_track* trackBlock = ted.Block;
             while ((++trackBlock)->index != 0xFF)
             {
                 CoordsXYZ blockLocation = location + CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(direction), 0 };
@@ -1520,8 +1520,8 @@ void sub_6CB945(Ride* ride)
                     if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
                         continue;
 
-                    teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+                    ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1616,8 +1616,8 @@ void sub_6CB945(Ride* ride)
 
                 Direction direction = (tileElement->GetDirection() - direction_reverse(trackElement->GetDirection())) & 3;
 
-                teDescriptor = GetTrackElementDescriptor(trackType);
-                if (!(teDescriptor.TrackSequenceProperties[trackSequence] & (1 << direction)))
+                ted = GetTrackElementDescriptor(trackType);
+                if (!(ted.TrackSequenceProperties[trackSequence] & (1 << direction)))
                 {
                     continue;
                 }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -630,7 +630,7 @@ void ride_construction_set_default_next_piece()
     TileElement* tileElement;
     _currentTrackPrice = MONEY32_UNDEFINED;
 
-    TrackElementDescriptor ted;
+    const TrackElementDescriptor* ted;
     switch (_rideConstructionState)
     {
         case RideConstructionState::Front:
@@ -659,8 +659,8 @@ void ride_construction_set_default_next_piece()
                 }
             }
 
-            ted = GetTrackElementDescriptor(trackType);
-            curve = ted.CurveChain.next;
+            ted = &GetTrackElementDescriptor(trackType);
+            curve = ted->CurveChain.next;
             bank = TrackDefinitions[trackType].bank_end;
             slope = TrackDefinitions[trackType].vangle_end;
 
@@ -705,8 +705,8 @@ void ride_construction_set_default_next_piece()
                 }
             }
 
-            ted = GetTrackElementDescriptor(trackType);
-            curve = ted.CurveChain.previous;
+            ted = &GetTrackElementDescriptor(trackType);
+            curve = ted->CurveChain.previous;
             bank = TrackDefinitions[trackType].bank_start;
             slope = TrackDefinitions[trackType].vangle_start;
 
@@ -1439,7 +1439,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
  */
 void sub_6CB945(Ride* ride)
 {
-    TrackElementDescriptor ted;
+    const TrackElementDescriptor* ted;
     if (ride->type != RIDE_TYPE_MAZE)
     {
         for (StationIndex stationId = 0; stationId < MAX_STATIONS; ++stationId)
@@ -1475,8 +1475,8 @@ void sub_6CB945(Ride* ride)
                     if (tileElement->AsTrack()->GetSequenceIndex() != 0)
                         continue;
 
-                    ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+                    ted = &GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1503,8 +1503,8 @@ void sub_6CB945(Ride* ride)
                 continue;
             }
 
-            ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-            const rct_preview_track* trackBlock = ted.Block;
+            ted = &GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+            const rct_preview_track* trackBlock = ted->Block;
             while ((++trackBlock)->index != 0xFF)
             {
                 CoordsXYZ blockLocation = location + CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(direction), 0 };
@@ -1520,8 +1520,8 @@ void sub_6CB945(Ride* ride)
                     if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
                         continue;
 
-                    ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+                    ted = &GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1616,8 +1616,8 @@ void sub_6CB945(Ride* ride)
 
                 Direction direction = (tileElement->GetDirection() - direction_reverse(trackElement->GetDirection())) & 3;
 
-                ted = GetTrackElementDescriptor(trackType);
-                if (!(ted.TrackSequenceProperties[trackSequence] & (1 << direction)))
+                ted = &GetTrackElementDescriptor(trackType);
+                if (!(ted->TrackSequenceProperties[trackSequence] & (1 << direction)))
                 {
                     continue;
                 }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -87,6 +87,7 @@ RideConstructionState gRideEntranceExitPlacePreviousRideConstructionState;
 Direction gRideEntranceExitPlaceDirection;
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::TrackMetaData;
 
 static int32_t ride_check_if_construction_allowed(Ride* ride)
 {
@@ -626,6 +627,8 @@ void ride_construction_set_default_next_piece()
     CoordsXYE xyElement;
     TileElement* tileElement;
     _currentTrackPrice = MONEY32_UNDEFINED;
+
+    TrackElementDescriptor teDescriptor;
     switch (_rideConstructionState)
     {
         case RideConstructionState::Front:
@@ -654,7 +657,8 @@ void ride_construction_set_default_next_piece()
                 }
             }
 
-            curve = gTrackCurveChain[trackType].next;
+            teDescriptor = GetTrackElementDescriptor(trackType);
+            curve = teDescriptor.CurveChain.next;
             bank = TrackDefinitions[trackType].bank_end;
             slope = TrackDefinitions[trackType].vangle_end;
 
@@ -699,7 +703,8 @@ void ride_construction_set_default_next_piece()
                 }
             }
 
-            curve = gTrackCurveChain[trackType].previous;
+            teDescriptor = GetTrackElementDescriptor(trackType);
+            curve = teDescriptor.CurveChain.previous;
             bank = TrackDefinitions[trackType].bank_start;
             slope = TrackDefinitions[trackType].vangle_start;
 

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -43,6 +43,7 @@
 #include "TrainManager.h"
 #include "Vehicle.h"
 
+using namespace OpenRCT2::TrackMetaData;
 bool gGotoStartPlacementMode = false;
 
 money16 gTotalRideValueForMoney;
@@ -1253,7 +1254,8 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
         {
             if (info.Element->AsTrack()->GetRideIndex() == gRideEntranceExitPlaceRideIndex)
             {
-                if (TrackSequenceProperties[info.Element->AsTrack()->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                const auto& teDescriptor = GetTrackElementDescriptor(info.Element->AsTrack()->GetTrackType());
+                if (teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                 {
                     if (info.Element->AsTrack()->GetTrackType() == TrackElemType::Maze)
                     {
@@ -1343,9 +1345,8 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
 
                     int32_t eax = (entranceExitCoords.direction + 2 - tileElement->GetDirection())
                         & TILE_ELEMENT_DIRECTION_MASK;
-                    if (TrackSequenceProperties[tileElement->AsTrack()->GetTrackType()]
-                                               [tileElement->AsTrack()->GetSequenceIndex()]
-                        & (1 << eax))
+                    const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (teDescriptor.TrackSequenceProperties[tileElement->AsTrack()->GetSequenceIndex()] & (1 << eax))
                     {
                         entranceExitCoords.direction = direction_reverse(entranceExitCoords.direction);
                         gRideEntranceExitPlaceDirection = entranceExitCoords.direction;
@@ -1438,6 +1439,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
  */
 void sub_6CB945(Ride* ride)
 {
+    TrackElementDescriptor teDescriptor;
     if (ride->type != RIDE_TYPE_MAZE)
     {
         for (StationIndex stationId = 0; stationId < MAX_STATIONS; ++stationId)
@@ -1450,7 +1452,6 @@ void sub_6CB945(Ride* ride)
 
             bool specialTrack = false;
             TileElement* tileElement = nullptr;
-
             while (true)
             {
                 if (direction != INVALID_DIRECTION)
@@ -1473,7 +1474,9 @@ void sub_6CB945(Ride* ride)
                         continue;
                     if (tileElement->AsTrack()->GetSequenceIndex() != 0)
                         continue;
-                    if (!(TrackSequenceProperties[tileElement->AsTrack()->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+
+                    teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1500,7 +1503,7 @@ void sub_6CB945(Ride* ride)
                 continue;
             }
 
-            const auto& teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+            teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
             const rct_preview_track* trackBlock = teDescriptor.Block;
             while ((++trackBlock)->index != 0xFF)
             {
@@ -1516,7 +1519,9 @@ void sub_6CB945(Ride* ride)
                         continue;
                     if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
                         continue;
-                    if (!(TrackSequenceProperties[tileElement->AsTrack()->GetTrackType()][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+
+                    teDescriptor = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
+                    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1611,7 +1616,8 @@ void sub_6CB945(Ride* ride)
 
                 Direction direction = (tileElement->GetDirection() - direction_reverse(trackElement->GetDirection())) & 3;
 
-                if (!(TrackSequenceProperties[trackType][trackSequence] & (1 << direction)))
+                teDescriptor = GetTrackElementDescriptor(trackType);
+                if (!(teDescriptor.TrackSequenceProperties[trackSequence] & (1 << direction)))
                 {
                     continue;
                 }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -1255,7 +1255,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
             if (info.Element->AsTrack()->GetRideIndex() == gRideEntranceExitPlaceRideIndex)
             {
                 const auto& ted = GetTrackElementDescriptor(info.Element->AsTrack()->GetTrackType());
-                if (ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
+                if (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                 {
                     if (info.Element->AsTrack()->GetTrackType() == TrackElemType::Maze)
                     {
@@ -1346,7 +1346,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
                     int32_t eax = (entranceExitCoords.direction + 2 - tileElement->GetDirection())
                         & TILE_ELEMENT_DIRECTION_MASK;
                     const auto& ted = GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (ted.TrackSequenceProperties[tileElement->AsTrack()->GetSequenceIndex()] & (1 << eax))
+                    if (ted.SequenceProperties[tileElement->AsTrack()->GetSequenceIndex()] & (1 << eax))
                     {
                         entranceExitCoords.direction = direction_reverse(entranceExitCoords.direction);
                         gRideEntranceExitPlaceDirection = entranceExitCoords.direction;
@@ -1476,7 +1476,7 @@ void sub_6CB945(Ride* ride)
                         continue;
 
                     ted = &GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+                    if (!(ted->SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1521,7 +1521,7 @@ void sub_6CB945(Ride* ride)
                         continue;
 
                     ted = &GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
-                    if (!(ted->TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+                    if (!(ted->SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
                         continue;
 
                     trackFound = true;
@@ -1617,7 +1617,7 @@ void sub_6CB945(Ride* ride)
                 Direction direction = (tileElement->GetDirection() - direction_reverse(trackElement->GetDirection())) & 3;
 
                 ted = &GetTrackElementDescriptor(trackType);
-                if (!(ted->TrackSequenceProperties[trackSequence] & (1 << direction)))
+                if (!(ted->SequenceProperties[trackSequence] & (1 << direction)))
                 {
                     continue;
                 }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -395,7 +395,7 @@ std::optional<CoordsXYZ> sub_6C683D(
 
     // Possibly z should be & 0xF8
     const auto& teDescriptor = GetTrackElementDescriptor(type);
-    auto trackBlock = teDescriptor.Block;
+    const auto* trackBlock = teDescriptor.Block;
     if (trackBlock == nullptr)
         return std::nullopt;
 

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -287,7 +287,7 @@ const static rct_track_coordinates TrackCoordinates[TrackElemType::Count] = {
 };
 
 /** rct2: 0x0099BA64 */
-const uint8_t TrackSequenceProperties[][MaxSequencesPerPiece] = {
+const static uint8_t TrackSequenceProperties[][MaxSequencesPerPiece] = {
     { 0 },
     /* TrackElemType::EndStation */    { TRACK_SEQUENCE_FLAG_DIRECTION_1 | TRACK_SEQUENCE_FLAG_DIRECTION_3 | TRACK_SEQUENCE_FLAG_ORIGIN | TRACK_SEQUENCE_FLAG_DISALLOW_DOORS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     /* TrackElemType::BeginStation */  { TRACK_SEQUENCE_FLAG_DIRECTION_1 | TRACK_SEQUENCE_FLAG_DIRECTION_3 | TRACK_SEQUENCE_FLAG_ORIGIN | TRACK_SEQUENCE_FLAG_DISALLOW_DOORS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -3087,7 +3087,7 @@ const uint8_t TrackPieceLengths[TrackElemType::Count] = {
 };
 
 // rct2: 0x00998C95
-const track_curve_chain gTrackCurveChain[TrackElemType::Count] = {
+const static track_curve_chain gTrackCurveChain[TrackElemType::Count] = {
     { TRACK_CURVE_NONE, TRACK_CURVE_NONE },
     { RideConstructionSpecialPieceSelected | TrackElemType::EndStation, RideConstructionSpecialPieceSelected | TrackElemType::EndStation },
     { RideConstructionSpecialPieceSelected | TrackElemType::EndStation, RideConstructionSpecialPieceSelected | TrackElemType::EndStation },

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -4045,7 +4045,7 @@ const money32 TrackPricing[TrackElemType::Count] = {
 };
 
 /** rct2: 0x0099EA1C */
-const track_type_t TrackElementMirrorMap[TrackElemType::Count] = {
+const static track_type_t TrackElementMirrorMap[TrackElemType::Count] = {
     TrackElemType::Flat,
     TrackElemType::EndStation,
     TrackElemType::BeginStation,

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -4316,7 +4316,7 @@ const track_type_t TrackElementMirrorMap[TrackElemType::Count] = {
 };
 
 /** rct2: 0x00999694 */
-const uint32_t TrackHeightMarkerPositions[TrackElemType::Count] = {
+const static uint32_t TrackHeightMarkerPositions[TrackElemType::Count] = {
     (1 << 0), // TrackElemType::Flat
     (1 << 0), // TrackElemType::EndStation
     (1 << 0), // TrackElemType::BeginStation

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -4858,7 +4858,7 @@ const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][MaxSequ
 };
 
 /** rct2: 0x0099423C */
-const uint16_t TrackFlags[TrackElemType::Count] = {
+const static uint16_t TrackFlags[TrackElemType::Count] = {
     /* TrackElemType::Flat                                          */   TRACK_ELEM_FLAG_ALLOW_LIFT_HILL,
     /* TrackElemType::EndStation                                    */   0,
     /* TrackElemType::BeginStation                                  */   0,

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -5148,14 +5148,14 @@ namespace OpenRCT2
                 desc.CurveChain = gTrackCurveChain[i];
                 desc.Flags = TrackFlags[i];
                 desc.HeightMarkerPositions = TrackHeightMarkerPositions[i];
-                desc.MirrorMap = TrackElementMirrorMap[i];
+                desc.MirrorElement = TrackElementMirrorMap[i];
                 desc.PieceLength = TrackPieceLengths[i];
-                desc.Pricing = TrackPricing[i];
+                desc.Price = TrackPricing[i];
 
                 for (uint8_t j = 0; j < MaxSequencesPerPiece; j++)
                 {
                     desc.SequenceElementAllowedWallEdges[j] = TrackSequenceElementAllowedWallEdges[i][j];
-                    desc.TrackSequenceProperties[j] = TrackSequenceProperties[i][j];
+                    desc.SequenceProperties[j] = TrackSequenceProperties[i][j];
                 }
                 _trackElementDescriptors.push_back(desc);
             }

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -2816,7 +2816,7 @@ const rct_preview_track *TrackBlocks[TrackElemType::Count] = {
     TrackBlocksFlatTrack3x3,
 };
 
-const uint8_t TrackPieceLengths[TrackElemType::Count] = {
+const static uint8_t TrackPieceLengths[TrackElemType::Count] = {
     32,     // TrackElemType::Flat
     32,     // TrackElemType::EndStation
     32,     // TrackElemType::BeginStation

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -16,7 +16,7 @@
 #include <iterator>
 
 // clang-format off
-const rct_track_coordinates TrackCoordinates[TrackElemType::Count] = {
+const static rct_track_coordinates TrackCoordinates[TrackElemType::Count] = {
         { 0, 0, 0, 0, 0, 0 },       // ELEM_FLAT
         { 0, 0, 0, 0, 0, 0 },       // ELEM_END_STATION
         { 0, 0, 0, 0, 0, 0 },       // ELEM_BEGIN_STATION

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -12,6 +12,7 @@
 #include "Track.h"
 #include "TrackPaint.h"
 
+#include <cstdint>
 #include <iterator>
 
 // clang-format off
@@ -5127,3 +5128,41 @@ const uint16_t TrackFlags[TrackElemType::Count] = {
     /* TrackElemType::FlatTrack3x3                                  */   0,
 };
 // clang-format on
+
+namespace OpenRCT2
+{
+    namespace TrackMetaData
+    {
+        static std::vector<TrackElementDescriptor> _trackElementDescriptors;
+        void Init()
+        {
+            _trackElementDescriptors.clear();
+            _trackElementDescriptors.reserve(TrackElemType::Count);
+
+            TrackElementDescriptor desc;
+            for (int i = 0; i < TrackElemType::Count; i++)
+            {
+                desc.AlternativeType = AlternativeTrackTypes[i];
+                desc.Block = const_cast<rct_preview_track*>(TrackBlocks[i]);
+                desc.Coordinates = TrackCoordinates[i];
+                desc.CurveChain = gTrackCurveChain[i];
+                desc.Flags = TrackFlags[i];
+                desc.HeightMarkerPositions = TrackHeightMarkerPositions[i];
+                desc.MirrorMap = TrackElementMirrorMap[i];
+                desc.PieceLength = TrackPieceLengths[i];
+                desc.Pricing = TrackPricing[i];
+
+                for (uint8_t j = 0; j < MaxSequencesPerPiece; j++)
+                {
+                    desc.SequenceElementAllowedWallEdges[j] = TrackSequenceElementAllowedWallEdges[i][j];
+                    desc.TrackSequenceProperties[j] = TrackSequenceProperties[i][j];
+                }
+                _trackElementDescriptors.push_back(desc);
+            }
+        }
+        const TrackElementDescriptor& GetTrackElementDescriptor(const uint32_t& type)
+        {
+            return _trackElementDescriptors[type];
+        }
+    } // namespace TrackMetaData
+} // namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -16,7 +16,7 @@
 #include <iterator>
 
 // clang-format off
-const static rct_track_coordinates TrackCoordinates[TrackElemType::Count] = {
+static constexpr rct_track_coordinates TrackCoordinates[TrackElemType::Count] = {
         { 0, 0, 0, 0, 0, 0 },       // ELEM_FLAT
         { 0, 0, 0, 0, 0, 0 },       // ELEM_END_STATION
         { 0, 0, 0, 0, 0, 0 },       // ELEM_BEGIN_STATION
@@ -287,7 +287,7 @@ const static rct_track_coordinates TrackCoordinates[TrackElemType::Count] = {
 };
 
 /** rct2: 0x0099BA64 */
-const static uint8_t TrackSequenceProperties[][MaxSequencesPerPiece] = {
+static constexpr uint8_t TrackSequenceProperties[][MaxSequencesPerPiece] = {
     { 0 },
     /* TrackElemType::EndStation */    { TRACK_SEQUENCE_FLAG_DIRECTION_1 | TRACK_SEQUENCE_FLAG_DIRECTION_3 | TRACK_SEQUENCE_FLAG_ORIGIN | TRACK_SEQUENCE_FLAG_DISALLOW_DOORS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     /* TrackElemType::BeginStation */  { TRACK_SEQUENCE_FLAG_DIRECTION_1 | TRACK_SEQUENCE_FLAG_DIRECTION_3 | TRACK_SEQUENCE_FLAG_ORIGIN | TRACK_SEQUENCE_FLAG_DISALLOW_DOORS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
@@ -559,7 +559,7 @@ const static uint8_t TrackSequenceProperties[][MaxSequencesPerPiece] = {
 
 #define TRACK_BLOCK_END { 255, 255, 255, 255, 255, {255, 255}, 255 }
 
-static constexpr const rct_preview_track TrackBlocks000[] = {
+static constexpr rct_preview_track TrackBlocks000[] = {
     { 0, 0, 0, 0, 0, { 0b1111, 0 }, 0 },
     TRACK_BLOCK_END
 };
@@ -2545,7 +2545,7 @@ static constexpr const rct_preview_track TrackBlocksFlatTrack3x3[] = {
 };
 
 // rct2: 0x00994638
-const static rct_preview_track *TrackBlocks[TrackElemType::Count] = {
+static constexpr std::array<const rct_preview_track*, TrackElemType::Count> TrackBlocks = {
     TrackBlocks000,
     TrackBlocks001,
     TrackBlocks002,
@@ -2816,7 +2816,7 @@ const static rct_preview_track *TrackBlocks[TrackElemType::Count] = {
     TrackBlocksFlatTrack3x3,
 };
 
-const static uint8_t TrackPieceLengths[TrackElemType::Count] = {
+static constexpr uint8_t TrackPieceLengths[TrackElemType::Count] = {
     32,     // TrackElemType::Flat
     32,     // TrackElemType::EndStation
     32,     // TrackElemType::BeginStation
@@ -3087,7 +3087,7 @@ const static uint8_t TrackPieceLengths[TrackElemType::Count] = {
 };
 
 // rct2: 0x00998C95
-const static track_curve_chain gTrackCurveChain[TrackElemType::Count] = {
+static constexpr track_curve_chain gTrackCurveChain[TrackElemType::Count] = {
     { TRACK_CURVE_NONE, TRACK_CURVE_NONE },
     { RideConstructionSpecialPieceSelected | TrackElemType::EndStation, RideConstructionSpecialPieceSelected | TrackElemType::EndStation },
     { RideConstructionSpecialPieceSelected | TrackElemType::EndStation, RideConstructionSpecialPieceSelected | TrackElemType::EndStation },
@@ -3503,7 +3503,7 @@ const track_descriptor gTrackDescriptors[142] = {
 };
 
 /** rct2: 0x00993D1C */
-const static track_type_t AlternativeTrackTypes[TrackElemType::Count] = {
+static constexpr track_type_t AlternativeTrackTypes[TrackElemType::Count] = {
     TrackElemType::FlatCovered,                        // TrackElemType::Flat
     TrackElemType::None,
     TrackElemType::None,
@@ -3774,7 +3774,7 @@ const static track_type_t AlternativeTrackTypes[TrackElemType::Count] = {
 };
 
 /** rct2: 0x0099DA34 */
-const static money32 TrackPricing[TrackElemType::Count] = {
+static constexpr money32 TrackPricing[TrackElemType::Count] = {
     65536,  // TrackElemType::Flat
     98304,  // TrackElemType::EndStation
     98304,  // TrackElemType::BeginStation
@@ -4045,7 +4045,7 @@ const static money32 TrackPricing[TrackElemType::Count] = {
 };
 
 /** rct2: 0x0099EA1C */
-const static track_type_t TrackElementMirrorMap[TrackElemType::Count] = {
+static constexpr track_type_t TrackElementMirrorMap[TrackElemType::Count] = {
     TrackElemType::Flat,
     TrackElemType::EndStation,
     TrackElemType::BeginStation,
@@ -4316,7 +4316,7 @@ const static track_type_t TrackElementMirrorMap[TrackElemType::Count] = {
 };
 
 /** rct2: 0x00999694 */
-const static uint32_t TrackHeightMarkerPositions[TrackElemType::Count] = {
+static constexpr uint32_t TrackHeightMarkerPositions[TrackElemType::Count] = {
     (1 << 0), // TrackElemType::Flat
     (1 << 0), // TrackElemType::EndStation
     (1 << 0), // TrackElemType::BeginStation
@@ -4587,7 +4587,7 @@ const static uint32_t TrackHeightMarkerPositions[TrackElemType::Count] = {
 };
 
 /** rct2: 0x00999A94 */
-const static uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][MaxSequencesPerPiece] = {
+static constexpr uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][MaxSequencesPerPiece] = {
     { 0b1010,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0 }, // TrackElemType::Flat
     {      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0 }, // TrackElemType::EndStation
     {      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0 }, // TrackElemType::BeginStation
@@ -4858,7 +4858,7 @@ const static uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][
 };
 
 /** rct2: 0x0099423C */
-const static uint16_t TrackFlags[TrackElemType::Count] = {
+static constexpr uint16_t TrackFlags[TrackElemType::Count] = {
     /* TrackElemType::Flat                                          */   TRACK_ELEM_FLAG_ALLOW_LIFT_HILL,
     /* TrackElemType::EndStation                                    */   0,
     /* TrackElemType::BeginStation                                  */   0,
@@ -5160,7 +5160,7 @@ namespace OpenRCT2
                 _trackElementDescriptors.push_back(desc);
             }
         }
-        const TrackElementDescriptor& GetTrackElementDescriptor(const uint32_t& type)
+        const TrackElementDescriptor& GetTrackElementDescriptor(const uint32_t type)
         {
             return _trackElementDescriptors[type];
         }

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -3774,7 +3774,7 @@ const static track_type_t AlternativeTrackTypes[TrackElemType::Count] = {
 };
 
 /** rct2: 0x0099DA34 */
-const money32 TrackPricing[TrackElemType::Count] = {
+const static money32 TrackPricing[TrackElemType::Count] = {
     65536,  // TrackElemType::Flat
     98304,  // TrackElemType::EndStation
     98304,  // TrackElemType::BeginStation

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -2545,7 +2545,7 @@ static constexpr const rct_preview_track TrackBlocksFlatTrack3x3[] = {
 };
 
 // rct2: 0x00994638
-const rct_preview_track *TrackBlocks[TrackElemType::Count] = {
+const static rct_preview_track *TrackBlocks[TrackElemType::Count] = {
     TrackBlocks000,
     TrackBlocks001,
     TrackBlocks002,

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -3503,7 +3503,7 @@ const track_descriptor gTrackDescriptors[142] = {
 };
 
 /** rct2: 0x00993D1C */
-const track_type_t AlternativeTrackTypes[TrackElemType::Count] = {
+const static track_type_t AlternativeTrackTypes[TrackElemType::Count] = {
     TrackElemType::FlatCovered,                        // TrackElemType::Flat
     TrackElemType::None,
     TrackElemType::None,

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -4587,7 +4587,7 @@ const static uint32_t TrackHeightMarkerPositions[TrackElemType::Count] = {
 };
 
 /** rct2: 0x00999A94 */
-const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][MaxSequencesPerPiece] = {
+const static uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][MaxSequencesPerPiece] = {
     { 0b1010,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0 }, // TrackElemType::Flat
     {      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0 }, // TrackElemType::EndStation
     {      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0 }, // TrackElemType::BeginStation

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -77,6 +77,6 @@ namespace OpenRCT2
     namespace TrackMetaData
     {
         void Init();
-        const TrackElementDescriptor& GetTrackElementDescriptor(const uint32_t& type);
+        const TrackElementDescriptor& GetTrackElementDescriptor(const uint32_t type);
     } // namespace TrackMetaData
 } // namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -19,8 +19,6 @@ constexpr const uint8_t MaxSequencesPerPiece = 16;
 
 extern const uint8_t TrackSequenceProperties[TrackElemType::Count][MaxSequencesPerPiece];
 
-extern const rct_preview_track* TrackBlocks[TrackElemType::Count];
-
 struct track_curve_chain
 {
     int32_t next;

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -62,7 +62,6 @@ constexpr const dodgems_track_size DodgemsTrackSize(track_type_t type)
         return { 4, 4, 59, 123 };
     return { 0, 0, 0, 0 };
 }
-extern const track_type_t TrackElementMirrorMap[TrackElemType::Count];
 
 extern const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][16];
 

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -63,13 +63,13 @@ struct TrackElementDescriptor
     uint8_t PieceLength;
     track_curve_chain CurveChain;
     track_type_t AlternativeType;
-    money32 Pricing;
-    track_type_t MirrorMap;
+    money32 Price;
+    track_type_t MirrorElement;
     uint32_t HeightMarkerPositions;
     uint16_t Flags;
 
     std::array<uint8_t, MaxSequencesPerPiece> SequenceElementAllowedWallEdges;
-    std::array<uint8_t, MaxSequencesPerPiece> TrackSequenceProperties;
+    std::array<uint8_t, MaxSequencesPerPiece> SequenceProperties;
 };
 
 namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -44,8 +44,6 @@ struct track_descriptor
 
 extern const track_descriptor gTrackDescriptors[142];
 
-extern const track_type_t AlternativeTrackTypes[TrackElemType::Count];
-
 extern const money32 TrackPricing[TrackElemType::Count];
 
 struct dodgems_track_size

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -74,3 +74,29 @@ extern const uint32_t TrackHeightMarkerPositions[TrackElemType::Count];
 extern const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][16];
 
 extern const uint16_t TrackFlags[TrackElemType::Count];
+
+struct TrackElementDescriptor
+{
+    rct_track_coordinates Coordinates;
+
+    rct_preview_track* Block;
+    uint8_t PieceLength;
+    track_curve_chain CurveChain;
+    track_type_t AlternativeType;
+    money32 Pricing;
+    track_type_t MirrorMap;
+    uint32_t HeightMarkerPositions;
+    uint16_t Flags;
+
+    std::array<uint8_t, MaxSequencesPerPiece> SequenceElementAllowedWallEdges;
+    std::array<uint8_t, MaxSequencesPerPiece> TrackSequenceProperties;
+};
+
+namespace OpenRCT2
+{
+    namespace TrackMetaData
+    {
+        void Init();
+        const TrackElementDescriptor& GetTrackElementDescriptor(const uint32_t& type);
+    } // namespace TrackMetaData
+} // namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -21,8 +21,6 @@ extern const uint8_t TrackSequenceProperties[TrackElemType::Count][MaxSequencesP
 
 extern const rct_preview_track* TrackBlocks[TrackElemType::Count];
 
-extern const uint8_t TrackPieceLengths[TrackElemType::Count];
-
 struct track_curve_chain
 {
     int32_t next;

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -40,8 +40,6 @@ struct track_descriptor
 
 extern const track_descriptor gTrackDescriptors[142];
 
-extern const money32 TrackPricing[TrackElemType::Count];
-
 struct dodgems_track_size
 {
     uint8_t left;

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -68,8 +68,6 @@ extern const uint32_t TrackHeightMarkerPositions[TrackElemType::Count];
 
 extern const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][16];
 
-extern const uint16_t TrackFlags[TrackElemType::Count];
-
 struct TrackElementDescriptor
 {
     rct_track_coordinates Coordinates;

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -16,7 +16,6 @@
 constexpr const uint8_t MaxSequencesPerPiece = 16;
 
 // 0x009968BB, 0x009968BC, 0x009968BD, 0x009968BF, 0x009968C1, 0x009968C3
-extern const rct_track_coordinates TrackCoordinates[TrackElemType::Count];
 
 extern const uint8_t TrackSequenceProperties[TrackElemType::Count][MaxSequencesPerPiece];
 

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -57,8 +57,6 @@ constexpr const dodgems_track_size DodgemsTrackSize(track_type_t type)
     return { 0, 0, 0, 0 };
 }
 
-extern const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][16];
-
 struct TrackElementDescriptor
 {
     rct_track_coordinates Coordinates;

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -64,8 +64,6 @@ constexpr const dodgems_track_size DodgemsTrackSize(track_type_t type)
 }
 extern const track_type_t TrackElementMirrorMap[TrackElemType::Count];
 
-extern const uint32_t TrackHeightMarkerPositions[TrackElemType::Count];
-
 extern const uint8_t TrackSequenceElementAllowedWallEdges[TrackElemType::Count][16];
 
 struct TrackElementDescriptor

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -29,8 +29,6 @@ struct track_curve_chain
     int32_t previous;
 };
 
-extern const track_curve_chain gTrackCurveChain[TrackElemType::Count];
-
 struct track_descriptor
 {
     bool starts_diagonal;

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -17,8 +17,6 @@ constexpr const uint8_t MaxSequencesPerPiece = 16;
 
 // 0x009968BB, 0x009968BC, 0x009968BD, 0x009968BF, 0x009968C1, 0x009968C3
 
-extern const uint8_t TrackSequenceProperties[TrackElemType::Count][MaxSequencesPerPiece];
-
 struct track_curve_chain
 {
     int32_t next;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -65,6 +65,7 @@
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
+using namespace OpenRCT2::TrackMetaData;
 
 bool gTrackDesignSceneryToggle;
 static CoordsXYZ _trackPreviewMin;
@@ -182,7 +183,8 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
     trackElement.y = newCoords->y;
     z = newCoords->z;
 
-    const rct_track_coordinates* trackCoordinates = &TrackCoordinates[trackElement.element->AsTrack()->GetTrackType()];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackElement.element->AsTrack()->GetTrackType());
+    const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
     auto trackBlock = TrackBlocks[trackType];
     // Used in the following loop to know when we have
     // completed all of the elements and are back at the
@@ -1519,6 +1521,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
     for (const auto& track : td6->track_elements)
     {
         auto trackType = track.type;
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
 
         track_design_update_max_min_coordinates(newCoords);
 
@@ -1534,7 +1537,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
                 break;
             case PTD_OPERATION_REMOVE_GHOST:
             {
-                const rct_track_coordinates* trackCoordinates = &TrackCoordinates[trackType];
+                const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
                 const rct_preview_track* trackBlock = TrackBlocks[trackType];
                 int32_t tempZ = newCoords.z - trackCoordinates->z_begin + trackBlock->z;
                 auto trackRemoveAction = TrackRemoveAction(
@@ -1549,7 +1552,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             case PTD_OPERATION_PLACE_GHOST:
             case PTD_OPERATION_PLACE_TRACK_PREVIEW:
             {
-                const rct_track_coordinates* trackCoordinates = &TrackCoordinates[trackType];
+                const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
 
                 // di
                 int16_t tempZ = newCoords.z - trackCoordinates->z_begin;
@@ -1606,7 +1609,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             }
             case PTD_OPERATION_GET_PLACE_Z:
             {
-                int32_t tempZ = newCoords.z - TrackCoordinates[trackType].z_begin;
+                int32_t tempZ = newCoords.z - teDescriptor.Coordinates.z_begin;
                 for (const rct_preview_track* trackBlock = TrackBlocks[trackType]; trackBlock->index != 0xFF; trackBlock++)
                 {
                     auto tile = CoordsXY{ newCoords } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
@@ -1646,7 +1649,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             }
         }
 
-        const rct_track_coordinates* track_coordinates = &TrackCoordinates[trackType];
+        const rct_track_coordinates* track_coordinates = &teDescriptor.Coordinates;
         auto offsetAndRotatedTrack = CoordsXY{ newCoords }
             + CoordsXY{ track_coordinates->x, track_coordinates->y }.Rotate(rotation);
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -770,7 +770,8 @@ static void track_design_mirror_ride(TrackDesign* td6)
 {
     for (auto& track : td6->track_elements)
     {
-        track.type = TrackElementMirrorMap[track.type];
+        const auto& teDescriptor = GetTrackElementDescriptor(track.type);
+        track.type = teDescriptor.MirrorMap;
     }
 
     for (auto& entrance : td6->entrance_elements)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -185,7 +185,7 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
 
     const auto& teDescriptor = GetTrackElementDescriptor(trackElement.element->AsTrack()->GetTrackType());
     const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
-    auto trackBlock = TrackBlocks[trackType];
+    auto trackBlock = teDescriptor.Block;
     // Used in the following loop to know when we have
     // completed all of the elements and are back at the
     // start.
@@ -1529,7 +1529,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
         switch (_trackDesignPlaceOperation)
         {
             case PTD_OPERATION_DRAW_OUTLINES:
-                for (const rct_preview_track* trackBlock = TrackBlocks[trackType]; trackBlock->index != 0xFF; trackBlock++)
+                for (const rct_preview_track* trackBlock = teDescriptor.Block; trackBlock->index != 0xFF; trackBlock++)
                 {
                     auto tile = CoordsXY{ newCoords } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
                     track_design_update_max_min_coordinates({ tile, newCoords.z });
@@ -1539,7 +1539,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             case PTD_OPERATION_REMOVE_GHOST:
             {
                 const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
-                const rct_preview_track* trackBlock = TrackBlocks[trackType];
+                const rct_preview_track* trackBlock = teDescriptor.Block;
                 int32_t tempZ = newCoords.z - trackCoordinates->z_begin + trackBlock->z;
                 auto trackRemoveAction = TrackRemoveAction(
                     trackType, 0, { newCoords, tempZ, static_cast<Direction>(rotation & 3) });
@@ -1611,7 +1611,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             case PTD_OPERATION_GET_PLACE_Z:
             {
                 int32_t tempZ = newCoords.z - teDescriptor.Coordinates.z_begin;
-                for (const rct_preview_track* trackBlock = TrackBlocks[trackType]; trackBlock->index != 0xFF; trackBlock++)
+                for (const rct_preview_track* trackBlock = teDescriptor.Block; trackBlock->index != 0xFF; trackBlock++)
                 {
                     auto tile = CoordsXY{ newCoords } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
                     if (!map_is_location_valid(tile))

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -771,7 +771,7 @@ static void track_design_mirror_ride(TrackDesign* td6)
     for (auto& track : td6->track_elements)
     {
         const auto& ted = GetTrackElementDescriptor(track.type);
-        track.type = ted.MirrorMap;
+        track.type = ted.MirrorElement;
     }
 
     for (auto& entrance : td6->entrance_elements)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -185,7 +185,7 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
 
     const auto& teDescriptor = GetTrackElementDescriptor(trackElement.element->AsTrack()->GetTrackType());
     const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
-    auto trackBlock = teDescriptor.Block;
+    const auto* trackBlock = teDescriptor.Block;
     // Used in the following loop to know when we have
     // completed all of the elements and are back at the
     // start.
@@ -1650,13 +1650,13 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             }
         }
 
-        const rct_track_coordinates* track_coordinates = &teDescriptor.Coordinates;
+        const rct_track_coordinates& track_coordinates = teDescriptor.Coordinates;
         auto offsetAndRotatedTrack = CoordsXY{ newCoords }
-            + CoordsXY{ track_coordinates->x, track_coordinates->y }.Rotate(rotation);
+            + CoordsXY{ track_coordinates.x, track_coordinates.y }.Rotate(rotation);
 
-        newCoords = { offsetAndRotatedTrack, newCoords.z - track_coordinates->z_begin + track_coordinates->z_end };
-        rotation = (rotation + track_coordinates->rotation_end - track_coordinates->rotation_begin) & 3;
-        if (track_coordinates->rotation_end & (1 << 2))
+        newCoords = { offsetAndRotatedTrack, newCoords.z - track_coordinates.z_begin + track_coordinates.z_end };
+        rotation = (rotation + track_coordinates.rotation_end - track_coordinates.rotation_begin) & 3;
+        if (track_coordinates.rotation_end & (1 << 2))
         {
             rotation |= (1 << 2);
         }

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -183,9 +183,9 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
     trackElement.y = newCoords->y;
     z = newCoords->z;
 
-    const auto& teDescriptor = GetTrackElementDescriptor(trackElement.element->AsTrack()->GetTrackType());
-    const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
-    const auto* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackElement.element->AsTrack()->GetTrackType());
+    const rct_track_coordinates* trackCoordinates = &ted.Coordinates;
+    const auto* trackBlock = ted.Block;
     // Used in the following loop to know when we have
     // completed all of the elements and are back at the
     // start.
@@ -770,8 +770,8 @@ static void track_design_mirror_ride(TrackDesign* td6)
 {
     for (auto& track : td6->track_elements)
     {
-        const auto& teDescriptor = GetTrackElementDescriptor(track.type);
-        track.type = teDescriptor.MirrorMap;
+        const auto& ted = GetTrackElementDescriptor(track.type);
+        track.type = ted.MirrorMap;
     }
 
     for (auto& entrance : td6->entrance_elements)
@@ -1522,14 +1522,14 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
     for (const auto& track : td6->track_elements)
     {
         auto trackType = track.type;
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        const auto& ted = GetTrackElementDescriptor(trackType);
 
         track_design_update_max_min_coordinates(newCoords);
 
         switch (_trackDesignPlaceOperation)
         {
             case PTD_OPERATION_DRAW_OUTLINES:
-                for (const rct_preview_track* trackBlock = teDescriptor.Block; trackBlock->index != 0xFF; trackBlock++)
+                for (const rct_preview_track* trackBlock = ted.Block; trackBlock->index != 0xFF; trackBlock++)
                 {
                     auto tile = CoordsXY{ newCoords } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
                     track_design_update_max_min_coordinates({ tile, newCoords.z });
@@ -1538,8 +1538,8 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
                 break;
             case PTD_OPERATION_REMOVE_GHOST:
             {
-                const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
-                const rct_preview_track* trackBlock = teDescriptor.Block;
+                const rct_track_coordinates* trackCoordinates = &ted.Coordinates;
+                const rct_preview_track* trackBlock = ted.Block;
                 int32_t tempZ = newCoords.z - trackCoordinates->z_begin + trackBlock->z;
                 auto trackRemoveAction = TrackRemoveAction(
                     trackType, 0, { newCoords, tempZ, static_cast<Direction>(rotation & 3) });
@@ -1553,7 +1553,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             case PTD_OPERATION_PLACE_GHOST:
             case PTD_OPERATION_PLACE_TRACK_PREVIEW:
             {
-                const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
+                const rct_track_coordinates* trackCoordinates = &ted.Coordinates;
 
                 // di
                 int16_t tempZ = newCoords.z - trackCoordinates->z_begin;
@@ -1610,8 +1610,8 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             }
             case PTD_OPERATION_GET_PLACE_Z:
             {
-                int32_t tempZ = newCoords.z - teDescriptor.Coordinates.z_begin;
-                for (const rct_preview_track* trackBlock = teDescriptor.Block; trackBlock->index != 0xFF; trackBlock++)
+                int32_t tempZ = newCoords.z - ted.Coordinates.z_begin;
+                for (const rct_preview_track* trackBlock = ted.Block; trackBlock->index != 0xFF; trackBlock++)
                 {
                     auto tile = CoordsXY{ newCoords } + CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(rotation);
                     if (!map_is_location_valid(tile))
@@ -1650,7 +1650,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
             }
         }
 
-        const rct_track_coordinates& track_coordinates = teDescriptor.Coordinates;
+        const rct_track_coordinates& track_coordinates = ted.Coordinates;
         auto offsetAndRotatedTrack = CoordsXY{ newCoords }
             + CoordsXY{ track_coordinates.x, track_coordinates.y }.Rotate(rotation);
 

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -27,6 +27,8 @@
 #include "TrackData.h"
 #include "TrackDesign.h"
 
+using namespace OpenRCT2::TrackMetaData;
+
 // clang-format off
 /* rct2: 0x007667AC */
 static constexpr TileCoordsXY EntranceOffsetEdgeNE[] = {
@@ -2202,7 +2204,8 @@ void PaintTrack(paint_session* session, Direction direction, int32_t height, con
         if (PaintShouldShowHeightMarkers(session, VIEWPORT_FLAG_TRACK_HEIGHTS))
         {
             session->InteractionType = ViewportInteractionItem::None;
-            if (TrackHeightMarkerPositions[trackType] & (1 << trackSequence))
+            const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+            if (teDescriptor.HeightMarkerPositions & (1 << trackSequence))
             {
                 uint16_t ax = ride->GetRideTypeDescriptor().Heights.VehicleZOffset;
                 // 0x1689 represents 0 height there are -127 to 128 heights above and below it

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2204,8 +2204,8 @@ void PaintTrack(paint_session* session, Direction direction, int32_t height, con
         if (PaintShouldShowHeightMarkers(session, VIEWPORT_FLAG_TRACK_HEIGHTS))
         {
             session->InteractionType = ViewportInteractionItem::None;
-            const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-            if (teDescriptor.HeightMarkerPositions & (1 << trackSequence))
+            const auto& ted = GetTrackElementDescriptor(trackType);
+            if (ted.HeightMarkerPositions & (1 << trackSequence))
             {
                 uint16_t ax = ride->GetRideTypeDescriptor().Heights.VehicleZOffset;
                 // 0x1689 represents 0 height there are -127 to 128 heights above and below it

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1707,8 +1707,8 @@ void Vehicle::UpdateMeasurements()
                 }
         }
 
-        const auto& teDescriptor = GetTrackElementDescriptor(trackElemType);
-        uint16_t trackFlags = teDescriptor.Flags;
+        const auto& ted = GetTrackElementDescriptor(trackElemType);
+        uint16_t trackFlags = ted.Flags;
 
         uint32_t testingFlags = curRide->testing_flags;
         if (testingFlags & RIDE_TESTING_TURN_LEFT && trackFlags & TRACK_ELEM_FLAG_TURN_LEFT)
@@ -7495,13 +7495,13 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
 void Vehicle::UpdateSceneryDoor() const
 {
     auto trackType = GetTrackType();
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_preview_track* trackBlock = teDescriptor.Block;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const rct_preview_track* trackBlock = ted.Block;
     while ((trackBlock + 1)->index != 255)
     {
         trackBlock++;
     }
-    const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
+    const rct_track_coordinates* trackCoordinates = &ted.Coordinates;
     auto wallCoords = CoordsXYZ{ x, y, TrackLocation.z - trackBlock->z + trackCoordinates->z_end }.ToTileStart();
     int32_t direction = (GetTrackDirection() + trackCoordinates->rotation_end) & 3;
 
@@ -7593,9 +7593,9 @@ static void trigger_on_ride_photo(const CoordsXYZ& loc, TileElement* tileElement
 void Vehicle::UpdateSceneryDoorBackwards() const
 {
     auto trackType = GetTrackType();
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_preview_track* trackBlock = teDescriptor.Block;
-    const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const rct_preview_track* trackBlock = ted.Block;
+    const rct_track_coordinates* trackCoordinates = &ted.Coordinates;
     auto wallCoords = CoordsXYZ{ TrackLocation, TrackLocation.z - trackBlock->z + trackCoordinates->z_begin };
     int32_t direction = (GetTrackDirection() + trackCoordinates->rotation_begin) & 3;
     direction = direction_reverse(direction);
@@ -7933,8 +7933,8 @@ void Vehicle::Sub6DBF3E()
     }
 
     auto trackType = GetTrackType();
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return;
     }
@@ -8547,8 +8547,8 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* cu
             if (next_vehicle_on_train == SPRITE_INDEX_NULL)
             {
                 trackType = tileElement->AsTrack()->GetTrackType();
-                const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-                if (!(teDescriptor.Flags & TRACK_ELEM_FLAG_DOWN))
+                const auto& ted = GetTrackElementDescriptor(trackType);
+                if (!(ted.Flags & TRACK_ELEM_FLAG_DOWN))
                 {
                     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_9;
                 }
@@ -9209,8 +9209,8 @@ loc_6DCE02:
     }
     {
         auto trackType = GetTrackType();
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
         {
             return;
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1707,7 +1707,8 @@ void Vehicle::UpdateMeasurements()
                 }
         }
 
-        uint16_t trackFlags = TrackFlags[trackElemType];
+        const auto& teDescriptor = GetTrackElementDescriptor(trackElemType);
+        uint16_t trackFlags = teDescriptor.Flags;
 
         uint32_t testingFlags = curRide->testing_flags;
         if (testingFlags & RIDE_TESTING_TURN_LEFT && trackFlags & TRACK_ELEM_FLAG_TURN_LEFT)
@@ -8545,7 +8546,8 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* cu
             if (next_vehicle_on_train == SPRITE_INDEX_NULL)
             {
                 trackType = tileElement->AsTrack()->GetTrackType();
-                if (!(TrackFlags[trackType] & TRACK_ELEM_FLAG_DOWN))
+                const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+                if (!(teDescriptor.Flags & TRACK_ELEM_FLAG_DOWN))
                 {
                     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_9;
                 }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7933,7 +7933,8 @@ void Vehicle::Sub6DBF3E()
     }
 
     auto trackType = GetTrackType();
-    if (!(TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return;
     }
@@ -9208,7 +9209,8 @@ loc_6DCE02:
     }
     {
         auto trackType = GetTrackType();
-        if (!(TrackSequenceProperties[trackType][0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        if (!(teDescriptor.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
         {
             return;
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7934,7 +7934,7 @@ void Vehicle::Sub6DBF3E()
 
     auto trackType = GetTrackType();
     const auto& ted = GetTrackElementDescriptor(trackType);
-    if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+    if (!(ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
     {
         return;
     }
@@ -9210,7 +9210,7 @@ loc_6DCE02:
     {
         auto trackType = GetTrackType();
         const auto& ted = GetTrackElementDescriptor(trackType);
-        if (!(ted.TrackSequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
+        if (!(ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN))
         {
             return;
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -50,6 +50,7 @@
 #include <algorithm>
 #include <iterator>
 
+using namespace OpenRCT2::TrackMetaData;
 static bool vehicle_boat_is_location_accessible(const CoordsXYZ& location);
 
 constexpr int16_t VEHICLE_MAX_SPIN_SPEED = 1536;
@@ -7493,12 +7494,13 @@ static void AnimateSceneryDoor(const CoordsXYZD& doorLocation, const CoordsXYZ& 
 void Vehicle::UpdateSceneryDoor() const
 {
     auto trackType = GetTrackType();
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
     const rct_preview_track* trackBlock = TrackBlocks[trackType];
     while ((trackBlock + 1)->index != 255)
     {
         trackBlock++;
     }
-    const rct_track_coordinates* trackCoordinates = &TrackCoordinates[trackType];
+    const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
     auto wallCoords = CoordsXYZ{ x, y, TrackLocation.z - trackBlock->z + trackCoordinates->z_end }.ToTileStart();
     int32_t direction = (GetTrackDirection() + trackCoordinates->rotation_end) & 3;
 
@@ -7590,8 +7592,9 @@ static void trigger_on_ride_photo(const CoordsXYZ& loc, TileElement* tileElement
 void Vehicle::UpdateSceneryDoorBackwards() const
 {
     auto trackType = GetTrackType();
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
     const rct_preview_track* trackBlock = TrackBlocks[trackType];
-    const rct_track_coordinates* trackCoordinates = &TrackCoordinates[trackType];
+    const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
     auto wallCoords = CoordsXYZ{ TrackLocation, TrackLocation.z - trackBlock->z + trackCoordinates->z_begin };
     int32_t direction = (GetTrackDirection() + trackCoordinates->rotation_begin) & 3;
     direction = direction_reverse(direction);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7496,7 +7496,7 @@ void Vehicle::UpdateSceneryDoor() const
 {
     auto trackType = GetTrackType();
     const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_preview_track* trackBlock = TrackBlocks[trackType];
+    const rct_preview_track* trackBlock = teDescriptor.Block;
     while ((trackBlock + 1)->index != 255)
     {
         trackBlock++;
@@ -7594,7 +7594,7 @@ void Vehicle::UpdateSceneryDoorBackwards() const
 {
     auto trackType = GetTrackType();
     const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_preview_track* trackBlock = TrackBlocks[trackType];
+    const rct_preview_track* trackBlock = teDescriptor.Block;
     const rct_track_coordinates* trackCoordinates = &teDescriptor.Coordinates;
     auto wallCoords = CoordsXYZ{ TrackLocation, TrackLocation.z - trackBlock->z + trackCoordinates->z_begin };
     int32_t direction = (GetTrackDirection() + trackCoordinates->rotation_begin) & 3;

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -91,8 +91,8 @@ money32 place_provisional_track_piece(
             return result;
 
         int16_t z_begin, z_end;
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        const rct_track_coordinates& coords = teDescriptor.Coordinates;
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        const rct_track_coordinates& coords = ted.Coordinates;
         if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_NO_TRACK))
         {
             z_begin = coords.z_begin;
@@ -306,8 +306,8 @@ bool window_ride_construction_update_state(
         && _currentTrackAlternative & RIDE_TYPE_ALTERNATIVE_TRACK_PIECES)
     {
         auto availablePieces = rtd.CoveredTrackPieces;
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        auto alternativeType = teDescriptor.AlternativeType;
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        auto alternativeType = ted.AlternativeType;
         if (alternativeType != TrackElemType::None && (availablePieces & (1ULL << trackType)))
         {
             trackType = alternativeType;
@@ -315,8 +315,8 @@ bool window_ride_construction_update_state(
         }
     }
 
-    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-    const rct_track_coordinates& trackCoordinates = teDescriptor.Coordinates;
+    const auto& ted = GetTrackElementDescriptor(trackType);
+    const rct_track_coordinates& trackCoordinates = ted.Coordinates;
 
     x = _currentTrackBegin.x;
     y = _currentTrackBegin.y;
@@ -349,13 +349,13 @@ bool window_ride_construction_update_state(
     bool turnOffLiftHill = false;
     if (!(_enabledRidePieces & (1ULL << TRACK_LIFT_HILL_CURVE)))
     {
-        if (teDescriptor.Flags & TRACK_ELEM_FLAG_CURVE_ALLOWS_LIFT)
+        if (ted.Flags & TRACK_ELEM_FLAG_CURVE_ALLOWS_LIFT)
         {
             turnOffLiftHill = true;
         }
     }
 
-    if (!(teDescriptor.Flags & TRACK_ELEM_FLAG_ALLOW_LIFT_HILL))
+    if (!(ted.Flags & TRACK_ELEM_FLAG_ALLOW_LIFT_HILL))
     {
         turnOffLiftHill = true;
     }

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -349,13 +349,13 @@ bool window_ride_construction_update_state(
     bool turnOffLiftHill = false;
     if (!(_enabledRidePieces & (1ULL << TRACK_LIFT_HILL_CURVE)))
     {
-        if (TrackFlags[trackType] & TRACK_ELEM_FLAG_CURVE_ALLOWS_LIFT)
+        if (teDescriptor.Flags & TRACK_ELEM_FLAG_CURVE_ALLOWS_LIFT)
         {
             turnOffLiftHill = true;
         }
     }
 
-    if (!(TrackFlags[trackType] & TRACK_ELEM_FLAG_ALLOW_LIFT_HILL))
+    if (!(teDescriptor.Flags & TRACK_ELEM_FLAG_ALLOW_LIFT_HILL))
     {
         turnOffLiftHill = true;
     }

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -27,6 +27,7 @@
 #include <iterator>
 #include <tuple>
 
+using namespace OpenRCT2::TrackMetaData;
 bool gDisableErrorWindowSound = false;
 
 uint64_t _enabledRidePieces;
@@ -90,7 +91,8 @@ money32 place_provisional_track_piece(
             return result;
 
         int16_t z_begin, z_end;
-        const rct_track_coordinates& coords = TrackCoordinates[trackType];
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        const rct_track_coordinates& coords = teDescriptor.Coordinates;
         if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_NO_TRACK))
         {
             z_begin = coords.z_begin;
@@ -312,7 +314,8 @@ bool window_ride_construction_update_state(
         }
     }
 
-    const rct_track_coordinates& trackCoordinates = TrackCoordinates[trackType];
+    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+    const rct_track_coordinates& trackCoordinates = teDescriptor.Coordinates;
 
     x = _currentTrackBegin.x;
     y = _currentTrackBegin.y;

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -306,7 +306,8 @@ bool window_ride_construction_update_state(
         && _currentTrackAlternative & RIDE_TYPE_ALTERNATIVE_TRACK_PIECES)
     {
         auto availablePieces = rtd.CoveredTrackPieces;
-        auto alternativeType = AlternativeTrackTypes[trackType];
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        auto alternativeType = teDescriptor.AlternativeType;
         if (alternativeType != TrackElemType::None && (availablePieces & (1ULL << trackType)))
         {
             trackType = alternativeType;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <iterator>
 
+using namespace OpenRCT2::TrackMetaData;
 void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElement* tileElement);
 
 ProvisionalFootpath gProvisionalFootpath;
@@ -880,13 +881,15 @@ static void loc_6A6D7E(
 
                         const auto trackType = tileElement->AsTrack()->GetTrackType();
                         const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
-                        if (!(TrackSequenceProperties[trackType][trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
+                        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+                        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
                         {
                             return;
                         }
                         uint16_t dx = direction_reverse(
                             (direction - tileElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK);
-                        if (!(TrackSequenceProperties[trackType][trackSequence] & (1 << dx)))
+
+                        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & (1 << dx)))
                         {
                             return;
                         }
@@ -962,12 +965,13 @@ static void loc_6A6C85(
 
         const auto trackType = tileElementPos.element->AsTrack()->GetTrackType();
         const uint8_t trackSequence = tileElementPos.element->AsTrack()->GetSequenceIndex();
-        if (!(TrackSequenceProperties[trackType][trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
+        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
         {
             return;
         }
         uint16_t dx = (direction - tileElementPos.element->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK;
-        if (!(TrackSequenceProperties[trackType][trackSequence] & (1 << dx)))
+        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & (1 << dx)))
         {
             return;
         }
@@ -2103,10 +2107,11 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
 
                     const auto trackType = tileElement->AsTrack()->GetTrackType();
                     const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
-                    if (TrackSequenceProperties[trackType][trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
+                    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
+                    if (teDescriptor.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
                     {
                         uint16_t dx = ((coords.direction - tileElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK);
-                        if (TrackSequenceProperties[trackType][trackSequence] & (1 << dx))
+                        if (teDescriptor.TrackSequenceProperties[trackSequence] & (1 << dx))
                         {
                             // Track element has the flags required for the given direction
                             return true;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -881,15 +881,15 @@ static void loc_6A6D7E(
 
                         const auto trackType = tileElement->AsTrack()->GetTrackType();
                         const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
-                        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-                        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
+                        const auto& ted = GetTrackElementDescriptor(trackType);
+                        if (!(ted.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
                         {
                             return;
                         }
                         uint16_t dx = direction_reverse(
                             (direction - tileElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK);
 
-                        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & (1 << dx)))
+                        if (!(ted.TrackSequenceProperties[trackSequence] & (1 << dx)))
                         {
                             return;
                         }
@@ -965,13 +965,13 @@ static void loc_6A6C85(
 
         const auto trackType = tileElementPos.element->AsTrack()->GetTrackType();
         const uint8_t trackSequence = tileElementPos.element->AsTrack()->GetSequenceIndex();
-        const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
+        const auto& ted = GetTrackElementDescriptor(trackType);
+        if (!(ted.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
         {
             return;
         }
         uint16_t dx = (direction - tileElementPos.element->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK;
-        if (!(teDescriptor.TrackSequenceProperties[trackSequence] & (1 << dx)))
+        if (!(ted.TrackSequenceProperties[trackSequence] & (1 << dx)))
         {
             return;
         }
@@ -2107,11 +2107,11 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
 
                     const auto trackType = tileElement->AsTrack()->GetTrackType();
                     const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
-                    const auto& teDescriptor = GetTrackElementDescriptor(trackType);
-                    if (teDescriptor.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
+                    const auto& ted = GetTrackElementDescriptor(trackType);
+                    if (ted.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
                     {
                         uint16_t dx = ((coords.direction - tileElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK);
-                        if (teDescriptor.TrackSequenceProperties[trackSequence] & (1 << dx))
+                        if (ted.TrackSequenceProperties[trackSequence] & (1 << dx))
                         {
                             // Track element has the flags required for the given direction
                             return true;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -882,14 +882,14 @@ static void loc_6A6D7E(
                         const auto trackType = tileElement->AsTrack()->GetTrackType();
                         const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
                         const auto& ted = GetTrackElementDescriptor(trackType);
-                        if (!(ted.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
+                        if (!(ted.SequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
                         {
                             return;
                         }
                         uint16_t dx = direction_reverse(
                             (direction - tileElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK);
 
-                        if (!(ted.TrackSequenceProperties[trackSequence] & (1 << dx)))
+                        if (!(ted.SequenceProperties[trackSequence] & (1 << dx)))
                         {
                             return;
                         }
@@ -966,12 +966,12 @@ static void loc_6A6C85(
         const auto trackType = tileElementPos.element->AsTrack()->GetTrackType();
         const uint8_t trackSequence = tileElementPos.element->AsTrack()->GetSequenceIndex();
         const auto& ted = GetTrackElementDescriptor(trackType);
-        if (!(ted.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
+        if (!(ted.SequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH))
         {
             return;
         }
         uint16_t dx = (direction - tileElementPos.element->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK;
-        if (!(ted.TrackSequenceProperties[trackSequence] & (1 << dx)))
+        if (!(ted.SequenceProperties[trackSequence] & (1 << dx)))
         {
             return;
         }
@@ -2108,10 +2108,10 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
                     const auto trackType = tileElement->AsTrack()->GetTrackType();
                     const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
                     const auto& ted = GetTrackElementDescriptor(trackType);
-                    if (ted.TrackSequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
+                    if (ted.SequenceProperties[trackSequence] & TRACK_SEQUENCE_FLAG_CONNECTS_TO_PATH)
                     {
                         uint16_t dx = ((coords.direction - tileElement->GetDirection()) & TILE_ELEMENT_DIRECTION_MASK);
-                        if (ted.TrackSequenceProperties[trackSequence] & (1 << dx))
+                        if (ted.SequenceProperties[trackSequence] & (1 << dx))
                         {
                             // Track element has the flags required for the given direction
                             return true;

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -855,8 +855,8 @@ namespace OpenRCT2::TileInspector
             if (ride == nullptr)
                 return std::make_unique<GameActions::Result>(GameActions::Status::Unknown, STR_NONE);
 
-            const auto& teDescriptor = GetTrackElementDescriptor(type);
-            const auto* trackBlock = teDescriptor.Block;
+            const auto& ted = GetTrackElementDescriptor(type);
+            const auto* trackBlock = ted.Block;
             trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
             uint8_t originDirection = trackElement->GetDirection();
@@ -868,7 +868,7 @@ namespace OpenRCT2::TileInspector
             originY = static_cast<int16_t>(coords.y);
             originZ -= trackBlock->z;
 
-            trackBlock = teDescriptor.Block;
+            trackBlock = ted.Block;
             for (; trackBlock->index != 255; trackBlock++)
             {
                 CoordsXYZD elem = { originX, originY, originZ + trackBlock->z, rotation };
@@ -939,8 +939,8 @@ namespace OpenRCT2::TileInspector
             if (ride == nullptr)
                 return std::make_unique<GameActions::Result>(GameActions::Status::Unknown, STR_NONE);
 
-            const auto& teDescriptor = GetTrackElementDescriptor(type);
-            auto trackBlock = teDescriptor.Block;
+            const auto& ted = GetTrackElementDescriptor(type);
+            auto trackBlock = ted.Block;
             trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
             uint8_t originDirection = trackElement->GetDirection();
@@ -952,7 +952,7 @@ namespace OpenRCT2::TileInspector
             originY = static_cast<int16_t>(coords.y);
             originZ -= trackBlock->z;
 
-            trackBlock = teDescriptor.Block;
+            trackBlock = ted.Block;
             for (; trackBlock->index != 255; trackBlock++)
             {
                 CoordsXYZD elem = { originX, originY, originZ + trackBlock->z, rotation };

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -37,6 +37,7 @@ TileCoordsXY windowTileInspectorTile;
 int32_t windowTileInspectorElementCount = 0;
 int32_t windowTileInspectorSelectedIndex;
 
+using namespace OpenRCT2::TrackMetaData;
 namespace OpenRCT2::TileInspector
 {
     static bool SwapTileElements(const CoordsXY& loc, int16_t first, int16_t second)
@@ -854,7 +855,8 @@ namespace OpenRCT2::TileInspector
             if (ride == nullptr)
                 return std::make_unique<GameActions::Result>(GameActions::Status::Unknown, STR_NONE);
 
-            auto trackBlock = TrackBlocks[type];
+            const auto& teDescriptor = GetTrackElementDescriptor(type);
+            auto trackBlock = teDescriptor.Block;
             trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
             uint8_t originDirection = trackElement->GetDirection();
@@ -866,7 +868,7 @@ namespace OpenRCT2::TileInspector
             originY = static_cast<int16_t>(coords.y);
             originZ -= trackBlock->z;
 
-            trackBlock = TrackBlocks[type];
+            trackBlock = teDescriptor.Block;
             for (; trackBlock->index != 255; trackBlock++)
             {
                 CoordsXYZD elem = { originX, originY, originZ + trackBlock->z, rotation };
@@ -937,7 +939,8 @@ namespace OpenRCT2::TileInspector
             if (ride == nullptr)
                 return std::make_unique<GameActions::Result>(GameActions::Status::Unknown, STR_NONE);
 
-            auto trackBlock = TrackBlocks[type];
+            const auto& teDescriptor = GetTrackElementDescriptor(type);
+            auto trackBlock = teDescriptor.Block;
             trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
             uint8_t originDirection = trackElement->GetDirection();
@@ -949,7 +952,7 @@ namespace OpenRCT2::TileInspector
             originY = static_cast<int16_t>(coords.y);
             originZ -= trackBlock->z;
 
-            trackBlock = TrackBlocks[type];
+            trackBlock = teDescriptor.Block;
             for (; trackBlock->index != 255; trackBlock++)
             {
                 CoordsXYZD elem = { originX, originY, originZ + trackBlock->z, rotation };

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -856,7 +856,7 @@ namespace OpenRCT2::TileInspector
                 return std::make_unique<GameActions::Result>(GameActions::Status::Unknown, STR_NONE);
 
             const auto& teDescriptor = GetTrackElementDescriptor(type);
-            auto trackBlock = teDescriptor.Block;
+            const auto* trackBlock = teDescriptor.Block;
             trackBlock += trackElement->AsTrack()->GetSequenceIndex();
 
             uint8_t originDirection = trackElement->GetDirection();


### PR DESCRIPTION
Instead of creating multiple files as the RideTypeDescriptor refactor, a loader class loads the legacy tables, and TrackElementDescriptor (TED) are created and stored in this class. To access the TED, you must use GetTrackElementDescriptor. Some points to adjust/to be done:

- When to load the tables, right now it is done at the start of the game
- Provide an interface to add new TEDs
- There is still the gTrackDescriptors table that is accessed in _legacy.cpp, I have no idea what this is for.