### PR TITLE
Remove unused serialiser trait

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -584,34 +584,6 @@ template<> struct DataSerializerTraits_t<CoordsXYZD>
         stream->Write(msg, strlen(msg));
     }
 };
-template<> struct DataSerializerTraits_t<rct12_xyzd8>
-{
-    static void encode(OpenRCT2::IStream* stream, const rct12_xyzd8& coord)
-    {
-        stream->WriteValue(ByteSwapBE(coord.x));
-        stream->WriteValue(ByteSwapBE(coord.y));
-        stream->WriteValue(ByteSwapBE(coord.z));
-        stream->WriteValue(ByteSwapBE(coord.direction));
-    }
-
-    static void decode(OpenRCT2::IStream* stream, rct12_xyzd8& coord)
-    {
-        auto x = ByteSwapBE(stream->ReadValue<uint8_t>());
-        auto y = ByteSwapBE(stream->ReadValue<uint8_t>());
-        auto z = ByteSwapBE(stream->ReadValue<uint8_t>());
-        auto d = ByteSwapBE(stream->ReadValue<uint8_t>());
-        coord = rct12_xyzd8{ x, y, z, d };
-    }
-
-    static void log(OpenRCT2::IStream* stream, const rct12_xyzd8& coord)
-    {
-        char msg[128] = {};
-        snprintf(
-            msg, sizeof(msg), "rct12_xyzd8(x = %d, y = %d, z = %d, direction = %d)", coord.x, coord.y, coord.z,
-            coord.direction);
-        stream->Write(msg, strlen(msg));
-    }
-};
 
 template<> struct DataSerializerTraits_t<NetworkCheatType_t>
 {


### PR DESCRIPTION
Was looking at rct12 headers and this is not used anymore. 