### PR TITLE
Refactor overload map_get_first_element_at

### DIFF
--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -96,7 +96,7 @@ private:
             return nullptr;
         }
 
-        TileElement* tileElement = map_get_first_element_at(banner->position.ToCoordsXY().ToTileCentre());
+        TileElement* tileElement = map_get_first_element_at(banner->position);
         if (tileElement == nullptr)
         {
             return nullptr;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2424,11 +2424,11 @@ static void sub_6CBCE2(
         auto southTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_SOUTH];
 
         // Replace map elements with temporary ones containing track
-        _backupTileElementArrays[0] = map_get_first_element_at(centreTileCoords.ToCoordsXY());
-        _backupTileElementArrays[1] = map_get_first_element_at(eastTileCoords.ToCoordsXY());
-        _backupTileElementArrays[2] = map_get_first_element_at(westTileCoords.ToCoordsXY());
-        _backupTileElementArrays[3] = map_get_first_element_at(northTileCoords.ToCoordsXY());
-        _backupTileElementArrays[4] = map_get_first_element_at(southTileCoords.ToCoordsXY());
+        _backupTileElementArrays[0] = map_get_first_element_at(centreTileCoords);
+        _backupTileElementArrays[1] = map_get_first_element_at(eastTileCoords);
+        _backupTileElementArrays[2] = map_get_first_element_at(westTileCoords);
+        _backupTileElementArrays[3] = map_get_first_element_at(northTileCoords);
+        _backupTileElementArrays[4] = map_get_first_element_at(southTileCoords);
         map_set_tile_element(centreTileCoords, &_tempTrackTileElement);
         map_set_tile_element(eastTileCoords, &_tempSideTrackTileElement);
         map_set_tile_element(westTileCoords, &_tempSideTrackTileElement);

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -214,7 +214,7 @@ void ClearAction::ResetClearLargeSceneryFlag()
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto tileElement = map_get_first_element_at(TileCoordsXY{ x, y });
             do
             {
                 if (tileElement == nullptr)

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -276,7 +276,7 @@ static uint8_t footpath_element_next_in_direction(TileCoordsXYZ loc, PathElement
     }
 
     loc += TileDirectionDelta[chosenDirection];
-    nextTileElement = map_get_first_element_at(loc.ToCoordsXY());
+    nextTileElement = map_get_first_element_at(loc);
     do
     {
         if (nextTileElement == nullptr)
@@ -327,7 +327,7 @@ static uint8_t footpath_element_dest_in_dir(
         return PATH_SEARCH_LIMIT_REACHED;
 
     loc += TileDirectionDelta[chosenDirection];
-    tileElement = map_get_first_element_at(loc.ToCoordsXY());
+    tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
     {
         return PATH_SEARCH_FAILED;
@@ -733,7 +733,7 @@ static void peep_pathfind_heuristic_search(
 
     /* Get the next map element of interest in the direction of test_edge. */
     bool found = false;
-    TileElement* tileElement = map_get_first_element_at(loc.ToCoordsXY());
+    TileElement* tileElement = map_get_first_element_at(loc);
     if (tileElement == nullptr)
     {
         return;
@@ -1275,7 +1275,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
 #endif // defined(DEBUG_LEVEL_1) && DEBUG_LEVEL_1
 
     // Get the path element at this location
-    TileElement* dest_tile_element = map_get_first_element_at(loc.ToCoordsXY());
+    TileElement* dest_tile_element = map_get_first_element_at(loc);
     /* Where there are multiple matching map elements placed with zero
      * clearance, save the first one for later use to determine the path
      * slope - this maintains the original behaviour (which only processes
@@ -1797,7 +1797,7 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
 static void get_ride_queue_end(TileCoordsXYZ& loc)
 {
     TileCoordsXY queueEnd = { 0, 0 };
-    TileElement* tileElement = map_get_first_element_at(loc.ToCoordsXY());
+    TileElement* tileElement = map_get_first_element_at(loc);
 
     if (tileElement == nullptr)
     {
@@ -1845,7 +1845,7 @@ static void get_ride_queue_end(TileCoordsXYZ& loc)
         }
         nextTile += TileDirectionDelta[direction];
 
-        tileElement = map_get_first_element_at(nextTile.ToCoordsXY());
+        tileElement = map_get_first_element_at(nextTile);
         found = false;
         if (tileElement == nullptr)
             break;

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -713,7 +713,7 @@ void Peep::UpdateFalling()
     }
 
     // If not drowning then falling. Note: peeps 'fall' after leaving a ride/enter the park.
-    TileElement* tile_element = map_get_first_element_at({ x, y });
+    TileElement* tile_element = map_get_first_element_at(CoordsXY{ x, y });
     TileElement* saved_map = nullptr;
     int32_t saved_height = 0;
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2527,7 +2527,7 @@ namespace RCT1
             {
                 for (int32_t y = 0; y < RCT1_MAX_MAP_SIZE; y++)
                 {
-                    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+                    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y });
                     if (tileElement == nullptr)
                         continue;
                     do

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2207,7 +2207,7 @@ static void ride_shop_connected(Ride* ride)
         return;
 
     TrackElement* trackElement = nullptr;
-    TileElement* tileElement = map_get_first_element_at(shopLoc.ToCoordsXY());
+    TileElement* tileElement = map_get_first_element_at(shopLoc);
     do
     {
         if (tileElement == nullptr)
@@ -2563,7 +2563,7 @@ void Ride::ChainQueues() const
 
         // This will fire for every entrance on this x, y and z, regardless whether that actually belongs to
         // the ride or not.
-        TileElement* tileElement = map_get_first_element_at(location.ToCoordsXY());
+        TileElement* tileElement = map_get_first_element_at(location);
         if (tileElement != nullptr)
         {
             do
@@ -2908,7 +2908,7 @@ static void ride_set_maze_entrance_exit_points(Ride* ride)
     {
         auto entranceExitMapPos = position->ToCoordsXYZ();
 
-        TileElement* tileElement = map_get_first_element_at(position->ToCoordsXY());
+        TileElement* tileElement = map_get_first_element_at(*position);
         do
         {
             if (tileElement == nullptr)
@@ -5552,7 +5552,7 @@ void determine_ride_entrance_and_exit_locations()
             {
                 for (uint8_t y = 1; y < MAXIMUM_MAP_SIZE_TECHNICAL - 1; y++)
                 {
-                    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+                    TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y });
 
                     if (tileElement != nullptr)
                     {

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -347,7 +347,7 @@ void ride_clear_blocked_tiles(Ride* ride)
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto element = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto element = map_get_first_element_at(TileCoordsXY{ x, y });
             if (element != nullptr)
             {
                 do

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1463,7 +1463,7 @@ static int32_t ride_ratings_get_scenery_score(Ride* ride)
              xx++)
         {
             // Count scenery items on this tile
-            TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ xx, yy }.ToCoordsXY());
+            TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ xx, yy });
             if (tileElement == nullptr)
                 continue;
             do

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -351,7 +351,7 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(const Ride& ride)
     {
         for (; x < MAXIMUM_MAP_SIZE_BIG; x += COORDS_XY_STEP)
         {
-            auto tileElement = map_get_first_element_at({ x, y });
+            auto tileElement = map_get_first_element_at(CoordsXY{ x, y });
             do
             {
                 if (tileElement == nullptr)
@@ -457,7 +457,7 @@ CoordsXYE TrackDesign::MazeGetFirstElement(const Ride& ride)
     {
         for (tile.x = 0; tile.x < MAXIMUM_MAP_SIZE_BIG; tile.x += COORDS_XY_STEP)
         {
-            tile.element = map_get_first_element_at({ tile.x, tile.y });
+            tile.element = map_get_first_element_at(CoordsXY{ tile.x, tile.y });
             do
             {
                 if (tile.element == nullptr)

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -547,7 +547,7 @@ static void track_design_save_select_nearby_scenery_for_tile(ride_id_t rideIndex
     {
         for (int32_t x = cx - TRACK_NEARBY_SCENERY_DISTANCE; x <= cx + TRACK_NEARBY_SCENERY_DISTANCE; x++)
         {
-            tileElement = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+            tileElement = map_get_first_element_at(TileCoordsXY{ x, y });
             if (tileElement == nullptr)
                 continue;
             do

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1897,7 +1897,7 @@ void Vehicle::UpdateMeasurements()
     {
         // Set tile_element to first element. Since elements aren't always ordered by base height,
         // we must start at the first element and iterate through each tile element.
-        auto tileElement = map_get_first_element_at({ x, y });
+        auto tileElement = map_get_first_element_at(CoordsXY{ x, y });
         if (tileElement == nullptr)
             return;
 

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -110,7 +110,7 @@ static void chairlift_paint_util_draw_supports(paint_session* session, int32_t s
 static const TrackElement* chairlift_paint_util_map_get_track_element_at_from_ride_fuzzy(
     int32_t x, int32_t y, int32_t z, const Ride* ride)
 {
-    const TileElement* tileElement = map_get_first_element_at({ x, y });
+    const TileElement* tileElement = map_get_first_element_at(CoordsXY{ x, y });
     if (tileElement == nullptr)
     {
         return nullptr;

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -145,7 +145,7 @@ TileElement* banner_get_tile_element(BannerIndex bannerIndex)
     auto banner = GetBanner(bannerIndex);
     if (banner != nullptr)
     {
-        auto tileElement = map_get_first_element_at(banner->position.ToCoordsXY());
+        auto tileElement = map_get_first_element_at(banner->position);
         if (tileElement != nullptr)
         {
             do
@@ -166,7 +166,7 @@ WallElement* banner_get_scrolling_wall_tile_element(BannerIndex bannerIndex)
     if (banner == nullptr)
         return nullptr;
 
-    auto tileElement = map_get_first_element_at(banner->position.ToCoordsXY());
+    auto tileElement = map_get_first_element_at(banner->position);
     if (tileElement == nullptr)
         return nullptr;
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1222,7 +1222,7 @@ void footpath_update_queue_chains()
             if (location.isNull())
                 continue;
 
-            TileElement* tileElement = map_get_first_element_at(location.ToCoordsXY());
+            TileElement* tileElement = map_get_first_element_at(location);
             if (tileElement != nullptr)
             {
                 do
@@ -2070,7 +2070,7 @@ static void footpath_remove_edges_towards(const CoordsXYRangedZ& footPathPos, in
 // entrances and exits, shops, paths).
 bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved)
 {
-    TileElement* tileElement = map_get_first_element_at(coords.ToCoordsXY());
+    TileElement* tileElement = map_get_first_element_at(coords);
     if (tileElement == nullptr)
         return false;
     do

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -283,15 +283,26 @@ void tile_element_iterator_restart_for_tile(tile_element_iterator* it)
     it->element = nullptr;
 }
 
-TileElement* map_get_first_element_at(const CoordsXY& elementPos)
+static bool IsTileLocationValid(const TileCoordsXY& coords)
 {
-    if (!map_is_location_valid(elementPos))
+    const bool is_x_valid = coords.x < MAXIMUM_MAP_SIZE_TECHNICAL && coords.x >= 0;
+    const bool is_y_valid = coords.y < MAXIMUM_MAP_SIZE_TECHNICAL && coords.y >= 0;
+    return is_x_valid && is_y_valid;
+}
+
+TileElement* map_get_first_element_at(const TileCoordsXY& tilePos)
+{
+    if (!IsTileLocationValid(tilePos))
     {
         log_verbose("Trying to access element outside of range");
         return nullptr;
     }
-    auto tileElementPos = TileCoordsXY{ elementPos };
-    return _tileIndex.GetFirstElementAt(tileElementPos);
+    return _tileIndex.GetFirstElementAt(tilePos);
+}
+
+TileElement* map_get_first_element_at(const CoordsXY& elementPos)
+{
+    return map_get_first_element_at(TileCoordsXY{ elementPos });
 }
 
 TileElement* map_get_nth_element_at(const CoordsXY& coords, int32_t n)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -243,7 +243,7 @@ void tile_element_iterator_begin(tile_element_iterator* it)
 {
     it->x = 0;
     it->y = 0;
-    it->element = map_get_first_element_at({ 0, 0 });
+    it->element = map_get_first_element_at(TileCoordsXY{ 0, 0 });
 }
 
 int32_t tile_element_iterator_next(tile_element_iterator* it)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -159,7 +159,7 @@ static void ReorganiseTileElements(size_t capacity)
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            const auto* element = map_get_first_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
+            const auto* element = map_get_first_element_at(TileCoordsXY{ x, y });
             if (element == nullptr)
             {
                 auto& newElement = newElements.emplace_back();
@@ -250,7 +250,7 @@ int32_t tile_element_iterator_next(tile_element_iterator* it)
 {
     if (it->element == nullptr)
     {
-        it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y }.ToCoordsXY());
+        it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y });
         return 1;
     }
 
@@ -263,7 +263,7 @@ int32_t tile_element_iterator_next(tile_element_iterator* it)
     if (it->x < (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
     {
         it->x++;
-        it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y }.ToCoordsXY());
+        it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y });
         return 1;
     }
 
@@ -271,7 +271,7 @@ int32_t tile_element_iterator_next(tile_element_iterator* it)
     {
         it->x = 0;
         it->y++;
-        it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y }.ToCoordsXY());
+        it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y });
         return 1;
     }
 
@@ -649,7 +649,7 @@ int16_t tile_element_water_height(const CoordsXY& loc)
  */
 bool map_coord_is_connected(const TileCoordsXYZ& loc, uint8_t faceDirection)
 {
-    TileElement* tileElement = map_get_first_element_at(loc.ToCoordsXY());
+    TileElement* tileElement = map_get_first_element_at(loc);
 
     if (tileElement == nullptr)
         return false;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -191,7 +191,8 @@ void map_init(int32_t size);
 
 void map_count_remaining_land_rights();
 void map_strip_ghost_flag_from_elements();
-TileElement* map_get_first_element_at(const CoordsXY& elementPos);
+TileElement* map_get_first_element_at(const CoordsXY& tilePos);
+TileElement* map_get_first_element_at(const TileCoordsXY& tilePos);
 TileElement* map_get_nth_element_at(const CoordsXY& coords, int32_t n);
 void map_set_tile_element(const TileCoordsXY& tilePos, TileElement* elements);
 int32_t map_height_from_slope(const CoordsXY& coords, int32_t slopeDirection, bool isSloped);


### PR DESCRIPTION
Going from TileCoordsXY to CoordsXY and then from CoordsXY back to TileCoordsXY doesn't seem very practical so I added an overload that accepts TileCoordsXY which is the right coordinate system to access the tiles. There is a lot of code that can be improved as there is a lot of forth and back since more functions have this the wrong way.