### PR TITLE
Fix #15390: Revert quadrant distribution change

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -14,6 +14,7 @@
 #include "../drawing/Drawing.h"
 #include "../interface/Colour.h"
 #include "../world/Location.hpp"
+#include "../world/Map.h"
 
 #include <mutex>
 #include <thread>
@@ -113,9 +114,9 @@ struct tunnel_entry
     uint8_t type;
 };
 
-// NOTE: This should be preferably a prime number. This is the amount of
-// buckets used with the position hash, so the bucket is hash % max.
-#define MAX_PAINT_QUADRANTS 521
+// The maximum size must be MAXIMUM_MAP_SIZE_TECHNICAL multiplied by 2 because
+// the quadrant index is based on the x and y components combined.
+static constexpr int32_t MaxPaintQuadrants = MAXIMUM_MAP_SIZE_TECHNICAL * 2;
 
 #define TUNNEL_MAX_COUNT 65
 
@@ -171,7 +172,7 @@ public:
 
 struct PaintSessionCore
 {
-    paint_struct* Quadrants[MAX_PAINT_QUADRANTS];
+    paint_struct* Quadrants[MaxPaintQuadrants];
     paint_struct* LastPS;
     paint_string_struct* PSStringHead;
     paint_string_struct* LastPSString;


### PR DESCRIPTION
This reverts the changes I made recently.

There appears to be some visual glitches, I need to look further into why this happens. The original code just clamps position between 0 and max which probably has some corner cases when two positions end up in the same bucket but are not part of the same region, this has also probably to do with the coordinate type of int32 which was int16 originally.