### PR TITLE
Remove unused argument of wooden_(a|b)_supports_paint_setup

### DIFF
--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -456,13 +456,8 @@ static constexpr const uint16_t word_97B3C4[] = {
  * @returns (al) true if any supports have been drawn, otherwise false.
  */
 bool wooden_a_supports_paint_setup(
-    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags, bool* underground)
+    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags)
 {
-    if (underground != nullptr)
-    {
-        *underground = false;
-    }
-
     if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
         return false;
@@ -477,10 +472,6 @@ bool wooden_a_supports_paint_setup(
     height -= z;
     if (height < 0)
     {
-        if (underground != nullptr)
-        {
-            *underground = true;
-        }
         return false;
     }
     height /= 16;
@@ -501,10 +492,6 @@ bool wooden_a_supports_paint_setup(
         height -= 2;
         if (height < 0)
         {
-            if (underground != nullptr)
-            {
-                *underground = true;
-            }
             return false;
         }
 
@@ -531,10 +518,6 @@ bool wooden_a_supports_paint_setup(
         height--;
         if (height < 0)
         {
-            if (underground != nullptr)
-            {
-                *underground = true;
-            }
             return false;
         }
 
@@ -636,21 +619,17 @@ bool wooden_a_supports_paint_setup(
  * @return (al) whether supports have been drawn
  */
 bool wooden_b_supports_paint_setup(
-    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags, bool* underground)
+    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags)
 {
     bool _9E32B1 = false;
 
     if (session->ViewFlags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS)
     {
-        if (underground != nullptr)
-            *underground = false; // AND
         return false;
     }
 
     if (!(session->Unk141E9DB & PaintSessionFlags::IsPassedSurface))
     {
-        if (underground != nullptr)
-            *underground = false; // AND
         return false;
     }
 
@@ -659,8 +638,6 @@ bool wooden_b_supports_paint_setup(
 
     if (supportLength < 0)
     {
-        if (underground != nullptr)
-            *underground = true; // STC
         return false;
     }
 
@@ -677,8 +654,6 @@ bool wooden_b_supports_paint_setup(
         heightSteps -= 2;
         if (heightSteps < 0)
         {
-            if (underground != nullptr)
-                *underground = true; // STC
             return false;
         }
 
@@ -708,8 +683,6 @@ bool wooden_b_supports_paint_setup(
         heightSteps -= 1;
         if (heightSteps < 0)
         {
-            if (underground != nullptr)
-                *underground = true; // STC
             return false;
         }
 
@@ -806,8 +779,6 @@ bool wooden_b_supports_paint_setup(
         }
     }
 
-    if (underground != nullptr)
-        *underground = false; // AND
     return _9E32B1;
 }
 

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -15,9 +15,9 @@
 constexpr const uint8_t NumVanillaWoodenSupportTypes = 49;
 
 bool wooden_a_supports_paint_setup(
-    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags, bool* underground);
+    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags);
 bool wooden_b_supports_paint_setup(
-    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags, bool* underground);
+    paint_session* session, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags);
 bool metal_a_supports_paint_setup(
     paint_session* session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, uint32_t imageColourFlags);
 bool metal_b_supports_paint_setup(

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -206,7 +206,7 @@ static void ride_entrance_exit_paint(
     {
         image_id = SPRITE_ID_PALETTE_COLOUR_1(COLOUR_SATURATED_BROWN);
     }
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, image_id, nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, image_id);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
 
@@ -332,7 +332,7 @@ static void park_entrance_paint(paint_session* session, uint8_t direction, int32
     {
         image_id = SPRITE_ID_PALETTE_COLOUR_1(COLOUR_SATURATED_BROWN);
     }
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, image_id, nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, image_id);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 80, 0x20);

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -52,7 +52,7 @@ static void large_scenery_paint_supports(
         supportImageColourFlags = dword_F4387C;
     }
 
-    wooden_b_supports_paint_setup(session, (direction & 1), ax, supportHeight, supportImageColourFlags, nullptr);
+    wooden_b_supports_paint_setup(session, (direction & 1), ax, supportHeight, supportImageColourFlags);
 
     int32_t clearanceHeight = ceil2(tileElement.GetClearanceZ() + 15, 16);
 

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -360,11 +360,11 @@ void PaintSmallScenery(paint_session* session, uint8_t direction, int32_t height
             }
             if (direction & 1)
             {
-                wooden_b_supports_paint_setup(session, 1, ax, supportHeight, supportImageColourFlags, nullptr);
+                wooden_b_supports_paint_setup(session, 1, ax, supportHeight, supportImageColourFlags);
             }
             else
             {
-                wooden_b_supports_paint_setup(session, 0, ax, supportHeight, supportImageColourFlags, nullptr);
+                wooden_b_supports_paint_setup(session, 0, ax, supportHeight, supportImageColourFlags);
             }
         }
     }

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -1534,7 +1534,7 @@ void track_paint_util_right_quarter_turn_5_tiles_wooden_supports(
             { 1, 0xFF, 3, 5, 0xFF, 3, 0 },
         };
         uint8_t supportType = supportTypes[direction][trackSequence];
-        wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 }
 

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -190,7 +190,7 @@ static void air_powered_vertical_rc_track_flat(
     uint32_t imageId = imageIds[direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height);
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -216,7 +216,7 @@ static void air_powered_vertical_rc_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 20, 1, height, 0, 6,
         height);
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
@@ -339,7 +339,7 @@ static void air_powered_vertical_rc_track_flat_to_left_bank(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 1, 26, height, 0, 27, height);
     }
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -368,7 +368,7 @@ static void air_powered_vertical_rc_track_flat_to_right_bank(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 1, 26, height, 0, 27, height);
     }
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -519,7 +519,7 @@ static void air_powered_vertical_rc_track_left_bank(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 3, height, 0, 6, height);
     }
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -548,7 +548,7 @@ static void air_powered_vertical_rc_track_brakes(
     uint32_t imageId = imageIds[direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height);
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -660,7 +660,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
             PaintAddImageAsParentRotated(session, direction, supportsImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
             PaintAddImageAsChildRotated(session, direction, trackImageId, 0, 0, 20, 32, bbHeight, height, 0, 6, height);
 
-            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -684,7 +684,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
                 PaintAddImageAsChildRotated(session, direction, trackImageId, 0, 0, 32, 20, bbHeight, height, 0, 6, height);
             }
 
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             if (trackSequence == 0)
             {
@@ -708,13 +708,12 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
                 PaintAddImageAsChildRotated(session, direction, supportsImageId, 0, 0, 32, 20, bbHeight, height, 0, 6, height);
             }
 
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
             break;
         case 5:
-            if (wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr))
+            if (wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]))
             {
                 uint32_t floorImageId;
                 if (direction & 1)
@@ -746,7 +745,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
                 PaintAddImageAsParentRotated(session, direction, trackImageId, 0, 0, 1, 20, 126, height, 27, 6, height);
                 PaintAddImageAsChildRotated(session, direction, supportsImageId, 0, 0, 1, 20, 126, height, 27, 6, height);
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             paint_util_set_vertical_tunnel(session, height + 240);
 
@@ -918,7 +917,7 @@ static void air_powered_vertical_rc_track_booster(
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
@@ -937,7 +936,7 @@ static void air_powered_vertical_rc_track_onride_photo(
     uint32_t imageId = imageIds[direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height);
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -32,28 +32,28 @@ static void heartline_twister_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21354, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21356, 0, 0, 32, 1, 26, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21355, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21357, 0, 0, 32, 1, 26, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21358, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21360, 0, 0, 32, 1, 26, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21359, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21361, 0, 0, 32, 1, 26, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -67,7 +67,7 @@ static void heartline_twister_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21294, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21296, 0, 0, 32, 1, 26, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
@@ -75,7 +75,7 @@ static void heartline_twister_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21295, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21297, 0, 0, 32, 1, 26, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -121,28 +121,28 @@ static void heartline_twister_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21378, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21382, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21379, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21383, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21380, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21384, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21381, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21385, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -155,28 +155,28 @@ static void heartline_twister_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21322, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21326, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21323, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21327, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21324, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21328, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21325, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21329, 0, 0, 32, 1, 50, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -206,28 +206,28 @@ static void heartline_twister_rc_track_60_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21402, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21406, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 21, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 21, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21403, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21407, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 22, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 22, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21404, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21408, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 23, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 23, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21405, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21409, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 24, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 24, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -240,28 +240,28 @@ static void heartline_twister_rc_track_60_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21346, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21350, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 21, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 21, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21347, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21351, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 22, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 22, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21348, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21352, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 23, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 23, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21349, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21353, 0, 0, 32, 1, 98, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 24, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 24, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -291,28 +291,28 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21362, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21366, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21363, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21367, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21364, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21368, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21365, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21369, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -325,28 +325,28 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21306, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21310, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21307, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21311, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21308, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21312, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21309, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21313, 0, 0, 32, 1, 42, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -376,28 +376,28 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21386, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21390, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 13, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 13, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21387, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21391, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 14, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 14, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21388, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21392, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 15, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 15, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21389, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21393, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 16, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 16, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -410,28 +410,28 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21330, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21334, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 13, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 13, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21331, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21335, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 14, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 14, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21332, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21336, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 15, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 15, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21333, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21337, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 16, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 16, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -461,28 +461,28 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21394, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21398, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 17, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 17, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21395, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21399, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 18, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 18, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21396, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21400, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 19, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 19, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21397, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21401, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 20, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 20, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -495,28 +495,28 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21338, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21342, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 17, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 17, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21339, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21343, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 18, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 18, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21340, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21344, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 19, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 19, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21341, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21345, 0, 0, 32, 1, 66, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 20, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 20, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -546,28 +546,28 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21370, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21374, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21371, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21375, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21372, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21376, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21373, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21377, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -580,28 +580,28 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21314, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21318, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21315, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21319, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21316, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21320, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21317, 0, 0, 32, 20, 2, height, 0, 6, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21321, 0, 0, 32, 1, 34, height, 0, 27, height);
-                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -681,7 +681,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21310, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -689,7 +689,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21311, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -697,7 +697,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21312, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -705,7 +705,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21313, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -735,7 +735,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21312, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 6, 5, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 5, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -750,7 +750,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21313, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 7, 6, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 6, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -765,7 +765,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21310, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 6, 7, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 7, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -780,7 +780,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21311, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 7, 8, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 8, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -795,7 +795,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21302, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -803,7 +803,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21303, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -811,7 +811,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21304, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -819,7 +819,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21305, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -945,7 +945,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21312, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 6, 5, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 5, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -960,7 +960,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21313, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 7, 6, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 6, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -975,7 +975,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21310, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 6, 7, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 7, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -990,7 +990,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsChildRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21311, 0, 0, 32, 1, 34, height + 16, 0, 27,
                         height + 16);
-                    wooden_a_supports_paint_setup(session, 7, 8, height + 8, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 8, height + 8, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1005,7 +1005,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21302, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1013,7 +1013,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21303, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1021,7 +1021,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21304, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1029,7 +1029,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21305, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1044,7 +1044,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21310, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1052,7 +1052,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21311, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1060,7 +1060,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21312, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1068,7 +1068,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21313, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 23);
-                    wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1101,7 +1101,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21422, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1109,7 +1109,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21425, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1117,7 +1117,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21428, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1125,7 +1125,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21431, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1141,7 +1141,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21423, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1149,7 +1149,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21426, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1157,7 +1157,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21429, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1165,7 +1165,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21432, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1180,7 +1180,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21424, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1188,7 +1188,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21427, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1196,7 +1196,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21430, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1204,7 +1204,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21433, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1219,7 +1219,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21430, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1227,7 +1227,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21433, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1235,7 +1235,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21424, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1243,7 +1243,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21427, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1258,7 +1258,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21429, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1266,7 +1266,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21432, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1274,7 +1274,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21423, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1282,7 +1282,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21426, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1297,7 +1297,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21428, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1305,7 +1305,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21431, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1313,7 +1313,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21422, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1321,7 +1321,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21425, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1347,7 +1347,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21446, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1355,7 +1355,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21449, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1363,7 +1363,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21452, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1371,7 +1371,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21455, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1387,7 +1387,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21447, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1395,7 +1395,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21450, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1403,7 +1403,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21453, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1411,7 +1411,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21456, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1426,7 +1426,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21448, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1434,7 +1434,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21451, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1442,7 +1442,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21454, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1450,7 +1450,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21457, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1465,7 +1465,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21454, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1473,7 +1473,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21457, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1481,7 +1481,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21448, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1489,7 +1489,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21451, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1504,7 +1504,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21453, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1512,7 +1512,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21456, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1520,7 +1520,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21447, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1528,7 +1528,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21450, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1543,7 +1543,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21452, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1551,7 +1551,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21455, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1559,7 +1559,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21446, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1567,7 +1567,7 @@ static void heartline_twister_rc_track_right_heartline_roll(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21449, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -51,7 +51,7 @@ namespace HybridRC
                 session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), 0, 0, 32, 20, 3,
                 height, 0, 6, height);
         }
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -81,7 +81,7 @@ namespace HybridRC
                 height + 3);
         }
 
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
         if (ride != nullptr)
             track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 10, trackElement);
@@ -107,8 +107,7 @@ namespace HybridRC
                 session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE + direction + 8), 0, 0, 32, 20, 2,
                 height, 0, 6, height + 3);
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -162,8 +161,7 @@ namespace HybridRC
             session->WoodenSupportsPrependTo = ps;
         }
 
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -192,8 +190,7 @@ namespace HybridRC
                 session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE + direction), 0, 0, 32, 20, 3, height,
                 0, 6, height);
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -274,8 +271,7 @@ namespace HybridRC
                     break;
             }
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -357,8 +353,7 @@ namespace HybridRC
                     break;
             }
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -387,8 +382,7 @@ namespace HybridRC
                 session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE + direction + 4), 0, 0, 32, 20, 2,
                 height, 0, 6, height + 3);
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -518,8 +512,7 @@ namespace HybridRC
                     session, direction, GetTrackColour(session) | imageIds[direction], 0, 0, boundBoxLengths[direction].x,
                     boundBoxLengths[direction].y, boundBoxLengths[direction].z, height, boundBoxOffsets[direction].x,
                     boundBoxOffsets[direction].y, boundBoxOffsets[direction].z);
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 if (direction == 0 || direction == 3)
                 {
                     paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -635,25 +628,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 0), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 3), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 6), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 9), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -673,25 +666,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 1), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 4), 0, 0, 16, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 7), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 10), 0, 0, 16, 16,
                             3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -706,25 +699,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 2), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 5), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 8), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE + 11), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -763,25 +756,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 0), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 5), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 10), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 15), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -803,25 +796,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 1), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 6), 0, 0, 36, 16,
                             3, height, 0, 4, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 11), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 16), 0, 0, 32, 14,
                             3, height, 0, 18, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -838,25 +831,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 2), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 7), 0, 0, 16, 16,
                             3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 12), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 17), 0, 0, 33, 33,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -879,25 +872,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 3), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 8), 0, 0, 16, 36,
                             3, height, 4, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 13), 0, 0, 16, 32,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 18), 0, 0, 14, 32,
                             3, height, 18, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -914,25 +907,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 4), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 9), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 14), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE + 19), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -971,25 +964,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 0), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 4), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 8), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 12), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -1006,25 +999,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 1), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 5), 0, 0, 34, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 9), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 13), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1037,25 +1030,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 2), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 6), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 10), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 14), 0, 0, 34, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1065,16 +1058,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1123,25 +1116,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 16), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 20), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 24), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 28), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -1158,25 +1151,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 17), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 21), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 25), 0, 0, 34, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 29), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1189,25 +1182,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 18), 0, 0, 34, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 22), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 26), 0, 0, 28, 28,
                             3, height, 4, 4, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE + 30), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1217,16 +1210,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1321,8 +1314,7 @@ namespace HybridRC
                             PaintAddImageAsParentRotated(
                                 session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_LIFT_TRACK_FLAT_DIAGONAL + 0), -16,
                                 -16, 32, 32, 3, height, -16, -16, height);
