### PR TITLE
Avoid redefining WIN32_LEAN_AND_MEAN

### DIFF
--- a/src/openrct2/core/Http.cURL.cpp
+++ b/src/openrct2/core/Http.cURL.cpp
@@ -18,7 +18,7 @@
 #    include <stdexcept>
 #    include <thread>
 
-#    ifdef _WIN32
+#    if defined(_WIN32) && !defined(WIN32_LEAN_AND_MEAN)
 // cURL includes windows.h, but we don't need all of it.
 #        define WIN32_LEAN_AND_MEAN
 #    endif


### PR DESCRIPTION
All other cases where we define `WIN32_LEAN_AND_MEAN` this is already handled correctly.