### PR TITLE
Supports field in rtd

### DIFF
--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -223,6 +223,7 @@ GameActions::Result::Ptr RideSetSettingAction::Execute() const
             break;
         case RideSetSetting::RideType:
             ride->type = _value;
+            UpdateSupports(false);
             gfx_invalidate_screen();
             break;
     }
@@ -296,4 +297,31 @@ rct_string_id RideSetSettingAction::GetOperationErrorMessage(Ride* ride) const
                 return STR_CANT_CHANGE_LAUNCH_SPEED;
             }
     }
+}
+
+
+void RideSetSettingAction::UpdateSupports(bool RCT1SupportsOverride) const
+{
+
+    uint8_t oldpaused = gGamePaused;
+    gGamePaused = 0;
+
+    tile_element_iterator it;
+
+    tile_element_iterator_begin(&it);
+    while (tile_element_iterator_next(&it))
+    {
+        if (it.element->GetType() != TILE_ELEMENT_TYPE_TRACK)
+            continue;
+
+        if (it.element->AsTrack()->GetRideIndex() != static_cast<ride_id_t>(_rideIndex))
+            continue;
+
+        it.element->AsTrack()->SetHasSupport(
+            it.element->AsTrack()->DetermineSupportState({ it.x, it.y }, RCT1SupportsOverride));
+
+        tile_element_iterator_restart_for_tile(&it);
+    }
+
+    gGamePaused = oldpaused;
 }

--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -299,10 +299,8 @@ rct_string_id RideSetSettingAction::GetOperationErrorMessage(Ride* ride) const
     }
 }
 
-
 void RideSetSettingAction::UpdateSupports(bool RCT1SupportsOverride) const
 {
-
     uint8_t oldpaused = gGamePaused;
     gGamePaused = 0;
 

--- a/src/openrct2/actions/RideSetSettingAction.h
+++ b/src/openrct2/actions/RideSetSettingAction.h
@@ -51,4 +51,5 @@ private:
     bool ride_is_valid_num_circuits() const;
     bool ride_is_valid_operation_option(Ride * ride) const;
     rct_string_id GetOperationErrorMessage(Ride * ride) const;
+    void UpdateSupports(bool RCT1SupportsOverride); const
 };

--- a/src/openrct2/actions/RideSetSettingAction.h
+++ b/src/openrct2/actions/RideSetSettingAction.h
@@ -51,5 +51,5 @@ private:
     bool ride_is_valid_num_circuits() const;
     bool ride_is_valid_operation_option(Ride * ride) const;
     rct_string_id GetOperationErrorMessage(Ride * ride) const;
-    void UpdateSupports(bool RCT1SupportsOverride); const
+    void UpdateSupports(bool RCT1SupportsOverride) const;
 };

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -561,6 +561,7 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         trackElement->SetRideIndex(_rideIndex);
         trackElement->SetTrackType(_trackType);
         trackElement->SetGhost(GetFlags() & GAME_COMMAND_FLAG_GHOST);
+        trackElement->SetHasSupport((_trackPlaceFlags & CONSTRUCTION_BUILD_SUPPORTS) && trackElement->DetermineSupportState(mapLoc, false));
 
         switch (_trackType)
         {

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -561,7 +561,8 @@ GameActions::Result::Ptr TrackPlaceAction::Execute() const
         trackElement->SetRideIndex(_rideIndex);
         trackElement->SetTrackType(_trackType);
         trackElement->SetGhost(GetFlags() & GAME_COMMAND_FLAG_GHOST);
-        trackElement->SetHasSupport((_trackPlaceFlags & CONSTRUCTION_BUILD_SUPPORTS) && trackElement->DetermineSupportState(mapLoc, false));
+        trackElement->SetHasSupport(
+            (_trackPlaceFlags & CONSTRUCTION_BUILD_SUPPORTS) && trackElement->DetermineSupportState(mapLoc, false));
 
         switch (_trackType)
         {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1523,6 +1523,13 @@ namespace RCT1
                             tileElements.resize(originalSize + 16);
                             auto dstElement = tileElements.data() + originalSize;
                             auto numAddedElements = ImportTileElement(dstElement, srcElement);
+                            if (dstElement->GetType() == TILE_ELEMENT_TYPE_TRACK)
+                            {
+                                const auto* ride = get_ride(RCT12RideIdToOpenRCT2RideId(srcElement->AsTrack()->GetRideIndex()));
+                                auto rideType = (ride != nullptr) ? ride->type : RIDE_TYPE_NULL;
+                                dstElement->AsTrack()->SetHasSupport(
+                                    dstElement->AsTrack()->DetermineSupportState(coords.ToCoordsXY(), rideType, true));
+                            }
                             tileElements.resize(originalSize + numAddedElements);
                         } while (!(srcElement++)->IsLastForTile());
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1116,7 +1116,12 @@ public:
                             || tileElementType == RCT12TileElementType::EightCarsCorrupt15)
                             std::memcpy(&dstElement, srcElement, sizeof(*srcElement));
                         else
+                        {
                             ImportTileElement(&dstElement, srcElement);
+                            if (dstElement.GetType() == TILE_ELEMENT_TYPE_TRACK)
+                                dstElement.AsTrack()->SetHasSupport(dstElement.AsTrack()->DetermineSupportState(
+                                    coords.ToCoordsXY(), _s6.rides[srcElement->AsTrack()->GetRideIndex()].type, false));
+                        }
                     }
                 } while (!(srcElement++)->IsLastForTile());
 
@@ -1192,6 +1197,7 @@ public:
                 auto src2 = src->AsTrack();
 
                 auto rideType = _s6.rides[src2->GetRideIndex()].type;
+                auto rtd = GetRideTypeDescriptor(rideType);
                 track_type_t trackType = static_cast<track_type_t>(src2->GetTrackType());
 
                 dst2->SetTrackType(RCT2TrackTypeToOpenRCT2(trackType, _s6.rides[src2->GetRideIndex()].type));

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1197,7 +1197,6 @@ public:
                 auto src2 = src->AsTrack();
 
                 auto rideType = _s6.rides[src2->GetRideIndex()].type;
-                auto rtd = GetRideTypeDescriptor(rideType);
                 track_type_t trackType = static_cast<track_type_t>(src2->GetTrackType());
 
                 dst2->SetTrackType(RCT2TrackTypeToOpenRCT2(trackType, _s6.rides[src2->GetRideIndex()].type));

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -957,7 +957,10 @@ enum
     TRACK_ELEMENT_SET_COLOUR_SCHEME = (1 << 2),
     TRACK_ELEMENT_SET_HAS_CABLE_LIFT_TRUE = (1 << 3),
     TRACK_ELEMENT_SET_HAS_CABLE_LIFT_FALSE = (1 << 4),
-    TRACK_ELEMENT_SET_SEAT_ROTATION = (1 << 5)
+    TRACK_ELEMENT_SET_SEAT_ROTATION = (1 << 5),
+    TRACK_ELEMENT_SET_HAS_SUPPORT_TRUE = (1 << 6),
+    TRACK_ELEMENT_SET_HAS_SUPPORT_FALSE = (1 << 7),
+    TRACK_ELEMENT_SET_HAS_SUPPORT_DEFAULT = (1 << 8)
 };
 
 struct RideOperatingSettings