-                            wooden_a_supports_paint_setup(
-                                session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                            wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                             break;
                     }
                 }
@@ -1340,16 +1332,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1381,16 +1373,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1483,20 +1475,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1528,20 +1516,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1634,20 +1618,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1679,20 +1659,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1785,16 +1761,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1826,16 +1802,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1928,20 +1904,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -1973,20 +1945,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2078,20 +2046,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2122,20 +2086,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2228,16 +2188,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2269,16 +2229,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2371,20 +2331,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2416,20 +2372,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2522,20 +2474,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2567,20 +2515,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2673,20 +2617,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2718,20 +2658,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2824,20 +2760,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2869,20 +2801,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -2975,20 +2903,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3020,20 +2944,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3126,20 +3046,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3171,20 +3087,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3252,7 +3164,7 @@ namespace HybridRC
                     height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -3291,7 +3203,7 @@ namespace HybridRC
                     height, 0, 27, height);
                 break;
         }
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -3344,8 +3256,7 @@ namespace HybridRC
                     height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -3391,8 +3302,7 @@ namespace HybridRC
                     height, 0, 27, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -3438,8 +3348,7 @@ namespace HybridRC
                     height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -3485,8 +3394,7 @@ namespace HybridRC
                     height, 0, 27, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -3560,7 +3468,7 @@ namespace HybridRC
                     height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -3606,16 +3514,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3633,16 +3541,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3693,16 +3601,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3723,16 +3631,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3786,16 +3694,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3813,16 +3721,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3873,16 +3781,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3903,16 +3811,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3966,16 +3874,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -3993,16 +3901,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4053,16 +3961,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4083,16 +3991,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4146,20 +4054,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4177,20 +4081,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4241,20 +4141,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4275,20 +4171,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4341,20 +4233,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4371,20 +4259,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4434,20 +4318,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4467,20 +4347,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4534,16 +4410,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4561,16 +4437,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4621,16 +4497,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4651,16 +4527,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4714,16 +4590,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4741,16 +4617,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4801,16 +4677,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4831,16 +4707,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -4877,7 +4753,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 1), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -4886,19 +4762,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 5), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 9), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 13), 0, 0,
                             26, 32, 3, height, 6, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -4918,25 +4794,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 2), 0, 0,
                             16, 16, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 6), 0, 0,
                             16, 16, 1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 10), 0, 0,
                             16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 14), 0, 0,
                             22, 22, 3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -4951,7 +4827,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 3), 0, 0,
                             32, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -4960,7 +4836,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 8), 0, 0, 1,
                             32, 26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -4969,13 +4845,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 12), 0, 0,
                             1, 32, 26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_CURVE_BANKED + 15), 0, 0,
                             32, 26, 3, height, 6, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -5017,7 +4893,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 1), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -5026,19 +4902,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 7), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 14), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 20), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5060,25 +4936,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 2), 0, 0,
                             32, 16, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 8), 0, 0,
                             48, 16, 1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 15), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 21), 0, 0,
                             32, 14, 3, height, 0, 18, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5095,7 +4971,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 3), 0, 0,
                             16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -5104,19 +4980,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 10), 0, 0,
                             16, 16, 1, height, 16, 16, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 16), 0, 0,
                             16, 16, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 22), 0, 0,
                             38, 38, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5139,25 +5015,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 4), 0, 0,
                             16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 11), 0, 0,
                             16, 48, 1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 17), 0, 0,
                             16, 32, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 23), 0, 0,
                             14, 32, 3, height, 18, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5174,7 +5050,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 5), 0, 0,
                             32, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -5183,7 +5059,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 13), 0, 0,
                             1, 32, 26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -5192,13 +5068,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 19), 0, 0,
                             1, 32, 26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_MEDIUM_CURVE_BANKED + 24), 0, 0,
                             32, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -5240,7 +5116,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 1), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -5249,19 +5125,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 6), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 12), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 16), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5278,7 +5154,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 2), 0, 0,
                             32, 16, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -5287,19 +5163,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 8), 0, 0,
                             34, 16, 0, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 13), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 17), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -5312,25 +5188,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 3), 0, 0,
                             16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 9), 0, 0,
                             16, 16, 0, height, 16, 16, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 14), 0, 0,
                             16, 16, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 18), 0, 0,
                             34, 16, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -5340,16 +5216,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -5401,13 +5277,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 20), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 24), 0, 0,
                             32, 32, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -5416,7 +5292,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 29), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -5425,7 +5301,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 36), 0, 0,
                             32, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5442,13 +5318,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 21), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 25), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -5457,13 +5333,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 31), 0, 0,
                             34, 16, 0, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 37), 0, 0,
                             32, 16, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -5476,25 +5352,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 22), 0, 0,
                             34, 16, 3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 26), 0, 0,
                             16, 16, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 32), 0, 0,
                             28, 28, 0, height, 4, 4, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_CURVE_BANKED + 38), 0, 0,
                             16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -5504,16 +5380,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
@@ -5582,25 +5458,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 0), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 2), 0, 6,
                             34, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 4), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 6), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5617,16 +5493,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5641,25 +5517,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 1), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 3), 6, 0,
                             20, 34, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 5), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 7), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -5690,25 +5566,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 8), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 10), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 12), 0, 6,
                             34, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 14), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5725,16 +5601,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5749,25 +5625,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 9), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 11), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 13), 6, 0,
                             20, 34, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE + 15), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -5814,25 +5690,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 0), 0, 0,
                             32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 5), 0, 0,
                             34, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 10), 0, 0,
                             32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 15), 0, 0,
                             32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -5854,25 +5730,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 1), 0, 0,
                             32, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 6), 0, 0,
                             32, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 11), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 16), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5889,25 +5765,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 2), 0, 0,
                             16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 7), 0, 0,
                             16, 16, 3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 12), 0, 0,
                             16, 16, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 17), 0, 0,
                             16, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5930,25 +5806,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 3), 0, 0,
                             16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 8), 0, 0,
                             16, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 13), 0, 0,
                             16, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 18), 0, 0,
                             16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -5965,25 +5841,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 4), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 9), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 14), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 19), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -6014,25 +5890,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 20), 0, 0,
                             32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 25), 0, 0,
                             32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 30), 0, 0,
                             34, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 35), 0, 0,
                             32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -6054,25 +5930,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 21), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 26), 0, 0,
                             32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 31), 0, 0,
                             32, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 36), 0, 0,
                             32, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -6089,25 +5965,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 22), 0, 0,
                             16, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 27), 0, 0,
                             16, 16, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 32), 0, 0,
                             16, 16, 3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 37), 0, 0,
                             16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -6130,25 +6006,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 23), 0, 0,
                             16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 28), 0, 0,
                             16, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 33), 0, 0,
                             16, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 38), 0, 0,
                             16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -6165,25 +6041,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 24), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 29), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 34), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE + 39), 0, 0,
                             20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -6230,7 +6106,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 1), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -6239,7 +6115,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 3), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -6248,7 +6124,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 5), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -6257,7 +6133,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 7), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
         track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height, -8, TUNNEL_SQUARE_7, +56, TUNNEL_SQUARE_8);
@@ -6278,7 +6154,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 9), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -6287,7 +6163,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 11), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -6296,7 +6172,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 13), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -6305,7 +6181,7 @@ namespace HybridRC
                 PaintAddImageAsParentRotated(
                     session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_STEEP_SMALL_CURVE + 15), 0, 0, 28, 28, 1,
                     height, 2, 2, height + 99);
-                wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
         track_paint_util_right_quarter_turn_1_tile_tunnel(
@@ -6462,8 +6338,7 @@ namespace HybridRC
                     2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -6506,8 +6381,7 @@ namespace HybridRC
                     2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -6550,8 +6424,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -6594,8 +6467,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -6669,8 +6541,7 @@ namespace HybridRC
                     20, 3, height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -6716,8 +6587,7 @@ namespace HybridRC
                     20, 3, height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -6763,8 +6633,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -6810,8 +6679,7 @@ namespace HybridRC
                     34, height, 0, 27, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -6879,8 +6747,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -6920,8 +6787,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -6978,8 +6844,7 @@ namespace HybridRC
                     20, 3, height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -7022,8 +6887,7 @@ namespace HybridRC
                     20, 3, height, 0, 6, height);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -7066,8 +6930,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -7110,8 +6973,7 @@ namespace HybridRC
                     20, 2, height, 0, 6, height + 3);
                 break;
         }
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -7165,7 +7027,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 0),
                             0, 6, 32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7174,19 +7036,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 3),
                             0, 6, 34, 1, 34, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 6),
                             0, 6, 32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 9),
                             0, 6, 32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -7203,16 +7065,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7227,7 +7089,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 1),
                             6, 0, 20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7236,7 +7098,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 5),
                             6, 0, 1, 34, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7245,13 +7107,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 8),
                             6, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 10),
                             6, 0, 20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -7282,13 +7144,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 11),
                             0, 6, 32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 13),
                             0, 6, 32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7297,13 +7159,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 17),
                             0, 6, 34, 1, 34, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 20),
                             0, 6, 32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -7320,16 +7182,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7344,7 +7206,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 12),
                             6, 0, 20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7353,7 +7215,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 15),
                             6, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7362,13 +7224,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 19),
                             6, 0, 1, 34, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_SMALL_CURVE_BANKED + 21),
                             6, 0, 20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -7415,7 +7277,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 0),
                             0, 0, 32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7424,19 +7286,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 6),
                             0, 0, 34, 1, 34, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 15),
                             0, 0, 32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 21),
                             0, 0, 32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -7458,7 +7320,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 1),
                             0, 0, 32, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7467,19 +7329,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 8),
                             0, 0, 1, 1, 34, height, 30, 30, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 16),
                             0, 0, 32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 22),
                             0, 0, 32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7496,7 +7358,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 2),
                             0, 0, 16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7505,19 +7367,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 10),
                             0, 0, 1, 1, 34, height, 30, 30, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 17),
                             0, 0, 1, 1, 3, height, 64, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 23),
                             0, 0, 16, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7540,7 +7402,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 3),
                             0, 0, 16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7549,19 +7411,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 12),
                             0, 0, 1, 1, 34, height, 30, 30, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 18),
                             0, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 24),
                             0, 0, 16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7578,7 +7440,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 4),
                             0, 0, 20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7587,7 +7449,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 14),
                             0, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7596,13 +7458,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 20),
                             0, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 25),
                             0, 0, 20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -7633,13 +7495,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 26),
                             0, 0, 32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 31),
                             0, 0, 32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7648,13 +7510,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 38),
                             0, 0, 34, 1, 34, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 47),
                             0, 0, 32, 20, 3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -7676,13 +7538,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 27),
                             0, 0, 32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 32),
                             0, 0, 32, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7691,13 +7553,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 40),
                             0, 0, 1, 1, 34, height, 30, 30, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 48),
                             0, 0, 32, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7714,13 +7576,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 28),
                             0, 0, 16, 16, 3, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 33),
                             0, 0, 1, 1, 3, height, 64, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7729,13 +7591,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 42),
                             0, 0, 1, 1, 34, height, 30, 30, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 49),
                             0, 0, 16, 16, 3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7758,13 +7620,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 29),
                             0, 0, 16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 34),
                             0, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7773,13 +7635,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 44),
                             0, 0, 1, 1, 34, height, 30, 30, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 50),
                             0, 0, 16, 32, 3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7796,7 +7658,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 30),
                             0, 0, 20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -7805,7 +7667,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 36),
                             0, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7814,13 +7676,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 46),
                             0, 0, 1, 32, 34, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_GENTLE_MEDIUM_CURVE_BANKED + 51),
                             0, 0, 20, 32, 3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -7867,25 +7729,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 0), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 4), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 3), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 7), 0, 0, 32, 32, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -7902,25 +7764,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 1), 0, 0, 32, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 5), 0, 0, 34, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 2), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 6), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7937,25 +7799,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 2), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 6), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 1), 0, 0, 32, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 5), 0, 0, 34, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -7972,25 +7834,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 3), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 7), 0, 0, 32, 32, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 0), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 4), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8021,25 +7883,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 8), 0, 0, 32, 32, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 12), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 11), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 15), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -8056,25 +7918,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 9), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 13), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 10), 0, 0, 34, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 14), 0, 0, 32, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8091,25 +7953,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 10), 0, 0, 34, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 14), 0, 0, 32, 26, 3,
                             height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 9), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 13), 0, 0, 32, 26, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8126,25 +7988,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 11), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 15), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 8), 0, 0, 32, 32, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_S_BEND + 12), 0, 0, 32, 20, 3,
                             height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8178,7 +8040,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 1), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8187,19 +8049,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 5), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 9), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 13), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -8213,16 +8075,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -8234,25 +8096,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 2), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 6), 0, 0, 16, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 10), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 14), 0, 0, 16, 16,
                             3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8267,7 +8129,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 3), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8276,7 +8138,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 8), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8285,13 +8147,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 12), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 15), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8313,7 +8175,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 13), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8322,7 +8184,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 1), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8331,13 +8193,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 5), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 9), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8356,16 +8218,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -8377,25 +8239,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 14), 0, 0, 16, 16,
                             3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 2), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 6), 0, 0, 16, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 10), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8410,13 +8272,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 15), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 3), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8425,7 +8287,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 8), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -8434,7 +8296,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 12), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -8460,13 +8322,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 16), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 19), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8475,7 +8337,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 24), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -8484,7 +8346,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 29), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -8498,16 +8360,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -8519,25 +8381,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 17), 0, 0, 16, 16,
                             3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 20), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 25), 0, 0, 16, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 30), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8552,7 +8414,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 18), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8561,7 +8423,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 22), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8570,13 +8432,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 27), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 31), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8598,7 +8460,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 19), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8607,7 +8469,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 24), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8616,13 +8478,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 29), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 16), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8641,16 +8503,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -8662,25 +8524,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 20), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 25), 0, 0, 16, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 30), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 17), 0, 0, 16, 16,
                             3, height, 16, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8698,7 +8560,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 22), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8707,19 +8569,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 27), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 31), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_SMALL_HELIX + 18), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -8774,7 +8636,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 1), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8783,19 +8645,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 7), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 14), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 20), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -8817,25 +8679,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 2), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 8), 0, 0, 33, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 15), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 21), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8852,7 +8714,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 3), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8861,19 +8723,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 10), 0, 0, 16, 16,
                             1, height, 16, 16, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 16), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 22), 0, 0, 34, 34,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8896,25 +8758,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 4), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 11), 0, 0, 16, 33,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 17), 0, 0, 16, 32,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 23), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -8931,7 +8793,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 5), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8940,7 +8802,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 13), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8949,13 +8811,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 19), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 24), 0, 0, 28, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -8977,7 +8839,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 20), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -8986,7 +8848,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 1), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8995,13 +8857,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 7), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 14), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -9028,25 +8890,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 21), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 2), 0, 0, 16, 32,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 8), 0, 0, 16, 32,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 15), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9063,13 +8925,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 22), 0, 0, 16, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 3), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9078,13 +8940,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 10), 0, 0, 16, 16,
                             1, height, 16, 16, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 16), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9107,25 +8969,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 23), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 4), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 11), 0, 0, 32, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 17), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9142,13 +9004,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 24), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 5), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9157,7 +9019,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 13), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -9166,7 +9028,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 19), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -9192,13 +9054,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 25), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 30), 0, 0, 32, 32,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9207,7 +9069,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 37), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -9216,7 +9078,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 45), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -9238,25 +9100,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 26), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 31), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 38), 0, 0, 33, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 46), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9273,13 +9135,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 27), 0, 0, 34, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 32), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9288,13 +9150,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 40), 0, 0, 16, 16,
                             1, height, 16, 16, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 47), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9317,25 +9179,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 28), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 33), 0, 0, 16, 32,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 41), 0, 0, 16, 33,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 48), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9352,7 +9214,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 29), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -9361,7 +9223,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 35), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9370,13 +9232,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 43), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 49), 0, 0, 32, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -9398,7 +9260,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 30), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -9407,7 +9269,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 37), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9416,13 +9278,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 45), 0, 0, 1, 32,
                             26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 25), 0, 0, 20, 32,
                             3, height, 6, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -9449,25 +9311,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 31), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 38), 0, 0, 16, 32,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 46), 0, 0, 16, 32,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 26), 0, 0, 16, 32,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9484,7 +9346,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 32), 0, 0, 16, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -9493,19 +9355,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 40), 0, 0, 16, 16,
                             1, height, 16, 16, height + 28);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 47), 0, 0, 16, 16,
                             3, height, 16, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 27), 0, 0, 16, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9528,25 +9390,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 33), 0, 0, 32, 16,
                             3, height, 0, 0, height);
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 41), 0, 0, 32, 16,
                             1, height, 0, 0, height + 28);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 48), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 28), 0, 0, 32, 16,
                             3, height, 0, 16, height);
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -9566,7 +9428,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 35), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -9575,19 +9437,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 43), 0, 0, 32, 1,
                             26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 49), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_LARGE_HELIX + 29), 0, 0, 32, 20,
                             3, height, 0, 6, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -9668,8 +9530,7 @@ namespace HybridRC
                             0, height, 0, 6, height + 40);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 if (direction == 0 || direction == 3)
                 {
                     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -9713,8 +9574,7 @@ namespace HybridRC
                             0, height, 0, 6, height + 40);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 48, 0x20);
                 break;
