### PR TITLE
Cleanup DrawSpriteArgs

### DIFF
--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -199,8 +199,8 @@ static bool SpriteImageExport(const rct_g1_element& spriteElement, const char* o
     dpi.zoom_level = 0;
 
     DrawSpriteArgs args(
-        &dpi, ImageId(), PaletteMap::GetDefault(), spriteElement, 0, 0, spriteElement.width, spriteElement.height, pixels);
-    gfx_sprite_to_buffer(args);
+        ImageId(), PaletteMap::GetDefault(), spriteElement, 0, 0, spriteElement.width, spriteElement.height, pixels);
+    gfx_sprite_to_buffer(dpi, args);
 
     auto const pixels8 = dpi.bits;
     auto const pixelsLen = (dpi.width + dpi.pitch) * dpi.height;

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -9,16 +9,15 @@
 
 #include "Drawing.h"
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
     auto dst = args.DestinationBits;
     auto& paletteMap = args.PalMap;
-    auto dpi = args.DPI;
-    auto zoomLevel = dpi->zoom_level;
+    auto zoomLevel = dpi.zoom_level;
     size_t srcLineWidth = g1.width;
-    size_t dstLineWidth = (static_cast<size_t>(dpi->width) / zoomLevel) + dpi->pitch;
+    size_t dstLineWidth = (static_cast<size_t>(dpi.width) / zoomLevel) + dpi.pitch;
     uint8_t zoom = 1 / zoomLevel;
     auto width = args.Width / zoomLevel;
     auto height = args.Height / zoomLevel;
