### PR TITLE
Fix #15271. Use formatter to pass description args to text input

### DIFF
--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -201,7 +201,7 @@ public:
             }
             case WIDX_BANNER_TEXT:
                 window_text_input_raw_open(
-                    this, WIDX_BANNER_TEXT, STR_BANNER_TEXT, STR_ENTER_BANNER_TEXT, banner->GetText().c_str(), 32);
+                    this, WIDX_BANNER_TEXT, STR_BANNER_TEXT, STR_ENTER_BANNER_TEXT, {}, banner->GetText().c_str(), 32);
                 break;
             case WIDX_BANNER_NO_ENTRY:
             {

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -867,7 +867,7 @@ private:
             case WIDX_MONEY_SPINNER:
                 money_to_string(_moneySpinnerValue, _moneySpinnerText, MONEY_STRING_MAXLENGTH, false);
                 window_text_input_raw_open(
-                    this, WIDX_MONEY_SPINNER, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, _moneySpinnerText,
+                    this, WIDX_MONEY_SPINNER, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneySpinnerText,
                     MONEY_STRING_MAXLENGTH);
                 break;
             case WIDX_SET_MONEY:

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -178,9 +178,10 @@ static void window_clear_scenery_textinput(rct_window* w, rct_widgetindex widget
 
 static void window_clear_scenery_inputsize(rct_window* w)
 {
-    TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
-    TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
-    window_text_input_open(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, STR_NONE, STR_NONE, 3);
+    Formatter ft;
+    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    window_text_input_open(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
 }
 
 /**

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -179,8 +179,8 @@ static void window_clear_scenery_textinput(rct_window* w, rct_widgetindex widget
 static void window_clear_scenery_inputsize(rct_window* w)
 {
     Formatter ft;
-    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
     window_text_input_open(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
 }
 

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -134,7 +134,7 @@ static void custom_currency_window_mousedown(rct_window* w, rct_widgetindex widg
 
         case WIDX_SYMBOL_TEXT:
             window_text_input_raw_open(
-                w, WIDX_SYMBOL_TEXT, STR_CUSTOM_CURRENCY_SYMBOL_INPUT_TITLE, STR_CUSTOM_CURRENCY_SYMBOL_INPUT_DESC,
+                w, WIDX_SYMBOL_TEXT, STR_CUSTOM_CURRENCY_SYMBOL_INPUT_TITLE, STR_CUSTOM_CURRENCY_SYMBOL_INPUT_DESC, {},
                 CurrencyDescriptors[EnumValue(CurrencyType::Custom)].symbol_unicode, CURRENCY_SYMBOL_MAX_SIZE);
             break;
     }
@@ -146,7 +146,7 @@ static void custom_currency_window_mouseup(rct_window* w, rct_widgetindex widget
     {
         case WIDX_RATE:
             window_text_input_open(
-                w, WIDX_RATE, STR_RATE_INPUT_TITLE, STR_RATE_INPUT_DESC, STR_FORMAT_INTEGER,
+                w, WIDX_RATE, STR_RATE_INPUT_TITLE, STR_RATE_INPUT_DESC, {}, STR_FORMAT_INTEGER,
                 static_cast<uint32_t>(CurrencyDescriptors[EnumValue(CurrencyType::Custom)].rate), CURRENCY_RATE_MAX_NUM_DIGITS);
             break;
     }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -371,16 +371,16 @@ static void window_editor_objective_options_main_mouseup(rct_window* w, rct_widg
         case WIDX_PARK_NAME:
         {
             auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
-            window_text_input_raw_open(w, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, park.Name.c_str(), 32);
+            window_text_input_raw_open(w, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), 32);
             break;
         }
         case WIDX_SCENARIO_NAME:
             window_text_input_raw_open(
-                w, WIDX_SCENARIO_NAME, STR_SCENARIO_NAME, STR_ENTER_SCENARIO_NAME, gScenarioName.c_str(), 64);
+                w, WIDX_SCENARIO_NAME, STR_SCENARIO_NAME, STR_ENTER_SCENARIO_NAME, {}, gScenarioName.c_str(), 64);
             break;
         case WIDX_DETAILS:
             window_text_input_raw_open(
-                w, WIDX_DETAILS, STR_PARK_SCENARIO_DETAILS, STR_ENTER_SCENARIO_DESCRIPTION, gScenarioDetails.c_str(), 256);
+                w, WIDX_DETAILS, STR_PARK_SCENARIO_DETAILS, STR_ENTER_SCENARIO_DESCRIPTION, {}, gScenarioDetails.c_str(), 256);
             break;
     }
 }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -602,7 +602,8 @@ void window_guest_overview_mouse_up(rct_window* w, rct_widgetindex widgetIndex)
         case WIDX_RENAME:
         {
             auto peepName = peep->GetName();
-            window_text_input_raw_open(w, widgetIndex, STR_GUEST_RENAME_TITLE, STR_GUEST_RENAME_PROMPT, peepName.c_str(), 32);
+            window_text_input_raw_open(
+                w, widgetIndex, STR_GUEST_RENAME_TITLE, STR_GUEST_RENAME_PROMPT, {}, peepName.c_str(), 32);
             break;
         }
         case WIDX_LOCATE:

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -301,7 +301,7 @@ public:
                 else
                 {
                     window_text_input_raw_open(
-                        this, WIDX_FILTER_BY_NAME, STR_GUESTS_FILTER_BY_NAME, STR_GUESTS_ENTER_NAME_TO_SEARCH,
+                        this, WIDX_FILTER_BY_NAME, STR_GUESTS_FILTER_BY_NAME, STR_GUESTS_ENTER_NAME_TO_SEARCH, {},
                         _filterName.c_str(), 32);
                 }
                 break;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -445,7 +445,7 @@ static void window_install_track_design(rct_window* w)
         log_info("%s already exists, prompting user for a different track design name", destPath);
         context_show_error(STR_UNABLE_TO_INSTALL_THIS_TRACK_DESIGN, STR_NONE, {});
         window_text_input_raw_open(
-            w, WIDX_INSTALL, STR_SELECT_NEW_NAME_FOR_TRACK_DESIGN, STR_AN_EXISTING_TRACK_DESIGN_ALREADY_HAS_THIS_NAME,
+            w, WIDX_INSTALL, STR_SELECT_NEW_NAME_FOR_TRACK_DESIGN, STR_AN_EXISTING_TRACK_DESIGN_ALREADY_HAS_THIS_NAME, {},
             _trackName.c_str(), 255);
     }
     else

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -60,8 +60,8 @@ private:
     void InputSize()
     {
         Formatter ft;
-        ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-        ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+        ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+        ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
         window_text_input_open(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
     }
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -59,9 +59,10 @@ private:
 
     void InputSize()
     {
-        TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
-        TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
-        window_text_input_open(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, STR_NONE, STR_NONE, 3);
+        Formatter ft;
+        ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+        ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+        window_text_input_open(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
     }
 
 public:

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -203,9 +203,10 @@ static void window_land_rights_textinput(rct_window* w, rct_widgetindex widgetIn
 
 static void window_land_rights_inputsize(rct_window* w)
 {
-    TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
-    TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
-    window_text_input_open(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, STR_NONE, STR_NONE, 3);
+    Formatter ft;
+    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    window_text_input_open(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
 }
 
 static void window_land_rights_update(rct_window* w)

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -204,8 +204,8 @@ static void window_land_rights_textinput(rct_window* w, rct_widgetindex widgetIn
 static void window_land_rights_inputsize(rct_window* w)
 {
     Formatter ft;
-    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
     window_text_input_open(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
 }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -450,12 +450,12 @@ static void window_loadsave_mouseup(rct_window* w, rct_widgetindex widgetIndex)
 
         case WIDX_NEW_FILE:
             window_text_input_open(
-                w, WIDX_NEW_FILE, STR_NONE, STR_FILEBROWSER_FILE_NAME_PROMPT, STR_STRING,
+                w, WIDX_NEW_FILE, STR_NONE, STR_FILEBROWSER_FILE_NAME_PROMPT, {}, STR_STRING,
                 reinterpret_cast<uintptr_t>(_defaultPath.c_str()), 64);
             break;
 
         case WIDX_NEW_FOLDER:
-            window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, "", 64);
+            window_text_input_raw_open(w, WIDX_NEW_FOLDER, STR_NONE, STR_FILEBROWSER_FOLDER_NAME_PROMPT, {}, "", 64);
             break;
 
         case WIDX_BROWSE:

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -985,16 +985,18 @@ static void window_map_show_default_scenario_editor_buttons(rct_window* w)
 
 static void window_map_inputsize_land(rct_window* w)
 {
-    TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
-    TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
-    window_text_input_open(w, WIDX_LAND_TOOL, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, STR_NONE, STR_NONE, 3);
+    Formatter ft;
+    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    window_text_input_open(w, WIDX_LAND_TOOL, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
 }
 
 static void window_map_inputsize_map(rct_window* w)
 {
-    TextInputDescriptionArgs[0] = MINIMUM_MAP_SIZE_PRACTICAL;
-    TextInputDescriptionArgs[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
-    window_text_input_open(w, WIDX_MAP_SIZE_SPINNER, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, STR_NONE, STR_NONE, 4);
+    Formatter ft;
+    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    window_text_input_open(w, WIDX_MAP_SIZE_SPINNER, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, ft, STR_NONE, STR_NONE, 4);
 }
 
 static void window_map_draw_tab_images(rct_window* w, rct_drawpixelinfo* dpi)

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -986,16 +986,16 @@ static void window_map_show_default_scenario_editor_buttons(rct_window* w)
 static void window_map_inputsize_land(rct_window* w)
 {
     Formatter ft;
-    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
     window_text_input_open(w, WIDX_LAND_TOOL, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
 }
 
 static void window_map_inputsize_map(rct_window* w)
 {
     Formatter ft;
-    ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-    ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+    ft.Add<int16_t>(MINIMUM_MAP_SIZE_PRACTICAL);
+    ft.Add<int16_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
     window_text_input_open(w, WIDX_MAP_SIZE_SPINNER, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, ft, STR_NONE, STR_NONE, 4);
 }
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -494,7 +494,7 @@ static void window_mapgen_base_mouseup(rct_window* w, rct_widgetindex widgetInde
     window_mapgen_shared_mouseup(w, widgetIndex);
 
     mapgen_settings mapgenSettings;
-
+    Formatter ft;
     switch (widgetIndex)
     {
         case WIDX_MAP_GENERATE:
@@ -508,22 +508,23 @@ static void window_mapgen_base_mouseup(rct_window* w, rct_widgetindex widgetInde
             gfx_invalidate_screen();
             break;
         case WIDX_MAP_SIZE:
-            TextInputDescriptionArgs[0] = MINIMUM_MAP_SIZE_PRACTICAL;
-            TextInputDescriptionArgs[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
+            ft.Add<int32_t>(MINIMUM_MAP_SIZE_PRACTICAL);
+            ft.Add<int32_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
             // Practical map size is 2 lower than the technical map size
-            window_text_input_open(w, WIDX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, STR_FORMAT_INTEGER, _mapSize - 2, 4);
+            window_text_input_open(
+                w, WIDX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, ft, STR_FORMAT_INTEGER, _mapSize - 2, 4);
             break;
         case WIDX_BASE_HEIGHT:
-            TextInputDescriptionArgs[0] = static_cast<uint16_t>((BASESIZE_MIN - 12) / 2);
-            TextInputDescriptionArgs[1] = static_cast<uint16_t>((BASESIZE_MAX - 12) / 2);
+            ft.Add<int32_t>((BASESIZE_MIN - 12) / 2);
+            ft.Add<int32_t>((BASESIZE_MAX - 12) / 2);
             window_text_input_open(
-                w, WIDX_BASE_HEIGHT, STR_BASE_HEIGHT, STR_ENTER_BASE_HEIGHT, STR_FORMAT_INTEGER, (_baseHeight - 12) / 2, 3);
+                w, WIDX_BASE_HEIGHT, STR_BASE_HEIGHT, STR_ENTER_BASE_HEIGHT, ft, STR_FORMAT_INTEGER, (_baseHeight - 12) / 2, 3);
             break;
         case WIDX_WATER_LEVEL:
-            TextInputDescriptionArgs[0] = static_cast<uint16_t>((WATERLEVEL_MIN - 12) / 2);
-            TextInputDescriptionArgs[1] = static_cast<uint16_t>((WATERLEVEL_MAX - 12) / 2);
+            ft.Add<int32_t>((WATERLEVEL_MIN - 12) / 2);
+            ft.Add<int32_t>((WATERLEVEL_MAX - 12) / 2);
             window_text_input_open(
-                w, WIDX_WATER_LEVEL, STR_WATER_LEVEL, STR_ENTER_WATER_LEVEL, STR_FORMAT_INTEGER, (_waterLevel - 12) / 2, 3);
+                w, WIDX_WATER_LEVEL, STR_WATER_LEVEL, STR_ENTER_WATER_LEVEL, ft, STR_FORMAT_INTEGER, (_waterLevel - 12) / 2, 3);
             break;
     }
 }
@@ -808,12 +809,15 @@ static void window_mapgen_simplex_mouseup(rct_window* w, rct_widgetindex widgetI
     switch (widgetIndex)
     {
         case WIDX_SIMPLEX_MAP_SIZE:
-            TextInputDescriptionArgs[0] = MINIMUM_MAP_SIZE_PRACTICAL;
-            TextInputDescriptionArgs[1] = MAXIMUM_MAP_SIZE_PRACTICAL;
+        {
+            Formatter ft;
+            ft.Add<int32_t>(MINIMUM_MAP_SIZE_PRACTICAL);
+            ft.Add<int32_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
             // Practical map size is 2 lower than the technical map size
             window_text_input_open(
-                w, WIDX_SIMPLEX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, STR_FORMAT_INTEGER, _mapSize - 2, 4);
+                w, WIDX_SIMPLEX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, ft, STR_FORMAT_INTEGER, _mapSize - 2, 4);
             break;
+        }
         case WIDX_SIMPLEX_GENERATE:
             mapgenSettings.mapSize = _mapSize;
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -508,21 +508,21 @@ static void window_mapgen_base_mouseup(rct_window* w, rct_widgetindex widgetInde
             gfx_invalidate_screen();
             break;
         case WIDX_MAP_SIZE:
-            ft.Add<int32_t>(MINIMUM_MAP_SIZE_PRACTICAL);
-            ft.Add<int32_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
+            ft.Add<int16_t>(MINIMUM_MAP_SIZE_PRACTICAL);
+            ft.Add<int16_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
             // Practical map size is 2 lower than the technical map size
             window_text_input_open(
                 w, WIDX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, ft, STR_FORMAT_INTEGER, _mapSize - 2, 4);
             break;
         case WIDX_BASE_HEIGHT:
-            ft.Add<int32_t>((BASESIZE_MIN - 12) / 2);
-            ft.Add<int32_t>((BASESIZE_MAX - 12) / 2);
+            ft.Add<int16_t>((BASESIZE_MIN - 12) / 2);
+            ft.Add<int16_t>((BASESIZE_MAX - 12) / 2);
             window_text_input_open(
                 w, WIDX_BASE_HEIGHT, STR_BASE_HEIGHT, STR_ENTER_BASE_HEIGHT, ft, STR_FORMAT_INTEGER, (_baseHeight - 12) / 2, 3);
             break;
         case WIDX_WATER_LEVEL:
-            ft.Add<int32_t>((WATERLEVEL_MIN - 12) / 2);
-            ft.Add<int32_t>((WATERLEVEL_MAX - 12) / 2);
+            ft.Add<int16_t>((WATERLEVEL_MIN - 12) / 2);
+            ft.Add<int16_t>((WATERLEVEL_MAX - 12) / 2);
             window_text_input_open(
                 w, WIDX_WATER_LEVEL, STR_WATER_LEVEL, STR_ENTER_WATER_LEVEL, ft, STR_FORMAT_INTEGER, (_waterLevel - 12) / 2, 3);
             break;
@@ -811,8 +811,8 @@ static void window_mapgen_simplex_mouseup(rct_window* w, rct_widgetindex widgetI
         case WIDX_SIMPLEX_MAP_SIZE:
         {
             Formatter ft;
-            ft.Add<int32_t>(MINIMUM_MAP_SIZE_PRACTICAL);
-            ft.Add<int32_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
+            ft.Add<int16_t>(MINIMUM_MAP_SIZE_PRACTICAL);
+            ft.Add<int16_t>(MAXIMUM_MAP_SIZE_PRACTICAL);
             // Practical map size is 2 lower than the technical map size
             window_text_input_open(
                 w, WIDX_SIMPLEX_MAP_SIZE, STR_MAP_SIZE_2, STR_ENTER_MAP_SIZE, ft, STR_FORMAT_INTEGER, _mapSize - 2, 4);

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -700,7 +700,7 @@ static void window_multiplayer_groups_mouseup(rct_window* w, rct_widgetindex wid
         case WIDX_RENAME_GROUP:;
             int32_t groupIndex = network_get_group_index(_selectedGroup);
             const utf8* groupName = network_get_group_name(groupIndex);
-            window_text_input_raw_open(w, widgetIndex, STR_GROUP_NAME, STR_ENTER_NEW_NAME_FOR_THIS_GROUP, groupName, 32);
+            window_text_input_raw_open(w, widgetIndex, STR_GROUP_NAME, STR_ENTER_NEW_NAME_FOR_THIS_GROUP, {}, groupName, 32);
             break;
     }
 }

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -95,7 +95,7 @@ rct_window* window_network_status_open_password()
     if (window == nullptr)
         return nullptr;
 
-    window_text_input_raw_open(window, WIDX_PASSWORD, STR_PASSWORD_REQUIRED, STR_PASSWORD_REQUIRED_DESC, _password, 32);
+    window_text_input_raw_open(window, WIDX_PASSWORD, STR_PASSWORD_REQUIRED, STR_PASSWORD_REQUIRED_DESC, {}, _password, 32);
 
     return window;
 }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -516,7 +516,7 @@ static void window_park_entrance_mouseup(rct_window* w, rct_widgetindex widgetIn
         {
             auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
             window_text_input_raw_open(
-                w, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, park.Name.c_str(), USER_STRING_MAX_LENGTH);
+                w, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), USER_STRING_MAX_LENGTH);
             break;
         }
         case WIDX_CLOSE_LIGHT:
@@ -1389,7 +1389,7 @@ static void window_park_objective_mouseup(rct_window* w, rct_widgetindex widgetI
             break;
         case WIDX_ENTER_NAME:
             window_text_input_open(
-                w, WIDX_ENTER_NAME, STR_ENTER_NAME, STR_PLEASE_ENTER_YOUR_NAME_FOR_THE_SCENARIO_CHART, 0, 0, 32);
+                w, WIDX_ENTER_NAME, STR_ENTER_NAME, STR_PLEASE_ENTER_YOUR_NAME_FOR_THE_SCENARIO_CHART, {}, 0, 0, 32);
             break;
     }
 }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1719,7 +1719,7 @@ static void window_ride_rename(rct_window* w)
     {
         auto rideName = ride->GetName();
         window_text_input_raw_open(
-            w, WIDX_RENAME, STR_RIDE_ATTRACTION_NAME, STR_ENTER_NEW_NAME_FOR_THIS_RIDE_ATTRACTION, rideName.c_str(), 32);
+            w, WIDX_RENAME, STR_RIDE_ATTRACTION_NAME, STR_ENTER_NEW_NAME_FOR_THIS_RIDE_ATTRACTION, {}, rideName.c_str(), 32);
     }
 }
 
@@ -6433,7 +6433,8 @@ static void window_ride_income_mouseup(rct_window* w, rct_widgetindex widgetInde
             {
                 money_to_string(static_cast<money32>(ride->price[0]), _moneyInputText, MONEY_STRING_MAXLENGTH, true);
                 window_text_input_raw_open(
-                    w, WIDX_PRIMARY_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, _moneyInputText, MONEY_STRING_MAXLENGTH);
+                    w, WIDX_PRIMARY_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneyInputText,
+                    MONEY_STRING_MAXLENGTH);
             }
             break;
         }
@@ -6446,7 +6447,7 @@ static void window_ride_income_mouseup(rct_window* w, rct_widgetindex widgetInde
 
             money_to_string(price32, _moneyInputText, MONEY_STRING_MAXLENGTH, true);
             window_text_input_raw_open(
-                w, WIDX_SECONDARY_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, _moneyInputText, MONEY_STRING_MAXLENGTH);
+                w, WIDX_SECONDARY_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneyInputText, MONEY_STRING_MAXLENGTH);
         }
         break;
         case WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK:

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -176,8 +176,8 @@ static void window_scenery_scatter_inputsize(rct_window* w, rct_widgetindex widg
     switch (widgetindex)
     {
         case WIDX_PREVIEW:
-            ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-            ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+            ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+            ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
             maxlen = 3;
             break;
     }

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -171,15 +171,17 @@ static void window_scenery_scatter_textinput(rct_window* w, rct_widgetindex widg
 static void window_scenery_scatter_inputsize(rct_window* w, rct_widgetindex widgetindex)
 {
     uint8_t maxlen = 0;
+    Formatter ft;
+
     switch (widgetindex)
     {
         case WIDX_PREVIEW:
-            TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
-            TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
+            ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+            ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
             maxlen = 3;
             break;
     }
-    window_text_input_open(w, widgetindex, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, STR_NONE, STR_NONE, maxlen);
+    window_text_input_open(w, widgetindex, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, maxlen);
 }
 
 static void window_scenery_scatter_invalidate(rct_window* w)

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -194,7 +194,7 @@ static void window_server_list_mouseup(rct_window* w, rct_widgetindex widgetInde
             server_list_fetch_servers_begin();
             break;
         case WIDX_ADD_SERVER:
-            window_text_input_open(w, widgetIndex, STR_ADD_SERVER, STR_ENTER_HOSTNAME_OR_IP_ADDRESS, STR_NONE, 0, 128);
+            window_text_input_open(w, widgetIndex, STR_ADD_SERVER, STR_ENTER_HOSTNAME_OR_IP_ADDRESS, {}, STR_NONE, 0, 128);
             break;
         case WIDX_START_SERVER:
             context_open_window(WC_SERVER_START);

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -65,7 +65,8 @@ private:
         if (banner != nullptr)
         {
             auto bannerText = banner->GetText();
-            window_text_input_raw_open(this, WIDX_SIGN_TEXT, STR_SIGN_TEXT_TITLE, STR_SIGN_TEXT_PROMPT, bannerText.c_str(), 32);
+            window_text_input_raw_open(
+                this, WIDX_SIGN_TEXT, STR_SIGN_TEXT_TITLE, STR_SIGN_TEXT_PROMPT, {}, bannerText.c_str(), 32);
         }
     }
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -440,7 +440,7 @@ void window_staff_overview_mouseup(rct_window* w, rct_widgetindex widgetIndex)
         {
             auto peepName = peep->GetName();
             window_text_input_raw_open(
-                w, widgetIndex, STR_STAFF_TITLE_STAFF_MEMBER_NAME, STR_STAFF_PROMPT_ENTER_NAME, peepName.c_str(), 32);
+                w, widgetIndex, STR_STAFF_TITLE_STAFF_MEMBER_NAME, STR_STAFF_PROMPT_ENTER_NAME, {}, peepName.c_str(), 32);
             break;
         }
     }

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -47,6 +47,7 @@ private:
 
     std::string _description;
     rct_string_id _descriptionStringId = STR_NONE;
+    Formatter _descriptionArgs;
 
     std::function<void(std::string_view)> _callback;
     std::function<void()> _cancelCallback;
@@ -89,10 +90,11 @@ public:
         }
     }
 
-    void SetTitle(rct_string_id title, rct_string_id description)
+    void SetTitle(rct_string_id title, rct_string_id description, const Formatter& decriptionArgs)
     {
         _titleStringId = title;
         _descriptionStringId = description;
+        _descriptionArgs = decriptionArgs;
     }
 
     void SetTitle(std::string_view title, std::string_view description)
@@ -209,10 +211,8 @@ public:
         }
         else
         {
-            auto ft = Formatter();
-            ft.Add<const char*>(TextInputDescriptionArgs);
             DrawTextWrapped(
-                &dpi, { windowPos.x + WW / 2, screenCoords.y }, WW, _descriptionStringId, ft,
+                &dpi, { windowPos.x + WW / 2, screenCoords.y }, WW, _descriptionStringId, _descriptionArgs,
                 { colours[1], TextAlignment::CENTRE });
         }
 
@@ -373,7 +373,7 @@ private:
 
 void window_text_input_raw_open(
     rct_window* call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description,
-    const_utf8string existing_text, int32_t maxLength)
+    const Formatter& descriptionArgs, const_utf8string existing_text, int32_t maxLength)
 {
     window_close_by_class(WC_TEXTINPUT);
 
@@ -382,7 +382,7 @@ void window_text_input_raw_open(
     if (w != nullptr)
     {
         w->SetParentWindow(call_w, call_widget);
-        w->SetTitle(title, description);
+        w->SetTitle(title, description, descriptionArgs);
         w->SetText(existing_text, maxLength);
     }
 }
@@ -403,10 +403,10 @@ void window_text_input_open(
 
 void window_text_input_open(
     rct_window* call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description,
-    rct_string_id existing_text, uintptr_t existing_args, int32_t maxLength)
+    const Formatter& descriptionArgs, rct_string_id existing_text, uintptr_t existing_args, int32_t maxLength)
 {
     auto existingText = format_string(existing_text, &existing_args);
-    window_text_input_raw_open(call_w, call_widget, title, description, existingText.c_str(), maxLength);
+    window_text_input_raw_open(call_w, call_widget, title, description, descriptionArgs, existingText.c_str(), maxLength);
 }
 
 void window_text_input_key(rct_window* w, char keychar)

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -359,7 +359,7 @@ static void window_themes_mouseup(rct_window* w, rct_widgetindex widgetIndex)
             activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
             activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
             window_text_input_open(
-                w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_THEMES_PROMPT_ENTER_THEME_NAME, STR_STRING,
+                w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_THEMES_PROMPT_ENTER_THEME_NAME, {}, STR_STRING,
                 reinterpret_cast<uintptr_t>(activeThemeName), 64);
             break;
         case WIDX_THEMES_DELETE_BUTTON:
@@ -382,7 +382,7 @@ static void window_themes_mouseup(rct_window* w, rct_widgetindex widgetIndex)
                 activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
                 activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
                 window_text_input_open(
-                    w, widgetIndex, STR_TRACK_MANAGE_RENAME, STR_THEMES_PROMPT_ENTER_THEME_NAME, STR_STRING,
+                    w, widgetIndex, STR_TRACK_MANAGE_RENAME, STR_THEMES_PROMPT_ENTER_THEME_NAME, {}, STR_STRING,
                     reinterpret_cast<uintptr_t>(activeThemeName), 64);
             }
             break;

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -280,14 +280,15 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
             if (!commandEditorOpen)
             {
                 window_text_input_open(
-                    w, widgetIndex, STR_TITLE_EDITOR_ACTION_CREATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_NONE, 0, 64);
+                    w, widgetIndex, STR_TITLE_EDITOR_ACTION_CREATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, {}, STR_NONE, 0,
+                    64);
             }
             break;
         case WIDX_TITLE_EDITOR_DUPLICATE_BUTTON:
             if (!commandEditorOpen && _editingTitleSequence != nullptr)
             {
                 window_text_input_open(
-                    w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_STRING,
+                    w, widgetIndex, STR_TITLE_EDITOR_ACTION_DUPLICATE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, {}, STR_STRING,
                     reinterpret_cast<uintptr_t>(_sequenceName), 64);
             }
             break;
@@ -302,7 +303,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
             if (window_title_editor_check_can_edit() && _editingTitleSequence != nullptr)
             {
                 window_text_input_open(
-                    w, widgetIndex, STR_TRACK_MANAGE_RENAME, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, STR_STRING,
+                    w, widgetIndex, STR_TRACK_MANAGE_RENAME, STR_TITLE_EDITOR_ENTER_NAME_FOR_SEQUENCE, {}, STR_STRING,
                     reinterpret_cast<uintptr_t>(_sequenceName), 64);
             }
             break;
@@ -338,7 +339,7 @@ static void window_title_editor_mouseup(rct_window* w, rct_widgetindex widgetInd
                 if (w->selected_list_item != -1)
                 {
                     window_text_input_open(
-                        w, widgetIndex, STR_FILEBROWSER_RENAME_SAVE_TITLE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SAVE, STR_STRING,
+                        w, widgetIndex, STR_FILEBROWSER_RENAME_SAVE_TITLE, STR_TITLE_EDITOR_ENTER_NAME_FOR_SAVE, {}, STR_STRING,
                         reinterpret_cast<uintptr_t>(_editingTitleSequence->Saves[w->selected_list_item].c_str()), 52 - 1);
                 }
             }
@@ -1140,7 +1141,7 @@ static void window_title_editor_add_park_callback(int32_t result, const utf8* pa
         _renameSavePath = _strdup(filename);
         rct_window* w = window_find_by_class(WC_TITLE_EDITOR);
         window_text_input_open(
-            w, WIDX_TITLE_EDITOR_RENAME_SAVE, STR_FILEBROWSER_RENAME_SAVE_TITLE, STR_ERROR_EXISTING_NAME, STR_STRING,
+            w, WIDX_TITLE_EDITOR_RENAME_SAVE, STR_FILEBROWSER_RENAME_SAVE_TITLE, STR_ERROR_EXISTING_NAME, {}, STR_STRING,
             reinterpret_cast<uintptr_t>(_renameSavePath), 52 - 1);
         return;
     }

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -138,8 +138,8 @@ static void window_track_manage_mouseup(rct_window* w, rct_widgetindex widgetInd
             break;
         case WIDX_RENAME:
             window_text_input_raw_open(
-                w, widgetIndex, STR_TRACK_DESIGN_RENAME_TITLE, STR_TRACK_DESIGN_RENAME_DESC, _trackDesignFileReference->name,
-                127);
+                w, widgetIndex, STR_TRACK_DESIGN_RENAME_TITLE, STR_TRACK_DESIGN_RENAME_DESC, {},
+                _trackDesignFileReference->name, 127);
             break;
         case WIDX_DELETE:
             window_track_delete_prompt_open();

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -177,9 +177,10 @@ public:
 private:
     void InputSize()
     {
-        TextInputDescriptionArgs[0] = MINIMUM_TOOL_SIZE;
-        TextInputDescriptionArgs[1] = MAXIMUM_TOOL_SIZE;
-        window_text_input_open(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, STR_NONE, STR_NONE, 3);
+        Formatter ft;
+        ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
+        ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+        window_text_input_open(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
     }
 };
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -178,8 +178,8 @@ private:
     void InputSize()
     {
         Formatter ft;
-        ft.Add<int32_t>(MINIMUM_TOOL_SIZE);
-        ft.Add<int32_t>(MAXIMUM_TOOL_SIZE);
+        ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+        ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
         window_text_input_open(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
     }
 };

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -154,10 +154,10 @@ void window_network_status_close();
 void window_text_input_key(rct_window* w, char keychar);
 void window_text_input_open(
     rct_window* call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description,
-    rct_string_id existing_text, uintptr_t existing_args, int32_t maxLength);
+    const Formatter& descriptionArgs, rct_string_id existing_text, uintptr_t existing_args, int32_t maxLength);
 void window_text_input_raw_open(
     rct_window* call_w, rct_widgetindex call_widget, rct_string_id title, rct_string_id description,
-    const_utf8string existing_text, int32_t maxLength);
+    const Formatter& descriptionArgs, const_utf8string existing_text, int32_t maxLength);
 
 void window_text_input_open(
     std::string_view title, std::string_view description, std::string_view initialValue, size_t maxLength,

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -41,7 +41,6 @@
 std::list<std::shared_ptr<rct_window>> g_window_list;
 rct_window* gWindowAudioExclusive;
 
-uint16_t TextInputDescriptionArgs[4];
 widget_identifier gCurrentTextBox = { { 255, 0 }, 0 };
 char gTextBoxInput[TEXT_INPUT_SIZE] = { 0 };
 int32_t gMaxTextBoxInputLength = 0;

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -41,7 +41,6 @@ enum class RideConstructionState : uint8_t;
 #define TEXT_INPUT_SIZE 1024
 #define TOP_TOOLBAR_HEIGHT 27
 
-extern uint16_t TextInputDescriptionArgs[4];
 extern char gTextBoxInput[TEXT_INPUT_SIZE];
 extern int32_t gMaxTextBoxInputLength;
 extern int32_t gTextBoxFrameNo;


### PR DESCRIPTION
~~Originally passed the variables via global vars which were not updated to 32bit during recent refactors.~~ This removes the global and makes the interface cleaner and corrects the type

Edit. Looks like the actual issue that was causing the issue was passing a pointer to the arguments to a formatter instead of passing the arguments to the formatter. Either way this PR makes things much simpler and removes the global.