@@ -985,6 +988,7 @@ struct RideOperatingSettings
 
 constexpr uint32_t CONSTRUCTION_LIFT_HILL_SELECTED = 1 << 0;
 constexpr uint32_t CONSTRUCTION_INVERTED_TRACK_SELECTED = 1 << 1;
+constexpr uint32_t CONSTRUCTION_BUILD_SUPPORTS = 1 << 2;
 
 Ride* get_ride(ride_id_t index);
 

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -454,6 +454,18 @@ std::optional<CoordsXYZ> GetTrackElementOriginAndApplyChanges(
         {
             trackElement->SetHasCableLift(false);
         }
+        if (flags & TRACK_ELEMENT_SET_HAS_SUPPORT_TRUE)
+        {
+            trackElement->SetHasSupport(true);
+        }
+        if (flags & TRACK_ELEMENT_SET_HAS_SUPPORT_FALSE)
+        {
+            trackElement->SetHasSupport(false);
+        }
+        if (flags & TRACK_ELEMENT_SET_HAS_SUPPORT_DEFAULT)
+        {
+            trackElement->SetHasSupport(trackElement->DetermineSupportState(cur,  false));
+        }
     }
     return retCoordsXYZ;
 }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -464,7 +464,7 @@ std::optional<CoordsXYZ> GetTrackElementOriginAndApplyChanges(
         }
         if (flags & TRACK_ELEMENT_SET_HAS_SUPPORT_DEFAULT)
         {
-            trackElement->SetHasSupport(trackElement->DetermineSupportState(cur,  false));
+            trackElement->SetHasSupport(trackElement->DetermineSupportState(cur, false));
         }
     }
     return retCoordsXYZ;

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -175,6 +175,7 @@ struct RideTypeDescriptor
     track_colour_preset_list ColourPresets;
     RideColourPreview ColourPreview;
     RideColourKey ColourKey;
+    uint8_t SupportsBehaviour;
 
     bool HasFlag(uint64_t flag) const;
     uint64_t GetAvailableTrackPieces() const;
@@ -331,6 +332,22 @@ extern const uint16_t RideFilmLength[3];
 
 extern const rct_string_id RideModeNames[static_cast<uint8_t>(RideMode::Count)];
 
+namespace RideSupportsBehaviour
+{
+    constexpr uint8_t AlwaysHasSupports = 1 << 0;
+    constexpr uint8_t ChairliftSupports = 1 << 1;
+    constexpr uint8_t ShouldHaveSupports = 1 << 2;
+    constexpr uint8_t RCT1ExtraSupports = 1 << 3;
+    constexpr uint8_t CoveredExtraSupports = 1 << 4;
+    constexpr uint8_t InversionExtraSupports = 1 << 5;
+    // LoopASupports is implied
+    constexpr uint8_t LoopBSupports = 1 << 6;
+    constexpr uint8_t LoopCSupports = 1 << 7;
+
+}; // namespace RideSupportsBehaviour
+
+const uint8_t _defaultCoasterSupports = RideSupportsBehaviour::ShouldHaveSupports;
+
 // clang-format off
 constexpr const RideTypeDescriptor DummyRTD =
 {
@@ -362,7 +379,8 @@ constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(BonusValue, 0),
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { static_cast<uint32_t>(SPR_NONE), static_cast<uint32_t>(SPR_NONE) }),
-    SET_FIELD(ColourKey, RideColourKey::Ride)
+    SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -900,7 +900,7 @@ void TrackElement::SetHighlight(bool on)
         Flags2 |= TRACK_ELEMENT_FLAGS2_HIGHLIGHT;
 }
 
