### PR TITLE
Make smart follow functions easier to follow

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -683,15 +683,12 @@ void viewport_update_smart_sprite_follow(rct_window* window)
             break;
 
         case EntityType::Guest:
-        case EntityType::Staff:
-        {
-            Peep* peep = static_cast<Peep*>(entity);
-            if (peep->Is<Guest>())
-                viewport_update_smart_guest_follow(window, peep);
-            else if (peep->Is<Staff>())
-                viewport_update_smart_staff_follow(window, peep);
+            viewport_update_smart_guest_follow(window, entity->As<Guest>());
             break;
-        }
+
+        case EntityType::Staff:
+            viewport_update_smart_staff_follow(window, entity->As<Staff>());
+            break;
 
         default: // All other types don't need any "smart" following; steam particle, duck, money effect, etc.
             window->viewport_focus_sprite.sprite_id = window->viewport_smart_follow_sprite;
@@ -700,7 +697,7 @@ void viewport_update_smart_sprite_follow(rct_window* window)
     }
 }
 
-viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Peep* peep)
+viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Guest* peep)
 {
     viewport_focus focus{};
     focus.type = VIEWPORT_FOCUS_TYPE_SPRITE;
@@ -759,7 +756,7 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Peep
     return focus;
 }
 
-void viewport_update_smart_staff_follow(rct_window* window, const Peep* peep)
+void viewport_update_smart_staff_follow(rct_window* window, const Staff* peep)
 {
     sprite_focus focus = {};
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -700,7 +700,7 @@ void viewport_update_smart_sprite_follow(rct_window* window)
     }
 }
 
-viewport_focus viewport_update_smart_guest_follow(rct_window* window, Peep* peep)
+viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Peep* peep)
 {
     viewport_focus focus{};
     focus.type = VIEWPORT_FOCUS_TYPE_SPRITE;
@@ -759,7 +759,7 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, Peep* peep
     return focus;
 }
 
-void viewport_update_smart_staff_follow(rct_window* window, Peep* peep)
+void viewport_update_smart_staff_follow(rct_window* window, const Peep* peep)
 {
     sprite_focus focus = {};
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -669,40 +669,34 @@ void viewport_update_sprite_follow(rct_window* window)
 void viewport_update_smart_sprite_follow(rct_window* window)
 {
     auto entity = TryGetEntity(window->viewport_smart_follow_sprite);
-    if (entity == nullptr)
+    if (entity == nullptr || entity->Type == EntityType::Null)
     {
         window->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
         window->viewport_target_sprite = SPRITE_INDEX_NULL;
+        return;
     }
-    else if (entity->Type == EntityType::Guest || entity->Type == EntityType::Staff)
+
+    switch (entity->Type)
     {
-        Peep* peep = TryGetEntity<Peep>(window->viewport_smart_follow_sprite);
-        if (peep == nullptr)
+        case EntityType::Vehicle:
+            viewport_update_smart_vehicle_follow(window);
+            break;
+
+        case EntityType::Guest:
+        case EntityType::Staff:
         {
-            // will never happen
-            window->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
-            window->viewport_target_sprite = SPRITE_INDEX_NULL;
-            return;
+            Peep* peep = static_cast<Peep*>(entity);
+            if (peep->Is<Guest>())
+                viewport_update_smart_guest_follow(window, peep);
+            else if (peep->Is<Staff>())
+                viewport_update_smart_staff_follow(window, peep);
+            break;
         }
 
-        if (peep->Is<Guest>())
-            viewport_update_smart_guest_follow(window, peep);
-        else if (peep->Is<Staff>())
-            viewport_update_smart_staff_follow(window, peep);
-    }
-    else if (entity->Type == EntityType::Vehicle)
-    {
-        viewport_update_smart_vehicle_follow(window);
-    }
-    else if (entity->Type != EntityType::Null)
-    {
-        window->viewport_focus_sprite.sprite_id = window->viewport_smart_follow_sprite;
-        window->viewport_target_sprite = window->viewport_smart_follow_sprite;
-    }
-    else
-    {
-        window->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
-        window->viewport_target_sprite = SPRITE_INDEX_NULL;
+        default: // All other types don't need any "smart" following; steam particle, duck, money effect, etc.
+            window->viewport_focus_sprite.sprite_id = window->viewport_smart_follow_sprite;
+            window->viewport_target_sprite = window->viewport_smart_follow_sprite;
+            break;
     }
 }
 
@@ -719,47 +713,46 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, Peep* peep
         window->viewport_target_sprite = SPRITE_INDEX_NULL;
         return focus;
     }
