### PR TITLE
Refactor object storage in s6

### DIFF
--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -160,20 +160,13 @@ void object_entry_get_name_fixed(utf8* buffer, size_t bufferSize, const rct_obje
 
 void* object_entry_get_chunk(ObjectType objectType, ObjectEntryIndex index)
 {
-    ObjectEntryIndex objectIndex = index;
-    for (int32_t i = 0; i < EnumValue(objectType); i++)
-    {
-        objectIndex += object_entry_group_counts[i];
-    }
-
-    void* result = nullptr;
     auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objectMgr.GetLoadedObject(objectIndex);
-    if (obj != nullptr)
+    auto* object = objectMgr.GetLoadedObject(objectType, index);
+    if (object != nullptr)
     {
-        result = obj->GetLegacyData();
+        return object->GetLegacyData();
     }
-    return result;
+    return nullptr;
 }
 
 const Object* object_entry_get_object(ObjectType objectType, ObjectEntryIndex index)

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -137,20 +137,6 @@ void get_type_entry_index(size_t index, ObjectType* outObjectType, ObjectEntryIn
         *outEntryIndex = static_cast<ObjectEntryIndex>(index);
 }
 
-const rct_object_entry* get_loaded_object_entry(size_t index)
-{
-    ObjectType objectType;
-    ObjectEntryIndex entryIndex;
-    get_type_entry_index(index, &objectType, &entryIndex);
-    auto obj = object_entry_get_object(objectType, entryIndex);
-    if (obj == nullptr)
-    {
-        return nullptr;
-    }
-
-    return obj->GetObjectEntry();
-}
-
 void object_entry_get_name_fixed(utf8* buffer, size_t bufferSize, const rct_object_entry* entry)
 {
     bufferSize = std::min(static_cast<size_t>(DAT_NAME_LENGTH) + 1, bufferSize);

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -151,14 +151,6 @@ const rct_object_entry* get_loaded_object_entry(size_t index)
     return obj->GetObjectEntry();
 }
 
-void* get_loaded_object_chunk(size_t index)
-{
-    ObjectType objectType;
-    ObjectEntryIndex entryIndex;
-    get_type_entry_index(index, &objectType, &entryIndex);
-    return object_entry_get_chunk(objectType, entryIndex);
-}
-
 void object_entry_get_name_fixed(utf8* buffer, size_t bufferSize, const rct_object_entry* entry)
 {
     bufferSize = std::min(static_cast<size_t>(DAT_NAME_LENGTH) + 1, bufferSize);

--- a/src/openrct2/object/ObjectList.h
+++ b/src/openrct2/object/ObjectList.h
@@ -18,4 +18,3 @@
 #include "ObjectLimits.h"
 
 void get_type_entry_index(size_t index, ObjectType* outObjectType, ObjectEntryIndex* outEntryIndex);
-const rct_object_entry* get_loaded_object_entry(size_t index);

--- a/src/openrct2/object/ObjectList.h
+++ b/src/openrct2/object/ObjectList.h
@@ -19,4 +19,3 @@
 
 void get_type_entry_index(size_t index, ObjectType* outObjectType, ObjectEntryIndex* outEntryIndex);
 const rct_object_entry* get_loaded_object_entry(size_t index);
-void* get_loaded_object_chunk(size_t index);

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -838,20 +838,20 @@ struct rct_s6_data
     // SC6[3]
     union
     {
-        rct_object_entry objects[RCT2_OBJECT_ENTRY_COUNT];
+        rct_object_entry Objects[RCT2_OBJECT_ENTRY_COUNT];
         struct
         {
-            rct_object_entry rideObjects[RCT12_MAX_RIDE_OBJECTS];
-            rct_object_entry sceneryObjects[RCT2_MAX_SMALL_SCENERY_OBJECTS];
-            rct_object_entry largeSceneryObjects[RCT2_MAX_LARGE_SCENERY_OBJECTS];
-            rct_object_entry wallSceneryObjects[RCT2_MAX_WALL_SCENERY_OBJECTS];
-            rct_object_entry bannerObjects[RCT2_MAX_BANNER_OBJECTS];
-            rct_object_entry pathObjects[RCT2_MAX_PATH_OBJECTS];
-            rct_object_entry pathAdditionObjects[RCT2_MAX_PATH_ADDITION_OBJECTS];
-            rct_object_entry sceneryGroupObjects[RCT2_MAX_SCENERY_GROUP_OBJECTS];
-            rct_object_entry parkEntranceObjects[RCT2_MAX_PARK_ENTRANCE_OBJECTS];
-            rct_object_entry waterObjects[RCT2_MAX_WATER_OBJECTS];
-            rct_object_entry scenarioTextObjects[RCT2_MAX_SCENARIO_TEXT_OBJECTS];
+            rct_object_entry RideObjects[RCT12_MAX_RIDE_OBJECTS];
+            rct_object_entry SceneryObjects[RCT2_MAX_SMALL_SCENERY_OBJECTS];
+            rct_object_entry LargeSceneryObjects[RCT2_MAX_LARGE_SCENERY_OBJECTS];
+            rct_object_entry WallSceneryObjects[RCT2_MAX_WALL_SCENERY_OBJECTS];
+            rct_object_entry BannerObjects[RCT2_MAX_BANNER_OBJECTS];
+            rct_object_entry PathObjects[RCT2_MAX_PATH_OBJECTS];
+            rct_object_entry PathAdditionObjects[RCT2_MAX_PATH_ADDITION_OBJECTS];
+            rct_object_entry SceneryGroupObjects[RCT2_MAX_SCENERY_GROUP_OBJECTS];
+            rct_object_entry ParkEntranceObjects[RCT2_MAX_PARK_ENTRANCE_OBJECTS];
+            rct_object_entry WaterObjects[RCT2_MAX_WATER_OBJECTS];
+            rct_object_entry ScenarioTextObjects[RCT2_MAX_SCENARIO_TEXT_OBJECTS];
         };
     };
 

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -836,7 +836,24 @@ struct rct_s6_data
     // packed objects
 
     // SC6[3]
-    rct_object_entry objects[RCT2_OBJECT_ENTRY_COUNT];
+    union
+    {
+        rct_object_entry objects[RCT2_OBJECT_ENTRY_COUNT];
+        struct
+        {
+            rct_object_entry rideObjects[RCT12_MAX_RIDE_OBJECTS];
+            rct_object_entry sceneryObjects[RCT2_MAX_SMALL_SCENERY_OBJECTS];
+            rct_object_entry largeSceneryObjects[RCT2_MAX_LARGE_SCENERY_OBJECTS];
+            rct_object_entry wallSceneryObjects[RCT2_MAX_WALL_SCENERY_OBJECTS];
+            rct_object_entry bannerObjects[RCT2_MAX_BANNER_OBJECTS];
+            rct_object_entry pathObjects[RCT2_MAX_PATH_OBJECTS];
+            rct_object_entry pathAdditionObjects[RCT2_MAX_PATH_ADDITION_OBJECTS];
+            rct_object_entry sceneryGroupObjects[RCT2_MAX_SCENERY_GROUP_OBJECTS];
+            rct_object_entry parkEntranceObjects[RCT2_MAX_PARK_ENTRANCE_OBJECTS];
+            rct_object_entry waterObjects[RCT2_MAX_WATER_OBJECTS];
+            rct_object_entry scenarioTextObjects[RCT2_MAX_SCENARIO_TEXT_OBJECTS];
+        };
+    };
 
     // SC6[4]
     uint16_t elapsed_months;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -255,15 +255,17 @@ static void scenario_fix_ghosts(rct_s6_data* s6)
     }
 }
 