@@ -9763,8 +9623,7 @@ namespace HybridRC
                         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_INVERTED_9);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 48, 0x20);
                 break;
@@ -9813,8 +9672,7 @@ namespace HybridRC
                             0, height, 0, 6, height + 40);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 if (direction == 0 || direction == 3)
                 {
                     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -9858,8 +9716,7 @@ namespace HybridRC
                             0, height, 0, 6, height + 40);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 48, 0x20);
                 break;
@@ -9899,8 +9756,7 @@ namespace HybridRC
                             0, height, 0, 6, height + 56);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 switch (direction)
                 {
                     case 1:
@@ -10011,8 +9867,7 @@ namespace HybridRC
                             64, height, 0, 32, height);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 64, 0x20);
                 break;
@@ -10052,8 +9907,7 @@ namespace HybridRC
                             32, height, 0, 32, height);
                         break;
                 }
-                wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 if (direction == 0 || direction == 3)
                 {
                     paint_util_push_tunnel_rotated(session, direction, height + 16, TUNNEL_0);
@@ -10078,7 +9932,7 @@ namespace HybridRC
         PaintAddImageAsParentRotated(
             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BRAKE + (direction & 1)), 0, 0, 32, 20, 3,
             height, 0, 6, height);
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -10093,7 +9947,7 @@ namespace HybridRC
             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_FLAT + (direction & 1)), 0, 0, 32, 20, 0, height,
             0, 6, height + 3);
         track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -10130,7 +9984,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 50 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 50 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 if (direction == 0 || direction == 3)
                 {
                     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -10163,7 +10017,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 54 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 54 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 48, 0x20);
                 break;
@@ -10192,7 +10046,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 58 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 58 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 64, 0x20);
                 break;
@@ -10221,7 +10075,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 62 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 62 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 switch (direction)
                 {
                     case 1:
@@ -10268,7 +10122,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 66 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 66 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 if (direction == 0 || direction == 3)
                 {
                     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_7);
@@ -10301,7 +10155,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 70 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 70 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 80, 0x20);
                 break;
@@ -10330,7 +10184,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 74 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 74 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
                 paint_util_set_general_support_height(session, height + 56, 0x20);
                 break;
@@ -10359,7 +10213,7 @@ namespace HybridRC
                         break;
                 }
                 wooden_a_supports_paint_setup(
-                    session, direction & 1, 78 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    session, direction & 1, 78 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
                 switch (direction)
                 {
                     case 1:
@@ -10396,7 +10250,7 @@ namespace HybridRC
         PaintAddImageAsParentRotated(
             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BLOCK_BRAKE + (direction & 1)), 0, 0, 32, 20, 3,
             height, 0, 6, height);
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -10409,7 +10263,7 @@ namespace HybridRC
         PaintAddImageAsParentRotated(
             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_BOOSTER + (direction & 1)), 0, 0, 32, 20, 3,
             height, 0, 6, height);
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -10422,8 +10276,7 @@ namespace HybridRC
         PaintAddImageAsParentRotated(
             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_POWERED_LIFT + direction), 0, 0, 32, 20, 3,
             height, 0, 6, height);
-        wooden_a_supports_paint_setup(
-            session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
         if (direction == 0 || direction == 3)
         {
             paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -10449,7 +10302,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 0), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -10458,19 +10311,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 3), 0, 6,
                             34, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 5), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 7), 0, 6,
                             32, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -10487,16 +10340,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10511,25 +10364,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 1), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 4), 6, 0,
                             20, 34, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 6), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 8), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -10560,13 +10413,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 9), 0, 6,
                             32, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 11), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10575,13 +10428,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 14), 0, 6,
                             34, 1, 26, height, 0, 27, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 16), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -10598,16 +10451,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10622,25 +10475,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 10), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 12), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 15), 6, 0,
                             20, 34, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 17), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -10671,25 +10524,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 12), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 15), 0, 6,
                             34, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 17), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 10), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -10706,16 +10559,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10730,7 +10583,7 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 11), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -10739,19 +10592,19 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 14), 6, 0,
                             1, 34, 26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 16), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 9), 6, 0,
                             32, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)
@@ -10782,25 +10635,25 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 8), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 1), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 4), 0, 6,
                             34, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 6), 0, 6,
                             32, 20, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 if (direction == 0 || direction == 3)
@@ -10817,16 +10670,16 @@ namespace HybridRC
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 paint_util_set_segment_support_height(
@@ -10841,13 +10694,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 7), 6, 0,
                             32, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 0), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -10856,13 +10709,13 @@ namespace HybridRC
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 3), 6, 0,
                             1, 34, 26, height, 27, 0, height);
-                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session) | (SPR_G2_HYBRID_TRACK_TURN_BANK_TRANSITION + 5), 6, 0,
                             20, 32, 3, height);
