### PR TITLE
Use real values for gGuestsInParkHistory (from NSF)

### DIFF
--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1065,7 +1065,20 @@ static void window_park_guests_paint(rct_window* w, rct_drawpixelinfo* dpi)
     // Graph
     screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 47, widget->top + 26 };
 
-    Graph::Draw(dpi, gGuestsInParkHistory, 32, screenPos);
+    uint8_t cappedHistory[32];
+    for (size_t i = 0; i < std::size(cappedHistory); i++)
+    {
+        auto value = gGuestsInParkHistory[i];
+        if (value != std::numeric_limits<uint32_t>::max())
+        {
+            cappedHistory[i] = static_cast<uint8_t>(std::min<uint32_t>(value, 5000) / 20);
+        }
+        else
+        {
+            cappedHistory[i] = std::numeric_limits<uint8_t>::max();
+        }
+    }
+    Graph::Draw(dpi, cappedHistory, static_cast<int32_t>(std::size(cappedHistory)), screenPos);
 }
 
 #pragma endregion

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2118,9 +2118,16 @@ namespace RCT1
 
             // Park rating
             gParkRating = _s4.park_rating;
-            for (size_t i = 0; i < 32; i++)
+
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            park.ResetHistories();
+            std::memcpy(gParkRatingHistory, _s4.park_rating_history, sizeof(_s4.park_rating_history));
+            for (size_t i = 0; i < std::size(_s4.guests_in_park_history); i++)
             {
-                gParkRatingHistory[i] = _s4.park_rating_history[i];
+                if (_s4.guests_in_park_history[i] != RCT12ParkHistoryUndefined)
+                {
+                    gGuestsInParkHistory[i] = _s4.guests_in_park_history[i] * RCT12GuestsInParkHistoryFactor;
+                }
             }
 
             // Awards

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2121,7 +2121,7 @@ namespace RCT1
 
             auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
             park.ResetHistories();