-template<typename T> static void ExportObjectList(IObjectManager& objMgr, T& objects, ObjectType type, size_t maxEntries)
+template<ObjectType TObjectType, size_t TMaxEntries, typename T>
+static void ExportObjectList(IObjectManager& objMgr, T& objects)
 {
-    for (size_t i = 0; i < maxEntries; i++)
+    for (size_t i = 0; i < TMaxEntries; i++)
     {
         auto& dst = objects[i];
 
-        auto* object = objMgr.GetLoadedObject(type, i);
+        const auto* object = objMgr.GetLoadedObject(TObjectType, i);
         if (object == nullptr || object->GetObjectEntry() == nullptr)
         {
+            // The sv6 format expects null/invalid entries to be filled with 0xFF.
             std::memset(&dst, 0xFF, sizeof(dst));
         }
         else
@@ -297,17 +299,17 @@ void S6Exporter::Export()
     uint32_t researchedTrackPiecesB[128] = {};
 
     auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
-    ExportObjectList(objectMgr, _s6.RideObjects, ObjectType::Ride, RCT12_MAX_RIDE_OBJECTS);
-    ExportObjectList(objectMgr, _s6.SceneryObjects, ObjectType::SmallScenery, RCT2_MAX_SMALL_SCENERY_OBJECTS);
-    ExportObjectList(objectMgr, _s6.LargeSceneryObjects, ObjectType::LargeScenery, RCT2_MAX_LARGE_SCENERY_OBJECTS);
-    ExportObjectList(objectMgr, _s6.WallSceneryObjects, ObjectType::Walls, RCT2_MAX_WALL_SCENERY_OBJECTS);
-    ExportObjectList(objectMgr, _s6.BannerObjects, ObjectType::Banners, RCT2_MAX_BANNER_OBJECTS);
-    ExportObjectList(objectMgr, _s6.PathObjects, ObjectType::Paths, RCT2_MAX_PATH_OBJECTS);
-    ExportObjectList(objectMgr, _s6.PathAdditionObjects, ObjectType::PathBits, RCT2_MAX_PATH_ADDITION_OBJECTS);
-    ExportObjectList(objectMgr, _s6.SceneryGroupObjects, ObjectType::SceneryGroup, RCT2_MAX_SCENERY_GROUP_OBJECTS);
-    ExportObjectList(objectMgr, _s6.ParkEntranceObjects, ObjectType::ParkEntrance, RCT2_MAX_PARK_ENTRANCE_OBJECTS);
-    ExportObjectList(objectMgr, _s6.WaterObjects, ObjectType::Water, RCT2_MAX_WATER_OBJECTS);
-    ExportObjectList(objectMgr, _s6.ScenarioTextObjects, ObjectType::ScenarioText, RCT2_MAX_SCENARIO_TEXT_OBJECTS);
+    ExportObjectList<ObjectType::Ride, RCT12_MAX_RIDE_OBJECTS>(objectMgr, _s6.RideObjects);
+    ExportObjectList<ObjectType::SmallScenery, RCT2_MAX_SMALL_SCENERY_OBJECTS>(objectMgr, _s6.SceneryObjects);
+    ExportObjectList<ObjectType::LargeScenery, RCT2_MAX_LARGE_SCENERY_OBJECTS>(objectMgr, _s6.LargeSceneryObjects);
+    ExportObjectList<ObjectType::Walls, RCT2_MAX_WALL_SCENERY_OBJECTS>(objectMgr, _s6.WallSceneryObjects);
+    ExportObjectList<ObjectType::Banners, RCT2_MAX_BANNER_OBJECTS>(objectMgr, _s6.BannerObjects);
+    ExportObjectList<ObjectType::Paths, RCT2_MAX_PATH_OBJECTS>(objectMgr, _s6.PathObjects);
+    ExportObjectList<ObjectType::PathBits, RCT2_MAX_PATH_ADDITION_OBJECTS>(objectMgr, _s6.PathAdditionObjects);
+    ExportObjectList<ObjectType::SceneryGroup, RCT2_MAX_SCENERY_GROUP_OBJECTS>(objectMgr, _s6.SceneryGroupObjects);
+    ExportObjectList<ObjectType::ParkEntrance, RCT2_MAX_PARK_ENTRANCE_OBJECTS>(objectMgr, _s6.ParkEntranceObjects);
+    ExportObjectList<ObjectType::Water, RCT2_MAX_WATER_OBJECTS>(objectMgr, _s6.WaterObjects);
+    ExportObjectList<ObjectType::ScenarioText, RCT2_MAX_SCENARIO_TEXT_OBJECTS>(objectMgr, _s6.ScenarioTextObjects);
 
     _s6.elapsed_months = static_cast<uint16_t>(gDateMonthsElapsed);
     _s6.current_day = gDateMonthTicks;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -120,7 +120,7 @@ void S6Exporter::Save(OpenRCT2::IStream* stream, bool isScenario)
     }
 
     // 3: Write available objects chunk
-    chunkWriter.WriteChunk(_s6.objects, sizeof(_s6.objects), SAWYER_ENCODING::ROTATE);
+    chunkWriter.WriteChunk(_s6.Objects, sizeof(_s6.Objects), SAWYER_ENCODING::ROTATE);
 
     // 4: Misc fields (data, rand...) chunk
     chunkWriter.WriteChunk(&_s6.elapsed_months, 16, SAWYER_ENCODING::RLECOMPRESSED);
@@ -297,17 +297,17 @@ void S6Exporter::Export()
     uint32_t researchedTrackPiecesB[128] = {};
 
     auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
-    ExportObjectList(objectMgr, _s6.rideObjects, ObjectType::Ride, RCT12_MAX_RIDE_OBJECTS);
-    ExportObjectList(objectMgr, _s6.sceneryObjects, ObjectType::SmallScenery, RCT2_MAX_SMALL_SCENERY_OBJECTS);
-    ExportObjectList(objectMgr, _s6.largeSceneryObjects, ObjectType::LargeScenery, RCT2_MAX_LARGE_SCENERY_OBJECTS);
-    ExportObjectList(objectMgr, _s6.wallSceneryObjects, ObjectType::Walls, RCT2_MAX_WALL_SCENERY_OBJECTS);
-    ExportObjectList(objectMgr, _s6.bannerObjects, ObjectType::Banners, RCT2_MAX_BANNER_OBJECTS);
-    ExportObjectList(objectMgr, _s6.pathObjects, ObjectType::Paths, RCT2_MAX_PATH_OBJECTS);
-    ExportObjectList(objectMgr, _s6.pathAdditionObjects, ObjectType::PathBits, RCT2_MAX_PATH_ADDITION_OBJECTS);
-    ExportObjectList(objectMgr, _s6.sceneryGroupObjects, ObjectType::SceneryGroup, RCT2_MAX_SCENERY_GROUP_OBJECTS);
-    ExportObjectList(objectMgr, _s6.parkEntranceObjects, ObjectType::ParkEntrance, RCT2_MAX_PARK_ENTRANCE_OBJECTS);
-    ExportObjectList(objectMgr, _s6.waterObjects, ObjectType::Water, RCT2_MAX_WATER_OBJECTS);
-    ExportObjectList(objectMgr, _s6.scenarioTextObjects, ObjectType::ScenarioText, RCT2_MAX_SCENARIO_TEXT_OBJECTS);
+    ExportObjectList(objectMgr, _s6.RideObjects, ObjectType::Ride, RCT12_MAX_RIDE_OBJECTS);
+    ExportObjectList(objectMgr, _s6.SceneryObjects, ObjectType::SmallScenery, RCT2_MAX_SMALL_SCENERY_OBJECTS);
+    ExportObjectList(objectMgr, _s6.LargeSceneryObjects, ObjectType::LargeScenery, RCT2_MAX_LARGE_SCENERY_OBJECTS);
+    ExportObjectList(objectMgr, _s6.WallSceneryObjects, ObjectType::Walls, RCT2_MAX_WALL_SCENERY_OBJECTS);
+    ExportObjectList(objectMgr, _s6.BannerObjects, ObjectType::Banners, RCT2_MAX_BANNER_OBJECTS);
+    ExportObjectList(objectMgr, _s6.PathObjects, ObjectType::Paths, RCT2_MAX_PATH_OBJECTS);
+    ExportObjectList(objectMgr, _s6.PathAdditionObjects, ObjectType::PathBits, RCT2_MAX_PATH_ADDITION_OBJECTS);
+    ExportObjectList(objectMgr, _s6.SceneryGroupObjects, ObjectType::SceneryGroup, RCT2_MAX_SCENERY_GROUP_OBJECTS);
+    ExportObjectList(objectMgr, _s6.ParkEntranceObjects, ObjectType::ParkEntrance, RCT2_MAX_PARK_ENTRANCE_OBJECTS);
+    ExportObjectList(objectMgr, _s6.WaterObjects, ObjectType::Water, RCT2_MAX_WATER_OBJECTS);
+    ExportObjectList(objectMgr, _s6.ScenarioTextObjects, ObjectType::ScenarioText, RCT2_MAX_SCENARIO_TEXT_OBJECTS);
 
     _s6.elapsed_months = static_cast<uint16_t>(gDateMonthsElapsed);
     _s6.current_day = gDateMonthTicks;

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -255,6 +255,24 @@ static void scenario_fix_ghosts(rct_s6_data* s6)
     }
 }
 
