### PR TITLE
Fix enum serialization not using byte swap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,9 @@ set(OBJECTS_VERSION "1.0.21")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c38af45d51a6e440386180feacf76c64720b6ac5")
 
-set(REPLAYS_VERSION "0.0.49")
+set(REPLAYS_VERSION "0.0.50")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "004AE4D38D1326913AF5DE7A90E8AF31DD31BF94")
+set(REPLAYS_SHA1 "C569C73147F1C1554807B6FBE74C39A4F0E20EAF")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.0.21/objects.zip</ObjectsUrl>
     <ObjectsSha1>c38af45d51a6e440386180feacf76c64720b6ac5</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.49/replays.zip</ReplaysUrl>
-    <ReplaysSha1>004AE4D38D1326913AF5DE7A90E8AF31DD31BF94</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.50/replays.zip</ReplaysUrl>
+    <ReplaysSha1>C569C73147F1C1554807B6FBE74C39A4F0E20EAF</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -38,19 +38,23 @@ template<typename T> struct DataSerializerTraits_t
 
 template<typename T> struct DataSerializerTraits_enum
 {
+    using TUnderlying = std::underlying_type_t<T>;
+
     static void encode(OpenRCT2::IStream* stream, const T& val)
     {
-        stream->Write(&val);
+        TUnderlying temp = ByteSwapBE(static_cast<TUnderlying>(val));
+        stream->Write(&temp);
     }
     static void decode(OpenRCT2::IStream* stream, T& val)
     {
-        stream->Read(&val);
+        TUnderlying temp;
+        stream->Read(&temp);
+        val = static_cast<T>(ByteSwapBE(temp));
     }
     static void log(OpenRCT2::IStream* stream, const T& val)
     {
-        using underlying = std::underlying_type_t<T>;
         std::stringstream ss;
-        ss << std::hex << std::setw(sizeof(underlying) * 2) << std::setfill('0') << static_cast<underlying>(val);
+        ss << std::hex << std::setw(sizeof(TUnderlying) * 2) << std::setfill('0') << static_cast<TUnderlying>(val);
 
         std::string str = ss.str();
         stream->Write(str.c_str(), str.size());

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -37,7 +37,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -63,7 +63,7 @@ struct Vehicle : EntityBase
         Tail,
     };
 
-    enum class Status
+    enum class Status : uint8_t
     {
         MovingToEndOfStation,
         WaitingForPassengers,


### PR DESCRIPTION
Found this bug while changing ride_id_t to strong enum, the bytes were not ordered the same as the underlying type.