-bool TrackSupportsHasFlag(uint8_t queryFlag, uint8_t sequenceFlags)
+static bool TrackSupportsHasFlag(uint8_t queryFlag, uint8_t sequenceFlags)
 {
     switch (queryFlag)
     {

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -938,7 +938,7 @@ bool TrackSupportDefaultState(
         {
             return TrackSupportsHasFlag(TRACK_SUPPORT_CHAIRLIFT_SUPPORT, sequence);
         }
-        bool shouldDraw = shouldDraw = TrackSupportsHasFlag(TRACK_SUPPORT_HAS_SUPPORT, ted.SequenceSupportBehaviour[sequence]);
+        bool shouldDraw = TrackSupportsHasFlag(TRACK_SUPPORT_HAS_SUPPORT, ted.SequenceSupportBehaviour[sequence]);
         if (TrackSupportsHasFlag(TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, ted.SequenceSupportBehaviour[sequence]))
         {
             // nominally any place RCT2 supports show up every other tile, RCT1 supports always show up

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -91,6 +91,7 @@ enum
     TRACK_ELEMENT_FLAGS2_HAS_GREEN_LIGHT = 1 << 4,
     TRACK_ELEMENT_FLAGS2_BLOCK_BRAKE_CLOSED = 1 << 5,
     TRACK_ELEMENT_FLAGS2_INDESTRUCTIBLE_TRACK_PIECE = 1 << 6,
+    TRACK_ELEMENT_FLAGS2_HAS_SUPPORT = 1 << 7
 };
 
 enum
@@ -233,6 +234,20 @@ enum
     TRACK_ELEM_FLAG_CURVE_ALLOWS_LIFT = (1 << 13),
     TRACK_ELEM_FLAG_INVERSION_TO_NORMAL = (1 << 14),
     TRACK_ELEM_FLAG_BANKED = (1 << 15), // Also set on Spinning Tunnel and Log Flume reverser, probably to save a flag.
+};
+
+enum
+{
+    TRACK_SUPPORT_HAS_SUPPORT = 1 << 0,
+    TRACK_SUPPORT_SHOULD_HAVE_SUPPORT = 1 << 1,
+    TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT = 1 << 2,
+    TRACK_SUPPORT_COVERED_EXTRA_SUPPORT = 1 << 3,
+    TRACK_SUPPORT_RCT1_EXTRA_SUPPORT = 1 << 4,
+    TRACK_SUPPORT_LOOP_A = 1 << 5,
+    TRACK_SUPPORT_LOOP_B = 1 << 6,
+    TRACK_SUPPORT_LOOP_C = 1 << 7,
+    TRACK_SUPPORT_CHAIRLIFT_SUPPORT = 0b11100000 // TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B | TRACK_SUPPORT_LOOP_C must be
+                                                 // notated as TRACK_SUPPORT_HAS_SUPPORT
 };
 
 namespace TrackElemType
@@ -566,6 +581,8 @@ bool track_circuit_iterators_match(const track_circuit_iterator* firstIt, const 
 void track_get_back(CoordsXYE* input, CoordsXYE* output);
 void track_get_front(CoordsXYE* input, CoordsXYE* output);
 
+bool trackShouldHaveSupports(const CoordsXY& position, RideTypeDescriptor rtd, track_type_t trackType, uint8_t sequence);
+
 bool track_element_is_covered(track_type_t trackElementType);
 bool track_type_is_station(track_type_t trackType);
 
@@ -581,3 +598,5 @@ money32 maze_set_track(
     uint8_t mode);
 
 bool TrackTypeHasSpeedSetting(track_type_t trackType);
+
+bool TrackSupportDefaultState(uint8_t rideType, CoordsXY position, track_type_t trackType, uint8_t sequence, bool RCT1StyleSupports);

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -599,4 +599,5 @@ money32 maze_set_track(
 
 bool TrackTypeHasSpeedSetting(track_type_t trackType);
 
-bool TrackSupportDefaultState(uint8_t rideType, CoordsXY position, track_type_t trackType, uint8_t sequence, bool RCT1StyleSupports);
+bool TrackSupportDefaultState(
+    uint8_t rideType, CoordsXY position, track_type_t trackType, uint8_t sequence, bool RCT1StyleSupports);

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -598,4 +598,6 @@ money32 maze_set_track(
 bool TrackTypeHasSpeedSetting(track_type_t trackType);
 
 bool TrackSupportDefaultState(
+    RideTypeDescriptor rtd, CoordsXY position, track_type_t trackType, uint8_t sequence, bool RCT1SupportsOverride);
+bool TrackSupportDefaultState(
     uint8_t rideType, CoordsXY position, track_type_t trackType, uint8_t sequence, bool RCT1StyleSupports);

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -581,8 +581,6 @@ bool track_circuit_iterators_match(const track_circuit_iterator* firstIt, const 
 void track_get_back(CoordsXYE* input, CoordsXYE* output);
 void track_get_front(CoordsXYE* input, CoordsXYE* output);
 
-bool trackShouldHaveSupports(const CoordsXY& position, RideTypeDescriptor rtd, track_type_t trackType, uint8_t sequence);
-
 bool track_element_is_covered(track_type_t trackElementType);
 bool track_type_is_station(track_type_t trackType);
 

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -5427,6 +5427,278 @@ constexpr static uint8_t TrackTypeToSpinFunction[TrackElemType::Count] = {
     NO_SPIN, NO_SPIN, NO_SPIN, NO_SPIN, NO_SPIN, NO_SPIN, NO_SPIN, NO_SPIN, NO_SPIN
 };
 
+// clang-format off
+constexpr uint8_t TrackSupportsBehaviour[TrackElemType::Count][MaxSequencesPerPiece] = {
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                           // TrackElemType::Flat
+    { TRACK_SUPPORT_HAS_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::EndStation
+    { TRACK_SUPPORT_HAS_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::BeginStation
+    { TRACK_SUPPORT_HAS_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MiddleStation
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Up25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Up60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Up25ToUp60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Up60ToUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Up25ToFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Down25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Down60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Down25ToDown60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                   // TrackElemType::Down60ToDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Down25ToFlat
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn5Tiles
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn5Tiles
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::FlatToLeftBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::FlatToRightBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::LeftBankToFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::RightBankToFlat
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::BankedLeftQuarterTurn5Tiles
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::BankedRightQuarterTurn5Tiles
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::LeftBankToUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::RightBankToUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Up25ToLeftBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Up25ToRightBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::LeftBankToDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::RightBankToDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Down25ToLeftBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Down25ToRightBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::LeftBank
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::RightBank
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn5TilesUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn5TilesUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn5TilesDown25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn5TilesDown25
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::SBendLeft
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::SBendRight
+    { TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_C, 0, 0, 0, 0, TRACK_SUPPORT_LOOP_C, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftVerticalLoop
+    { TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_C, 0, 0, 0, 0, TRACK_SUPPORT_LOOP_C, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightVerticalLoop
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn3Tiles
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn3Tiles
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedQuarterTurn3Tiles
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedQuarterTurn3Tiles
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn3TilesUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn3TilesUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn3TilesDown25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn3TilesDown25
+    { TRACK_SUPPORT_HAS_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::LeftQuarterTurn1Tile
+    { TRACK_SUPPORT_HAS_SUPPORT | TRACK_SUPPORT_CHAIRLIFT_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::RightQuarterTurn1Tile
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftTwistDownToUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightTwistDownToUp
+    { TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftTwistUpToDown
+    { TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightTwistUpToDown
+    { TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_C, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::HalfLoopUp
+    { 0, TRACK_SUPPORT_LOOP_C, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::HalfLoopDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftCorkscrewUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightCorkscrewUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftCorkscrewDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightCorkscrewDown
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToUp60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Up60ToFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToDown60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Down60ToFlat
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::TowerBase
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                                         // TrackElemType::TowerSection
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::FlatCovered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Up25Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Up60Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::FlatToUp25Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Up25ToUp60Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Up60ToUp25Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Up25ToFlatCovered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Down25Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Down60Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::FlatToDown25Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Down25ToDown60Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Down60ToDown25Covered
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT | TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },   // TrackElemType::Down25ToFlatCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn5TilesCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn5TilesCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                     // TrackElemType::SBendLeftCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                     // TrackElemType::SBendRightCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn3TilesCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn3TilesCovered
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftHalfBankedHelixUpSmall
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightHalfBankedHelixUpSmall
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftHalfBankedHelixDownSmall
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightHalfBankedHelixDownSmall
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0 }, // TrackElemType::LeftHalfBankedHelixUpLarge
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0 }, // TrackElemType::RightHalfBankedHelixUpLarge
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0 }, // TrackElemType::LeftHalfBankedHelixDownLarge
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0 }, // TrackElemType::RightHalfBankedHelixDownLarge
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::LeftQuarterTurn1TileUp60
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::RightQuarterTurn1TileUp60
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::LeftQuarterTurn1TileDown60
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::RightQuarterTurn1TileDown60
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Brakes
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Booster
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::Maze
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterBankedHelixLargeUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterBankedHelixLargeUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterBankedHelixLargeDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterBankedHelixLargeDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterHelixLargeUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterHelixLargeUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterHelixLargeDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterHelixLargeDown
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Up25LeftBanked
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Up25RightBanked
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::Waterfall
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::Rapids
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::OnRidePhoto
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Down25LeftBanked
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::Down25RightBanked
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },         // TrackElemType::Watersplash
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToUp60LongBase
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Up60ToFlatLongBase
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Whirlpool
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Down60ToFlatLongBase
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToDown60LongBase
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::CableLiftHill
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::ReverseFreefallSlope
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::ReverseFreefallVertical
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Up90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Down90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Up60ToUp90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Down90ToDown60
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Up90ToUp60
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Down60ToDown90
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::BrakeForDrop
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftEighthToDiag
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightEighthToDiag
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftEighthToOrthogonal
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightEighthToOrthogonal
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftEighthBankToDiag
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightEighthBankToDiag
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftEighthBankToOrthogonal
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightEighthBankToOrthogonal
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp60
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlatToUp25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp25ToUp60
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp60ToUp25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp25ToFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown60
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlatToDown25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown25ToDown60
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown60ToDown25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown25ToFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlatToUp60
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp60ToFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlatToDown60
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown60ToFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlatToLeftBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagFlatToRightBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagLeftBankToFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagRightBankToFlat
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagLeftBankToUp25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagRightBankToUp25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp25ToLeftBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagUp25ToRightBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagLeftBankToDown25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagRightBankToDown25
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown25ToLeftBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagDown25ToRightBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagLeftBank
+    { 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::DiagRightBank
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LogFlumeReverser
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::SpinningTunnel
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBarrelRollUpToDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBarrelRollUpToDown
+    { TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBarrelRollDownToUp
+    { TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBarrelRollDownToUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankToLeftQuarterTurn3TilesUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankToRightQuarterTurn3TilesUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn3TilesDown25ToLeftBank
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn3TilesDown25ToRightBank
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::PoweredLift
+    { TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A, 0, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_C, 0, 0, TRACK_SUPPORT_LOOP_B, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftLargeHalfLoopUp
+    { TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A, 0, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_C, 0, 0, TRACK_SUPPORT_LOOP_B, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightLargeHalfLoopUp
+    { TRACK_SUPPORT_LOOP_B, 0, 0, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_C, 0, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightLargeHalfLoopDown
+    { TRACK_SUPPORT_LOOP_B, 0, 0, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_C, 0, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftLargeHalfLoopDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftFlyerTwistUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightFlyerTwistUp
+    { TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftFlyerTwistDown
+    { TRACK_SUPPORT_INVERSION_EXTRA_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightFlyerTwistDown
+    { TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_C, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlyerHalfLoopUp
+    { 0, TRACK_SUPPORT_LOOP_C, TRACK_SUPPORT_LOOP_A, TRACK_SUPPORT_LOOP_A | TRACK_SUPPORT_LOOP_B, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlyerHalfLoopDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::LeftFlyerCorkscrewUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::RightFlyerCorkscrewUp
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::LeftFlyerCorkscrewDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                         // TrackElemType::RightFlyerCorkscrewDown
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::HeartLineTransferUp
+    { 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::HeartLineTransferDown
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftHeartLineRoll
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightHeartLineRoll
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MinigolfHoleA
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MinigolfHoleB
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MinigolfHoleC
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MinigolfHoleD
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MinigolfHoleE
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::MultiDimInvertedFlatToDown90QuarterLoop
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::Up90ToInvertedFlatQuarterLoop
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::InvertedFlatToDown90QuarterLoop
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftCurvedLiftHill
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightCurvedLiftHill
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftReverser
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightReverser
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::AirThrustTopCap
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                                                 // TrackElemType::AirThrustVerticalDown
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::AirThrustVerticalDownToLevel
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },                 // TrackElemType::BlockBrakes
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedQuarterTurn3TileUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedQuarterTurn3TileUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedQuarterTurn3TileDown25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedQuarterTurn3TileDown25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedQuarterTurn5TileUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedQuarterTurn5TileUp25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedQuarterTurn5TileDown25
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedQuarterTurn5TileDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Up25ToLeftBankedUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Up25ToRightBankedUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedUp25ToUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedUp25ToUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Down25ToLeftBankedDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::Down25ToRightBankedDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedDown25ToDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedDown25ToDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedFlatToLeftBankedUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedFlatToRightBankedUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedUp25ToLeftBankedFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedUp25ToRightBankedFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedFlatToLeftBankedDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedFlatToRightBankedDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedDown25ToLeftBankedFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedDown25ToRightBankedFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToLeftBankedUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToRightBankedUp25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedUp25ToFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedUp25ToFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToLeftBankedDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatToRightBankedDown25
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftBankedDown25ToFlat
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightBankedDown25ToFlat
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn1TileUp90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn1TileUp90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::LeftQuarterTurn1TileDown90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RightQuarterTurn1TileDown90
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MultiDimUp90ToInvertedFlatQuarterLoop
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MultiDimFlatToDown90QuarterLoop
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::MultiDimInvertedUp90ToFlatQuarterLoop
+    { TRACK_SUPPORT_SHOULD_HAVE_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::RotationControlToggle
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack1x4A
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack2x2
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT }, // TrackElemType::FlatTrack4x4
+    { TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack2x4
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack1x5
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack1x1A
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack1x4B
+    { TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack1x1B
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_COVERED_EXTRA_SUPPORT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack1x4C
+    { TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, TRACK_SUPPORT_HAS_SUPPORT, 0, 0, 0, 0, 0, 0, 0 }, // TrackElemType::FlatTrack3x3
+};
+// clang-format on
+
 namespace OpenRCT2
 {
     namespace TrackMetaData
@@ -5456,6 +5728,7 @@ namespace OpenRCT2
                 {
                     desc.SequenceElementAllowedWallEdges[j] = TrackSequenceElementAllowedWallEdges[i][j];
                     desc.SequenceProperties[j] = TrackSequenceProperties[i][j];
+                    desc.SequenceSupportBehaviour[j] = TrackSupportsBehaviour[i][j];
                 }
                 _trackElementDescriptors.push_back(desc);
             }

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -87,6 +87,7 @@ struct TrackElementDescriptor
 
     std::array<uint8_t, MaxSequencesPerPiece> SequenceElementAllowedWallEdges;
     std::array<uint8_t, MaxSequencesPerPiece> SequenceProperties;
+    std::array<uint8_t, MaxSequencesPerPiece> SequenceSupportBehaviour;
 
     rct_trackdefinition Definition;
     uint8_t SpinFunction;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1563,7 +1563,7 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
                 uint32_t brakeSpeed = (track.flags & 0x0F) * 2;
                 uint32_t seatRotation = track.flags & 0x0F;
 
-                int32_t liftHillAndAlternativeState = 0;
+                int32_t liftHillAndAlternativeState = CONSTRUCTION_BUILD_SUPPORTS;
                 if (track.flags & RCT12_TRACK_ELEMENT_TYPE_FLAG_CHAIN_LIFT)
                 {
                     liftHillAndAlternativeState |= 1;

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -54,8 +54,10 @@ static void bobsleigh_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14579, 0, 0, 32, 1, 26, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     else
     {
@@ -76,8 +78,10 @@ static void bobsleigh_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14575, 0, 0, 32, 1, 26, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
@@ -101,8 +105,7 @@ static void bobsleigh_rc_track_station(
         height + 3);
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
-    if (trackElement.HasSupport())
-        track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
+    track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -143,8 +146,10 @@ static void bobsleigh_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14641, 0, 0, 32, 1, 50, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     else
     {
@@ -175,8 +180,10 @@ static void bobsleigh_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14617, 0, 0, 32, 1, 50, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     if (direction == 0 || direction == 3)
     {
@@ -225,8 +232,10 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14625, 0, 0, 32, 1, 42, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     else
     {
@@ -257,8 +266,10 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14601, 0, 0, 32, 1, 42, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     if (direction == 0 || direction == 3)
     {
@@ -307,8 +318,10 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14633, 0, 0, 32, 1, 34, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     else
     {
@@ -339,8 +352,10 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14609, 0, 0, 32, 1, 34, height, 0, 27, height);
                 break;
         }
-        if (trackElement.HasSupport())
+        if (track_paint_util_should_paint_supports(session->MapPosition))
+        {
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+        }
     }
     if (direction == 0 || direction == 3)
     {
@@ -418,9 +433,7 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -588,9 +601,7 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -648,8 +659,10 @@ static void bobsleigh_rc_track_flat_to_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14649, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -688,8 +701,10 @@ static void bobsleigh_rc_track_flat_to_right_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14657, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -728,8 +743,10 @@ static void bobsleigh_rc_track_left_bank_to_flat(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14655, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -768,8 +785,10 @@ static void bobsleigh_rc_track_right_bank_to_flat(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14647, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -815,9 +834,7 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -985,9 +1002,7 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -1045,8 +1060,10 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14681, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1092,8 +1109,10 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14689, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1139,8 +1158,10 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14665, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_0);
@@ -1186,8 +1207,10 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14673, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_0);
@@ -1265,8 +1288,10 @@ static void bobsleigh_rc_track_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14697, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -1320,9 +1345,7 @@ static void bobsleigh_rc_track_s_bend_left(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1340,9 +1363,8 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14843, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1350,9 +1372,8 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14847, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1399,9 +1420,8 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14843, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1409,9 +1429,8 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14847, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1453,9 +1472,7 @@ static void bobsleigh_rc_track_s_bend_left(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 1:
@@ -1511,9 +1528,7 @@ static void bobsleigh_rc_track_s_bend_right(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1531,9 +1546,8 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14851, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1541,9 +1555,8 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14855, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1590,9 +1603,8 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14851, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1600,9 +1612,8 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14855, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    if (trackElement.HasSupport())
-                        metal_a_supports_paint_setup(
-                            session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    metal_a_supports_paint_setup(
+                        session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1644,9 +1655,7 @@ static void bobsleigh_rc_track_s_bend_right(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 1:
@@ -1702,9 +1711,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1787,9 +1794,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -1854,9 +1859,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1939,9 +1942,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2006,9 +2007,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -2092,9 +2091,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2141,9 +2138,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -2232,9 +2227,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -2286,9 +2279,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -2372,9 +2363,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -2421,9 +2410,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2512,9 +2499,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -2595,9 +2580,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -2766,9 +2749,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2815,9 +2796,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -2991,9 +2970,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -3045,9 +3022,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -3216,9 +3191,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -3265,9 +3238,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -3441,9 +3412,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -3507,8 +3476,10 @@ static void bobsleigh_rc_track_brakes(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14585, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3540,8 +3511,10 @@ static void bobsleigh_rc_track_block_brakes(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14591, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3555,46 +3528,27 @@ static void bobsleigh_rc_track_on_ride_photo(
     switch (direction)
     {
         case 0:
-            if (trackElement.HasSupport())
-            {
-                PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            }
+            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14572, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14574, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             break;
         case 1:
-
-            if (trackElement.HasSupport())
-            {
-                PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            }
+            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14573, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14575, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             break;
         case 2:
-            if (trackElement.HasSupport())
-            {
-                PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            }
+            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14572, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(
@@ -3602,15 +3556,9 @@ static void bobsleigh_rc_track_on_ride_photo(
 
             break;
         case 3:
-            if (trackElement.HasSupport())
-            {
-                PaintAddImageAsParentRotated(
-                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            }
+            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14573, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -54,10 +54,8 @@ static void bobsleigh_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14579, 0, 0, 32, 1, 26, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     else
     {
@@ -78,10 +76,8 @@ static void bobsleigh_rc_track_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14575, 0, 0, 32, 1, 26, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
@@ -105,7 +101,8 @@ static void bobsleigh_rc_track_station(
         height + 3);
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
-    track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
+    if (trackElement.HasSupport())
+        track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
     track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -146,10 +143,8 @@ static void bobsleigh_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14641, 0, 0, 32, 1, 50, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     else
     {
@@ -180,10 +175,8 @@ static void bobsleigh_rc_track_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14617, 0, 0, 32, 1, 50, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     if (direction == 0 || direction == 3)
     {
@@ -232,10 +225,8 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14625, 0, 0, 32, 1, 42, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     else
     {
@@ -266,10 +257,8 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14601, 0, 0, 32, 1, 42, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     if (direction == 0 || direction == 3)
     {
@@ -318,10 +307,8 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14633, 0, 0, 32, 1, 34, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     else
     {
@@ -352,10 +339,8 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
                     session, direction, session->TrackColours[SCHEME_TRACK] | 14609, 0, 0, 32, 1, 34, height, 0, 27, height);
                 break;
         }
-        if (track_paint_util_should_paint_supports(session->MapPosition))
-        {
+        if (trackElement.HasSupport())
             metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
-        }
     }
     if (direction == 0 || direction == 3)
     {
@@ -433,7 +418,9 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -601,7 +588,9 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -659,10 +648,8 @@ static void bobsleigh_rc_track_flat_to_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14649, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -701,10 +688,8 @@ static void bobsleigh_rc_track_flat_to_right_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14657, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -743,10 +728,8 @@ static void bobsleigh_rc_track_left_bank_to_flat(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14655, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -785,10 +768,8 @@ static void bobsleigh_rc_track_right_bank_to_flat(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14647, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -834,7 +815,9 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1002,7 +985,9 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -1060,10 +1045,8 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14681, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1109,10 +1092,8 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14689, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1158,10 +1139,8 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14665, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_0);
@@ -1207,10 +1186,8 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14673, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     if (direction == 0 || direction == 3)
     {
         paint_util_push_tunnel_rotated(session, direction, height - 8, TUNNEL_0);
@@ -1288,10 +1265,8 @@ static void bobsleigh_rc_track_left_bank(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14697, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -1345,7 +1320,9 @@ static void bobsleigh_rc_track_s_bend_left(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1363,8 +1340,9 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14843, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1372,8 +1350,9 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14847, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1420,8 +1399,9 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14843, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1429,8 +1409,9 @@ static void bobsleigh_rc_track_s_bend_left(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14847, 0, 0, 32, 26, 0, height, 0, 0,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 6, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1472,7 +1453,9 @@ static void bobsleigh_rc_track_s_bend_left(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 1:
@@ -1528,7 +1511,9 @@ static void bobsleigh_rc_track_s_bend_right(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1546,8 +1531,9 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14851, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -1555,8 +1541,9 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14855, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1603,8 +1590,9 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14851, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -1612,8 +1600,9 @@ static void bobsleigh_rc_track_s_bend_right(
                     PaintAddImageAsParentRotated(
                         session, direction, session->TrackColours[SCHEME_TRACK] | 14855, 0, 0, 32, 26, 0, height, 0, 6,
                         height + 27);
-                    metal_a_supports_paint_setup(
-                        session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                    if (trackElement.HasSupport())
+                        metal_a_supports_paint_setup(
+                            session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             paint_util_set_segment_support_height(
@@ -1655,7 +1644,9 @@ static void bobsleigh_rc_track_s_bend_right(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 1:
@@ -1711,7 +1702,9 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1794,7 +1787,9 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -1859,7 +1854,9 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -1942,7 +1939,9 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2007,7 +2006,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -2091,7 +2092,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2138,7 +2141,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -2227,7 +2232,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -2279,7 +2286,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -2363,7 +2372,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -2410,7 +2421,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 2, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2499,7 +2512,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -2580,7 +2595,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -2749,7 +2766,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -2796,7 +2815,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -2970,7 +2991,9 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -3022,7 +3045,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
@@ -3191,7 +3216,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 0:
@@ -3238,7 +3265,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 1, height, session->TrackColours[SCHEME_SUPPORTS]);
             switch (direction)
             {
                 case 2:
@@ -3412,7 +3441,9 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
                         height + 27);
                     break;
             }
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 4, 7, height, session->TrackColours[SCHEME_SUPPORTS]);
             if (direction == 0 || direction == 3)
             {
                 paint_util_push_tunnel_rotated(session, direction, height + 8, TUNNEL_0);
@@ -3476,10 +3507,8 @@ static void bobsleigh_rc_track_brakes(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14585, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3511,10 +3540,8 @@ static void bobsleigh_rc_track_block_brakes(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14591, 0, 0, 32, 1, 26, height, 0, 27, height);
             break;
     }
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_0);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_C4 | SEGMENT_CC | SEGMENT_D0, direction), 0xFFFF, 0);
@@ -3528,27 +3555,46 @@ static void bobsleigh_rc_track_on_ride_photo(
     switch (direction)
     {
         case 0:
-            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+            {
+                PaintAddImageAsParentRotated(
+                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            }
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14572, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14574, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             break;
         case 1:
-            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+
+            if (trackElement.HasSupport())
+            {
+                PaintAddImageAsParentRotated(
+                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            }
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14573, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14575, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             break;
         case 2:
-            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+            {
+                PaintAddImageAsParentRotated(
+                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            }
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14572, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(
@@ -3556,9 +3602,15 @@ static void bobsleigh_rc_track_on_ride_photo(
 
             break;
         case 3:
-            PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            if (trackElement.HasSupport())
+            {
+                PaintAddImageAsParentRotated(
+                    session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_TUBES, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            }
             PaintAddImageAsParentRotated(
                 session, direction, session->TrackColours[SCHEME_TRACK] | 14573, 0, 0, 32, 20, 0, height, 0, 6, height + 3);
             PaintAddImageAsParentRotated(

--- a/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor AirPoweredVerticalCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_AIR_POWERED_VERTICAL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
+++ b/src/openrct2/ride/coaster/meta/BobsleighCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor BobsleighCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOBSLEIGH_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ClassicMiniRollerCoaster.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor ClassicMiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CompactInvertedCoaster.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor CompactInvertedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_COMPACT_INVERTED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/CorkscrewRollerCoaster.h
@@ -58,5 +58,6 @@ constexpr const RideTypeDescriptor CorkscrewRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/FlyingRollerCoaster.h
@@ -54,6 +54,7 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::InversionExtraSupports),
 };
 
 // Inverted variant
@@ -94,5 +95,6 @@ constexpr const RideTypeDescriptor FlyingRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_FLYING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports | RideSupportsBehaviour::InversionExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/GigaCoaster.h
+++ b/src/openrct2/ride/coaster/meta/GigaCoaster.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor GigaCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_GIGA_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HeartlineTwisterCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor HeartlineTwisterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HEARTLINE_TWISTER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HybridCoaster.h
+++ b/src/openrct2/ride/coaster/meta/HybridCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor HybridCoasterRTD =
     )),
   SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_HYBRID_COASTER_SUPPORTS }),
   SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/HyperTwister.h
+++ b/src/openrct2/ride/coaster/meta/HyperTwister.h
@@ -58,5 +58,6 @@ constexpr const RideTypeDescriptor HyperTwisterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::CoveredExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Hypercoaster.h
+++ b/src/openrct2/ride/coaster/meta/Hypercoaster.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor HypercoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_CORKSCREW_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedHairpinCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor InvertedHairpinCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_HAIRPIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedImpulseCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor InvertedImpulseCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_IMPULSE_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports | RideSupportsBehaviour::ChairliftSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/InvertedRollerCoaster.h
@@ -55,5 +55,6 @@ constexpr const RideTypeDescriptor InvertedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_INVERTED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports | RideSupportsBehaviour::InversionExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/JuniorRollerCoaster.h
@@ -58,5 +58,6 @@ constexpr const RideTypeDescriptor JuniorRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_JUNIOR_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LIMLaunchedRollerCoaster.h
@@ -52,6 +52,7 @@ constexpr const RideTypeDescriptor LIMLaunchedRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LIM_LAUNCHED_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports || RideSupportsBehaviour::LoopBSupports ),
     
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LayDownRollerCoaster.h
@@ -52,6 +52,7 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::InversionExtraSupports ),
 };
 
 constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
@@ -90,5 +91,6 @@ constexpr const RideTypeDescriptor LayDownRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAY_DOWN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports | RideSupportsBehaviour::InversionExtraSupports ),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/LoopingRollerCoaster.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor LoopingRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOOPING_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopCSupports ),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineRide.h
+++ b/src/openrct2/ride/coaster/meta/MineRide.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor MineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor MineTrainCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniRollerCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor MiniRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MiniSuspendedCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor MiniSuspendedCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_SUSPENDED_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MultiDimensionRollerCoaster.h
@@ -53,6 +53,7 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::InversionExtraSupports),
 };
 
 constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
@@ -91,5 +92,6 @@ constexpr const RideTypeDescriptor MultiDimensionRollerCoasterAltRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MULTI_DIMENSION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports | RideSupportsBehaviour::InversionExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverseFreefallCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor ReverseFreefallCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSE_FREEFALL_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ReverserRollerCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor ReverserRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_REVERSER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SideFrictionRollerCoaster.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SideFrictionRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SIDE_FRICTION_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SingleRailRollerCoaster.h
@@ -50,5 +50,6 @@ constexpr const RideTypeDescriptor SingleRailRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SINGLE_RAIL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SpinningWildMouse.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor SpinningWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SpiralRollerCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor SpiralRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPIRAL_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/StandUpRollerCoaster.h
@@ -55,5 +55,6 @@ constexpr const RideTypeDescriptor StandUpRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_STAND_UP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SteelWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/SteelWildMouse.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor SteelWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/Steeplechase.h
+++ b/src/openrct2/ride/coaster/meta/Steeplechase.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor SteeplechaseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_TRACK, SPR_RIDE_DESIGN_PREVIEW_STEEPLECHASE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
+++ b/src/openrct2/ride/coaster/meta/SuspendedSwingingCoaster.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor SuspendedSwingingCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_SWINGING_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ShouldHaveSupports | RideSupportsBehaviour::LoopBSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/TwisterRollerCoaster.h
@@ -62,5 +62,6 @@ constexpr const RideTypeDescriptor TwisterRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_TWISTER_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::CoveredExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
+++ b/src/openrct2/ride/coaster/meta/VerticalDropCoaster.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor VerticalDropCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_VERTICAL_DROP_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::CoveredExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/VirginiaReel.h
+++ b/src/openrct2/ride/coaster/meta/VirginiaReel.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor VirginiaReelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_TRACK, SPR_RIDE_DESIGN_PREVIEW_VIRGINIA_REEL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WaterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WaterCoaster.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor WaterCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports | RideSupportsBehaviour::CoveredExtraSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WoodenRollerCoaster.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor WoodenRollerCoasterRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_ROLLER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
+++ b/src/openrct2/ride/coaster/meta/WoodenWildMouse.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor WoodenWildMouseRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_TRACK, SPR_RIDE_DESIGN_PREVIEW_WOODEN_WILD_MOUSE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -167,8 +167,8 @@ static void paint_car_ride_track_flat(
     {
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
-    if (trackElement.HasSupport())
-        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+
+    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -206,8 +206,7 @@ static void paint_car_ride_track_25_deg_up(
             break;
     }
 
-    if (trackElement.HasSupport())
-        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
+    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 56, 0x20);
@@ -245,8 +244,7 @@ static void paint_car_ride_track_flat_to_25_deg_up(
             break;
     }
 
-    if (trackElement.HasSupport())
-        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
+    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -284,8 +282,7 @@ static void paint_car_ride_track_25_deg_up_to_flat(
             break;
     }
 
-    if (trackElement.HasSupport())
-        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 40, 0x20);
@@ -352,12 +349,12 @@ static void paint_car_ride_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    if ((direction == 0 || direction == 2) && trackElement.HasSupport())
+    if (direction == 0 || direction == 2)
     {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
-    else if (trackElement.HasSupport())
+    else
     {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
@@ -384,10 +381,7 @@ static void paint_car_ride_track_right_quarter_turn_3_tiles(
     {
         case 0:
         case 3:
-
-            if (trackElement.HasSupport())
-                metal_a_supports_paint_setup(
-                    session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+            metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
 
@@ -441,8 +435,7 @@ static void paint_car_ride_track_left_quarter_turn_1_tile(
             break;
     }
 
-    if (trackElement.HasSupport())
-        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height, 0, TUNNEL_0, 0, TUNNEL_0);
 
@@ -485,8 +478,7 @@ static void paint_car_ride_track_spinning_tunnel(
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
 
-    if (trackElement.HasSupport())
-        wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
+    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -531,8 +523,10 @@ static void paint_car_ride_track_60_deg_up(
             break;
     }
 
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 32, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
 
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
@@ -585,8 +579,10 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(
             break;
     }
 
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
 
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
@@ -639,8 +635,10 @@ static void paint_car_ride_track_60_deg_up_to_25_deg_up(
             break;
     }
 
-    if (trackElement.HasSupport())
+    if (track_paint_util_should_paint_supports(session->MapPosition))
+    {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 20, height, session->TrackColours[SCHEME_SUPPORTS]);
+    }
 
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
@@ -696,8 +694,7 @@ static void paint_car_ride_track_log_bumps(
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
 
-    if (trackElement.HasSupport())
-        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -167,8 +167,8 @@ static void paint_car_ride_track_flat(
     {
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
-
-    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    if (trackElement.HasSupport())
+        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -206,7 +206,8 @@ static void paint_car_ride_track_25_deg_up(
             break;
     }
 
-    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
+    if (trackElement.HasSupport())
+        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 56, 0x20);
@@ -244,7 +245,8 @@ static void paint_car_ride_track_flat_to_25_deg_up(
             break;
     }
 
-    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
+    if (trackElement.HasSupport())
+        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 3, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -282,7 +284,8 @@ static void paint_car_ride_track_25_deg_up_to_flat(
             break;
     }
 
-    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
+    if (trackElement.HasSupport())
+        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 6, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 40, 0x20);
@@ -349,12 +352,12 @@ static void paint_car_ride_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    if (direction == 0 || direction == 2)
+    if ((direction == 0 || direction == 2) && trackElement.HasSupport())
     {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 5, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
-    else
+    else if (trackElement.HasSupport())
     {
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 6, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
@@ -381,7 +384,10 @@ static void paint_car_ride_track_right_quarter_turn_3_tiles(
     {
         case 0:
         case 3:
-            metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+
+            if (trackElement.HasSupport())
+                metal_a_supports_paint_setup(
+                    session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             break;
     }
 
@@ -435,7 +441,8 @@ static void paint_car_ride_track_left_quarter_turn_1_tile(
             break;
     }
 
-    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    if (trackElement.HasSupport())
+        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
     track_paint_util_left_quarter_turn_1_tile_tunnel(session, direction, height, 0, TUNNEL_0, 0, TUNNEL_0);
 
@@ -478,7 +485,8 @@ static void paint_car_ride_track_spinning_tunnel(
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
 
-    wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
+    if (trackElement.HasSupport())
+        wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -523,10 +531,8 @@ static void paint_car_ride_track_60_deg_up(
             break;
     }
 
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 32, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
 
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
@@ -579,10 +585,8 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(
             break;
     }
 
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 12, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
 
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
@@ -635,10 +639,8 @@ static void paint_car_ride_track_60_deg_up_to_25_deg_up(
             break;
     }
 
-    if (track_paint_util_should_paint_supports(session->MapPosition))
-    {
+    if (trackElement.HasSupport())
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 20, height, session->TrackColours[SCHEME_SUPPORTS]);
-    }
 
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
@@ -694,7 +696,8 @@ static void paint_car_ride_track_log_bumps(
         paint_util_push_tunnel_right(session, height, TUNNEL_0);
     }
 
-    metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
+    if (trackElement.HasSupport())
+        metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 4, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     paint_util_set_segment_support_height(
         session, paint_util_rotate_segments(SEGMENT_D0 | SEGMENT_C4 | SEGMENT_CC, direction), 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/meta/CarRide.h
+++ b/src/openrct2/ride/gentle/meta/CarRide.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor CarRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/CrookedHouse.h
+++ b/src/openrct2/ride/gentle/meta/CrookedHouse.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor CrookedHouseRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Dodgems.h
+++ b/src/openrct2/ride/gentle/meta/Dodgems.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor DodgemsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DODGEMS_TRACK, SPR_RIDE_DESIGN_PREVIEW_DODGEMS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FerrisWheel.h
+++ b/src/openrct2/ride/gentle/meta/FerrisWheel.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor FerrisWheelRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FERRIS_WHEEL_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/FlyingSaucers.h
+++ b/src/openrct2/ride/gentle/meta/FlyingSaucers.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor FlyingSaucersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_FLYING_SAUCERS_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/GhostTrain.h
+++ b/src/openrct2/ride/gentle/meta/GhostTrain.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_TRACK, SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/HauntedHouse.h
+++ b/src/openrct2/ride/gentle/meta/HauntedHouse.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor HauntedHouseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor MazeRTD =
     )),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MerryGoRound.h
+++ b/src/openrct2/ride/gentle/meta/MerryGoRound.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor MerryGoRoundRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -51,5 +51,6 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonorailCycles.h
+++ b/src/openrct2/ride/gentle/meta/MonorailCycles.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonsterTrucks.h
+++ b/src/openrct2/ride/gentle/meta/MonsterTrucks.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor MonsterTrucksRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/ObservationTower.h
+++ b/src/openrct2/ride/gentle/meta/ObservationTower.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor ObservationTowerRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_TRACK, SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpaceRings.h
+++ b/src/openrct2/ride/gentle/meta/SpaceRings.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor SpaceRingsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_SLIDE_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -46,5 +46,6 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::CashMachine),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Drink),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::FirstAid),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Food),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::InfoKiosk),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(ColourPresets, DEFAULT_STALL_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Shop),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -47,5 +47,6 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Toilets),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/3DCinema.h
+++ b/src/openrct2/ride/thrill/meta/3DCinema.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor CinemaRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Enterprise.h
+++ b/src/openrct2/ride/thrill/meta/Enterprise.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor EnterpriseRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/GoKarts.h
+++ b/src/openrct2/ride/thrill/meta/GoKarts.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor GoKartsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
+++ b/src/openrct2/ride/thrill/meta/LaunchedFreefall.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor LaunchedFreefallRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_TRACK, SPR_RIDE_DESIGN_PREVIEW_LAUNCHED_FREEFALL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MagicCarpet.h
+++ b/src/openrct2/ride/thrill/meta/MagicCarpet.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor MagicCarpetRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_TRACK, SPR_RIDE_DESIGN_PREVIEW_MAGIC_CARPET_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/MotionSimulator.h
+++ b/src/openrct2/ride/thrill/meta/MotionSimulator.h
@@ -49,5 +49,6 @@ constexpr const RideTypeDescriptor MotionSimulatorRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/RotoDrop.h
+++ b/src/openrct2/ride/thrill/meta/RotoDrop.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor RotoDropRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_TRACK, SPR_RIDE_DESIGN_PREVIEW_ROTO_DROP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingInverterShip.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SwingingInverterShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_INVERTER_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/SwingingShip.h
+++ b/src/openrct2/ride/thrill/meta/SwingingShip.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SwingingShipRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SWINGING_SHIP_TRACK, SPR_RIDE_DESIGN_PREVIEW_SWINGING_SHIP_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/TopSpin.h
+++ b/src/openrct2/ride/thrill/meta/TopSpin.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor TopSpinRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_TOP_SPIN_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -48,5 +48,6 @@ constexpr const RideTypeDescriptor TwistRTD =
     SET_FIELD(ColourPresets, DEFAULT_FLAT_RIDE_COLOUR_PRESET),
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Chairlift.h
+++ b/src/openrct2/ride/transport/meta/Chairlift.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor ChairliftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_TRACK, SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::ChairliftSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Lift.h
+++ b/src/openrct2/ride/transport/meta/Lift.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor LiftRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LIFT_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/MiniatureRailway.h
+++ b/src/openrct2/ride/transport/meta/MiniatureRailway.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Monorail.h
+++ b/src/openrct2/ride/transport/meta/Monorail.h
@@ -57,5 +57,6 @@ constexpr const RideTypeDescriptor MonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/SuspendedMonorail.h
+++ b/src/openrct2/ride/transport/meta/SuspendedMonorail.h
@@ -56,5 +56,6 @@ constexpr const RideTypeDescriptor SuspendedMonorailRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUSPENDED_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, 0),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/DinghySlide.h
+++ b/src/openrct2/ride/water/meta/DinghySlide.h
@@ -64,5 +64,6 @@ constexpr const RideTypeDescriptor DinghySlideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_DINGHY_SLIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/LogFlume.h
+++ b/src/openrct2/ride/water/meta/LogFlume.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRafts.h
+++ b/src/openrct2/ride/water/meta/RiverRafts.h
@@ -53,5 +53,6 @@ constexpr const RideTypeDescriptor RiverRaftsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAFTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/RiverRapids.h
+++ b/src/openrct2/ride/water/meta/RiverRapids.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SplashBoats.h
+++ b/src/openrct2/ride/water/meta/SplashBoats.h
@@ -54,5 +54,6 @@ constexpr const RideTypeDescriptor SplashBoatsRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, RideSupportsBehaviour::AlwaysHasSupports),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -52,5 +52,6 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     )),
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
+    SET_FIELD(SupportsBehaviour, _defaultCoasterSupports),
 };
 // clang-format on

--- a/src/openrct2/windows/_legacy.cpp
+++ b/src/openrct2/windows/_legacy.cpp
@@ -259,6 +259,7 @@ bool window_ride_construction_update_state(
     track_type_t trackType = std::get<1>(updated_element);
     liftHillAndInvertedState = 0;
     rideIndex = _currentRideIndex;
+    liftHillAndInvertedState = CONSTRUCTION_BUILD_SUPPORTS;
     if (_currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED)
     {
         liftHillAndInvertedState |= CONSTRUCTION_LIFT_HILL_SELECTED;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -433,6 +433,11 @@ public:
     bool IsHighlighted() const;
     void SetHighlight(bool on);
 
+    bool DetermineSupportState(CoordsXY position, bool RCT1SupportsOverride) const;
+    bool DetermineSupportState(CoordsXY position, uint8_t trackType, bool RCT1SupportsOverride) const;
+    bool HasSupport() const;
+    void SetHasSupport(bool hasSupport);
+
     // Used by ghost train, RCT1 feature, will be reintroduced at some point.
     // (See https://github.com/OpenRCT2/OpenRCT2/issues/7059)
     uint8_t GetDoorAState() const;


### PR DESCRIPTION
Regarding https://github.com/OpenRCT2/OpenRCT2/issues/15346 and inspired by https://github.com/OpenRCT2/OpenRCT2/pull/15345

Bit 7 in the Flags2 field decides definitively if supports are drawn.

This feature is not intended to serialize in SV6. It's just not. It won't go into SV6 because there's no versioning SV6 to know if the park was saved before or after this feature was implemented. This feature is intended for NSF.

Gymnasiast says it's fine if RCT1 supports don't serialize.

Known discrepancies with RCT2 behaviour:
- Monster Trucks supports always draw on Up25ToUp60, Up60, Up60ToUp25, Down25ToDown60, Down60, Down60ToDown25 instead of ShouldHave
- Submarine ride supports always draw on LeftQuarterTurn1Tile, RightQuarterTurn1Tile, StationStart, StationEnd, StationMiddle instead of never
- Inverted Hairpin coaster supports ShouldHave draw on Up25ToUp60, Down60ToDown25 instead of never
- Inverted Hairpin coaster supports ShouldHave draw on Up60ToUp25, Down25ToDown60 instead of always