+template<typename T> static void ExportObjectList(IObjectManager& objMgr, T& objects, ObjectType type, size_t maxEntries)
+{
+    for (size_t i = 0; i < maxEntries; i++)
+    {
+        auto& dst = objects[i];
+
+        auto* object = objMgr.GetLoadedObject(type, i);
+        if (object == nullptr || object->GetObjectEntry() == nullptr)
+        {
+            std::memset(&dst, 0xFF, sizeof(dst));
+        }
+        else
+        {
+            dst = *object->GetObjectEntry();
+        }
+    }
+}
+
 void S6Exporter::Export()
 {
     _s6.info = {};
@@ -278,20 +296,18 @@ void S6Exporter::Export()
     uint32_t researchedTrackPiecesA[128] = {};
     uint32_t researchedTrackPiecesB[128] = {};
 
-    for (int32_t i = 0; i < RCT2_OBJECT_ENTRY_COUNT; i++)
-    {
-        const rct_object_entry* entry = get_loaded_object_entry(i);
-        void* entryData = get_loaded_object_chunk(i);
-        // RCT2 uses (void *)-1 to mark NULL. Make sure it's written in a vanilla-compatible way.
-        if (entry == nullptr || entryData == nullptr || entryData == reinterpret_cast<void*>(-1))
-        {
-            std::memset(&_s6.objects[i], 0xFF, sizeof(rct_object_entry));
-        }
-        else
-        {
-            _s6.objects[i] = *entry;
-        }
-    }
+    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    ExportObjectList(objectMgr, _s6.rideObjects, ObjectType::Ride, RCT12_MAX_RIDE_OBJECTS);
+    ExportObjectList(objectMgr, _s6.sceneryObjects, ObjectType::SmallScenery, RCT2_MAX_SMALL_SCENERY_OBJECTS);
+    ExportObjectList(objectMgr, _s6.largeSceneryObjects, ObjectType::LargeScenery, RCT2_MAX_LARGE_SCENERY_OBJECTS);
+    ExportObjectList(objectMgr, _s6.wallSceneryObjects, ObjectType::Walls, RCT2_MAX_WALL_SCENERY_OBJECTS);
+    ExportObjectList(objectMgr, _s6.bannerObjects, ObjectType::Banners, RCT2_MAX_BANNER_OBJECTS);
+    ExportObjectList(objectMgr, _s6.pathObjects, ObjectType::Paths, RCT2_MAX_PATH_OBJECTS);
+    ExportObjectList(objectMgr, _s6.pathAdditionObjects, ObjectType::PathBits, RCT2_MAX_PATH_ADDITION_OBJECTS);
+    ExportObjectList(objectMgr, _s6.sceneryGroupObjects, ObjectType::SceneryGroup, RCT2_MAX_SCENERY_GROUP_OBJECTS);
+    ExportObjectList(objectMgr, _s6.parkEntranceObjects, ObjectType::ParkEntrance, RCT2_MAX_PARK_ENTRANCE_OBJECTS);
+    ExportObjectList(objectMgr, _s6.waterObjects, ObjectType::Water, RCT2_MAX_WATER_OBJECTS);
+    ExportObjectList(objectMgr, _s6.scenarioTextObjects, ObjectType::ScenarioText, RCT2_MAX_SCENARIO_TEXT_OBJECTS);
 
     _s6.elapsed_months = static_cast<uint16_t>(gDateMonthsElapsed);
     _s6.current_day = gDateMonthTicks;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -169,7 +169,7 @@ public:
             _isSV7 = _stricmp(extension, ".sv7") == 0;
         }
 
