### PR TITLE
Fix hash bucketing of paint entries

### DIFF
--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -56,7 +56,7 @@ static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, paint_struct* 
 static void PaintPSImage(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t imageId, int32_t x, int32_t y);
 static uint32_t PaintPSColourifyImage(uint32_t imageId, ViewportInteractionItem spriteType, uint32_t viewFlags);
 
-static constexpr int32_t CalculatePositionHash(const paint_struct& ps, uint8_t rotation)
+static constexpr uint32_t CalculatePositionHash(const paint_struct& ps, uint8_t rotation)
 {
     auto pos = CoordsXY{ ps.bounds.x, ps.bounds.y }.Rotate(rotation);
     switch (rotation)
@@ -72,13 +72,13 @@ static constexpr int32_t CalculatePositionHash(const paint_struct& ps, uint8_t r
             break;
     }
 
-    return pos.x + pos.y;
+    return static_cast<uint32_t>(pos.x + pos.y);
 }
 
 static void PaintSessionAddPSToQuadrant(paint_session* session, paint_struct* ps)
 {
     auto positionHash = CalculatePositionHash(*ps, session->CurrentRotation);
-    uint32_t paintQuadrantIndex = std::clamp(positionHash / 32, 0, MAX_PAINT_QUADRANTS - 1);
+    uint32_t paintQuadrantIndex = (positionHash / 32) % MAX_PAINT_QUADRANTS;
     ps->quadrant_index = paintQuadrantIndex;
     ps->next_quadrant_ps = session->Quadrants[paintQuadrantIndex];
     session->Quadrants[paintQuadrantIndex] = ps;

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -113,7 +113,10 @@ struct tunnel_entry
     uint8_t type;
 };
 
-#define MAX_PAINT_QUADRANTS 512
+// NOTE: This should be preferably a prime number. This is the amount of
+// buckets used with the position hash, so the bucket is hash % max.
+#define MAX_PAINT_QUADRANTS 521
+
 #define TUNNEL_MAX_COUNT 65
 
 /**


### PR DESCRIPTION
Using clamp makes no sense for hash buckets.
develop:
```
>openrct2 benchgfx parks/bpb.sv6
Engine: Software
Render Count: 60
Zoom[0] average: 0.075071s, 13 FPS
Zoom[1] average: 0.032724s, 31 FPS
Zoom[2] average: 0.015505s, 64 FPS
Total average: 0.041100s, 24 FPS
Time: 2.46601s
```

PR:
```
>openrct2 benchgfx parks/bpb.sv6
Engine: Software
Render Count: 60
Zoom[0] average: 0.073520s, 14 FPS
Zoom[1] average: 0.032551s, 31 FPS
Zoom[2] average: 0.014496s, 69 FPS
Total average: 0.040189s, 25 FPS
Time: 2.41136s
```
Some free FPS, this reflects better in-game, in bpb for the max zoom I was on 94 (develop), now its 108~.