### PR TITLE
Strip RCT1 out of RCT1 struct names in namespace

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -35,20 +35,20 @@ namespace RCT1
     constexpr const uint32_t RCT1_NUM_TERRAIN_EDGES = 15;
 
 #pragma pack(push, 1)
-    struct rct1_entrance
+    struct Entrance
     {
         uint16_t x;
         uint16_t y;
         uint16_t z;
         uint8_t direction;
     };
-    assert_struct_size(rct1_entrance, 7);
+    assert_struct_size(Entrance, 7);
 
     /**
      * RCT1 ride structure
      * size: 0x260
      */
-    struct rct1_ride
+    struct Ride
     {
         uint8_t type;             // 0x000
         uint8_t vehicle_type;     // 0x001
@@ -207,9 +207,9 @@ namespace RCT1
         uint8_t entrance_style;                          // 0x179
         uint8_t unk_17A[230];                            // 0x17A
     };
-    assert_struct_size(rct1_ride, 0x260);
+    assert_struct_size(Ride, 0x260);
 
-    struct rct1_unk_sprite : RCT12SpriteBase
+    struct UnkEntity : RCT12SpriteBase
     {
         uint8_t pad_1F[3];             // 0x1f
         rct_string_id name_string_idx; // 0x22
@@ -221,7 +221,7 @@ namespace RCT1
         uint8_t var_71;
     };
 
-    struct rct1_vehicle : RCT12SpriteBase
+    struct Vehicle : RCT12SpriteBase
     {
         uint8_t Pitch;         // 0x1F
         uint8_t bank_rotation; // 0x20
@@ -333,7 +333,7 @@ namespace RCT1
         }
     };
 
-    struct rct1_peep : RCT12SpriteBase
+    struct Peep : RCT12SpriteBase
     {
         uint8_t pad_1F[3];
         rct_string_id name_string_idx; // 0x22
@@ -477,7 +477,7 @@ namespace RCT1
             return item_standard_flags;
         }
     };
-    assert_struct_size(rct1_peep, 0x100);
+    assert_struct_size(Peep, 0x100);
 
     enum RCT1_PEEP_SPRITE_TYPE
     {
@@ -511,12 +511,12 @@ namespace RCT1
         RCT1_PEEP_SPRITE_TYPE_TOFFEE_APPLE = 30
     };
 
-    union rct1_sprite
+    union Entity
     {
         uint8_t pad_00[0x100];
-        rct1_unk_sprite unknown;
-        rct1_vehicle vehicle;
-        rct1_peep peep;
+        UnkEntity unknown;
+        Vehicle vehicle;
+        Peep peep;
         RCT12SpriteLitter litter;
         RCT12SpriteBalloon balloon;
         RCT12SpriteDuck duck;
@@ -526,9 +526,9 @@ namespace RCT1
         RCT12SpriteCrashSplash crash_splash;
         RCT12SpriteSteamParticle steam_particle;
     };
-    assert_struct_size(rct1_sprite, 0x100);
+    assert_struct_size(Entity, 0x100);
 
-    struct rct1_research_item
+    struct ResearchItem
     {
         uint8_t item;
         uint8_t related_ride;
@@ -536,13 +536,13 @@ namespace RCT1
         uint8_t flags;
         uint8_t category;
     };
-    assert_struct_size(rct1_research_item, 5);
+    assert_struct_size(ResearchItem, 5);
 
     /**
      * RCT1,AA,LL scenario / saved game structure.
      * size: 0x1F850C
      */