-        chunkReader.ReadChunk(&_s6.objects, sizeof(_s6.objects));
+        chunkReader.ReadChunk(&_s6.Objects, sizeof(_s6.Objects));
 
         if (isScenario)
         {
@@ -1586,17 +1586,17 @@ public:
     {
         std::vector<rct_object_entry> result;
 
-        AddRequiredObjects(result, _s6.rideObjects, MAX_RIDE_OBJECTS);
-        AddRequiredObjects(result, _s6.sceneryObjects, MAX_SMALL_SCENERY_OBJECTS);
-        AddRequiredObjects(result, _s6.largeSceneryObjects, MAX_LARGE_SCENERY_OBJECTS);
-        AddRequiredObjects(result, _s6.wallSceneryObjects, MAX_WALL_SCENERY_OBJECTS);
-        AddRequiredObjects(result, _s6.bannerObjects, MAX_BANNER_OBJECTS);
-        AddRequiredObjects(result, _s6.pathObjects, MAX_PATH_OBJECTS);
-        AddRequiredObjects(result, _s6.pathAdditionObjects, MAX_PATH_ADDITION_OBJECTS);
-        AddRequiredObjects(result, _s6.sceneryGroupObjects, MAX_SCENERY_GROUP_OBJECTS);
-        AddRequiredObjects(result, _s6.parkEntranceObjects, MAX_PARK_ENTRANCE_OBJECTS);
-        AddRequiredObjects(result, _s6.waterObjects, MAX_WATER_OBJECTS);
-        AddRequiredObjects(result, _s6.scenarioTextObjects, MAX_SCENARIO_TEXT_OBJECTS);
+        AddRequiredObjects(result, _s6.RideObjects, MAX_RIDE_OBJECTS);
+        AddRequiredObjects(result, _s6.SceneryObjects, MAX_SMALL_SCENERY_OBJECTS);
+        AddRequiredObjects(result, _s6.LargeSceneryObjects, MAX_LARGE_SCENERY_OBJECTS);
+        AddRequiredObjects(result, _s6.WallSceneryObjects, MAX_WALL_SCENERY_OBJECTS);
+        AddRequiredObjects(result, _s6.BannerObjects, MAX_BANNER_OBJECTS);
+        AddRequiredObjects(result, _s6.PathObjects, MAX_PATH_OBJECTS);
+        AddRequiredObjects(result, _s6.PathAdditionObjects, MAX_PATH_ADDITION_OBJECTS);
+        AddRequiredObjects(result, _s6.SceneryGroupObjects, MAX_SCENERY_GROUP_OBJECTS);
+        AddRequiredObjects(result, _s6.ParkEntranceObjects, MAX_PARK_ENTRANCE_OBJECTS);
+        AddRequiredObjects(result, _s6.WaterObjects, MAX_WATER_OBJECTS);
+        AddRequiredObjects(result, _s6.ScenarioTextObjects, MAX_SCENARIO_TEXT_OBJECTS);
 
         return result;
     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1563,8 +1563,8 @@ public:
         return justText.data();
     }
 
-    template<typename T>
-    static void AddRequiredObjects(std::vector<rct_object_entry>& required, const T& list, size_t internalLimit)
+    template<size_t TInternalLimit, typename T>
+    static void AddRequiredObjects(std::vector<rct_object_entry>& required, const T& list)
     {
         rct_object_entry nullEntry = {};
         std::memset(&nullEntry, 0xFF, sizeof(nullEntry));
@@ -1576,7 +1576,7 @@ public:
 
         // NOTE: The segment of this object type needs to be filled to the internal limit
         // the object manager currently expects this.
-        for (size_t i = std::size(list); i < internalLimit; i++)
+        for (size_t i = std::size(list); i < TInternalLimit; i++)
         {
             required.push_back(nullEntry);
         }
@@ -1586,17 +1586,17 @@ public:
     {
         std::vector<rct_object_entry> result;
 
-        AddRequiredObjects(result, _s6.RideObjects, MAX_RIDE_OBJECTS);
-        AddRequiredObjects(result, _s6.SceneryObjects, MAX_SMALL_SCENERY_OBJECTS);
-        AddRequiredObjects(result, _s6.LargeSceneryObjects, MAX_LARGE_SCENERY_OBJECTS);
-        AddRequiredObjects(result, _s6.WallSceneryObjects, MAX_WALL_SCENERY_OBJECTS);
-        AddRequiredObjects(result, _s6.BannerObjects, MAX_BANNER_OBJECTS);
-        AddRequiredObjects(result, _s6.PathObjects, MAX_PATH_OBJECTS);
-        AddRequiredObjects(result, _s6.PathAdditionObjects, MAX_PATH_ADDITION_OBJECTS);
-        AddRequiredObjects(result, _s6.SceneryGroupObjects, MAX_SCENERY_GROUP_OBJECTS);
-        AddRequiredObjects(result, _s6.ParkEntranceObjects, MAX_PARK_ENTRANCE_OBJECTS);
-        AddRequiredObjects(result, _s6.WaterObjects, MAX_WATER_OBJECTS);
-        AddRequiredObjects(result, _s6.ScenarioTextObjects, MAX_SCENARIO_TEXT_OBJECTS);
+        AddRequiredObjects<MAX_RIDE_OBJECTS>(result, _s6.RideObjects);
+        AddRequiredObjects<MAX_SMALL_SCENERY_OBJECTS>(result, _s6.SceneryObjects);
+        AddRequiredObjects<MAX_LARGE_SCENERY_OBJECTS>(result, _s6.LargeSceneryObjects);
+        AddRequiredObjects<MAX_WALL_SCENERY_OBJECTS>(result, _s6.WallSceneryObjects);
+        AddRequiredObjects<MAX_BANNER_OBJECTS>(result, _s6.BannerObjects);
+        AddRequiredObjects<MAX_PATH_OBJECTS>(result, _s6.PathObjects);
+        AddRequiredObjects<MAX_PATH_ADDITION_OBJECTS>(result, _s6.PathAdditionObjects);
+        AddRequiredObjects<MAX_SCENERY_GROUP_OBJECTS>(result, _s6.SceneryGroupObjects);
+        AddRequiredObjects<MAX_PARK_ENTRANCE_OBJECTS>(result, _s6.ParkEntranceObjects);
+        AddRequiredObjects<MAX_WATER_OBJECTS>(result, _s6.WaterObjects);
+        AddRequiredObjects<MAX_SCENARIO_TEXT_OBJECTS>(result, _s6.ScenarioTextObjects);
 
         return result;
     }


### PR DESCRIPTION
The first step towards simplifying the overall object manager stuff. Separating the single list into multiple makes it a lot easier to refactor the object manager to also have individual object lists, all object access is usually type + local index so this would only make sense to also store it like that.