-                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
                 switch (direction)

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -42,22 +42,22 @@ static void mine_train_rc_track_flat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20054, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20055, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20056, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20057, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -69,13 +69,13 @@ static void mine_train_rc_track_flat(
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20052, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20053, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -131,22 +131,22 @@ static void mine_train_rc_track_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20102, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20103, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20104, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20105, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -157,22 +157,22 @@ static void mine_train_rc_track_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20074, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20075, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20076, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20077, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -198,22 +198,22 @@ static void mine_train_rc_track_60_deg_up(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20090, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 21, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 21, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20091, 0, 0, 1, 32, 98, height, 27, 0, height);
-            wooden_a_supports_paint_setup(session, 7, 22, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 22, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20092, 0, 0, 1, 32, 98, height, 27, 0, height);
-            wooden_a_supports_paint_setup(session, 6, 23, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 23, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20093, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 24, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 24, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -240,22 +240,22 @@ static void mine_train_rc_track_flat_to_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20094, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20095, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20096, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20097, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -266,22 +266,22 @@ static void mine_train_rc_track_flat_to_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20066, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20067, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20068, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20069, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -307,26 +307,26 @@ static void mine_train_rc_track_25_deg_up_to_60_deg_up(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20078, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 13, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 13, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20079, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20082, 0, 0, 32, 1, 66, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 14, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 14, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20080, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20083, 0, 0, 32, 1, 66, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 15, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 15, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20081, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 16, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 16, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -351,26 +351,26 @@ static void mine_train_rc_track_60_deg_up_to_25_deg_up(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20084, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 17, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 17, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20085, 0, 0, 24, 1, 61, height, 4, 29, height - 16);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20088, 0, 0, 32, 2, 66, height, 0, 4, height);
-            wooden_a_supports_paint_setup(session, 7, 18, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 18, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session->WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20086, 0, 0, 24, 1, 61, height, 4, 29, height - 16);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20089, 0, 0, 32, 2, 66, height, 0, 4, height);
-            wooden_a_supports_paint_setup(session, 6, 19, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 19, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20087, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 20, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 20, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -397,22 +397,22 @@ static void mine_train_rc_track_25_deg_up_to_flat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20098, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20099, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20100, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20101, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -423,22 +423,22 @@ static void mine_train_rc_track_25_deg_up_to_flat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20070, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20071, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20072, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 20073, 0, 0, 32, 20, 1, height, 0, 6, height);
-                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -515,22 +515,22 @@ static void mine_train_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20155, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20160, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20165, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20150, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -551,24 +551,24 @@ static void mine_train_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20154, 0, 0, 32, 16, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20159, 0, 0, 32, 16, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20164, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20149, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -585,24 +585,24 @@ static void mine_train_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20153, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20158, 0, 0, 16, 16, 1, height, 16, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20163, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20148, 0, 0, 16, 16, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -625,23 +625,23 @@ static void mine_train_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20152, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20157, 0, 0, 16, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20162, 0, 0, 16, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20147, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -657,22 +657,22 @@ static void mine_train_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20151, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20156, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20161, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20146, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -711,24 +711,24 @@ static void mine_train_rc_track_flat_to_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20106, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20114, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20107, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20115, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20108, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20109, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -746,26 +746,26 @@ static void mine_train_rc_track_flat_to_right_bank(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20110, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20111, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20112, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20116, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20113, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20117, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -785,24 +785,24 @@ static void mine_train_rc_track_left_bank_to_flat(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20112, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20116, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20113, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20117, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20110, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20111, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -820,26 +820,26 @@ static void mine_train_rc_track_right_bank_to_flat(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20108, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20109, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20106, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20114, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20107, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20115, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -863,23 +863,23 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20186, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20180, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20185, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20170, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -900,25 +900,25 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20174, 0, 0, 32, 16, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20179, 0, 0, 32, 16, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20184, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20169, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -935,24 +935,24 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20173, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20178, 0, 0, 16, 16, 1, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20183, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20168, 0, 0, 16, 16, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -975,24 +975,24 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20172, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20177, 0, 0, 16, 32, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20182, 0, 0, 16, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20167, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1008,13 +1008,13 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20171, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20176, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1022,12 +1022,12 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20187, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20166, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1066,24 +1066,24 @@ static void mine_train_rc_track_left_bank_to_25_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20118, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20122, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20119, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20123, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20120, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20121, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -1108,26 +1108,26 @@ static void mine_train_rc_track_right_bank_to_25_deg_up(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20124, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20125, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20126, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20128, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20127, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20129, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -1154,24 +1154,24 @@ static void mine_train_rc_track_25_deg_up_to_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20130, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20134, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20131, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20135, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20132, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20133, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -1196,26 +1196,26 @@ static void mine_train_rc_track_25_deg_up_to_right_bank(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20136, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20137, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20138, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20140, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20139, 0, 0, 32, 20, 1, height, 0, 6, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20141, 0, 0, 32, 1, 34, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -1272,22 +1272,22 @@ static void mine_train_rc_track_left_bank(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20142, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20143, 0, 0, 32, 1, 26, height, 0, 27, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20144, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20145, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1316,22 +1316,22 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20250, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20255, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20260, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20265, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1352,24 +1352,24 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20251, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20256, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20261, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20266, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1386,24 +1386,24 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20252, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20257, 0, 0, 16, 16, 1, height, 16, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20262, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20267, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1426,23 +1426,23 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20253, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20258, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20263, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20268, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1458,22 +1458,22 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20254, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20259, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20264, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20269, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1504,22 +1504,22 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20230, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20235, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20240, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20245, 0, 0, 32, 27, 1, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1541,23 +1541,23 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20231, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20236, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20241, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20246, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1573,25 +1573,25 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20232, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20237, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20242, 0, 0, 16, 16, 1, height, 16, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20247, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1614,23 +1614,23 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20233, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20238, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20243, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20248, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1646,22 +1646,22 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20234, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20239, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20244, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20249, 0, 0, 27, 32, 1, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1710,22 +1710,22 @@ static void mine_train_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20270, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20274, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20273, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20277, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1741,22 +1741,22 @@ static void mine_train_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20271, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20275, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20272, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20276, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1772,22 +1772,22 @@ static void mine_train_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20272, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20276, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20271, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20275, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1803,22 +1803,22 @@ static void mine_train_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20273, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20277, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20270, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20274, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1849,22 +1849,22 @@ static void mine_train_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20278, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20282, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20281, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20285, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1880,22 +1880,22 @@ static void mine_train_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20279, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20283, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20280, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20284, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1911,22 +1911,22 @@ static void mine_train_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20280, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20284, 0, 0, 32, 26, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20279, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20283, 0, 0, 32, 26, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1942,22 +1942,22 @@ static void mine_train_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20281, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20285, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20278, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20282, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1988,22 +1988,22 @@ static void mine_train_rc_track_left_quarter_turn_3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20193, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20196, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20199, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20190, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2017,16 +2017,16 @@ static void mine_train_rc_track_left_quarter_turn_3(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -2064,22 +2064,22 @@ static void mine_train_rc_track_left_quarter_turn_3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20191, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20194, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20197, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20188, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2122,23 +2122,23 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20212, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20208, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20211, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20202, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2152,16 +2152,16 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -2200,13 +2200,13 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20203, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20206, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2214,12 +2214,12 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20213, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20200, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2259,22 +2259,22 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20225, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20227, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20229, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20223, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2288,16 +2288,16 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 56, 0x20);
@@ -2313,22 +2313,22 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20224, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20226, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20228, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20222, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2359,22 +2359,22 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20214, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20216, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20218, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20220, 0, 6, 32, 20, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2388,16 +2388,16 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 56, 0x20);
@@ -2413,22 +2413,22 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20215, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20217, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20219, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20221, 6, 0, 20, 32, 1, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2480,23 +2480,23 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20312, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20308, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20311, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20302, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2514,16 +2514,16 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -2562,13 +2562,13 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20303, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20306, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2576,12 +2576,12 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20313, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20300, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2606,7 +2606,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20302, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2614,18 +2614,18 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20312, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20308, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20311, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2648,16 +2648,16 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -2696,18 +2696,18 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20300, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20303, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20306, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2715,7 +2715,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20313, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2745,18 +2745,18 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20286, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20289, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20292, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2764,7 +2764,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20299, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2782,16 +2782,16 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -2830,7 +2830,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20288, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2838,18 +2838,18 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20298, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20294, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20297, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2874,13 +2874,13 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20289, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20292, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2888,12 +2888,12 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20299, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20286, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2916,16 +2916,16 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -2967,23 +2967,23 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20298, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20294, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20297, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20288, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3046,23 +3046,23 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20356, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20350, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20355, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20340, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3087,25 +3087,25 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20344, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20349, 0, 0, 32, 16, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20354, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20339, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3122,7 +3122,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20343, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3131,18 +3131,18 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20178, 0, 0, 16, 16, 1, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20353, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20338, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3163,7 +3163,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20342, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3172,18 +3172,18 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20177, 0, 0, 16, 32, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20352, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20337, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3199,13 +3199,13 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20341, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20346, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3213,12 +3213,12 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20357, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20336, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3243,7 +3243,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20340, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3251,18 +3251,18 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20356, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20350, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20355, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3293,24 +3293,24 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20339, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20344, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20349, 0, 0, 16, 32, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20354, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3326,13 +3326,13 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20338, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20343, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3341,13 +3341,13 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20178, 0, 0, 16, 16, 1, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20353, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3368,13 +3368,13 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20337, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20342, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3383,12 +3383,12 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20177, 0, 0, 32, 16, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20352, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3404,18 +3404,18 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20336, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20341, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20346, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3423,7 +3423,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20357, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3453,18 +3453,18 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20314, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20319, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20324, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3472,7 +3472,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20335, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3498,24 +3498,24 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20315, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20320, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20325, 0, 0, 32, 16, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20330, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3531,25 +3531,25 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20316, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20321, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20326, 0, 0, 16, 16, 1, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20331, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3570,24 +3570,24 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20317, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20322, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20327, 0, 0, 16, 32, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20332, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3603,7 +3603,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20318, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3611,18 +3611,18 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20334, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20328, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20333, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3647,13 +3647,13 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20319, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20324, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3661,12 +3661,12 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20335, 0, 0, 1, 32, 26, height, 27, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20314, 0, 0, 20, 32, 1, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3697,24 +3697,24 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20320, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20325, 0, 0, 16, 32, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20330, 0, 0, 16, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20315, 0, 0, 16, 32, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3731,24 +3731,24 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20321, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20326, 0, 0, 16, 16, 1, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20331, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20316, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3768,25 +3768,25 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20322, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20327, 0, 0, 32, 16, 1, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20332, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20317, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -3805,23 +3805,23 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20334, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20328, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20333, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20318, 0, 0, 32, 20, 1, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3879,13 +3879,13 @@ static void mine_train_rc_track_brakes(
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20058, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20059, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -3903,22 +3903,22 @@ static void mine_train_rc_track_on_ride_photo(
         case 0:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20052, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20053, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20052, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 20053, 0, 0, 32, 20, 1, height, 0, 6, height);
-            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     track_paint_util_onride_photo_paint(session, direction, height + 2, trackElement);
@@ -3940,22 +3940,22 @@ static void mine_train_rc_track_left_eighth_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20452, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20456, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20460, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20464, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3971,24 +3971,24 @@ static void mine_train_rc_track_left_eighth_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20453, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20457, 0, 0, 34, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20461, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20465, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4001,24 +4001,24 @@ static void mine_train_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20454, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20458, 0, 0, 16, 16, 1, height, 16, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20462, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20466, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4028,16 +4028,16 @@ static void mine_train_rc_track_left_eighth_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4085,22 +4085,22 @@ static void mine_train_rc_track_right_eighth_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20436, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20440, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20444, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20448, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4117,23 +4117,23 @@ static void mine_train_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20437, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20441, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20445, 0, 0, 34, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20449, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4145,24 +4145,24 @@ static void mine_train_rc_track_right_eighth_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20438, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20442, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20446, 0, 0, 28, 28, 1, height, 4, 4, height);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20450, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4172,16 +4172,16 @@ static void mine_train_rc_track_right_eighth_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4248,23 +4248,23 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20484, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20488, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20492, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20496, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4280,25 +4280,25 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20485, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20489, 0, 0, 34, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20493, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20497, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4311,24 +4311,24 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20486, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20490, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20494, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20498, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4338,16 +4338,16 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4395,24 +4395,24 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20468, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20472, 0, 0, 32, 32, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20476, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20480, 0, 0, 32, 1, 26, height, 0, 27,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4429,24 +4429,24 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20469, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20473, 0, 0, 32, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20477, 0, 0, 34, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20481, 0, 0, 32, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4458,25 +4458,25 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20470, 0, 0, 16, 16, 1, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20474, 0, 0, 16, 16, 1, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20478, 0, 0, 28, 28, 0, height, 4, 4,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20482, 0, 0, 16, 16, 1, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4486,16 +4486,16 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4590,16 +4590,16 @@ static void mine_train_rc_track_diag_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20386, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4611,16 +4611,16 @@ static void mine_train_rc_track_diag_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20358, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4633,19 +4633,19 @@ static void mine_train_rc_track_diag_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20388, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4654,19 +4654,19 @@ static void mine_train_rc_track_diag_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20360, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4744,20 +4744,16 @@ static void mine_train_rc_track_diag_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20398, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4769,20 +4765,16 @@ static void mine_train_rc_track_diag_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20370, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4795,23 +4787,19 @@ static void mine_train_rc_track_diag_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20400, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4820,23 +4808,19 @@ static void mine_train_rc_track_diag_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20372, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4898,16 +4882,16 @@ static void mine_train_rc_track_diag_60_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20382, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4917,19 +4901,19 @@ static void mine_train_rc_track_diag_60_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20384, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4992,16 +4976,16 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20390, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5013,16 +4997,16 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20362, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5035,19 +5019,19 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20392, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5056,19 +5040,19 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20364, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5130,16 +5114,16 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20374, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5149,19 +5133,19 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20376, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5208,16 +5192,16 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20378, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5227,19 +5211,19 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20380, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5302,20 +5286,16 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20394, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5327,20 +5307,16 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20366, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5353,23 +5329,19 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20396, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5378,23 +5350,19 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20368, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5472,20 +5440,16 @@ static void mine_train_rc_track_diag_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20400, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5497,20 +5461,16 @@ static void mine_train_rc_track_diag_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20372, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5523,23 +5483,19 @@ static void mine_train_rc_track_diag_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20398, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5548,23 +5504,19 @@ static void mine_train_rc_track_diag_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20370, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5626,16 +5578,16 @@ static void mine_train_rc_track_diag_60_deg_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20384, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5645,19 +5597,19 @@ static void mine_train_rc_track_diag_60_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20382, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5719,20 +5671,16 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20396, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5744,20 +5692,16 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20368, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5769,23 +5713,19 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20394, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5794,23 +5734,19 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20366, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_b_supports_paint_setup(
-                            session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5872,16 +5808,16 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20380, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5891,19 +5827,19 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20378, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5950,16 +5886,16 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20376, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -5969,19 +5905,19 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20374, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6044,16 +5980,16 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20392, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6065,16 +6001,16 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20364, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6087,19 +6023,19 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20390, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6108,19 +6044,19 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 20362, -16, -16, 32, 32, 1, height, -16,
                             -16, height);
-                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6185,16 +6121,16 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20410, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6204,19 +6140,19 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20408, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6263,16 +6199,16 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20411, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6282,10 +6218,10 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6294,10 +6230,10 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20415, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6347,16 +6283,16 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20415, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6366,19 +6302,19 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20411, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6425,16 +6361,16 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20408, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6444,10 +6380,10 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6456,10 +6392,10 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20410, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6509,16 +6445,16 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20430, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6528,19 +6464,19 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20428, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6587,16 +6523,16 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20431, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6606,10 +6542,10 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6618,10 +6554,10 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20435, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6671,16 +6607,16 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20420, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6690,19 +6626,19 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20418, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6749,16 +6685,16 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20421, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6768,10 +6704,10 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6780,10 +6716,10 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20425, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6831,16 +6767,16 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20425, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -6848,19 +6784,19 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20421, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -6904,16 +6840,16 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20418, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -6921,10 +6857,10 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 10, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 11, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6933,10 +6869,10 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20420, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 8, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 9, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -6985,16 +6921,16 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20435, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7004,19 +6940,19 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20431, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7063,16 +6999,16 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20428, -16, -16, 32, 32, 1, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7082,10 +7018,10 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7094,10 +7030,10 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20430, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7145,16 +7081,16 @@ static void mine_train_rc_track_diag_left_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20402, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7165,19 +7101,19 @@ static void mine_train_rc_track_diag_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20404, -16, -16, 32, 32, 3, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7227,16 +7163,16 @@ static void mine_train_rc_track_diag_right_bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20404, -16, -16, 32, 32, 3, height, -16, -16,
                         height);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7247,19 +7183,19 @@ static void mine_train_rc_track_diag_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 10, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 11, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 20402, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 9, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -7291,7 +7227,7 @@ static void mine_train_rc_track_block_brakes(
     PaintAddImageAsParentRotated(
         session, direction, session->TrackColours[SCHEME_TRACK] | _MineTrainBlockBrakeImages[direction][isClosed], 0, 0, 32, 20,
         1, height, 0, 6, height);
-    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -212,7 +212,7 @@ static void paint_reverse_freefall_rc_flat(
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
@@ -233,8 +233,7 @@ static void paint_reverse_freefall_rc_station(
         imageId = reverse_freefall_rc_track_pieces_station[direction] | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsChild(session, imageId, 0, 0, 32, 20, 1, height, 0, 6, height);
 
-        wooden_a_supports_paint_setup(
-            session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
     else if (direction == 1 || direction == 3)
@@ -247,8 +246,7 @@ static void paint_reverse_freefall_rc_station(
         imageId = reverse_freefall_rc_track_pieces_station[direction] | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsChild(session, imageId, 0, 0, 20, 32, 1, height, 6, 0, height);
 
-        wooden_a_supports_paint_setup(
-            session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, (direction & 1) ? 1 : 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
@@ -306,13 +304,12 @@ static void paint_reverse_freefall_rc_slope(
                 PaintAddImageAsChildRotated(session, direction, supportsImageId, 0, 0, 32, 20, bbHeight, height, 0, 6, height);
             }
 
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
             break;
         case 5:
-            if (wooden_a_supports_paint_setup(
-                    session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr))
+            if (wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]))
             {
                 uint32_t floorImageId;
                 if (direction & 1)
@@ -348,7 +345,7 @@ static void paint_reverse_freefall_rc_slope(
                 PaintAddImageAsParentRotated(session, direction, trackImageId, 0, 0, 1, 20, 126, height, 27, 6, height);
                 PaintAddImageAsChildRotated(session, direction, supportsImageId, 0, 0, 1, 20, 126, height, 27, 6, height);
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + supportHeights[trackSequence], 0x20);
             break;
@@ -411,7 +408,7 @@ static void paint_reverse_freefall_rc_onride_photo(
     uint32_t imageId = imageIds[direction] | colour;
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 1, height, 0, 6, height);
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     track_paint_util_onride_photo_paint(session, direction, height + 3, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -58,13 +58,13 @@ static void reverser_rc_track_flat(
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21520, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21521, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -76,13 +76,13 @@ static void reverser_rc_track_flat(
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21504, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21505, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -107,7 +107,7 @@ static void reverser_rc_track_station(
     PaintAddImageAsChildRotated(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2,
         height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -126,22 +126,22 @@ static void reverser_rc_track_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21530, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21531, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21532, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21533, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -152,22 +152,22 @@ static void reverser_rc_track_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21516, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21517, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21518, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21519, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -195,22 +195,22 @@ static void reverser_rc_track_flat_to_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21522, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21523, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21524, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21525, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -221,22 +221,22 @@ static void reverser_rc_track_flat_to_25_deg_up(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21508, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21509, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21510, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21511, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -264,22 +264,22 @@ static void reverser_rc_track_25_deg_up_to_flat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21526, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21527, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21528, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21529, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -290,22 +290,22 @@ static void reverser_rc_track_25_deg_up_to_flat(
             case 0:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21512, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21513, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21514, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21515, 0, 0, 32, 27, 2, height, 0, 2, height);
-                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -358,22 +358,22 @@ static void reverser_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21543, 0, 2, 32, 27, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21548, 0, 2, 32, 27, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21553, 0, 2, 32, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21538, 0, 2, 32, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -394,22 +394,22 @@ static void reverser_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21542, 0, 0, 32, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21547, 0, 0, 32, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21552, 0, 16, 32, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21537, 0, 16, 32, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -425,22 +425,22 @@ static void reverser_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21541, 0, 16, 16, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21546, 16, 16, 16, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21551, 16, 0, 16, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21536, 0, 0, 16, 16, 2, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -462,22 +462,22 @@ static void reverser_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21540, 16, 0, 16, 34, 2, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21545, 0, 0, 16, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21550, 0, 0, 16, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21535, 16, 0, 16, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -493,22 +493,22 @@ static void reverser_rc_track_left_quarter_turn_5(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21539, 2, 0, 32, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21544, 2, 0, 27, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21549, 2, 0, 27, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21534, 2, 0, 32, 32, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -548,22 +548,22 @@ static void reverser_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21566, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21570, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21569, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21573, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -579,22 +579,22 @@ static void reverser_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21567, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21571, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21568, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21572, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -610,22 +610,22 @@ static void reverser_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21568, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21572, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21567, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21571, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -641,22 +641,22 @@ static void reverser_rc_track_s_bend_left(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21569, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21573, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21566, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21570, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -687,22 +687,22 @@ static void reverser_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21574, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21578, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21577, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21581, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -718,22 +718,22 @@ static void reverser_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21575, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21579, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21576, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21580, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -749,22 +749,22 @@ static void reverser_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21576, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21580, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21575, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21579, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -780,22 +780,22 @@ static void reverser_rc_track_s_bend_right(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21577, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21581, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21574, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21578, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -826,22 +826,22 @@ static void reverser_rc_track_left_quarter_turn_3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21559, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21562, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21565, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21556, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -887,22 +887,22 @@ static void reverser_rc_track_left_quarter_turn_3(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21557, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21560, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21563, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21554, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -940,13 +940,13 @@ static void reverser_rc_track_brakes(
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 21506, 0, 0, 32, 27, 2, height, 0, 2, height);
-            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 21507, 0, 0, 32, 27, 2, height, 0, 2, height);
-            wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -967,22 +967,22 @@ static void reverser_rc_track_left_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21582, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21588, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21594, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21600, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -998,22 +998,22 @@ static void reverser_rc_track_left_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21585, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21591, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21597, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21603, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1025,22 +1025,22 @@ static void reverser_rc_track_left_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21586, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21592, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21598, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21604, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1052,22 +1052,22 @@ static void reverser_rc_track_left_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21587, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21593, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21599, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21605, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1079,22 +1079,22 @@ static void reverser_rc_track_left_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21583, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21589, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21595, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21601, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1106,22 +1106,22 @@ static void reverser_rc_track_left_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21584, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21590, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21596, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21602, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1152,22 +1152,22 @@ static void reverser_rc_track_right_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21596, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21602, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21584, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21590, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1183,22 +1183,22 @@ static void reverser_rc_track_right_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21599, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21605, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21587, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21593, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1210,22 +1210,22 @@ static void reverser_rc_track_right_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21598, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21604, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21586, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21592, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1237,22 +1237,22 @@ static void reverser_rc_track_right_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21597, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21603, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21585, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21591, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1264,22 +1264,22 @@ static void reverser_rc_track_right_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21595, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21601, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21583, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21589, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1291,22 +1291,22 @@ static void reverser_rc_track_right_reverser(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21594, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21600, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21582, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21588, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -80,7 +80,7 @@ static void side_friction_rc_track_flat(
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21664, 0, 0, 32, 27, 0, height, 0, 2,
                     height + 27);
-                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
@@ -88,7 +88,7 @@ static void side_friction_rc_track_flat(
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21665, 0, 0, 32, 27, 0, height, 0, 2,
                     height + 27);
-                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
@@ -96,7 +96,7 @@ static void side_friction_rc_track_flat(
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21668, 0, 0, 32, 27, 0, height, 0, 2,
                     height + 27);
-                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
@@ -104,7 +104,7 @@ static void side_friction_rc_track_flat(
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21669, 0, 0, 32, 27, 0, height, 0, 2,
                     height + 27);
-                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -119,7 +119,7 @@ static void side_friction_rc_track_flat(
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21608, 0, 0, 32, 27, 0, height, 0, 2,
                     height + 27);
-                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
@@ -128,7 +128,7 @@ static void side_friction_rc_track_flat(
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21609, 0, 0, 32, 27, 0, height, 0, 2,
                     height + 27);
-                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -151,7 +151,7 @@ static void side_friction_rc_track_station(
 
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2, height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -172,28 +172,28 @@ static void side_friction_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21678, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21690, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21679, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21691, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21680, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21692, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21681, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21693, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -206,28 +206,28 @@ static void side_friction_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21622, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21634, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21623, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21635, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21624, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21636, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21625, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21637, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -257,28 +257,28 @@ static void side_friction_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21670, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21682, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21671, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21683, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21672, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21684, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21673, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21685, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -291,28 +291,28 @@ static void side_friction_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21614, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21626, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21615, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21627, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21616, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21628, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21617, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21629, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -342,28 +342,28 @@ static void side_friction_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21674, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21686, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21675, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21687, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21676, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21688, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21677, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21689, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -376,28 +376,28 @@ static void side_friction_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21618, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21630, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21619, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21631, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21620, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21632, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21621, 0, 0, 32, 27, 2, height, 0, 2, height);
                 PaintAddImageAsParentRotated(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 21633, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -453,7 +453,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21747, 0, 2, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -461,7 +461,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21752, 0, 2, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -469,7 +469,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21757, 0, 2, 32, 32, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -477,7 +477,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21742, 0, 2, 32, 32, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -501,7 +501,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21746, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -509,7 +509,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21751, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -517,7 +517,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21756, 0, 16, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -525,7 +525,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21741, 0, 16, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -544,7 +544,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21745, 0, 16, 16, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -552,7 +552,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21750, 16, 16, 16, 16, 0, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -560,7 +560,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21755, 16, 0, 16, 16, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -568,7 +568,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21740, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -593,7 +593,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21744, 16, 0, 16, 34, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -601,7 +601,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21749, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -609,7 +609,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21754, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -617,7 +617,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21739, 16, 0, 16, 32, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -636,7 +636,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21743, 2, 0, 32, 32, 0, height, 2, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -644,7 +644,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21748, 2, 0, 27, 32, 0, height, 2, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -652,7 +652,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21753, 2, 0, 27, 32, 0, height, 2, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -660,7 +660,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21738, 2, 0, 32, 32, 0, height, 2, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -703,7 +703,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21904, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -711,7 +711,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21908, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -719,7 +719,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21907, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -727,7 +727,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21911, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -746,7 +746,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21905, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -754,7 +754,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21909, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -762,7 +762,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21906, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -770,7 +770,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21910, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -789,7 +789,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21906, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -797,7 +797,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21910, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -805,7 +805,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21905, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -813,7 +813,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21909, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -832,7 +832,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21907, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -840,7 +840,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21911, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -848,7 +848,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21904, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -856,7 +856,7 @@ static void side_friction_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21908, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -890,7 +890,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21912, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -898,7 +898,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21916, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -906,7 +906,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21915, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -914,7 +914,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21919, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -933,7 +933,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21913, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -941,7 +941,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21917, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -949,7 +949,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21914, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -957,7 +957,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21918, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -976,7 +976,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21914, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -984,7 +984,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21918, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -992,7 +992,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21913, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1000,7 +1000,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21917, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1019,7 +1019,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21915, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1027,7 +1027,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21919, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1035,7 +1035,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21912, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1043,7 +1043,7 @@ static void side_friction_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21916, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1077,7 +1077,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21711, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1085,7 +1085,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21714, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1093,7 +1093,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21717, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1101,7 +1101,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21708, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1162,7 +1162,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21709, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1170,7 +1170,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21712, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1178,7 +1178,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21715, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1186,7 +1186,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21706, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1226,7 +1226,7 @@ static void side_friction_rc_track_brakes(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 21610, 0, 0, 32, 27, 2, height, 0, 2, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 21612, 0, 0, 32, 27, 0, height, 0, 2, height + 27);
-            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
@@ -1234,7 +1234,7 @@ static void side_friction_rc_track_brakes(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 21611, 0, 0, 32, 27, 2, height, 0, 2, height);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 21613, 0, 0, 32, 27, 0, height, 0, 2, height + 27);
-            wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1258,7 +1258,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21806, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1266,7 +1266,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21810, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1274,7 +1274,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21814, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1282,7 +1282,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21818, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1301,7 +1301,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21807, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1309,7 +1309,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21811, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1318,7 +1318,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21815, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1327,7 +1327,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21819, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1343,7 +1343,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21808, 0, 0, 16, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1352,7 +1352,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21812, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1361,7 +1361,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21816, 0, 0, 16, 16, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1369,7 +1369,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21820, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1379,16 +1379,16 @@ static void side_friction_rc_track_left_eighth_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1451,7 +1451,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21774, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1459,7 +1459,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21778, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1467,7 +1467,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21782, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1475,7 +1475,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21786, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1495,7 +1495,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21775, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1504,7 +1504,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21779, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1512,7 +1512,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21783, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1520,7 +1520,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21787, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1535,7 +1535,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21776, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1544,7 +1544,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21780, 0, 0, 16, 16, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1552,7 +1552,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21784, 0, 0, 28, 28, 0, height, 4, 4,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1561,7 +1561,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 21788, 0, 0, 16, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1571,16 +1571,16 @@ static void side_friction_rc_track_right_eighth_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -1690,16 +1690,16 @@ static void side_friction_rc_track_diag_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21850, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1714,16 +1714,16 @@ static void side_friction_rc_track_diag_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21826, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1736,10 +1736,10 @@ static void side_friction_rc_track_diag_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -1748,10 +1748,10 @@ static void side_friction_rc_track_diag_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21851, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1760,10 +1760,10 @@ static void side_friction_rc_track_diag_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -1772,10 +1772,10 @@ static void side_friction_rc_track_diag_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21827, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1856,20 +1856,16 @@ static void side_friction_rc_track_diag_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21868, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1884,20 +1880,16 @@ static void side_friction_rc_track_diag_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21844, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1910,12 +1902,10 @@ static void side_friction_rc_track_diag_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -1924,12 +1914,10 @@ static void side_friction_rc_track_diag_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21869, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -1938,12 +1926,10 @@ static void side_friction_rc_track_diag_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -1952,12 +1938,10 @@ static void side_friction_rc_track_diag_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21845, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2038,16 +2022,16 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21856, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2062,16 +2046,16 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21832, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2084,10 +2068,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2096,10 +2080,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21857, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2108,10 +2092,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2120,10 +2104,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21833, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2204,20 +2188,16 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21862, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2232,20 +2212,16 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21838, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2258,12 +2234,10 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2272,12 +2246,10 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21863, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2286,12 +2258,10 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2300,12 +2270,10 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21839, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2386,20 +2354,16 @@ static void side_friction_rc_track_diag_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21869, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2414,20 +2378,16 @@ static void side_friction_rc_track_diag_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21845, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2440,12 +2400,10 @@ static void side_friction_rc_track_diag_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2454,12 +2412,10 @@ static void side_friction_rc_track_diag_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21868, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2468,12 +2424,10 @@ static void side_friction_rc_track_diag_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2482,12 +2436,10 @@ static void side_friction_rc_track_diag_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21844, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2566,20 +2518,16 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21863, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2594,20 +2542,16 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21839, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2618,12 +2562,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2632,12 +2574,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21862, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2646,12 +2586,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2660,12 +2598,10 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21838, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2745,16 +2681,16 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21857, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2769,16 +2705,16 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21833, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2791,10 +2727,10 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2803,10 +2739,10 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21856, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2815,10 +2751,10 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -2827,10 +2763,10 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsParentRotated(
                             session, direction, session->TrackColours[SCHEME_TRACK] | 21832, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -2879,7 +2815,7 @@ static void side_friction_rc_track_60_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_0_B, 0, 0, 32, 1, 9,
                 height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 21, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 21, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -2890,7 +2826,7 @@ static void side_friction_rc_track_60_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_1_B, 0, 0, 32, 1, 9,
                 height, 0, 26, height + 5);
 
-            wooden_a_supports_paint_setup(session, 1, 22, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 22, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -2900,7 +2836,7 @@ static void side_friction_rc_track_60_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_2_B, 0, 0, 32, 1, 9,
                 height, 0, 26, height + 5);
 
-            wooden_a_supports_paint_setup(session, 0, 23, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 23, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -2909,7 +2845,7 @@ static void side_friction_rc_track_60_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_DIR_3_B, 0, 0, 32, 1, 9,
                 height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 24, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 24, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
 
@@ -2945,7 +2881,7 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_0_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 13, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 13, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -2954,7 +2890,7 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_1_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 14, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 14, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -2963,7 +2899,7 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_2_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 15, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 15, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -2972,7 +2908,7 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_25_DEG_UP_TO_60_DEG_UP_DIR_3_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 16, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 16, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
 
@@ -3008,7 +2944,7 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_0_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 17, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 17, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -3017,7 +2953,7 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_1_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 18, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 18, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -3026,7 +2962,7 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_2_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 19, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 19, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -3035,7 +2971,7 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_60_DEG_UP_TO_25_DEG_UP_DIR_3_B, 0,
                 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 20, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 20, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
 
@@ -3086,16 +3022,16 @@ static void side_friction_rc_track_diag_60_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_0_B, -16,
                         -16, 32, 32, 0, height, -16, -16, height + 43);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
 
@@ -3106,10 +3042,10 @@ static void side_friction_rc_track_diag_60_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3118,10 +3054,10 @@ static void side_friction_rc_track_diag_60_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_DIR_2_B, -16,
                         -16, 32, 32, 0, height, -16, -16, height + 43);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3181,16 +3117,16 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
                         session, direction,
                         session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_0_B, -16, -16,
                         32, 32, 0, height, -16, -16, height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3200,10 +3136,10 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3214,10 +3150,10 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
                         session, direction,
                         session->TrackColours[SCHEME_TRACK] | SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_2_B, -16, -16,
                         32, 32, 0, height, -16, -16, height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3277,16 +3213,16 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 24033, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -3296,10 +3232,10 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3309,10 +3245,10 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 24034, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -231,7 +231,7 @@ static void paint_virginia_reel_track_flat(
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -268,19 +268,19 @@ static void paint_virginia_reel_track_25_deg_up(
     switch (direction)
     {
         case 0:
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_7);
             break;
         case 1:
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_SQUARE_8);
             break;
         case 2:
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_SQUARE_8);
             break;
         case 3:
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_7);
             break;
     }
@@ -307,27 +307,27 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(
         case 0:
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
 
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
         case 1:
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 27, 32, 2 }, { 2, 0, height });
             session->WoodenSupportsPrependTo = ps;
 
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_8);
             break;
         case 2:
             ps = PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 27, 2 }, { 0, 2, height });
             session->WoodenSupportsPrependTo = ps;
 
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_8);
             break;
         case 3:
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 27, 32, 2 }, { 2, 0, height });
 
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             break;
     }
@@ -367,19 +367,19 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(
     switch (direction)
     {
         case 0:
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
         case 1:
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_14);
             break;
         case 2:
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_14);
             break;
         case 3:
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
     }
@@ -440,7 +440,7 @@ static void paint_virginia_reel_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -468,8 +468,8 @@ static void paint_virginia_reel_track_left_quarter_turn_3_tiles(
         case 0:
         case 3:
             wooden_a_supports_paint_setup(
-                session, virginia_reel_left_quarter_turn_supports[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS],
-                nullptr);
+                session, virginia_reel_left_quarter_turn_supports[direction], 0, height,
+                session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, paint_util_rotate_segments(SEGMENTS_ALL, direction), 0xFFFF, 0);
             break;
     }
@@ -501,18 +501,18 @@ static void paint_virginia_reel_track_left_quarter_turn_1_tile(
     switch (direction)
     {
         case 0:
-            wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
         case 1:
-            wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
-            wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             break;
         case 3:
-            wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -458,7 +458,7 @@ static void wooden_rc_track_flat(
     wooden_rc_track_paint(
         session, imageIds[direction][isChained], railsImageIds[direction][isChained], direction, 0, 2, 32, 25, 2, height, 0, 3,
         height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -490,7 +490,7 @@ static void wooden_rc_track_station(
             session, stationImageIds[direction][0], stationImageIds[direction][1], direction, 0, 2, 32, 27, 2, height, 0, 2,
             height);
     }
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -531,8 +531,7 @@ static void wooden_rc_track_25_deg_up(
             session, imageIds[isChained][direction][2], imageIds[isChained][direction][3], direction, 0, 0, 32, 1, 9, height, 0,
             26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -569,8 +568,7 @@ static void wooden_rc_track_60_deg_up(
         session->WoodenSupportsPrependTo = wooden_rc_track_paint(
             session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 93, height, 28, 4, height - 16);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -619,8 +617,7 @@ static void wooden_rc_track_flat_to_25_deg_up(
             session, imageIds[isChained][direction][2], imageIds[isChained][direction][3], direction, 0, 0, 32, 1, 9, height, 0,
             26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -661,8 +658,7 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4, height);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -703,8 +699,7 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4, height);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -753,8 +748,7 @@ static void wooden_rc_track_25_deg_up_to_flat(
             session, imageIds[isChained][direction][2], imageIds[isChained][direction][3], direction, 0, 0, 32, 1, 9, height, 0,
             26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -1029,7 +1023,7 @@ static void wooden_rc_track_right_quarter_turn_5(
     if (supportType[direction][trackSequence] != -1)
     {
         wooden_a_supports_paint_setup(
-            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     int32_t blockedSegments = 0;
@@ -1092,7 +1086,7 @@ static void wooden_rc_track_flat_to_left_bank(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -1119,7 +1113,7 @@ static void wooden_rc_track_flat_to_right_bank(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -1353,7 +1347,7 @@ static void wooden_rc_track_banked_right_quarter_turn_5(
     if (supportType[direction][trackSequence] != -1)
     {
         wooden_a_supports_paint_setup(
-            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     int32_t blockedSegments = 0;
@@ -1416,8 +1410,7 @@ static void wooden_rc_track_left_bank_to_25_deg_up(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1451,8 +1444,7 @@ static void wooden_rc_track_right_bank_to_25_deg_up(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1486,8 +1478,7 @@ static void wooden_rc_track_25_deg_up_to_left_bank(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -1521,8 +1512,7 @@ static void wooden_rc_track_25_deg_up_to_right_bank(
         wooden_rc_track_paint(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -1581,7 +1571,7 @@ static void wooden_rc_track_left_bank(
 
     wooden_rc_track_paint(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -1610,7 +1600,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23781, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24647, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1623,21 +1613,21 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24678, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23791, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24657, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23796, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24662, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1660,7 +1650,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23782, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24648, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1673,7 +1663,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24679, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1682,7 +1672,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24658, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1697,7 +1687,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24685, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1717,7 +1707,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24649, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1732,7 +1722,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24680, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1741,7 +1731,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24659, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1754,7 +1744,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24686, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1780,7 +1770,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24650, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1793,7 +1783,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24681, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1806,7 +1796,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24683, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1821,7 +1811,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24687, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1839,7 +1829,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23785, 0, 0, 27, 32, 2, height, 2, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24651, 0, 0, 27, 32, 2, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1852,7 +1842,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24682, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1865,7 +1855,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24684, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1878,7 +1868,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24688, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1911,14 +1901,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23761, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24627, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23766, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24632, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1931,14 +1921,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24673, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23776, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24642, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1969,7 +1959,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24667, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1978,7 +1968,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24633, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1991,14 +1981,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24674, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23777, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24643, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2022,7 +2012,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24668, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2031,7 +2021,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24634, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2046,7 +2036,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24675, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2055,7 +2045,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24644, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2087,7 +2077,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24669, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2100,7 +2090,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24671, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2113,7 +2103,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24676, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2122,7 +2112,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24645, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2146,7 +2136,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24670, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2159,7 +2149,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24672, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2172,14 +2162,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24677, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23780, 0, 0, 27, 32, 2, height, 2, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24646, 0, 0, 27, 32, 2, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2230,7 +2220,7 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, wooden_rc_get_track_colour(session) | 23725, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24591, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2243,14 +2233,14 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24607, 0, 0, 32, 25, 0, height, 0, 3,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23728, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24594, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2263,7 +2253,7 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24610, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2281,7 +2271,7 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, wooden_rc_get_track_colour(session) | 23726, 0, 0, 32, 26, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24592, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2294,14 +2284,14 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24608, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23727, 0, 0, 32, 26, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24593, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2314,7 +2304,7 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24609, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2332,7 +2322,7 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, wooden_rc_get_track_colour(session) | 23727, 0, 0, 32, 26, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24593, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2345,14 +2335,14 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24609, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23726, 0, 0, 32, 26, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24592, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2365,7 +2355,7 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24608, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2383,7 +2373,7 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, wooden_rc_get_track_colour(session) | 23728, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24594, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2396,14 +2386,14 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24610, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23725, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24591, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2416,7 +2406,7 @@ static void wooden_rc_track_s_bend_left(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24607, 0, 0, 32, 25, 0, height, 0, 3,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2455,14 +2445,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24611, 0, 0, 32, 25, 0, height, 0, 3,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23737, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24603, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2475,14 +2465,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24614, 0, 0, 32, 25, 0, height, 0, 3,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23740, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24606, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2506,14 +2496,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24612, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23738, 0, 0, 32, 26, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24604, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2526,14 +2516,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24613, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23739, 0, 0, 32, 26, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24605, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2557,14 +2547,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24613, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23739, 0, 0, 32, 26, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24605, 0, 0, 32, 26, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2577,14 +2567,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24612, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23738, 0, 0, 32, 26, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24604, 0, 0, 32, 26, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -2608,14 +2598,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24614, 0, 0, 32, 25, 0, height, 0, 3,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23740, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24606, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2628,14 +2618,14 @@ static void wooden_rc_track_s_bend_right(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24611, 0, 0, 32, 25, 0, height, 0, 3,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23737, 0, 0, 32, 25, 2, height, 0, 3, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24603, 0, 0, 32, 25, 2, height, 0, 3, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3150,7 +3140,7 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, wooden_rc_get_track_colour(session) | 23828, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24694, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3163,14 +3153,14 @@ static void wooden_rc_track_left_quarter_turn_3(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24706, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23834, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24700, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3183,7 +3173,7 @@ static void wooden_rc_track_left_quarter_turn_3(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24703, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3254,7 +3244,7 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, wooden_rc_get_track_colour(session) | 23826, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24692, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3267,14 +3257,14 @@ static void wooden_rc_track_left_quarter_turn_3(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24704, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23832, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24698, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3287,7 +3277,7 @@ static void wooden_rc_track_left_quarter_turn_3(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24701, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3329,7 +3319,7 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         session, direction, wooden_rc_get_track_colour(session) | 23846, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24712, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3342,14 +3332,14 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24724, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23852, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24718, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3362,7 +3352,7 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24721, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3433,7 +3423,7 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         session, direction, wooden_rc_get_track_colour(session) | 23844, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24710, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3446,14 +3436,14 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24722, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23850, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24716, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3466,7 +3456,7 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24719, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3508,7 +3498,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23906, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24772, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3521,14 +3511,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24785, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23910, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24776, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3541,7 +3531,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24783, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3567,7 +3557,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23905, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24771, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3580,7 +3570,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24784, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3593,7 +3583,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24786, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3606,7 +3596,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24782, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3645,14 +3635,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24777, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23897, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24763, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3665,14 +3655,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24780, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23901, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24767, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3704,7 +3694,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24778, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3717,7 +3707,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24779, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3730,14 +3720,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24781, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23902, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24768, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3788,7 +3778,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         session, direction, wooden_rc_get_track_colour(session) | 23882, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24748, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3801,14 +3791,14 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24760, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23888, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24754, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3821,7 +3811,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24757, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3839,16 +3829,16 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -3911,7 +3901,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         session, direction, wooden_rc_get_track_colour(session) | 23880, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24746, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3924,14 +3914,14 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24758, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23886, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24752, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3944,7 +3934,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24755, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3977,14 +3967,14 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24757, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23882, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24748, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3997,14 +3987,14 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24760, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23888, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24754, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -4027,16 +4017,16 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -4105,14 +4095,14 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24755, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23880, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24746, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4125,14 +4115,14 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24758, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23886, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24752, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4170,14 +4160,14 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24737, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23862, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24728, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4190,14 +4180,14 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24740, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23868, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24734, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4215,16 +4205,16 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -4293,14 +4283,14 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24739, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23864, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24730, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4313,14 +4303,14 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24742, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23870, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24736, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -4347,7 +4337,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         session, direction, wooden_rc_get_track_colour(session) | 23862, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24728, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4360,14 +4350,14 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24740, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23868, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24734, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4380,7 +4370,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24737, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -4403,16 +4393,16 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -4475,7 +4465,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         session, direction, wooden_rc_get_track_colour(session) | 23864, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24730, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4488,14 +4478,14 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24742, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23870, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24736, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4508,7 +4498,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24739, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4568,7 +4558,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, wooden_rc_get_track_colour(session) | 23704, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24570, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4581,14 +4571,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24590, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23714, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24580, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4601,7 +4591,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24585, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4628,7 +4618,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, wooden_rc_get_track_colour(session) | 23703, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24569, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4641,7 +4631,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24589, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4650,7 +4640,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24579, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4665,7 +4655,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24584, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4685,7 +4675,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24568, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4700,7 +4690,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24588, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 29);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4709,7 +4699,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24578, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4722,7 +4712,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24583, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4746,7 +4736,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24567, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4759,14 +4749,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24587, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23711, 0, 0, 16, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24577, 0, 0, 16, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4781,7 +4771,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24582, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4799,7 +4789,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, wooden_rc_get_track_colour(session) | 23700, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24566, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4812,14 +4802,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24586, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23710, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24576, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4832,7 +4822,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24581, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -4865,14 +4855,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24585, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23704, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24570, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4885,14 +4875,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24590, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23714, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24580, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -4932,14 +4922,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24584, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23703, 0, 0, 16, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24569, 0, 0, 16, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4952,7 +4942,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24589, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4961,7 +4951,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24579, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -4985,7 +4975,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24583, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4994,7 +4984,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24568, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5009,7 +4999,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24588, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 29);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5018,7 +5008,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24578, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5048,7 +5038,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24582, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5057,7 +5047,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24567, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5070,14 +5060,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24587, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23711, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24577, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5101,14 +5091,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24581, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23700, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24566, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5121,14 +5111,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24586, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23710, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24576, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -5166,14 +5156,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24551, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23670, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24536, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5186,14 +5176,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24556, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23680, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24546, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -5228,7 +5218,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24552, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5237,7 +5227,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24537, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5250,14 +5240,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24557, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23681, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24547, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5281,7 +5271,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24553, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5290,7 +5280,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24538, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5305,7 +5295,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24558, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 29);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5314,7 +5304,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24548, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5344,14 +5334,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24554, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23673, 0, 0, 16, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24539, 0, 0, 16, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5364,7 +5354,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24559, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5373,7 +5363,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24549, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5397,14 +5387,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24555, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23674, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24540, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5417,14 +5407,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24560, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23684, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24550, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -5451,7 +5441,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, wooden_rc_get_track_colour(session) | 23670, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24536, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5464,14 +5454,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24556, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23680, 0, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24546, 0, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5484,7 +5474,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24551, 0, 0, 20, 32, 0, height, 6, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -5518,7 +5508,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24537, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5531,14 +5521,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24557, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23681, 0, 0, 16, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24547, 0, 0, 16, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5553,7 +5543,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24552, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5573,7 +5563,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24538, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5588,7 +5578,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24558, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 29);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5597,7 +5587,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24548, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5610,7 +5600,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24553, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5632,7 +5622,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, wooden_rc_get_track_colour(session) | 23673, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24539, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5645,7 +5635,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24559, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5654,7 +5644,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24549, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5669,7 +5659,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24554, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -5687,7 +5677,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, wooden_rc_get_track_colour(session) | 23674, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24540, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5700,14 +5690,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24560, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 33);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23684, 0, 0, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24550, 0, 0, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5720,7 +5710,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24555, 0, 0, 32, 20, 0, height, 0, 6,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -5901,7 +5891,7 @@ static void wooden_rc_track_brakes(
 
     wooden_rc_track_paint(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 2, 32, 25, 2, height, 0, 3, height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -5919,7 +5909,7 @@ static void wooden_rc_track_25_deg_up_left_banked(
                 session, direction, wooden_rc_get_track_colour(session) | 24249, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25115, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -5930,7 +5920,7 @@ static void wooden_rc_track_25_deg_up_left_banked(
                 session, direction, wooden_rc_get_track_colour(session) | 24257, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25123, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -5941,14 +5931,14 @@ static void wooden_rc_track_25_deg_up_left_banked(
                 session, direction, wooden_rc_get_track_colour(session) | 24258, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25124, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24252, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25118, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -5975,7 +5965,7 @@ static void wooden_rc_track_25_deg_up_right_banked(
                 session, direction, wooden_rc_get_track_colour(session) | 24253, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25119, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -5986,7 +5976,7 @@ static void wooden_rc_track_25_deg_up_right_banked(
                 session, direction, wooden_rc_get_track_colour(session) | 24259, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25125, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -5997,14 +5987,14 @@ static void wooden_rc_track_25_deg_up_right_banked(
                 session, direction, wooden_rc_get_track_colour(session) | 24260, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25126, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24256, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25122, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -6051,7 +6041,7 @@ static void wooden_rc_track_on_ride_photo(
                 session, direction, wooden_rc_get_rails_colour(session) | 24620, 0, 2, 32, 25, 2, height, 0, 3, height);
             break;
     }
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_onride_photo_small_paint(session, direction, height + 16, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6168,7 +6158,7 @@ static void wooden_rc_track_water_splash(
                         session, direction, wooden_rc_get_rails_colour(session) | 24858, 0, 0, 32, 25, 2, height, 0, 3, height);
                     break;
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_rotated(session, direction, height + 16, TUNNEL_SQUARE_FLAT);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -6257,7 +6247,7 @@ static void wooden_rc_track_water_splash(
                         session, direction, wooden_rc_get_rails_colour(session) | 24846, 0, 0, 32, 25, 2, height, 0, 3, height);
                     break;
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + 48, 0x20);
             break;
@@ -6307,7 +6297,7 @@ static void wooden_rc_track_water_splash(
                         session, direction, wooden_rc_get_rails_colour(session) | 24868, 0, 0, 32, 25, 2, height, 0, 3, height);
                     break;
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + 48, 0x20);
             break;
@@ -6395,7 +6385,7 @@ static void wooden_rc_track_water_splash(
                         session, direction, wooden_rc_get_rails_colour(session) | 24848, 0, 0, 32, 25, 2, height, 0, 3, height);
                     break;
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + 48, 0x20);
             break;
@@ -6483,7 +6473,7 @@ static void wooden_rc_track_water_splash(
                         session, direction, wooden_rc_get_rails_colour(session) | 24860, 0, 0, 32, 25, 2, height, 0, 3, height);
                     break;
             }
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_rotated(session, direction, height + 16, TUNNEL_SQUARE_FLAT);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -6506,7 +6496,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, wooden_rc_get_track_colour(session) | 24137, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25003, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -6519,14 +6509,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25019, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24145, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25011, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -6539,7 +6529,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25023, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -6557,7 +6547,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, wooden_rc_get_track_colour(session) | 24138, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25004, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -6570,7 +6560,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25020, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6579,7 +6569,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25012, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -6594,7 +6584,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25024, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6610,7 +6600,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25005, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -6625,7 +6615,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25021, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6634,7 +6624,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25013, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -6647,7 +6637,7 @@ static void wooden_rc_track_left_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25025, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6657,16 +6647,16 @@ static void wooden_rc_track_left_eighth_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6745,14 +6735,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24995, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24117, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24983, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6765,14 +6755,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24999, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24125, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24991, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -6798,7 +6788,7 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24996, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -6807,7 +6797,7 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24984, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6820,14 +6810,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25000, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24126, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24992, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6847,7 +6837,7 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24997, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -6856,7 +6846,7 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24985, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6869,7 +6859,7 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25001, 0, 0, 28, 28, 0, height, 4, 4,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -6878,7 +6868,7 @@ static void wooden_rc_track_right_eighth_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24993, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6888,16 +6878,16 @@ static void wooden_rc_track_right_eighth_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6988,7 +6978,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, wooden_rc_get_track_colour(session) | 24185, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25051, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -7001,14 +6991,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25067, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24193, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25059, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -7021,7 +7011,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25071, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -7039,7 +7029,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, wooden_rc_get_track_colour(session) | 24186, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25052, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -7052,7 +7042,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25068, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7061,7 +7051,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25060, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -7076,7 +7066,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25072, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7092,7 +7082,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25053, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -7107,7 +7097,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25069, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7116,7 +7106,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25061, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -7129,7 +7119,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25073, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7139,16 +7129,16 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7227,14 +7217,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25043, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24165, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25031, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7247,14 +7237,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25047, 0, 0, 32, 32, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24173, 0, 0, 32, 32, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25039, 0, 0, 32, 32, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -7280,7 +7270,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25044, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -7289,7 +7279,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25032, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7302,14 +7292,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25048, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24174, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25040, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7329,7 +7319,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25045, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -7338,7 +7328,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25033, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7351,7 +7341,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25049, 0, 0, 28, 28, 0, height, 4, 4,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -7360,7 +7350,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25041, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7370,16 +7360,16 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7512,16 +7502,16 @@ static void wooden_rc_track_diag_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24917, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7542,16 +7532,16 @@ static void wooden_rc_track_diag_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24875, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7564,10 +7554,10 @@ static void wooden_rc_track_diag_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7582,10 +7572,10 @@ static void wooden_rc_track_diag_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24918, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7594,10 +7584,10 @@ static void wooden_rc_track_diag_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7612,10 +7602,10 @@ static void wooden_rc_track_diag_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24876, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 27);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7714,20 +7704,16 @@ static void wooden_rc_track_diag_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24935, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7748,20 +7734,16 @@ static void wooden_rc_track_diag_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24893, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7774,12 +7756,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7794,12 +7774,10 @@ static void wooden_rc_track_diag_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24936, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7808,12 +7786,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -7828,12 +7804,10 @@ static void wooden_rc_track_diag_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24894, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -7913,16 +7887,16 @@ static void wooden_rc_track_diag_60_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24911, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 91);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7932,10 +7906,10 @@ static void wooden_rc_track_diag_60_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7950,10 +7924,10 @@ static void wooden_rc_track_diag_60_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24912, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 91);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8034,16 +8008,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24923, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8064,16 +8038,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24881, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8086,10 +8060,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8104,10 +8078,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24924, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8116,10 +8090,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8134,10 +8108,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24882, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8217,16 +8191,16 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24899, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8236,10 +8210,10 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -8254,10 +8228,10 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24900, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8319,16 +8293,16 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24905, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8338,10 +8312,10 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -8356,10 +8330,10 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24906, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8440,20 +8414,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24929, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8474,20 +8444,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24887, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8500,12 +8466,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8520,12 +8484,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24930, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8534,12 +8496,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8554,12 +8514,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24888, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8658,20 +8616,16 @@ static void wooden_rc_track_diag_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24936, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8692,20 +8646,16 @@ static void wooden_rc_track_diag_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24894, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8718,12 +8668,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8738,12 +8686,10 @@ static void wooden_rc_track_diag_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24935, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8752,12 +8698,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -8772,12 +8716,10 @@ static void wooden_rc_track_diag_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24893, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 43);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -8857,16 +8799,16 @@ static void wooden_rc_track_diag_60_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24912, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 91);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8876,10 +8818,10 @@ static void wooden_rc_track_diag_60_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -8894,10 +8836,10 @@ static void wooden_rc_track_diag_60_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24911, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 91);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8976,20 +8918,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24930, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9010,20 +8948,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24888, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9034,12 +8968,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9054,12 +8986,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24929, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9068,12 +8998,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 switch (direction)
                 {
                     case 0:
-                        wooden_b_supports_paint_setup(
-                            session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_b_supports_paint_setup(
-                            session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9088,12 +9016,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24887, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_b_supports_paint_setup(
-                            session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_b_supports_paint_setup(
-                            session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9172,16 +9098,16 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24906, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9191,10 +9117,10 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9209,10 +9135,10 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24905, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9274,16 +9200,16 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24900, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9293,10 +9219,10 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9311,10 +9237,10 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24899, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 59);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9395,16 +9321,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24924, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9425,16 +9351,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24882, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9447,10 +9373,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9465,10 +9391,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24923, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9477,10 +9403,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 switch (direction)
                 {
                     case 0:
-                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -9495,10 +9421,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         PaintAddImageAsChildRotated(
                             session, direction, wooden_rc_get_rails_colour(session) | 24881, -16, -16, 32, 32, 0, height, -16,
                             -16, height + 35);
-                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                        wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -9578,16 +9504,16 @@ static void wooden_rc_track_diag_flat_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24947, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9597,10 +9523,10 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9615,10 +9541,10 @@ static void wooden_rc_track_diag_flat_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24948, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9680,16 +9606,16 @@ static void wooden_rc_track_diag_flat_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24953, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9699,10 +9625,10 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9717,10 +9643,10 @@ static void wooden_rc_track_diag_flat_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24954, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9782,16 +9708,16 @@ static void wooden_rc_track_diag_left_bank_to_flat(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24954, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9801,10 +9727,10 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9819,10 +9745,10 @@ static void wooden_rc_track_diag_left_bank_to_flat(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24953, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9884,16 +9810,16 @@ static void wooden_rc_track_diag_right_bank_to_flat(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24948, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9903,10 +9829,10 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -9921,10 +9847,10 @@ static void wooden_rc_track_diag_right_bank_to_flat(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24947, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9986,16 +9912,16 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24971, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10005,10 +9931,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10023,10 +9949,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24972, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10088,16 +10014,16 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24977, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10107,10 +10033,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10125,10 +10051,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24978, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10190,16 +10116,16 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24959, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10209,10 +10135,10 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10227,10 +10153,10 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24960, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10292,16 +10218,16 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24965, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10311,10 +10237,10 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10329,10 +10255,10 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24966, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10392,16 +10318,16 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24966, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -10409,10 +10335,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10427,10 +10353,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24965, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -10489,16 +10415,16 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24960, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -10506,10 +10432,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             switch (direction)
             {
                 case 0:
-                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 4, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 5, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10524,10 +10450,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24959, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 2, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_b_supports_paint_setup(session, 3, 0, height + 16, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             break;
@@ -10588,16 +10514,16 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24978, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10607,10 +10533,10 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10625,10 +10551,10 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24977, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10690,16 +10616,16 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24972, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10709,10 +10635,10 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10727,10 +10653,10 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24971, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 35);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10792,16 +10718,16 @@ static void wooden_rc_track_diag_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24941, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10811,10 +10737,10 @@ static void wooden_rc_track_diag_left_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10829,10 +10755,10 @@ static void wooden_rc_track_diag_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24942, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10894,16 +10820,16 @@ static void wooden_rc_track_diag_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24942, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10913,10 +10839,10 @@ static void wooden_rc_track_diag_right_bank(
             switch (direction)
             {
                 case 0:
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -10931,10 +10857,10 @@ static void wooden_rc_track_diag_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24941, -16, -16, 32, 32, 0, height, -16, -16,
                         height + 27);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10973,7 +10899,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23958, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24824, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -10986,14 +10912,14 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24837, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23962, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24828, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11006,7 +10932,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24835, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11032,7 +10958,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23957, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24823, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11045,7 +10971,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24836, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11058,7 +10984,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24838, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11071,7 +10997,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24834, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -11110,14 +11036,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24829, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23949, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24815, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11130,14 +11056,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24832, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23953, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24819, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11169,7 +11095,7 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24830, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11182,7 +11108,7 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24831, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11195,14 +11121,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24833, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23954, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24820, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -11241,7 +11167,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24831, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11254,14 +11180,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24833, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23954, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24820, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11274,7 +11200,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24830, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11300,7 +11226,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, wooden_rc_get_track_colour(session) | 23949, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24815, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11313,14 +11239,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24832, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23953, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24819, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11333,7 +11259,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24829, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -11372,14 +11298,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24834, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23957, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24823, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11392,7 +11318,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24836, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11405,7 +11331,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24838, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11437,14 +11363,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24835, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23958, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24824, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11457,14 +11383,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24837, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23962, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24828, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -11491,7 +11417,7 @@ static void wooden_rc_track_block_brakes(
                                                           : _wooden_rc_block_brakes_image_ids[direction][0];
     wooden_rc_track_paint(
         session, brakeImg, _wooden_rc_block_brakes_image_ids[direction][2], direction, 0, 2, 32, 25, 2, height, 0, 3, height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -11512,7 +11438,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23932, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24798, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11525,14 +11451,14 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24811, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23936, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24802, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11545,7 +11471,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24809, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11571,7 +11497,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 23931, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24797, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11584,7 +11510,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24810, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11597,7 +11523,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24812, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11610,7 +11536,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24808, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -11649,14 +11575,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24803, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23923, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24789, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11669,14 +11595,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24806, 0, 6, 32, 20, 0, height, 0, 6,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23927, 0, 6, 32, 20, 2, height, 0, 6, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24793, 0, 6, 32, 20, 2, height, 0, 6, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11708,7 +11634,7 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24804, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11721,7 +11647,7 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24805, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11734,14 +11660,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24807, 6, 0, 20, 32, 0, height, 6, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 23928, 6, 0, 20, 32, 2, height, 6, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 24794, 6, 0, 20, 32, 2, height, 6, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -11794,7 +11720,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 24321, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25187, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11807,21 +11733,21 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25218, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24331, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25197, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24336, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25202, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -11844,7 +11770,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 24322, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25188, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11857,7 +11783,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25219, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11866,7 +11792,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25198, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11881,7 +11807,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25225, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -11901,7 +11827,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25189, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11916,7 +11842,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25220, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11925,7 +11851,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25199, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -11938,7 +11864,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25226, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -11964,7 +11890,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25190, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -11977,7 +11903,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25221, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -11990,7 +11916,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25223, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -12005,7 +11931,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25227, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12023,7 +11949,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 24325, 0, 0, 27, 32, 2, height, 2, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25191, 0, 0, 27, 32, 2, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -12036,7 +11962,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25222, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12049,7 +11975,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25224, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -12062,7 +11988,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25228, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -12095,14 +12021,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, wooden_rc_get_track_colour(session) | 24301, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25167, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24306, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25172, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12115,14 +12041,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25213, 0, 0, 32, 27, 0, height, 0, 2,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24316, 0, 0, 32, 27, 2, height, 0, 2, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25182, 0, 0, 32, 27, 2, height, 0, 2, height);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -12153,7 +12079,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25207, 0, 0, 32, 16, 0, height, 0, 16,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -12162,7 +12088,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25173, 0, 0, 32, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12175,14 +12101,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25214, 0, 0, 32, 16, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24317, 0, 0, 32, 16, 2, height, 0, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25183, 0, 0, 32, 16, 2, height, 0, 0, height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12206,7 +12132,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25208, 0, 0, 16, 16, 0, height, 0, 0,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -12215,7 +12141,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25174, 0, 0, 16, 16, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12230,7 +12156,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25215, 0, 0, 16, 16, 0, height, 16, 16,
                         height + 59);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -12239,7 +12165,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25184, 0, 0, 16, 16, 2, height, 0, 16,
                         height);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12271,7 +12197,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25209, 0, 0, 16, 32, 0, height, 16, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -12284,7 +12210,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25211, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12297,7 +12223,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25216, 0, 0, 16, 32, 0, height, 0, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 2, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -12306,7 +12232,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25185, 0, 0, 16, 32, 2, height, 16, 0,
                         height);
-                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 3, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -12330,7 +12256,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25210, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -12343,7 +12269,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25212, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -12356,14 +12282,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25217, 0, 0, 27, 32, 0, height, 2, 0,
                         height + 67);
-                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, wooden_rc_get_track_colour(session) | 24320, 0, 0, 27, 32, 2, height, 2, 0, height);
                     PaintAddImageAsChildRotated(
                         session, direction, wooden_rc_get_rails_colour(session) | 25186, 0, 0, 27, 32, 2, height, 2, 0, height);
-                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+                    wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -12413,28 +12339,28 @@ static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24261, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25127, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24262, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25128, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24263, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25129, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24264, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25130, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12461,28 +12387,28 @@ static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24265, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25131, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24266, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25132, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24267, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25133, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24268, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25134, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12509,28 +12435,28 @@ static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24269, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25135, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24270, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25136, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24271, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25137, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24272, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25138, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12557,28 +12483,28 @@ static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24273, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25139, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24274, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25140, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24275, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25141, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24276, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25142, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12639,7 +12565,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24277, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25143, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -12650,7 +12576,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24293, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25159, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -12661,14 +12587,14 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24294, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25160, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24280, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25146, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12695,7 +12621,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24281, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25147, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -12706,7 +12632,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24295, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25161, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -12717,14 +12643,14 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24296, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25162, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24284, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25150, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12751,7 +12677,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24285, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25151, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -12762,7 +12688,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24297, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25163, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -12773,14 +12699,14 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24298, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25164, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24288, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25154, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12807,7 +12733,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24289, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25155, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -12818,7 +12744,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24299, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25165, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -12829,14 +12755,14 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24300, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25166, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24292, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25158, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12899,7 +12825,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24225, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25091, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -12910,7 +12836,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24241, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25107, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -12921,14 +12847,14 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24242, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25108, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24228, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25094, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -12955,7 +12881,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24229, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25095, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -12966,7 +12892,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24243, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25109, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -12977,14 +12903,14 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
                 session, direction, wooden_rc_get_track_colour(session) | 24244, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25110, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24232, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25098, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -13011,7 +12937,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24233, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25099, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -13022,7 +12948,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24245, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25111, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -13033,14 +12959,14 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24246, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25112, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24236, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25102, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -13067,7 +12993,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24237, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25103, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -13078,7 +13004,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24247, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25113, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -13089,14 +13015,14 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
                 session, direction, wooden_rc_get_track_colour(session) | 24248, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25114, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, wooden_rc_get_track_colour(session) | 24240, 0, 0, 32, 25, 2, height, 0, 3, height);
             PaintAddImageAsChildRotated(
                 session, direction, wooden_rc_get_rails_colour(session) | 25106, 0, 0, 32, 25, 2, height, 0, 3, height);
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     if (direction == 0 || direction == 3)
@@ -13162,7 +13088,7 @@ static void wooden_rc_track_booster(
 
     wooden_rc_track_paint(
         session, imageIds[direction], railsImageIds[direction], direction, 0, 2, 32, 25, 2, height, 0, 3, height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -134,7 +134,7 @@ static void wooden_wild_mouse_track_flat(
 
     uint32_t imageId = imageIds[direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 6, 32, 20, 1, height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session,
@@ -162,7 +162,7 @@ static void wooden_wild_mouse_track_station(
     PaintAddImageAsChildRotated(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 1, height, 0, 0,
         height);
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -193,8 +193,7 @@ static void wooden_wild_mouse_track_25_deg_up(
     uint32_t imageId = imageIds[isChained][direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 2, 32, 25, 1, height, 0, 3, height);
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -241,8 +240,7 @@ static void wooden_wild_mouse_track_60_deg_up(
             session, direction, imageId, 0, 6, 2, 24, 93, height, 28, 4, height - 16);
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -281,8 +279,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_up(
     uint32_t imageId = imageIds[isChained][direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 2, 32, 25, 1, height, 0, 3, height);
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -333,8 +330,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 6, 32, 2, 43, height, 0, 4, height);
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -384,8 +380,7 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 6, 32, 2, 43, height, 0, 4, height);
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -424,8 +419,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_flat(
     uint32_t imageId = imageIds[isChained][direction] | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 2, 32, 25, 1, height, 0, 3, height);
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -524,8 +518,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_3(
     {
         case 0:
         case 3:
-            wooden_a_supports_paint_setup(
-                session, supportType[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, supportType[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
 
@@ -582,7 +575,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_1(
             PaintAddImageAsParent(session, imageId, { 6, 6, height }, { 24, 24, 1 });
             break;
     }
-    wooden_a_supports_paint_setup(session, supportType[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, supportType[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height, 0, TUNNEL_0, 0, TUNNEL_0);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -631,8 +624,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_up(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 6, 32, 2, 43, height, 0, 4, height);
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 29 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 29 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -682,8 +674,7 @@ static void wooden_wild_mouse_track_60_deg_up_to_flat(
         PaintAddImageAsParentRotated(session, direction, imageId, 0, 6, 32, 2, 43, height, 0, 4, height);
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 33 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 33 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -478,7 +478,7 @@ static void paint_car_ride_track_spinning_tunnel(
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -60,7 +60,7 @@ static void paint_circus(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -67,7 +67,7 @@ static void paint_crooked_house(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -45,7 +45,7 @@ static void paint_dodgems(
 
     int32_t edges = edges_4x4[relativeTrackSequence];
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     uint32_t imageId = SPR_DODGEMS_FLOOR | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -145,7 +145,7 @@ static void paint_ferris_wheel(
         edges = edges_1x4_ne_sw[relativeTrackSequence];
     }
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -40,7 +40,7 @@ static void paint_flying_saucers(
 
     int32_t edges = edges_4x4[relativeTrackSequence];
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     uint32_t imageId = SPR_FLYING_SAUCERS_FLOOR | session->TrackColours[SCHEME_TRACK];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -492,7 +492,7 @@ static void paint_ghost_train_track_spinning_tunnel(
     auto tunnelImage = get_tunnel_doors_image_straight_flat(trackElement, direction);
     paint_util_push_tunnel_rotated(session, direction, height, tunnelImage);
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -99,7 +99,7 @@ static void paint_haunted_house(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/gentle/Maze.cpp
+++ b/src/openrct2/ride/gentle/Maze.cpp
@@ -56,7 +56,7 @@ static void maze_paint_setup(
     int32_t image_id = SPR_TERRAIN_DIRT | session->TrackColours[SCHEME_MISC];
     PaintAddImageAsParent(session, image_id, { 0, 0, height }, { 32, 32, 0 });
 
-    wooden_a_supports_paint_setup(session, (rotation & 1) ? 0 : 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
+    wooden_a_supports_paint_setup(session, (rotation & 1) ? 0 : 1, 0, height, session->TrackColours[SCHEME_3]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL & ~SEGMENT_C4, 0xFFFF, 0);
 

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -110,7 +110,7 @@ static void paint_merry_go_round(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -731,7 +731,7 @@ static void paint_mini_golf_station(
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -832,7 +832,7 @@ static void paint_mini_golf_hole_ab(
     CoordsXY boundBox, boundBoxOffset;
 
     bool drewSupports = wooden_a_supports_paint_setup(
-        session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -904,7 +904,7 @@ static void paint_mini_golf_hole_c(
     CoordsXY boundBox, boundBoxOffset;
 
     bool drewSupports = wooden_a_supports_paint_setup(
-        session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -977,8 +977,7 @@ static void paint_mini_golf_hole_d(
     int32_t supportType = (direction & 1);
     if (trackSequence == 2)
         supportType = 1 - supportType;
-    bool drewSupports = wooden_a_supports_paint_setup(
-        session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    bool drewSupports = wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -1071,8 +1070,7 @@ static void paint_mini_golf_hole_e(
     int32_t supportType = (direction & 1);
     if (trackSequence == 2)
         supportType = 1 - supportType;
-    bool drewSupports = wooden_a_supports_paint_setup(
-        session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    bool drewSupports = wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -92,7 +92,7 @@ static void paint_observation_tower_base(
     int32_t edges = edges_3x3[trackSequence];
     CoordsXY position = session->MapPosition;
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     uint32_t imageId = SPR_FLOOR_METAL_B | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -100,7 +100,7 @@ static void paint_space_rings(
 
     uint32_t imageId;
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = ride_get_station_object(ride);
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -198,7 +198,7 @@ static void paint_spiral_slide(
 
     int32_t edges = edges_2x2[trackSequence];
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     // Base
     uint32_t imageId = ((direction & 1) ? SPIRAL_SLIDE_BASE_B : SPIRAL_SLIDE_BASE_A) | session->TrackColours[SCHEME_SUPPORTS];

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -26,8 +26,7 @@ static void facility_paint_setup(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    bool hasSupports = wooden_a_supports_paint_setup(
-        session, direction & 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
+    bool hasSupports = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_3]);
 
     if (ride == nullptr)
         return;

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -26,8 +26,7 @@ static void shop_paint_setup(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    bool hasSupports = wooden_a_supports_paint_setup(
-        session, direction & 1, 0, height, session->TrackColours[SCHEME_3], nullptr);
+    bool hasSupports = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_3]);
 
     if (ride == nullptr)
         return;

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -60,7 +60,7 @@ static void paint_3d_cinema(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -89,7 +89,7 @@ static void paint_enterprise(
 
     int32_t edges = edges_4x4[trackSequence];
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = ride_get_station_object(ride);
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -150,7 +150,7 @@ static void paint_go_karts_track_flat(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -189,19 +189,19 @@ static void paint_go_karts_track_25_deg_up(
     switch (direction)
     {
         case 0:
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_7);
             break;
         case 1:
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_SQUARE_8);
             break;
         case 2:
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_SQUARE_8);
             break;
         case 3:
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_7);
             break;
     }
@@ -243,19 +243,19 @@ static void paint_go_karts_track_flat_to_25_deg_up(
     switch (direction)
     {
         case 0:
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
         case 1:
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_8);
             break;
         case 2:
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_8);
             break;
         case 3:
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             break;
     }
@@ -297,19 +297,19 @@ static void paint_go_karts_track_25_deg_up_to_flat(
     switch (direction)
     {
         case 0:
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
         case 1:
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_14);
             break;
         case 2:
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_14);
             break;
         case 3:
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
     }
@@ -448,7 +448,7 @@ static void paint_go_karts_station(
         }
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -518,7 +518,7 @@ static void paint_go_karts_track_left_quarter_turn_1_tile(
             break;
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -94,7 +94,7 @@ static void paint_launched_freefall_base(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     uint32_t imageId = SPR_FLOOR_METAL | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -147,7 +147,7 @@ static void paint_motionsimulator(
 
     int32_t edges = edges_2x2[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -104,7 +104,7 @@ static void paint_roto_drop_base(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     uint32_t imageId = SPR_FLOOR_METAL_B | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -186,7 +186,7 @@ static void paint_swinging_ship(
 
     if (relativeTrackSequence == 1 || relativeTrackSequence == 4)
     {
-        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
     else if (direction & 1)
     {

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -252,7 +252,7 @@ static void paint_top_spin(
 
     int32_t edges = edges_3x3[trackSequence];
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = nullptr;
     if (ride != nullptr)

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -92,7 +92,7 @@ static void paint_twist(
 
     uint32_t imageId;
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     StationObject* stationObject = ride_get_station_object(ride);
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_MISC], height, floorSpritesCork, stationObject);

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -187,7 +187,7 @@ static void chairlift_paint_station_ne_sw(
 
     auto stationObj = ride_get_station_object(ride);
 
-    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_MISC]);
 
     if (!isStart && !isEnd)
     {
@@ -280,7 +280,7 @@ static void chairlift_paint_station_se_nw(
 
     auto stationObj = ride_get_station_object(ride);
 
-    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_MISC], nullptr);
+    wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     if (!isStart && !isEnd)
     {

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -600,8 +600,7 @@ static void paint_miniature_railway_track_flat(
         paintGrooved = true;
     }
 
-    bool isSupported = wooden_a_supports_paint_setup(
-        session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    bool isSupported = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     uint32_t imageId, imageIdAlt;
 
     // In the following 3 calls to PaintAddImageAsParentRotated/PaintAddImageAsChildRotated, we add 1 to the
@@ -673,7 +672,7 @@ static void paint_miniature_railway_station(
 {
     uint32_t imageId;
 
-    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     imageId = miniature_railway_station_floor[direction] | session->TrackColours[SCHEME_MISC];
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 28, 2, height - 2, 0, 2, height);
@@ -715,8 +714,7 @@ static void paint_miniature_railway_track_25_deg_up(
             break;
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 45 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 45 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 56, 0x20);
@@ -747,8 +745,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_up(
             break;
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 37 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 37 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -779,8 +776,7 @@ static void paint_miniature_railway_track_25_deg_up_to_flat(
             break;
     }
 
-    wooden_a_supports_paint_setup(
-        session, direction & 1, 41 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, direction & 1, 41 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 40, 0x20);
@@ -925,7 +921,7 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
     {
         bool isSupported = wooden_a_supports_paint_setup(
             session, right_quarter_turn_5_supports_type[direction][trackSequence], 0, height,
-            session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session->TrackColours[SCHEME_SUPPORTS]);
 
         if (!isSupported || (trackSequence == 3 && direction == 2))
         {
@@ -1040,8 +1036,7 @@ static void paint_miniature_railway_track_s_bend_left(
     }
 
     bool isSupported = wooden_a_supports_paint_setup(
-        session, s_bend_left_supports_type[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS],
-        nullptr);
+        session, s_bend_left_supports_type[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     static constexpr const CoordsXY offsetList[] = {
         { 0, 2 },
@@ -1142,8 +1137,7 @@ static void paint_miniature_railway_track_s_bend_right(
     }
 
     bool isSupported = wooden_a_supports_paint_setup(
-        session, s_bend_right_supports_type[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS],
-        nullptr);
+        session, s_bend_right_supports_type[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     static constexpr const CoordsXY offsetList[] = {
         { 0, 2 },
@@ -1273,7 +1267,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
     {
         static constexpr const uint8_t supportType[] = { 4, 5, 2, 3 };
         isSupported = wooden_a_supports_paint_setup(
-            session, supportType[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session, supportType[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
     if (!isSupported)
     {
@@ -1426,7 +1420,7 @@ static void paint_miniature_railway_track_left_eighth_to_diag(
     if (trackSequence != 4 || !isRightEighthToOrthog)
     {
         isSupported = wooden_a_supports_paint_setup(
-            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
     uint32_t imageId;
     if (!isSupported)
@@ -1562,7 +1556,7 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
     if (trackSequence != 4 || !isLeftEighthToOrthog)
     {
         isSupported = wooden_a_supports_paint_setup(
-            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session, supportType[direction][trackSequence], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     uint32_t imageId;
@@ -1690,8 +1684,7 @@ static void miniature_railway_track_diag_flat(
         floorImage = floors[supportType].image_id;
         floorBoundSize = floors[supportType].bound_size;
         floorBoundOffset = floors[supportType].bound_offset;
-        isSupported = wooden_a_supports_paint_setup(
-            session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        isSupported = wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -1731,16 +1724,15 @@ enum
 };
 
 static bool wooden_supports_paint_setup(
-    paint_session* session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags,
-    bool* underground)
+    paint_session* session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, uint32_t imageColourFlags)
 {
     switch (woodType)
     {
         case WOOD_A:
-            return wooden_a_supports_paint_setup(session, supportType, special, height, imageColourFlags, underground);
+            return wooden_a_supports_paint_setup(session, supportType, special, height, imageColourFlags);
 
         case WOOD_B:
-            return wooden_b_supports_paint_setup(session, supportType, special, height, imageColourFlags, underground);
+            return wooden_b_supports_paint_setup(session, supportType, special, height, imageColourFlags);
     }
 
     return false;
@@ -1779,7 +1771,7 @@ static void miniature_railway_track_diag_25_deg_up(
         floorBoundSize = floors[supportType].bound_size;
         floorBoundOffset = floors[supportType].bound_offset;
         hasSupports = wooden_supports_paint_setup(
-            session, supportFunction, supportType, 0, height + heightDiff, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session, supportFunction, supportType, 0, height + heightDiff, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -1838,8 +1830,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_up(
         floorImage = floors[supportType].image_id;
         floorBoundSize = floors[supportType].bound_size;
         floorBoundOffset = floors[supportType].bound_offset;
-        hasSupports = wooden_a_supports_paint_setup(
-            session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        hasSupports = wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -1904,7 +1895,7 @@ static void miniature_railway_track_diag_25_deg_up_to_flat(
         floorBoundOffset = floors[supportType].bound_offset;
         hasSupports = wooden_supports_paint_setup(
             session, supportFunction, supportType, 0, height + supportOffsets[direction][trackSequence],
-            session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -1980,7 +1971,7 @@ static void miniature_railway_track_diag_25_deg_down(
         floorBoundOffset = floors[supportType].bound_offset;
         hasSupports = wooden_supports_paint_setup(
             session, supportFunction, supportType, 0, height + supportOffsets[direction][trackSequence],
-            session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -2054,7 +2045,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_down(
         floorBoundOffset = floors[supportType].bound_offset;
         hasSupports = wooden_supports_paint_setup(
             session, supportFunction, supportType, 0, height + supportOffsets[direction][trackSequence],
-            session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)
@@ -2112,8 +2103,7 @@ static void miniature_railway_track_diag_25_deg_down_to_flat(
         floorImage = floors[supportType].image_id;
         floorBoundSize = floors[supportType].bound_size;
         floorBoundOffset = floors[supportType].bound_offset;
-        hasSupports = wooden_a_supports_paint_setup(
-            session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        hasSupports = wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     if (direction == 1 && trackSequence == 3)

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -303,7 +303,7 @@ static void paint_river_rapids_track_flat(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 3 }, { 0, 27, height + 17 });
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction & 1)
     {
@@ -344,7 +344,7 @@ static void paint_river_rapids_track_25_deg(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 9, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_7);
             break;
 
@@ -356,7 +356,7 @@ static void paint_river_rapids_track_25_deg(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 10, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_SQUARE_8);
             break;
 
@@ -368,7 +368,7 @@ static void paint_river_rapids_track_25_deg(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 34 }, { 0, 27, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 11, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_SQUARE_8);
             break;
 
@@ -379,7 +379,7 @@ static void paint_river_rapids_track_25_deg(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 34 }, { 27, 0, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_7);
             break;
     }
@@ -403,7 +403,7 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 18 }, { 0, 27, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 5, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
 
@@ -415,7 +415,7 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 18 }, { 27, 0, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height + 8, TUNNEL_14);
             break;
 
@@ -427,7 +427,7 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 18 }, { 0, 27, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height + 8, TUNNEL_14);
             break;
 
@@ -438,7 +438,7 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 18 }, { 27, 0, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height - 8, TUNNEL_SQUARE_FLAT);
             break;
     }
@@ -462,7 +462,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
             break;
 
@@ -474,7 +474,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_8);
             break;
 
@@ -486,7 +486,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 0, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_8);
             break;
 
@@ -497,7 +497,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
             imageId = sprites[direction][1] | session->TrackColours[SCHEME_TRACK];
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 26 }, { 27, 0, height + 16 });
 
-            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, 1, 4, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
             break;
     }
@@ -607,7 +607,7 @@ static void paint_river_rapids_track_left_quarter_turn_1_tile(
             break;
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
@@ -664,7 +664,7 @@ static void paint_river_rapids_track_right_quarter_turn_1_tile(
             break;
     }
 
-    wooden_a_supports_paint_setup(session, 1 - (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, 1 - (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
@@ -717,7 +717,7 @@ static void paint_river_rapids_track_waterfall(
         PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 32, 1, 27 }, { 0, 27, height + 17 });
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction & 1)
     {
@@ -758,7 +758,7 @@ static void paint_river_rapids_track_rapids(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 11 }, { 0, 27, height + 17 });
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction & 1)
     {
@@ -819,7 +819,7 @@ static void paint_river_rapids_track_whirlpool(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 3 }, { 0, 27, height + 17 });
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction & 1)
     {

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -485,8 +485,7 @@ static void paint_splash_boats_track_25_deg_up(
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 1, 50, height, 0, 27, height);
 
-    wooden_a_supports_paint_setup(
-        session, (direction & 1), 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 9 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -511,8 +510,7 @@ static void paint_splash_boats_track_60_deg_up(
         session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 1, 98, height, 0, 27, height);
 
-    wooden_a_supports_paint_setup(
-        session, (direction & 1), 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 21 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -536,8 +534,7 @@ static void paint_splash_boats_track_flat_to_25_deg_up(
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 1, 42, height, 0, 27, height);
 
-    wooden_a_supports_paint_setup(
-        session, (direction & 1), 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 1 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -561,8 +558,7 @@ static void paint_splash_boats_track_25_deg_up_to_flat(
     PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 1, 34, height, 0, 27, height);
 
-    wooden_a_supports_paint_setup(
-        session, (direction & 1), 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 5 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -587,8 +583,7 @@ static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
         session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
-    wooden_a_supports_paint_setup(
-        session, (direction & 1), 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 13 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -613,8 +608,7 @@ static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
         session, direction, imageId, 0, 0, 32, 20, 2, height, 0, 6, height);
     PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 1, 66, height, 0, 27, height);
 
-    wooden_a_supports_paint_setup(
-        session, (direction & 1), 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 17 + direction, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -640,7 +634,7 @@ static void paint_splash_boats_track_25_deg_down(
 
     static constexpr const uint8_t specialSupport[] = { 11, 12, 9, 10 };
     wooden_a_supports_paint_setup(
-        session, (direction & 1), specialSupport[direction], height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        session, (direction & 1), specialSupport[direction], height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -673,7 +667,7 @@ static void paint_splash_boats_track_flat_to_25_deg_down(
 
     static constexpr const uint8_t specialSupport[] = { 7, 8, 5, 6 };
     wooden_a_supports_paint_setup(
-        session, (direction & 1), specialSupport[direction], height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        session, (direction & 1), specialSupport[direction], height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -713,7 +707,7 @@ static void paint_splash_boats_track_25_deg_down_to_flat(
 
     static constexpr const uint8_t specialSupport[] = { 3, 4, 1, 2 };
     wooden_a_supports_paint_setup(
-        session, (direction & 1), specialSupport[direction], height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        session, (direction & 1), specialSupport[direction], height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction == 0 || direction == 3)
     {
@@ -766,7 +760,7 @@ static void paint_splash_boats_track_flat(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 26 }, { 0, 27, height });
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (direction & 1)
     {
@@ -805,7 +799,7 @@ static void paint_splash_boats_station(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 });
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 7, trackElement);
@@ -835,7 +829,7 @@ static void paint_splash_boats_track_left_quarter_turn_5_tiles(
             { 1, 0xFF, 4, 2, 0xFF, 4, 0 },
         };
         uint8_t supportType = supportTypes[direction][trackSequence];
-        wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     switch (trackSequence)
@@ -916,7 +910,7 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(
             { 1, 0xFF, 3, 5, 0xFF, 3, 0 },
         };
         uint8_t supportType = supportTypes[direction][trackSequence];
-        wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+        wooden_a_supports_paint_setup(session, supportType, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
     switch (trackSequence)
@@ -1013,7 +1007,7 @@ static void paint_splash_boats_track_s_bend_left(
         case 0:
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 27, 2, height, 0, 2, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 27, 0, height, 0, 2, height + 27);
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
         case 1:
@@ -1021,8 +1015,7 @@ static void paint_splash_boats_track_s_bend_left(
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 26, 2, height, 0, bboy, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 26, 0, height, 0, bboy, height + 27);
 
-            wooden_a_supports_paint_setup(
-                session, supportTypes1[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, supportTypes1[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             paint_util_set_segment_support_height(
                 session,
@@ -1035,8 +1028,7 @@ static void paint_splash_boats_track_s_bend_left(
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 26, 2, height, 0, bboy, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 26, 0, height, 0, bboy, height + 27);
 
-            wooden_a_supports_paint_setup(
-                session, supportTypes2[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, supportTypes2[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             paint_util_set_segment_support_height(
                 session,
@@ -1047,7 +1039,7 @@ static void paint_splash_boats_track_s_bend_left(
         case 3:
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 27, 2, height, 0, 2, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 27, 0, height, 0, 2, height + 27);
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
     }
@@ -1105,7 +1097,7 @@ static void paint_splash_boats_track_s_bend_right(
         case 0:
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 27, 2, height, 0, 2, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 27, 0, height, 0, 2, height + 27);
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
         case 1:
@@ -1113,8 +1105,7 @@ static void paint_splash_boats_track_s_bend_right(
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 26, 2, height, 0, bboy, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 26, 0, height, 0, bboy, height + 27);
 
-            wooden_a_supports_paint_setup(
-                session, supportTypes1[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, supportTypes1[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             paint_util_set_segment_support_height(
                 session,
@@ -1127,8 +1118,7 @@ static void paint_splash_boats_track_s_bend_right(
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 26, 2, height, 0, bboy, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 26, 0, height, 0, bboy, height + 27);
 
-            wooden_a_supports_paint_setup(
-                session, supportTypes2[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, supportTypes2[direction], 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
             paint_util_set_segment_support_height(
                 session,
@@ -1139,7 +1129,7 @@ static void paint_splash_boats_track_s_bend_right(
         case 3:
             PaintAddImageAsParentRotated(session, direction, imageId, 0, 0, 32, 27, 2, height, 0, 2, height);
             PaintAddImageAsParentRotated(session, direction, frontImageId, 0, 0, 32, 27, 0, height, 0, 2, height + 27);
-            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS], nullptr);
+            wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
             break;
     }


### PR DESCRIPTION
The argument is always null so lets just remove it