-    struct rct1_s4
+    struct S4
     {
         uint16_t month;
         uint16_t day;
@@ -551,7 +551,7 @@ namespace RCT1
         uint32_t random_b;
         RCT12TileElement tile_elements[RCT1_MAX_TILE_ELEMENTS];
         uint32_t unk_counter;
-        rct1_sprite sprites[RCT1_MAX_SPRITES];
+        Entity sprites[RCT1_MAX_SPRITES];
         uint16_t next_sprite_index;
         uint16_t first_vehicle_sprite_index;
         uint16_t first_peep_sprite_index;
@@ -570,7 +570,7 @@ namespace RCT1
         money32 loan;
         uint32_t park_flags;
         money16 park_entrance_fee;
-        rct1_entrance park_entrance;
+        Entrance park_entrance;
         uint8_t unk_198849;
         rct12_peep_spawn peep_spawn[RCT12_MAX_PEEP_SPAWNS];
         uint8_t unk_198856;
@@ -600,7 +600,7 @@ namespace RCT1
         uint8_t last_research_ride;
         uint8_t last_research_type;
         uint8_t last_research_flags;
-        rct1_research_item research_items[200];
+        ResearchItem research_items[200];
         uint8_t next_research_item;
         uint8_t next_research_ride;
         uint8_t next_research_type;
@@ -668,12 +668,12 @@ namespace RCT1
         uint8_t unk_199C96[3];
         uint8_t water_colour;
         uint16_t unk_199C9A;
-        rct1_research_item research_items_LL[180];
+        ResearchItem research_items_LL[180];
         uint8_t unk_19A020[5468];
         RCT12Banner banners[RCT1_MAX_BANNERS];
         char string_table[RCT12_MAX_USER_STRINGS][RCT12_USER_STRING_MAX_LENGTH];
         uint32_t game_time_counter;
-        rct1_ride rides[RCT12_MAX_RIDES_IN_PARK];
+        Ride rides[RCT12_MAX_RIDES_IN_PARK];
         uint16_t unk_game_time_counter;
         int16_t view_x;
         int16_t view_y;
@@ -713,13 +713,13 @@ namespace RCT1
         uint8_t unk_1F8358[432];
         uint32_t expansion_pack_checksum;
     };
-    assert_struct_size(rct1_s4, 0x1F850C);
+    assert_struct_size(S4, 0x1F850C);
 
     /**
      * Track design structure. Only for base RCT1
      * size: 0x2006
      */
-    struct rct_track_td4
+    struct TD4
     {
         uint8_t type; // 0x00
         uint8_t vehicle_type;
@@ -761,13 +761,13 @@ namespace RCT1
         money16 upkeep_cost;         // 0x36
     };
 
-    assert_struct_size(rct_track_td4, 0x38);
+    assert_struct_size(TD4, 0x38);
 
     /**
      * Track design structure for Added Attractions / Loopy Landscapes
      * size: 0x2006
      */
-    struct rct_track_td4_aa : public rct_track_td4
+    struct TD4AA : public TD4
     {
         uint8_t track_spine_colour[RCT12_NUM_COLOUR_SCHEMES];   // 0x38
         uint8_t track_rail_colour[RCT12_NUM_COLOUR_SCHEMES];    // 0x3C
@@ -777,7 +777,7 @@ namespace RCT1
         uint8_t pad_45[0x7F]; // 0x45
     };
 
