### PR TITLE
Remove utf-8 BOM from source files

### DIFF
--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md

--- a/src/openrct2/world/TileElementsView.h
+++ b/src/openrct2/world/TileElementsView.h
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  * Copyright (c) 2014-2021 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md


### PR DESCRIPTION
Found these instances with `git grep`, so I'm confident there are no others:

```bash
git grep "$(printf '\xef\xbb\xbf')" *.h *.cpp *.hpp
```