### PR TITLE
Fix #15257: Chat widgets removed from Scenario Editor

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -176,6 +176,7 @@ The following people are not part of the development team, but have been contrib
 * Kane Shaw (seifer7)
 * Saad Rehman (SaadRehmanCS)
 * (ocalhoun6)
+* Sean Payne (seanmajorpayne)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,8 +22,8 @@
 - Fix: [#15193] Crash when rides/stalls are demolished.
 - Fix: [#15199] Construction window is not closed when a ride gets demolished.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
-- Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
 - Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
+- Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Fix: [#15199] Construction window is not closed when a ride gets demolished.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
+- Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -675,19 +675,33 @@ static void window_top_toolbar_invalidate(rct_window* w)
     window_top_toolbar_widgets[WIDX_NETWORK].type = WindowWidgetType::TrnBtn;
 
     if (!gConfigInterface.toolbar_show_mute)
-    {
         window_top_toolbar_widgets[WIDX_MUTE].type = WindowWidgetType::Empty;
-    }
 
     if (!gConfigInterface.toolbar_show_chat)
-    {
         window_top_toolbar_widgets[WIDX_CHAT].type = WindowWidgetType::Empty;
+
+    if (!gConfigInterface.toolbar_show_research)
+        window_top_toolbar_widgets[WIDX_RESEARCH].type = WindowWidgetType::Empty;
+
+    if (!gConfigInterface.toolbar_show_cheats)
+        window_top_toolbar_widgets[WIDX_CHEATS].type = WindowWidgetType::Empty;
+
+    if (!gConfigInterface.toolbar_show_news)
+        window_top_toolbar_widgets[WIDX_NEWS].type = WindowWidgetType::Empty;
+
+    if (!gConfigInterface.toolbar_show_zoom)
+    {
+        window_top_toolbar_widgets[WIDX_ZOOM_IN].type = WindowWidgetType::Empty;
+        window_top_toolbar_widgets[WIDX_ZOOM_OUT].type = WindowWidgetType::Empty;
     }
 
     if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR || gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
     {
         window_top_toolbar_widgets[WIDX_PAUSE].type = WindowWidgetType::Empty;
     }
+
+    if ((gParkFlags & PARK_FLAGS_NO_MONEY) || !gConfigInterface.toolbar_show_finances)
+        window_top_toolbar_widgets[WIDX_FINANCES].type = WindowWidgetType::Empty;
 
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
@@ -725,39 +739,19 @@ static void window_top_toolbar_invalidate(rct_window* w)
             window_top_toolbar_widgets[WIDX_VIEW_MENU].type = WindowWidgetType::Empty;
         }
     }
-    else
+
+    switch (network_get_mode())
     {
-        if ((gParkFlags & PARK_FLAGS_NO_MONEY) || !gConfigInterface.toolbar_show_finances)
-            window_top_toolbar_widgets[WIDX_FINANCES].type = WindowWidgetType::Empty;
-
-        if (!gConfigInterface.toolbar_show_research)
-            window_top_toolbar_widgets[WIDX_RESEARCH].type = WindowWidgetType::Empty;
-
-        if (!gConfigInterface.toolbar_show_cheats)
-            window_top_toolbar_widgets[WIDX_CHEATS].type = WindowWidgetType::Empty;
-
-        if (!gConfigInterface.toolbar_show_news)
-            window_top_toolbar_widgets[WIDX_NEWS].type = WindowWidgetType::Empty;
-
-        if (!gConfigInterface.toolbar_show_zoom)
-        {
-            window_top_toolbar_widgets[WIDX_ZOOM_IN].type = WindowWidgetType::Empty;
-            window_top_toolbar_widgets[WIDX_ZOOM_OUT].type = WindowWidgetType::Empty;
-        }
-
-        switch (network_get_mode())
-        {
-            case NETWORK_MODE_NONE:
-                window_top_toolbar_widgets[WIDX_NETWORK].type = WindowWidgetType::Empty;
-                window_top_toolbar_widgets[WIDX_CHAT].type = WindowWidgetType::Empty;
-                break;
-            case NETWORK_MODE_CLIENT:
-                window_top_toolbar_widgets[WIDX_PAUSE].type = WindowWidgetType::Empty;
-                [[fallthrough]];
-            case NETWORK_MODE_SERVER:
-                window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WindowWidgetType::Empty;
-                break;
-        }
+        case NETWORK_MODE_NONE:
+            window_top_toolbar_widgets[WIDX_NETWORK].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_CHAT].type = WindowWidgetType::Empty;
+            break;
+        case NETWORK_MODE_CLIENT:
+            window_top_toolbar_widgets[WIDX_PAUSE].type = WindowWidgetType::Empty;
+            [[fallthrough]];
+        case NETWORK_MODE_SERVER:
+            window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WindowWidgetType::Empty;
+            break;
     }
 
     enabledWidgets = 0;


### PR DESCRIPTION
Removed else statement which caused the game to skip top toolbar widget deactivations. Small formatting update for consistency.

Previously, chat widget would show in Scenario Editor & Track Builder. Now these do not show.
Previously, zoom widgets would show even if unchecked in options. Now these do not show if unchecked.

First PR to this project. Thank you in advance for your review.