-    assert_struct_size(rct_track_td4_aa, 0xC4);
+    assert_struct_size(TD4AA, 0xC4);
 #pragma pack(pop)
 
     enum

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1029,8 +1029,7 @@ namespace RCT1
                 for (int i = 0; i < RCT1_MAX_TRAINS_PER_RIDE; i++)
                 {
                     // RCT1 had no third colour
-                    RCT1::VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
-                        src->vehicle_type);
+                    const auto colourSchemeCopyDescriptor = GetColourSchemeCopyDescriptor(src->vehicle_type);
                     if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_1)
                     {
                         dst->vehicle_colours[i].Body = RCT1::GetColour(src->vehicle_colours[i].body);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -117,7 +117,7 @@ namespace RCT1
     {
     private:
         std::string _s4Path;
-        rct1_s4 _s4 = {};
+        S4 _s4 = {};
         uint8_t _gameVersion = 0;
         uint8_t _parkValueConversionFactor = 0;
         bool _isScenario = false;
@@ -310,27 +310,27 @@ namespace RCT1
         }
 
     private:
-        std::unique_ptr<rct1_s4> ReadAndDecodeS4(IStream* stream, bool isScenario)
+        std::unique_ptr<S4> ReadAndDecodeS4(IStream* stream, bool isScenario)
         {
-            auto s4 = std::make_unique<rct1_s4>();
+            auto s4 = std::make_unique<S4>();
             size_t dataSize = stream->GetLength() - stream->GetPosition();
             auto data = stream->ReadArray<uint8_t>(dataSize);
-            auto decodedData = std::make_unique<uint8_t[]>(sizeof(rct1_s4));
+            auto decodedData = std::make_unique<uint8_t[]>(sizeof(S4));
 
             size_t decodedSize;
             int32_t fileType = sawyercoding_detect_file_type(data.get(), dataSize);
             if (isScenario && (fileType & FILE_VERSION_MASK) != FILE_VERSION_RCT1)
             {
-                decodedSize = sawyercoding_decode_sc4(data.get(), decodedData.get(), dataSize, sizeof(rct1_s4));
+                decodedSize = sawyercoding_decode_sc4(data.get(), decodedData.get(), dataSize, sizeof(S4));
             }
             else
             {
-                decodedSize = sawyercoding_decode_sv4(data.get(), decodedData.get(), dataSize, sizeof(rct1_s4));
+                decodedSize = sawyercoding_decode_sv4(data.get(), decodedData.get(), dataSize, sizeof(S4));
             }
 
-            if (decodedSize == sizeof(rct1_s4))
+            if (decodedSize == sizeof(S4))
             {
-                std::memcpy(s4.get(), decodedData.get(), sizeof(rct1_s4));
+                std::memcpy(s4.get(), decodedData.get(), sizeof(S4));
                 return s4;
             }
             else
@@ -424,12 +424,12 @@ namespace RCT1
         void AddAvailableEntriesFromResearchList()
         {
             size_t researchListCount;
-            const rct1_research_item* researchList = GetResearchList(&researchListCount);
+            const ResearchItem* researchList = GetResearchList(&researchListCount);
             std::bitset<RCT1_RIDE_TYPE_COUNT> rideTypeInResearch = GetRideTypesPresentInResearchList(
                 researchList, researchListCount);
             for (size_t i = 0; i < researchListCount; i++)
             {
-                const rct1_research_item* researchItem = &researchList[i];
+                const ResearchItem* researchItem = &researchList[i];
 
                 if (researchItem->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
                 {
@@ -719,7 +719,7 @@ namespace RCT1
             }
         }
 
-        void ImportRide(Ride* dst, rct1_ride* src, ride_id_t rideIndex)
+        void ImportRide(::Ride* dst, RCT1::Ride* src, ride_id_t rideIndex)
         {
             *dst = {};
             dst->id = rideIndex;
@@ -986,7 +986,7 @@ namespace RCT1
             dst->music_tune_id = 255;
         }
 
-        void SetRideColourScheme(Ride* dst, rct1_ride* src)
+        void SetRideColourScheme(::Ride* dst, RCT1::Ride* src)
         {
             // Colours
             dst->colour_scheme_type = src->colour_scheme;
@@ -1029,8 +1029,8 @@ namespace RCT1
                 for (int i = 0; i < RCT1_MAX_TRAINS_PER_RIDE; i++)
                 {
                     // RCT1 had no third colour
-                    RCT1::RCT1VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::
-                        GetColourSchemeCopyDescriptor(src->vehicle_type);
+                    RCT1::VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
+                        src->vehicle_type);
                     if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_1)
                     {
                         dst->vehicle_colours[i].Body = RCT1::GetColour(src->vehicle_colours[i].body);
@@ -1128,11 +1128,11 @@ namespace RCT1
             FixImportStaff();
         }
 
-        void SetVehicleColours(Vehicle* dst, const rct1_vehicle* src)
+        void SetVehicleColours(::Vehicle* dst, const RCT1::Vehicle* src)
         {
-            rct1_ride* srcRide = &_s4.rides[src->ride];
-            uint8_t vehicleTypeIndex = srcRide->vehicle_type;
-            RCT1::RCT1VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
+            const auto& srcRide = _s4.rides[src->ride];
+            uint8_t vehicleTypeIndex = srcRide.vehicle_type;
+            RCT1::VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
                 vehicleTypeIndex);
 
             // RCT1 had no third colour
@@ -1195,7 +1195,7 @@ namespace RCT1
             staff_update_greyed_patrol_areas();
         }
 
-        void ImportPeep(Peep* dst, const rct1_peep* src)
+        void ImportPeep(::Peep* dst, const RCT1::Peep* src)
         {
             // Peep vs. staff (including which kind)
             dst->SpriteType = RCT1::GetPeepSpriteType(src->sprite_type);
@@ -1851,7 +1851,7 @@ namespace RCT1
             research_reset_items();
 
             size_t researchListCount;
-            const rct1_research_item* researchList = GetResearchList(&researchListCount);
+            const RCT1::ResearchItem* researchList = GetResearchList(&researchListCount);
 
             // Initialise the "seen" tables
             _researchRideEntryUsed.reset();
@@ -1866,29 +1866,29 @@ namespace RCT1
             bool researched = true;
             std::bitset<RCT1_RIDE_TYPE_COUNT> rideTypeInResearch = GetRideTypesPresentInResearchList(
                 researchList, researchListCount);
-            std::vector<rct1_research_item> vehiclesWithMissingRideTypes;
+            std::vector<RCT1::ResearchItem> vehiclesWithMissingRideTypes;
             for (size_t i = 0; i < researchListCount; i++)
             {
-                const rct1_research_item* researchItem = &researchList[i];
-                if (researchItem->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
+                const auto& researchItem = researchList[i];
+                if (researchItem.flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
                 {
-                    if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE)
+                    if (researchItem.item == RCT1_RESEARCH_END_AVAILABLE)
                     {
                         researched = false;
                         continue;
                     }
                     // We don't import the random items yet.
-                    else if (researchItem->item == RCT1_RESEARCH_END_RESEARCHABLE || researchItem->item == RCT1_RESEARCH_END)
+                    else if (researchItem.item == RCT1_RESEARCH_END_RESEARCHABLE || researchItem.item == RCT1_RESEARCH_END)
                     {
                         break;
                     }
                 }
 
-                switch (researchItem->type)
+                switch (researchItem.type)
                 {
                     case RCT1_RESEARCH_TYPE_THEME:
                     {
-                        uint8_t rct1SceneryTheme = researchItem->item;
+                        uint8_t rct1SceneryTheme = researchItem.item;
                         auto sceneryGroupEntryIndex = _sceneryThemeTypeToEntryMap[rct1SceneryTheme];
                         if (sceneryGroupEntryIndex != OBJECT_ENTRY_INDEX_IGNORE
                             && sceneryGroupEntryIndex != OBJECT_ENTRY_INDEX_NULL)
@@ -1899,7 +1899,7 @@ namespace RCT1
                     }
                     case RCT1_RESEARCH_TYPE_RIDE:
                     {
-                        uint8_t rct1RideType = researchItem->item;
+                        uint8_t rct1RideType = researchItem.item;
                         _researchRideTypeUsed[rct1RideType] = true;
 
                         auto ownRideEntryIndex = _rideTypeToRideEntryMap[rct1RideType];
@@ -1913,11 +1913,11 @@ namespace RCT1
                             // Add all vehicles for this ride type that are researched or before this research item
                             for (size_t j = 0; j < researchListCount; j++)
                             {
-                                const rct1_research_item* researchItem2 = &researchList[j];
-                                if (researchItem2->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
+                                const auto& researchItem2 = researchList[j];
+                                if (researchItem2.flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
                                 {
-                                    if (researchItem2->item == RCT1_RESEARCH_END_RESEARCHABLE
-                                        || researchItem2->item == RCT1_RESEARCH_END)
+                                    if (researchItem2.item == RCT1_RESEARCH_END_RESEARCHABLE
+                                        || researchItem2.item == RCT1_RESEARCH_END)
                                     {
                                         break;
                                     }
@@ -1925,10 +1925,10 @@ namespace RCT1
                                     continue;
                                 }
 
-                                if (researchItem2->type == RCT1_RESEARCH_TYPE_VEHICLE
-                                    && researchItem2->related_ride == rct1RideType)
+                                if (researchItem2.type == RCT1_RESEARCH_TYPE_VEHICLE
+                                    && researchItem2.related_ride == rct1RideType)
                                 {
-                                    auto rideEntryIndex2 = _vehicleTypeToRideEntryMap[researchItem2->item];
+                                    auto rideEntryIndex2 = _vehicleTypeToRideEntryMap[researchItem2.item];
                                     bool isOwnType = (ownRideEntryIndex == rideEntryIndex2);
                                     if (isOwnType)
                                     {
@@ -1961,13 +1961,13 @@ namespace RCT1
                         // Only add vehicle if the related ride has been seen, this to make sure that vehicles
                         // are researched only after the ride has been researched. Otherwise, remove them from the research
                         // list, so that they are automatically co-invented when their master ride is invented.
-                        if (_researchRideTypeUsed[researchItem->related_ride])
+                        if (_researchRideTypeUsed[researchItem.related_ride])
                         {
                             InsertResearchVehicle(researchItem, researched);
                         }
-                        else if (!rideTypeInResearch[researchItem->related_ride] && _gameVersion == FILE_VERSION_RCT1_LL)
+                        else if (!rideTypeInResearch[researchItem.related_ride] && _gameVersion == FILE_VERSION_RCT1_LL)
                         {
-                            vehiclesWithMissingRideTypes.push_back(*researchItem);
+                            vehiclesWithMissingRideTypes.push_back(researchItem);
                         }
 
                         break;
@@ -1977,9 +1977,9 @@ namespace RCT1
                         break;
                 }
             }
-            for (const rct1_research_item& researchItem : vehiclesWithMissingRideTypes)
+            for (const auto& researchItem : vehiclesWithMissingRideTypes)
             {
-                InsertResearchVehicle(&researchItem, false);
+                InsertResearchVehicle(researchItem, false);
             }
 
             // Research funding / priority
@@ -2025,7 +2025,7 @@ namespace RCT1
             }
             else
             {
-                ResearchItem researchItem = {};
+                ::ResearchItem researchItem = {};
                 ConvertResearchEntry(&researchItem, _s4.last_research_item, _s4.last_research_type);
                 gResearchLastItem = researchItem;
             }
@@ -2038,45 +2038,44 @@ namespace RCT1
             }
             else
             {
-                ResearchItem researchItem = {};
+                ::ResearchItem researchItem = {};
                 ConvertResearchEntry(&researchItem, _s4.next_research_item, _s4.next_research_type);
                 gResearchNextItem = researchItem;
             }
         }
 
         static std::bitset<RCT1_RIDE_TYPE_COUNT> GetRideTypesPresentInResearchList(
-            const rct1_research_item* researchList, size_t researchListCount)
+            const RCT1::ResearchItem* researchList, size_t researchListCount)
         {
             std::bitset<RCT1_RIDE_TYPE_COUNT> ret = {};
 
             for (size_t i = 0; i < researchListCount; i++)
             {
-                const rct1_research_item* researchItem = &researchList[i];
-                if (researchItem->flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
+                const auto& researchItem = researchList[i];
+                if (researchItem.flags == RCT1_RESEARCH_FLAGS_SEPARATOR)
                 {
-                    if (researchItem->item == RCT1_RESEARCH_END_AVAILABLE
-                        || researchItem->item == RCT1_RESEARCH_END_RESEARCHABLE)
+                    if (researchItem.item == RCT1_RESEARCH_END_AVAILABLE || researchItem.item == RCT1_RESEARCH_END_RESEARCHABLE)
                     {
                         continue;
                     }
-                    else if (researchItem->item == RCT1_RESEARCH_END)
+                    else if (researchItem.item == RCT1_RESEARCH_END)
                     {
                         break;
                     }
                 }
 
-                if (researchItem->type == RCT1_RESEARCH_TYPE_RIDE)
+                if (researchItem.type == RCT1_RESEARCH_TYPE_RIDE)
                 {
-                    ret[researchItem->item] = true;
+                    ret[researchItem.item] = true;
                 }
             }
 
             return ret;
         }
 
-        void InsertResearchVehicle(const rct1_research_item* researchItem, bool researched)
+        void InsertResearchVehicle(const ResearchItem& researchItem, bool researched)
         {
-            uint8_t vehicle = researchItem->item;
+            uint8_t vehicle = researchItem.item;
             auto rideEntryIndex = _vehicleTypeToRideEntryMap[vehicle];
 
             if (!_researchRideEntryUsed[rideEntryIndex])
@@ -2150,7 +2149,7 @@ namespace RCT1
                     uint8_t researchItem = src->Assoc & 0x000000FF;
                     uint8_t researchType = (src->Assoc & 0x00FF0000) >> 16;
 
-                    ResearchItem tmpResearchItem = {};
+                    ::ResearchItem tmpResearchItem = {};
                     ConvertResearchEntry(&tmpResearchItem, researchItem, researchType);
                     dst->Assoc = tmpResearchItem.rawValue;
                 }
@@ -2194,7 +2193,7 @@ namespace RCT1
             gTotalRideValueForMoney = _s4.total_ride_value_for_money;
         }
 
-        void ConvertResearchEntry(ResearchItem* dst, uint8_t srcItem, uint8_t srcType)
+        void ConvertResearchEntry(::ResearchItem* dst, uint8_t srcItem, uint8_t srcType)
         {
             dst->SetNull();
             if (srcType == RCT1_RESEARCH_TYPE_RIDE)
@@ -2426,7 +2425,7 @@ namespace RCT1
             return nullptr;
         }
 
-        const rct1_research_item* GetResearchList(size_t* count)
+        const RCT1::ResearchItem* GetResearchList(size_t* count)
         {
             // Loopy Landscapes stores research items in a different place
             if (_gameVersion == FILE_VERSION_RCT1_LL)
@@ -2589,7 +2588,7 @@ namespace RCT1
         ObjectEntryIndex GetBuildTheBestRideId()
         {
             size_t researchListCount;
-            const rct1_research_item* researchList = GetResearchList(&researchListCount);
+            const RCT1::ResearchItem* researchList = GetResearchList(&researchListCount);
             for (size_t i = 0; i < researchListCount; i++)
             {
                 if (researchList[i].flags == 0xFF)
@@ -2617,7 +2616,7 @@ namespace RCT1
                 output = EntityType::Vehicle;
                 break;
             case RCT12SpriteIdentifier::Peep:
-                if (RCT12PeepType(static_cast<const rct1_peep*>(&src)->type) == RCT12PeepType::Guest)
+                if (RCT12PeepType(static_cast<const RCT1::Peep*>(&src)->type) == RCT12PeepType::Guest)
                 {
                     output = EntityType::Guest;
                 }
@@ -2671,10 +2670,10 @@ namespace RCT1
         return output;
     }
 
-    template<> void S4Importer::ImportEntity<Vehicle>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<::Vehicle>(const RCT12SpriteBase& srcBase)
     {
-        auto* dst = CreateEntityAt<Vehicle>(srcBase.sprite_index);
-        auto* src = static_cast<const rct1_vehicle*>(&srcBase);
+        auto* dst = CreateEntityAt<::Vehicle>(srcBase.sprite_index);
+        auto* src = static_cast<const RCT1::Vehicle*>(&srcBase);
         const auto* ride = get_ride(src->ride);
         if (ride == nullptr)
             return;
@@ -2685,7 +2684,7 @@ namespace RCT1
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(ride->subtype);
 
         dst->vehicle_type = vehicleEntryIndex;
-        dst->SubType = Vehicle::Type(src->type);
+        dst->SubType = ::Vehicle::Type(src->type);
         dst->var_44 = src->var_44;
         dst->remaining_distance = src->remaining_distance;
 
@@ -2749,16 +2748,16 @@ namespace RCT1
             }
         }
 
-        Vehicle::Status statusSrc = Vehicle::Status::MovingToEndOfStation;
-        if (src->status <= static_cast<uint8_t>(Vehicle::Status::StoppedByBlockBrakes))
+        ::Vehicle::Status statusSrc = ::Vehicle::Status::MovingToEndOfStation;
+        if (src->status <= static_cast<uint8_t>(::Vehicle::Status::StoppedByBlockBrakes))
         {
-            statusSrc = static_cast<Vehicle::Status>(src->status);
+            statusSrc = static_cast<::Vehicle::Status>(src->status);
         }
         dst->status = statusSrc;
         dst->TrackSubposition = VehicleTrackSubposition{ src->TrackSubposition };
         dst->TrackLocation = { src->track_x, src->track_y, src->track_z };
         dst->current_station = src->current_station;
-        if (src->boat_location.isNull() || ride->mode != RideMode::BoatHire || statusSrc != Vehicle::Status::TravellingBoat)
+        if (src->boat_location.isNull() || ride->mode != RideMode::BoatHire || statusSrc != ::Vehicle::Status::TravellingBoat)
         {
             dst->BoatLocation.setNull();
             dst->SetTrackDirection(src->GetTrackDirection());
@@ -2790,7 +2789,7 @@ namespace RCT1
     template<> void S4Importer::ImportEntity<Guest>(const RCT12SpriteBase& srcBase)
     {
         auto* dst = CreateEntityAt<Guest>(srcBase.sprite_index);
-        auto* src = static_cast<const rct1_peep*>(&srcBase);
+        auto* src = static_cast<const RCT1::Peep*>(&srcBase);
         ImportPeep(dst, src);
 
         dst->OutsideOfPark = static_cast<bool>(src->outside_of_park);
@@ -2887,7 +2886,7 @@ namespace RCT1
     template<> void S4Importer::ImportEntity<Staff>(const RCT12SpriteBase& srcBase)
     {
         auto* dst = CreateEntityAt<Staff>(srcBase.sprite_index);
-        auto* src = static_cast<const rct1_peep*>(&srcBase);
+        auto* src = static_cast<const RCT1::Peep*>(&srcBase);
         ImportPeep(dst, src);
         dst->AssignedStaffType = StaffType(src->staff_type);
         dst->MechanicTimeSinceCall = src->mechanic_time_since_call;
@@ -3005,7 +3004,7 @@ namespace RCT1
         switch (GetEntityTypeFromRCT1Sprite(src))
         {
             case EntityType::Vehicle:
-                ImportEntity<Vehicle>(src);
+                ImportEntity<::Vehicle>(src);
                 break;
             case EntityType::Guest:
                 ImportEntity<Guest>(src);

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -95,8 +95,8 @@ namespace RCT1
         std::unique_ptr<TrackDesign> ImportAA()
         {
             std::unique_ptr<TrackDesign> td = std::make_unique<TrackDesign>();
-            rct_track_td4_aa td4aa{};
-            _stream.Read(&td4aa, sizeof(rct_track_td4_aa));
+            TD4AA td4aa{};
+            _stream.Read(&td4aa, sizeof(TD4AA));
 
             for (int32_t i = 0; i < RCT12_NUM_COLOUR_SCHEMES; i++)
             {
@@ -113,8 +113,8 @@ namespace RCT1
         std::unique_ptr<TrackDesign> ImportTD4()
         {
             std::unique_ptr<TrackDesign> td = std::make_unique<TrackDesign>();
-            rct_track_td4 td4{};
-            _stream.Read(&td4, sizeof(rct_track_td4));
+            TD4 td4{};
+            _stream.Read(&td4, sizeof(TD4));
             for (int32_t i = 0; i < NUM_COLOUR_SCHEMES; i++)
             {
                 td->track_spine_colour[i] = RCT1::GetColour(td4.track_spine_colour_v0);
@@ -137,7 +137,7 @@ namespace RCT1
             return ImportTD4Base(std::move(td), td4);
         }
 
-        std::unique_ptr<TrackDesign> ImportTD4Base(std::unique_ptr<TrackDesign> td, rct_track_td4& td4Base)
+        std::unique_ptr<TrackDesign> ImportTD4Base(std::unique_ptr<TrackDesign> td, TD4& td4Base)
         {
             td->type = RCT1::GetRideType(td4Base.type, td4Base.vehicle_type);
 
@@ -172,7 +172,7 @@ namespace RCT1
             for (int32_t i = 0; i < RCT1_MAX_TRAINS_PER_RIDE; i++)
             {
                 // RCT1 had no third colour
-                RCT1::RCT1VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
+                RCT1::VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
                     td4Base.vehicle_type);
                 if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_1)
                 {

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -275,9 +275,9 @@ namespace RCT1
         return map[rideType];
     }
 
-    RCT1VehicleColourSchemeCopyDescriptor GetColourSchemeCopyDescriptor(uint8_t vehicleType)
+    VehicleColourSchemeCopyDescriptor GetColourSchemeCopyDescriptor(uint8_t vehicleType)
     {
-        static RCT1VehicleColourSchemeCopyDescriptor map[89] =
+        static VehicleColourSchemeCopyDescriptor map[89] =
         {
             { COPY_COLOUR_1, COPY_COLOUR_2, COLOUR_BLACK }, // RCT1_VEHICLE_TYPE_STEEL_ROLLER_COASTER_TRAIN = 0,
             { COPY_COLOUR_1, COPY_COLOUR_2, COLOUR_BLACK }, // RCT1_VEHICLE_TYPE_STEEL_ROLLER_COASTER_TRAIN_BACKWARDS,

--- a/src/openrct2/rct1/Tables.h
+++ b/src/openrct2/rct1/Tables.h
@@ -16,7 +16,7 @@
 
 namespace RCT1
 {
-    struct RCT1VehicleColourSchemeCopyDescriptor
+    struct VehicleColourSchemeCopyDescriptor
     {
         int8_t colour1, colour2, colour3;
     };
@@ -27,7 +27,7 @@ namespace RCT1
     ObjectEntryIndex GetTerrainEdge(uint8_t terrainEdge);
 
     uint8_t GetRideType(uint8_t rideType, uint8_t vehicleType);
-    RCT1VehicleColourSchemeCopyDescriptor GetColourSchemeCopyDescriptor(uint8_t vehicleType);
+    VehicleColourSchemeCopyDescriptor GetColourSchemeCopyDescriptor(uint8_t vehicleType);
     bool RideTypeUsesVehicles(uint8_t rideType);
     bool PathIsQueue(uint8_t pathType);
     uint8_t NormalisePathAddition(uint8_t pathAdditionType);


### PR DESCRIPTION
As the OpenRCT2 structs are not in a namespace yet had to add a good few `::` and fully qualified the RCT1's as well to make things less ambiguous. 