-            std::memcpy(gParkRatingHistory, _s4.park_rating_history, sizeof(_s4.park_rating_history));
+            std::copy(std::begin(_s4.park_rating_history), std::end(_s4.park_rating_history), gParkRatingHistory);
             for (size_t i = 0; i < std::size(_s4.guests_in_park_history); i++)
             {
                 if (_s4.guests_in_park_history[i] != RCT12ParkHistoryUndefined)

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -90,6 +90,9 @@ constexpr const uint16_t RCT12VehicleTrackTypeMask = 0b1111111111111100;
 
 constexpr const uint8_t RCT12PeepThoughtItemNone = std::numeric_limits<uint8_t>::max();
 
+constexpr const uint8_t RCT12GuestsInParkHistoryFactor = 20;
+constexpr const uint8_t RCT12ParkHistoryUndefined = std::numeric_limits<uint8_t>::max();
+
 enum class RCT12TrackDesignVersion : uint8_t
 {
     TD4,

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -351,7 +351,7 @@ void S6Exporter::Export()
 
     _s6.park_rating = gParkRating;
 
-    std::memcpy(_s6.park_rating_history, gParkRatingHistory, sizeof(_s6.park_rating_history));
+    std::copy(std::begin(gParkRatingHistory), std::end(gParkRatingHistory), _s6.park_rating_history);
     std::fill(std::begin(_s6.guests_in_park_history), std::end(_s6.guests_in_park_history), RCT12ParkHistoryUndefined);
     for (size_t i = 0; i < std::size(gGuestsInParkHistory); i++)
     {

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -352,6 +352,15 @@ void S6Exporter::Export()
     _s6.park_rating = gParkRating;
 
     std::memcpy(_s6.park_rating_history, gParkRatingHistory, sizeof(_s6.park_rating_history));
+    std::fill(std::begin(_s6.guests_in_park_history), std::end(_s6.guests_in_park_history), RCT12ParkHistoryUndefined);
+    for (size_t i = 0; i < std::size(gGuestsInParkHistory); i++)
+    {
+        if (gGuestsInParkHistory[i] != GuestsInParkHistoryUndefined)
+        {
+            _s6.guests_in_park_history[i] = std::min<uint16_t>(gGuestsInParkHistory[i], 5000) / RCT12GuestsInParkHistoryFactor;
+        }
+    }
+
     std::memcpy(_s6.guests_in_park_history, gGuestsInParkHistory, sizeof(_s6.guests_in_park_history));
 
     _s6.active_research_types = gResearchPriorities;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -272,7 +272,7 @@ public:
 
         auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
         park.ResetHistories();
-        std::memcpy(gParkRatingHistory, _s6.park_rating_history, sizeof(_s6.park_rating_history));
+        std::copy(std::begin(_s6.park_rating_history), std::end(_s6.park_rating_history), gParkRatingHistory);
         for (size_t i = 0; i < std::size(_s6.guests_in_park_history); i++)
         {
             if (_s6.guests_in_park_history[i] != RCT12ParkHistoryUndefined)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -270,8 +270,16 @@ public:
 
         gParkRating = _s6.park_rating;
 
+        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+        park.ResetHistories();
         std::memcpy(gParkRatingHistory, _s6.park_rating_history, sizeof(_s6.park_rating_history));
-        std::memcpy(gGuestsInParkHistory, _s6.guests_in_park_history, sizeof(_s6.guests_in_park_history));
+        for (size_t i = 0; i < std::size(_s6.guests_in_park_history); i++)
+        {
+            if (_s6.guests_in_park_history[i] != RCT12ParkHistoryUndefined)
+            {
+                gGuestsInParkHistory[i] = _s6.guests_in_park_history[i] * RCT12GuestsInParkHistoryFactor;
+            }
+        }
 
         gResearchPriorities = _s6.active_research_types;
         gResearchProgressStage = _s6.research_progress_stage;
@@ -464,7 +472,6 @@ public:
         map_count_remaining_land_rights();
         determine_ride_entrance_and_exit_locations();
 
-        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
         park.Name = GetUserString(_s6.park_name);
 
         FixLandOwnership();

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -46,22 +46,22 @@
 
 using namespace OpenRCT2;
 
-uint32_t gParkFlags;
+uint64_t gParkFlags;
 uint16_t gParkRating;
 money16 gParkEntranceFee;
 uint16_t gParkSize;
 money16 gLandPrice;
 money16 gConstructionRightsPrice;
 
-uint32_t gTotalAdmissions;
-money32 gTotalIncomeFromAdmissions;
+uint64_t gTotalAdmissions;
+money64 gTotalIncomeFromAdmissions;
 
-money32 gParkValue;
-money32 gCompanyValue;
+money64 gParkValue;
+money64 gCompanyValue;
 
 int16_t gParkRatingCasualtyPenalty;
 uint8_t gParkRatingHistory[32];
-uint8_t gGuestsInParkHistory[32];
+uint32_t gGuestsInParkHistory[32];
 
 // If this value is more than or equal to 0, the park rating is forced to this value. Used for cheat
 static int32_t _forcedParkRating = -1;
@@ -743,11 +743,8 @@ template<typename T, size_t TSize> static void HistoryPushRecord(T history[TSize
 
 void Park::ResetHistories()
 {
-    for (size_t i = 0; i < 32; i++)
-    {
-        gParkRatingHistory[i] = 255;
-        gGuestsInParkHistory[i] = 255;
-    }
+    std::fill(std::begin(gParkRatingHistory), std::end(gParkRatingHistory), ParkRatingHistoryUndefined);
+    std::fill(std::begin(gGuestsInParkHistory), std::end(gGuestsInParkHistory), GuestsInParkHistoryUndefined);
 }
 
 void Park::UpdateHistories()
@@ -767,7 +764,7 @@ void Park::UpdateHistories()
 
     // Update park rating, guests in park and current cash history
     HistoryPushRecord<uint8_t, 32>(gParkRatingHistory, CalculateParkRating() / 4);
-    HistoryPushRecord<uint8_t, 32>(gGuestsInParkHistory, std::min<uint16_t>(gNumGuestsInPark, 5000) / 20);
+    HistoryPushRecord<uint32_t, 32>(gGuestsInParkHistory, gNumGuestsInPark);
     HistoryPushRecord<money64, std::size(gCashHistory)>(gCashHistory, finance_get_current_cash() - gBankLoan);
 
     // Update weekly profit history

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -18,6 +18,9 @@
 
 #define MAX_ENTRANCE_FEE MONEY(200, 00)
 
+constexpr const uint8_t ParkRatingHistoryUndefined = std::numeric_limits<uint8_t>::max();
+constexpr const uint32_t GuestsInParkHistoryUndefined = std::numeric_limits<uint32_t>::max();
+
 enum : uint32_t
 {
     PARK_FLAGS_PARK_OPEN = (1 << 0),
@@ -87,22 +90,22 @@ namespace OpenRCT2
     };
 } // namespace OpenRCT2
 
-extern uint32_t gParkFlags;
+extern uint64_t gParkFlags;
 extern uint16_t gParkRating;
 extern money16 gParkEntranceFee;
 extern uint16_t gParkSize;
 extern money16 gLandPrice;
 extern money16 gConstructionRightsPrice;
 
-extern uint32_t gTotalAdmissions;
-extern money32 gTotalIncomeFromAdmissions;
+extern uint64_t gTotalAdmissions;
+extern money64 gTotalIncomeFromAdmissions;
 
-extern money32 gParkValue;
-extern money32 gCompanyValue;
+extern money64 gParkValue;
+extern money64 gCompanyValue;
 
 extern int16_t gParkRatingCasualtyPenalty;
 extern uint8_t gParkRatingHistory[32];
-extern uint8_t gGuestsInParkHistory[32];
+extern uint32_t gGuestsInParkHistory[32];
 extern int32_t _guestGenerationProbability;
 extern uint32_t _suggestedGuestMaximum;
 


### PR DESCRIPTION
This one is nice and simple for a change :D

You know the drill: do not squash merge.