### PR TITLE
Fix #15322: Circus Music Not Playing

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,7 +24,6 @@
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
-- Fix: [#15322] Circus music is not playing when show starts.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
+- Fix: [#15322] Circus music is not playing when show starts.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1805,6 +1805,7 @@ static void ride_music_update(Ride* ride)
             }
         }
     }
+
     // Select random tune from available tunes for a music style (of course only merry-go-rounds have more than one tune)
     if (ride->music_tune_id == 255)
     {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1805,10 +1805,9 @@ static void ride_music_update(Ride* ride)
             }
         }
     }
-
+    // Select random tune from available tunes for a music style (of course only merry-go-rounds have more than one tune)
     if (ride->music_tune_id == 255)
     {
-        // Select random tune from available tunes for a music style (of course only merry-go-rounds have more than one tune)
         auto& objManager = GetContext()->GetObjectManager();
         auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride->music));
         if (musicObj != nullptr)
@@ -1817,6 +1816,7 @@ static void ride_music_update(Ride* ride)
             ride->music_tune_id = static_cast<uint8_t>(util_rand() % numTracks);
             ride->music_position = 0;
         }
+        return;
     }
 
     CoordsXYZ rideCoords = ride->stations[0].GetStart().ToTileCentre();

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1754,7 +1754,7 @@ Staff* ride_get_assigned_mechanic(Ride* ride)
  */
 static void ride_music_update(Ride* ride)
 {
-    // Circus does not have "music." Music is a sound effect
+    // The circus does not have music in the normal sense - its “music” is a sound effect.
     if (ride->type == RIDE_TYPE_CIRCUS)
     {
         Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[0]);


### PR DESCRIPTION
Added check to ride_update_music to see if ride type is circus. Separated circus music processing from the rest of the rides.

Previously, Circus would not play music.
Now, Circus will play music as expected.

Issue was just an 'if' statement that was returning immediately if the music flag for a ride was not set. As the circus is a sound effect, not music, it was continually returning.