@@ -36,7 +35,7 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(DrawSpr
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
@@ -44,10 +43,9 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(DrawSpri
     auto& paletteMap = args.PalMap;
     auto width = args.Width;
     auto height = args.Height;
-    auto dpi = args.DPI;
-    auto zoomLevel = dpi->zoom_level;
+    auto zoomLevel = dpi.zoom_level;
     size_t srcLineWidth = g1.width * zoomLevel;
-    size_t dstLineWidth = (static_cast<size_t>(dpi->width) / zoomLevel) + dpi->pitch;
+    size_t dstLineWidth = (static_cast<size_t>(dpi.width) / zoomLevel) + dpi.pitch;
     uint8_t zoom = 1 * zoomLevel;
     for (; height > 0; height -= zoom)
     {
@@ -62,15 +60,15 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(DrawSpri
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
-    if (args.DPI->zoom_level < 0)
+    if (dpi.zoom_level < 0)
     {
-        DrawBMPSpriteMagnify<TBlendOp>(args);
+        DrawBMPSpriteMagnify<TBlendOp>(dpi, args);
     }
     else
     {
-        DrawBMPSpriteMinify<TBlendOp>(args);
+        DrawBMPSpriteMinify<TBlendOp>(dpi, args);
     }
 }
 
@@ -80,7 +78,7 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(DrawSpriteArgs
  *  rct2: 0x0067A690
  * @param imageId Only flags are used.
  */
-void FASTCALL gfx_bmp_sprite_to_buffer(DrawSpriteArgs& args)
+void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
     auto imageId = args.Image;
 
@@ -90,29 +88,29 @@ void FASTCALL gfx_bmp_sprite_to_buffer(DrawSpriteArgs& args)
         if (imageId.IsBlended())
         {
             // Copy non-transparent bitmap data but blend src and dst pixel using the palette map.
-            DrawBMPSprite<BLEND_TRANSPARENT | BLEND_SRC | BLEND_DST>(args);
+            DrawBMPSprite<BLEND_TRANSPARENT | BLEND_SRC | BLEND_DST>(dpi, args);
         }
         else
         {
             // Copy non-transparent bitmap data but re-colour using the palette map.
-            DrawBMPSprite<BLEND_TRANSPARENT | BLEND_SRC>(args);
+            DrawBMPSprite<BLEND_TRANSPARENT | BLEND_SRC>(dpi, args);
         }
     }
     else if (imageId.IsBlended())
     {
         // Image is only a transparency mask. Just colour the pixels using the palette map.
         // Used for glass.
-        DrawBMPSprite<BLEND_TRANSPARENT | BLEND_DST>(args);
+        DrawBMPSprite<BLEND_TRANSPARENT | BLEND_DST>(dpi, args);
         return;
     }
     else if (!(args.SourceImage.flags & G1_FLAG_BMP))
     {
         // Copy raw bitmap data to target
-        DrawBMPSprite<BLEND_NONE>(args);
+        DrawBMPSprite<BLEND_NONE>(dpi, args);
     }
     else
     {
         // Copy raw bitmap data to target but exclude transparent pixels
-        DrawBMPSprite<BLEND_TRANSPARENT>(args);
+        DrawBMPSprite<BLEND_TRANSPARENT>(dpi, args);
     }
 }

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -12,9 +12,9 @@
 #include <algorithm>
 #include <cstring>
 
-template<DrawBlendOp TBlendOp, size_t TZoom> static void FASTCALL DrawRLESpriteMagnify(DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp, size_t TZoom>
+static void FASTCALL DrawRLESpriteMagnify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
-    auto dpi = args.DPI;
     auto src0 = args.SourceImage.offset;
     auto dst0 = args.DestinationBits;
     auto srcX = args.SrcX;
@@ -23,7 +23,7 @@ template<DrawBlendOp TBlendOp, size_t TZoom> static void FASTCALL DrawRLESpriteM
     auto height = args.Height;
     auto& paletteMap = args.PalMap;
     auto zoom = 1 << TZoom;
-    auto dstLineWidth = (static_cast<size_t>(dpi->width) << TZoom) + dpi->pitch;
+    auto dstLineWidth = (static_cast<size_t>(dpi.width) << TZoom) + dpi.pitch;
 
     // Move up to the first line of the image if source_y_start is negative. Why does this even occur?
     if (srcY < 0)
@@ -83,9 +83,9 @@ template<DrawBlendOp TBlendOp, size_t TZoom> static void FASTCALL DrawRLESpriteM
     }
 }
 
-template<DrawBlendOp TBlendOp, size_t TZoom> static void FASTCALL DrawRLESpriteMinify(DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp, size_t TZoom>
+static void FASTCALL DrawRLESpriteMinify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
-    auto dpi = args.DPI;
     auto src0 = args.SourceImage.offset;
     auto dst0 = args.DestinationBits;
     auto srcX = args.SrcX;
@@ -93,7 +93,7 @@ template<DrawBlendOp TBlendOp, size_t TZoom> static void FASTCALL DrawRLESpriteM
     auto width = args.Width;
     auto height = args.Height;
     auto zoom = 1 << TZoom;
-    auto dstLineWidth = (static_cast<size_t>(dpi->width) >> TZoom) + dpi->pitch;
+    auto dstLineWidth = (static_cast<size_t>(dpi.width) >> TZoom) + dpi.pitch;
 
     // Move up to the first line of the image if source_y_start is negative. Why does this even occur?
     if (srcY < 0)
@@ -178,28 +178,28 @@ template<DrawBlendOp TBlendOp, size_t TZoom> static void FASTCALL DrawRLESpriteM
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
-    auto zoom_level = static_cast<int8_t>(args.DPI->zoom_level);
+    auto zoom_level = static_cast<int8_t>(dpi.zoom_level);
     switch (zoom_level)
     {
         case -2:
-            DrawRLESpriteMagnify<TBlendOp, 2>(args);
+            DrawRLESpriteMagnify<TBlendOp, 2>(dpi, args);
             break;
         case -1:
-            DrawRLESpriteMagnify<TBlendOp, 1>(args);
+            DrawRLESpriteMagnify<TBlendOp, 1>(dpi, args);
             break;
         case 0:
-            DrawRLESpriteMinify<TBlendOp, 0>(args);
+            DrawRLESpriteMinify<TBlendOp, 0>(dpi, args);
             break;
         case 1:
-            DrawRLESpriteMinify<TBlendOp, 1>(args);
+            DrawRLESpriteMinify<TBlendOp, 1>(dpi, args);
             break;
         case 2:
-            DrawRLESpriteMinify<TBlendOp, 2>(args);
+            DrawRLESpriteMinify<TBlendOp, 2>(dpi, args);
             break;
         case 3:
-            DrawRLESpriteMinify<TBlendOp, 3>(args);
+            DrawRLESpriteMinify<TBlendOp, 3>(dpi, args);
             break;
         default:
             assert(false);
@@ -213,25 +213,25 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(DrawSpriteArgs
  *  rct2: 0x0067AA18
  * @param imageId Only flags are used.
  */
-void FASTCALL gfx_rle_sprite_to_buffer(DrawSpriteArgs& args)
+void FASTCALL gfx_rle_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
     if (args.Image.HasPrimary())
     {
         if (args.Image.IsBlended())
         {
-            DrawRLESprite<BLEND_TRANSPARENT | BLEND_SRC | BLEND_DST>(args);
+            DrawRLESprite<BLEND_TRANSPARENT | BLEND_SRC | BLEND_DST>(dpi, args);
         }
         else
         {
-            DrawRLESprite<BLEND_TRANSPARENT | BLEND_SRC>(args);
+            DrawRLESprite<BLEND_TRANSPARENT | BLEND_SRC>(dpi, args);
         }
     }
     else if (args.Image.IsBlended())
     {
-        DrawRLESprite<BLEND_TRANSPARENT | BLEND_DST>(args);
+        DrawRLESprite<BLEND_TRANSPARENT | BLEND_DST>(dpi, args);
     }
     else
     {
-        DrawRLESprite<BLEND_TRANSPARENT>(args);
+        DrawRLESprite<BLEND_TRANSPARENT>(dpi, args);
     }
 }

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -575,19 +575,19 @@ void FASTCALL gfx_draw_sprite_palette_set_software(
     // Move the pointer to the start point of the destination
     dest_pointer += ((dpi->width / zoom_level) + dpi->pitch) * dest_start_y + dest_start_x;
 
-    DrawSpriteArgs args(dpi, imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
-    gfx_sprite_to_buffer(args);
+    DrawSpriteArgs args(imageId, paletteMap, *g1, source_start_x, source_start_y, width, height, dest_pointer);
+    gfx_sprite_to_buffer(*dpi, args);
 }
 
-void FASTCALL gfx_sprite_to_buffer(DrawSpriteArgs& args)
+void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
 {
     if (args.SourceImage.flags & G1_FLAG_RLE_COMPRESSION)
     {
-        gfx_rle_sprite_to_buffer(args);
+        gfx_rle_sprite_to_buffer(dpi, args);
     }
     else if (!(args.SourceImage.flags & G1_FLAG_1))
     {
-        gfx_bmp_sprite_to_buffer(args);
+        gfx_bmp_sprite_to_buffer(dpi, args);
     }
 }
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -543,7 +543,6 @@ public:
 
 struct DrawSpriteArgs
 {
-    rct_drawpixelinfo* DPI;
     ImageId Image;
     const PaletteMap& PalMap;
     const rct_g1_element& SourceImage;
@@ -554,10 +553,9 @@ struct DrawSpriteArgs
     uint8_t* DestinationBits;
 
     DrawSpriteArgs(
-        rct_drawpixelinfo* dpi, ImageId image, const PaletteMap& palMap, const rct_g1_element& sourceImage, int32_t srcX,
-        int32_t srcY, int32_t width, int32_t height, uint8_t* destinationBits)
-        : DPI(dpi)
-        , Image(image)
+        ImageId image, const PaletteMap& palMap, const rct_g1_element& sourceImage, int32_t srcX, int32_t srcY, int32_t width,
+        int32_t height, uint8_t* destinationBits)
+        : Image(image)
         , PalMap(palMap)
         , SourceImage(sourceImage)
         , SrcX(srcX)
@@ -713,9 +711,9 @@ void gfx_object_free_images(uint32_t baseImageId, uint32_t count);
 void gfx_object_check_all_images_freed();
 size_t ImageListGetUsedCount();
 size_t ImageListGetMaximum();
-void FASTCALL gfx_sprite_to_buffer(DrawSpriteArgs& args);
-void FASTCALL gfx_bmp_sprite_to_buffer(DrawSpriteArgs& args);
-void FASTCALL gfx_rle_sprite_to_buffer(DrawSpriteArgs& args);
+void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
+void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
+void FASTCALL gfx_rle_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, ImageId image_id, const ScreenCoordsXY& coords);
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, int32_t image_id, const ScreenCoordsXY& coords, uint32_t tertiary_colour);
 void FASTCALL


### PR DESCRIPTION
Most of the data is read only so having DPI in there didn't allow it to be const, this also makes more sense composition wise.