-    else
+
+    bool overallFocus = true;
+    if (peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide
+        || (peep->State == PeepState::LeavingRide && peep->x == LOCATION_NULL))
     {
-        bool overallFocus = true;
-        if (peep->State == PeepState::OnRide || peep->State == PeepState::EnteringRide
-            || (peep->State == PeepState::LeavingRide && peep->x == LOCATION_NULL))
+        auto ride = get_ride(peep->CurrentRide);
+        if (ride != nullptr && (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
         {
-            auto ride = get_ride(peep->CurrentRide);
-            if (ride != nullptr && (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
+            auto train = GetEntity<Vehicle>(ride->vehicles[peep->CurrentTrain]);
+            if (train != nullptr)
             {
-                auto train = GetEntity<Vehicle>(ride->vehicles[peep->CurrentTrain]);
-                if (train != nullptr)
+                const auto car = train->GetCar(peep->CurrentCar);
+                if (car != nullptr)
                 {
-                    const auto car = train->GetCar(peep->CurrentCar);
-                    if (car != nullptr)
-                    {
-                        focus.sprite.sprite_id = car->sprite_index;
-                        overallFocus = false;
-                    }
+                    focus.sprite.sprite_id = car->sprite_index;
+                    overallFocus = false;
                 }
             }
         }
-        if (peep->x == LOCATION_NULL && overallFocus)
-        {
-            auto ride = get_ride(peep->CurrentRide);
-            if (ride != nullptr)
-            {
-                auto xy = ride->overall_view.ToTileCentre();
-                focus.type = VIEWPORT_FOCUS_TYPE_COORDINATE;
-                focus.coordinate.x = xy.x;
-                focus.coordinate.y = xy.y;
-                focus.coordinate.z = tile_element_height(xy) + (4 * COORDS_Z_STEP);
-                focus.sprite.type |= VIEWPORT_FOCUS_TYPE_COORDINATE;
-            }
-        }
-        else
-        {
-            focus.sprite.type |= VIEWPORT_FOCUS_TYPE_SPRITE | VIEWPORT_FOCUS_TYPE_COORDINATE;
-            focus.sprite.pad_486 &= 0xFFFF;
-        }
-        focus.coordinate.rotation = get_current_rotation();
     }
+
+    if (peep->x == LOCATION_NULL && overallFocus)
+    {
+        auto ride = get_ride(peep->CurrentRide);
+        if (ride != nullptr)
+        {
+            auto xy = ride->overall_view.ToTileCentre();
+            focus.type = VIEWPORT_FOCUS_TYPE_COORDINATE;
+            focus.coordinate.x = xy.x;
+            focus.coordinate.y = xy.y;
+            focus.coordinate.z = tile_element_height(xy) + (4 * COORDS_Z_STEP);
+            focus.sprite.type |= VIEWPORT_FOCUS_TYPE_COORDINATE;
+        }
+    }
+    else
+    {
+        focus.sprite.type |= VIEWPORT_FOCUS_TYPE_SPRITE | VIEWPORT_FOCUS_TYPE_COORDINATE;
+        focus.sprite.pad_486 &= 0xFFFF;
+    }
+    focus.coordinate.rotation = get_current_rotation();
 
     window->viewport_focus_sprite = focus.sprite;
     window->viewport_target_sprite = window->viewport_focus_sprite.sprite_id;
@@ -774,15 +767,12 @@ void viewport_update_smart_staff_follow(rct_window* window, Peep* peep)
 
     if (peep->State == PeepState::Picked)
     {
-        // focus.sprite.sprite_id = SPRITE_INDEX_NULL;
         window->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
         window->viewport_target_sprite = SPRITE_INDEX_NULL;
         return;
     }
-    else
-    {
-        focus.type |= VIEWPORT_FOCUS_TYPE_SPRITE | VIEWPORT_FOCUS_TYPE_COORDINATE;
-    }
+
+    focus.type |= VIEWPORT_FOCUS_TYPE_SPRITE | VIEWPORT_FOCUS_TYPE_COORDINATE;
 
     window->viewport_focus_sprite = focus;
     window->viewport_target_sprite = window->viewport_focus_sprite.sprite_id;
@@ -790,9 +780,7 @@ void viewport_update_smart_staff_follow(rct_window* window, Peep* peep)
 
 void viewport_update_smart_vehicle_follow(rct_window* window)
 {
-    // Can be expanded in the future if needed
     sprite_focus focus = {};
-
     focus.sprite_id = window->viewport_smart_follow_sprite;
 
     window->viewport_focus_sprite = focus;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -111,8 +111,8 @@ void viewports_invalidate(int32_t left, int32_t top, int32_t right, int32_t bott
 void viewport_update_position(rct_window* window);
 void viewport_update_sprite_follow(rct_window* window);
 void viewport_update_smart_sprite_follow(rct_window* window);
-viewport_focus viewport_update_smart_guest_follow(rct_window* window, Peep* peep);
-void viewport_update_smart_staff_follow(rct_window* window, Peep* peep);
+viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Peep* peep);
+void viewport_update_smart_staff_follow(rct_window* window, const Peep* peep);
 void viewport_update_smart_vehicle_follow(rct_window* window);
 void viewport_render(
     rct_drawpixelinfo* dpi, const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom,

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -20,11 +20,12 @@ struct paint_session;
 struct RecordedPaintSession;
 struct paint_struct;
 struct rct_drawpixelinfo;
-struct Peep;
 struct TileElement;
 struct rct_window;
-union paint_entry;
 struct EntityBase;
+struct Guest;
+struct Staff;
+union paint_entry;
 
 enum
 {
@@ -111,8 +112,8 @@ void viewports_invalidate(int32_t left, int32_t top, int32_t right, int32_t bott
 void viewport_update_position(rct_window* window);
 void viewport_update_sprite_follow(rct_window* window);
 void viewport_update_smart_sprite_follow(rct_window* window);
-viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Peep* peep);
-void viewport_update_smart_staff_follow(rct_window* window, const Peep* peep);
+viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Guest* peep);
+void viewport_update_smart_staff_follow(rct_window* window, const Staff* peep);
 void viewport_update_smart_vehicle_follow(rct_window* window);
 void viewport_render(
     rct_drawpixelinfo* dpi, const rct_viewport* viewport, int32_t left, int32_t top, int32_t right, int32_t bottom,

--- a/src/openrct2/rct2/S6Exporter.h
+++ b/src/openrct2/rct2/S6Exporter.h
@@ -26,8 +26,9 @@ namespace OpenRCT2
 struct Litter;
 struct ObjectRepositoryItem;
 struct RCT12SpriteBase;
-union rct_sprite;
 struct EntityBase;
+struct Peep;
+union rct_sprite;
 
 /**
  * Class to export RollerCoaster Tycoon 2 scenarios (*.SC6) and saved games (*.SV6).


### PR DESCRIPTION
- Opted for a switch-case instead of if-else if-else if-else
- Reuse entity - is already checked for null and doesn't change
- Remove unnecessary else blocks after if-block that returns
- Make `peep` argument const - following should not change the peep in any way

Turn whitespace changes off in the diff, since most of it are just indention changes.

If you want to test this, you can do so by using the "follow sprite" option in the sequence editor, then playing the sequence.