### PR TITLE
Remove unnecessary else blocks

### DIFF
--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -204,8 +204,7 @@ namespace OpenRCT2::Ui
                     ShowMessageBox(window, msg);
                     return ShowFileDialog(window, desc);
                 }
-                else if (
-                    desc.Type == FILE_DIALOG_TYPE::SAVE && access(result.c_str(), F_OK) != -1 && dtype == DIALOG_TYPE::KDIALOG)
+                if (desc.Type == FILE_DIALOG_TYPE::SAVE && access(result.c_str(), F_OK) != -1 && dtype == DIALOG_TYPE::KDIALOG)
                 {
                     std::string cmd = String::StdFormat("%s --yesno \"Overwrite %s?\"", executablePath.c_str(), result.c_str());
                     if (Platform::Execute(cmd) != 0)

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -156,10 +156,7 @@ public:
                 {
                     return this->OpenWindow(WC_RESEARCH);
                 }
-                else
-                {
-                    return window_new_ride_open_research();
-                }
+                return window_new_ride_open_research();
             case WV_MAZE_CONSTRUCTION:
                 return window_maze_construction_open();
             case WV_NETWORK_PASSWORD:

--- a/src/openrct2-ui/drawing/BitmapReader.cpp
+++ b/src/openrct2-ui/drawing/BitmapReader.cpp
@@ -88,11 +88,9 @@ static Image ReadBitmap(std::istream& istream, IMAGE_FORMAT format)
 
             return image;
         }
-        else
-        {
-            SDL_FreeSurface(bitmap);
-            throw std::runtime_error("Unable to lock surface.");
-        }
+
+        SDL_FreeSurface(bitmap);
+        throw std::runtime_error("Unable to lock surface.");
     }
     else
     {

--- a/src/openrct2-ui/drawing/engines/opengl/TransparencyDepth.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TransparencyDepth.cpp
@@ -57,8 +57,8 @@ static inline SweepLine CreateXList(const RectCommandBatch& transparent)
     std::sort(x_sweep.begin(), x_sweep.end(), [](const XData& a, const XData& b) -> bool {
         if (a.xposition != b.xposition)
             return a.xposition < b.xposition;
-        else
-            return !a.begin && b.begin;
+
+        return !a.begin && b.begin;
     });
 
     return x_sweep;

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -188,28 +188,28 @@ void InputManager::Process(const InputEvent& e)
             }
             return;
         }
-        else if (gChatOpen)
+
+        if (gChatOpen)
         {
             ProcessChat(e);
             return;
         }
-        else
+
+        if (e.DeviceKind == InputDeviceKind::Keyboard)
         {
-            if (e.DeviceKind == InputDeviceKind::Keyboard)
+            auto w = window_find_by_class(WC_TEXTINPUT);
+            if (w != nullptr)
             {
-                auto w = window_find_by_class(WC_TEXTINPUT);
-                if (w != nullptr)
+                if (e.State == InputEventState::Release)
                 {
-                    if (e.State == InputEventState::Release)
-                    {
-                        window_text_input_key(w, e.Button);
-                    }
-                    return;
+                    window_text_input_key(w, e.Button);
                 }
-                else if (gUsingWidgetTextBox)
-                {
-                    return;
-                }
+                return;
+            }
+
+            if (gUsingWidgetTextBox)
+            {
+                return;
             }
         }
     }

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -145,12 +145,10 @@ static MouseState GameGetNextInput(ScreenCoordsXY& screenCoords)
         screenCoords = cursorState->position;
         return MouseState::Released;
     }
-    else
-    {
-        screenCoords.x = input->x;
-        screenCoords.y = input->y;
-        return input->state;
-    }
+
+    screenCoords.x = input->x;
+    screenCoords.y = input->y;
+    return input->state;
 }
 
 /**
@@ -164,12 +162,10 @@ static RCTMouseData* GetMouseInput()
     {
         return nullptr;
     }
-    else
-    {
-        RCTMouseData* result = &_mouseInputQueue[_mouseInputQueueReadIndex];
-        _mouseInputQueueReadIndex = (_mouseInputQueueReadIndex + 1) % std::size(_mouseInputQueue);
-        return result;
-    }
+
+    RCTMouseData* result = &_mouseInputQueue[_mouseInputQueueReadIndex];
+    _mouseInputQueueReadIndex = (_mouseInputQueueReadIndex + 1) % std::size(_mouseInputQueue);
+    return result;
 }
 
 /**

--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -27,54 +27,52 @@ static uint32_t ParseModifier(std::string_view text)
     {
         return KMOD_CTRL;
     }
-    else if (String::Equals(text, "LCTRL", true))
+    if (String::Equals(text, "LCTRL", true))
     {
         return KMOD_LCTRL;
     }
-    else if (String::Equals(text, "RCTRL", true))
+    if (String::Equals(text, "RCTRL", true))
     {
         return KMOD_RCTRL;
     }
-    else if (String::Equals(text, "SHIFT", true))
+    if (String::Equals(text, "SHIFT", true))
     {
         return KMOD_SHIFT;
     }
-    else if (String::Equals(text, "LSHIFT", true))
+    if (String::Equals(text, "LSHIFT", true))
     {
         return KMOD_LSHIFT;
     }
-    else if (String::Equals(text, "RSHIFT", true))
+    if (String::Equals(text, "RSHIFT", true))
     {
         return KMOD_RSHIFT;
     }
-    else if (String::Equals(text, "ALT", true))
+    if (String::Equals(text, "ALT", true))
     {
         return KMOD_ALT;
     }
-    else if (String::Equals(text, "LALT", true))
+    if (String::Equals(text, "LALT", true))
     {
         return KMOD_LALT;
     }
-    else if (String::Equals(text, "RALT", true))
+    if (String::Equals(text, "RALT", true))
     {
         return KMOD_RALT;
     }
-    else if (String::Equals(text, "GUI", true))
+    if (String::Equals(text, "GUI", true))
     {
         return KMOD_GUI;
     }
-    else if (String::Equals(text, "LCTRL", true))
+    if (String::Equals(text, "LCTRL", true))
     {
         return KMOD_LGUI;
     }
-    else if (String::Equals(text, "RGUI", true))
+    if (String::Equals(text, "RGUI", true))
     {
         return KMOD_RGUI;
     }
-    else
-    {
-        return 0;
-    }
+
+    return 0;
 }
 
 static uint32_t ParseKey(std::string_view text)
@@ -99,10 +97,8 @@ static size_t FindPlus(std::string_view s, size_t index)
             index++;
             continue;
         }
-        else
-        {
-            break;
-        }
+
+        break;
     }
     return index;
 }
@@ -209,15 +205,11 @@ std::string_view ShortcutInput::GetModifierName(uint32_t key, bool localised)
         {
             return language_get_string(r->second.second);
         }
-        else
-        {
-            return r->second.first;
-        }
+
+        return r->second.first;
     }
-    else
-    {
-        return {};
-    }
+
+    return {};
 }
 
 std::string_view ShortcutInput::GetLocalisedKeyName(uint32_t key)
@@ -260,10 +252,8 @@ std::string_view ShortcutInput::GetLocalisedKeyName(uint32_t key)
     {
         return language_get_string(r->second);
     }
-    else
-    {
-        return {};
-    }
+
+    return {};
 }
 
 std::string ShortcutInput::ToString() const
@@ -350,13 +340,13 @@ bool ShortcutInput::AppendModifier(std::string& s, uint32_t left, uint32_t right
         s += "+";
         return true;
     }
-    else if (Modifiers & left)
+    if (Modifiers & left)
     {
         s += GetModifierName(left, localised);
         s += "+";
         return true;
     }
-    else if (Modifiers & right)
+    if (Modifiers & right)
     {
         s += GetModifierName(right, localised);
         s += "+";
@@ -379,7 +369,7 @@ static bool HasModifier(uint32_t shortcut, uint32_t actual, uint32_t left, uint3
         }
         return false;
     }
-    else if (actual & (left | right))
+    if (actual & (left | right))
     {
         return false;
     }

--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -50,10 +50,8 @@ uint32_t LandTool::SizeToSpriteIndex(uint16_t size)
     {
         return toolSizeSpriteIndices[size];
     }
-    else
-    {
-        return 0xFFFFFFFF;
-    }
+
+    return 0xFFFFFFFF;
 }
 
 void LandTool::ShowSurfaceStyleDropdown(rct_window* w, rct_widget* widget, ObjectEntryIndex currentSurfaceType)

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -743,10 +743,8 @@ uint8_t ThemeGetColour(rct_windowclass wc, uint8_t index)
         }
         return desc->DefaultTheme.Colours[index];
     }
-    else
-    {
-        return entry->Theme.Colours[index];
-    }
+
+    return entry->Theme.Colours[index];
 }
 
 void ThemeSetColour(rct_windowclass wc, uint8_t index, colour_t colour)

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -79,11 +79,9 @@ InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoord
     {
         if (info.SpriteType == ViewportInteractionItem::Entity && (sprite->Is<Balloon>() || sprite->Is<Duck>()))
             return info;
-        else
-        {
-            info.SpriteType = ViewportInteractionItem::None;
-            return info;
-        }
+
+        info.SpriteType = ViewportInteractionItem::None;
+        return info;
     }
 
     switch (info.SpriteType)

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -354,17 +354,15 @@ namespace OpenRCT2::Ui::Windows
                 {
                     return &Desc.Widgets[widgetDescIndex];
                 }
-                else
+
+                auto page = static_cast<size_t>(w->page);
+                if (Desc.Tabs.size() > page)
                 {
-                    auto page = static_cast<size_t>(w->page);
-                    if (Desc.Tabs.size() > page)
+                    auto& widgets = Desc.Tabs[page].Widgets;
+                    auto tabWidgetIndex = widgetDescIndex - Desc.Widgets.size();
+                    if (tabWidgetIndex < widgets.size())
                     {
-                        auto& widgets = Desc.Tabs[page].Widgets;
-                        auto tabWidgetIndex = widgetDescIndex - Desc.Widgets.size();
-                        if (tabWidgetIndex < widgets.size())
-                        {
-                            return &widgets[widgetDescIndex];
-                        }
+                        return &widgets[widgetDescIndex];
                     }
                 }
             }

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -152,29 +152,27 @@ namespace OpenRCT2::Scripting
             {
                 return ToDuk(_ctx, undefined);
             }
+
+            DukObject obj(_ctx);
+            obj.Set("id", id);
+            obj.Set("offset", ToDuk<ScreenCoordsXY>(_ctx, { g1->x_offset, g1->y_offset }));
+            obj.Set("width", g1->width);
+            obj.Set("height", g1->height);
+
+            obj.Set("isBMP", (g1->flags & G1_FLAG_BMP) != 0);
+            obj.Set("isRLE", (g1->flags & G1_FLAG_RLE_COMPRESSION) != 0);
+            obj.Set("isPalette", (g1->flags & G1_FLAG_PALETTE) != 0);
+            obj.Set("noZoom", (g1->flags & G1_FLAG_NO_ZOOM_DRAW) != 0);
+
+            if (g1->flags & G1_FLAG_HAS_ZOOM_SPRITE)
+            {
+                obj.Set("nextZoomId", id - g1->zoomed_offset);
+            }
             else
             {
-                DukObject obj(_ctx);
-                obj.Set("id", id);
-                obj.Set("offset", ToDuk<ScreenCoordsXY>(_ctx, { g1->x_offset, g1->y_offset }));
-                obj.Set("width", g1->width);
-                obj.Set("height", g1->height);
-
-                obj.Set("isBMP", (g1->flags & G1_FLAG_BMP) != 0);
-                obj.Set("isRLE", (g1->flags & G1_FLAG_RLE_COMPRESSION) != 0);
-                obj.Set("isPalette", (g1->flags & G1_FLAG_PALETTE) != 0);
-                obj.Set("noZoom", (g1->flags & G1_FLAG_NO_ZOOM_DRAW) != 0);
-
-                if (g1->flags & G1_FLAG_HAS_ZOOM_SPRITE)
-                {
-                    obj.Set("nextZoomId", id - g1->zoomed_offset);
-                }
-                else
-                {
-                    obj.Set("nextZoomId", undefined);
-                }
-                return obj.Take();
+                obj.Set("nextZoomId", undefined);
             }
+            return obj.Take();
         }
 
         DukValue measureText(const std::string& text)

--- a/src/openrct2-ui/scripting/ScTileSelection.hpp
+++ b/src/openrct2-ui/scripting/ScTileSelection.hpp
@@ -45,11 +45,9 @@ namespace OpenRCT2::Scripting
                 range.Set("rightBottom", rightBottom.Take());
                 return range.Take();
             }
-            else
-            {
-                duk_push_null(_ctx);
-                return DukValue::take_from_stack(_ctx);
-            }
+
+            duk_push_null(_ctx);
+            return DukValue::take_from_stack(_ctx);
         }
 
         void range_set(DukValue value)

--- a/src/openrct2-ui/scripting/ScViewport.hpp
+++ b/src/openrct2-ui/scripting/ScViewport.hpp
@@ -245,8 +245,8 @@ namespace OpenRCT2::Scripting
         {
             if (_class == WC_MAIN_WINDOW)
                 return window_get_main();
-            else
-                return window_find_by_number(_class, _number);
+
+            return window_find_by_number(_class, _number);
         }
 
         rct_viewport* GetViewport() const
@@ -292,11 +292,9 @@ namespace OpenRCT2::Scripting
                     {
                         return CoordsXYZ(x, y, dukZ.as_int());
                     }
-                    else
-                    {
-                        auto z = tile_element_height(CoordsXY(x, y));
-                        return CoordsXYZ(x, y, z);
-                    }
+
+                    auto z = tile_element_height(CoordsXY(x, y));
+                    return CoordsXYZ(x, y, z);
                 }
             }
             return std::nullopt;

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -386,8 +386,8 @@ namespace OpenRCT2::Scripting
         {
             if (_class == WC_MAIN_WINDOW)
                 return window_get_main();
-            else
-                return window_find_by_number(_class, _number);
+
+            return window_find_by_number(_class, _number);
         }
 
         rct_widget* GetWidget() const

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -1003,11 +1003,12 @@ private:
         {
             return;
         }
-        else if (widgetIndex == WIDX_WEATHER_DROPDOWN_BUTTON)
+
+        if (widgetIndex == WIDX_WEATHER_DROPDOWN_BUTTON)
         {
             CheatsSet(CheatType::ForceWeather, dropdownIndex);
         }
-        else if (widgetIndex == WIDX_STAFF_SPEED_DROPDOWN_BUTTON)
+        if (widgetIndex == WIDX_STAFF_SPEED_DROPDOWN_BUTTON)
         {
             int32_t speed = CHEATS_STAFF_FAST_SPEED;
             switch (dropdownIndex)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1452,14 +1452,12 @@ static bool filter_selected(uint8_t objectFlag)
     {
         return true;
     }
-    else if (_FILTER_NONSELECTED && !(objectFlag & OBJECT_SELECTION_FLAG_SELECTED))
+    if (_FILTER_NONSELECTED && !(objectFlag & OBJECT_SELECTION_FLAG_SELECTED))
     {
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 static bool filter_string(const ObjectRepositoryItem* item)
@@ -1611,6 +1609,6 @@ static ObjectType get_selected_object_type(rct_window* w)
     auto tab = w->selected_tab;
     if (tab >= EnumValue(ObjectType::ScenarioText))
         return static_cast<ObjectType>(tab + 1);
-    else
-        return static_cast<ObjectType>(tab);
+
+    return static_cast<ObjectType>(tab);
 }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1158,7 +1158,7 @@ static TileElement* footpath_get_tile_element_to_remove()
 
                 return tileElement;
             }
-            else if (tileElement->GetBaseZ() == zLow)
+            if (tileElement->GetBaseZ() == zLow)
             {
                 if (!tileElement->AsPath()->IsSloped())
                 {
@@ -1421,11 +1421,9 @@ static bool FootpathSelectDefault()
             // No surfaces or legacy paths available
             return false;
         }
-        else
-        {
-            // No surfaces available, so default to legacy path
-            gFootpathSelection.LegacyPath = legacyPathIndex;
-        }
+
+        // No surfaces available, so default to legacy path
+        gFootpathSelection.LegacyPath = legacyPathIndex;
     }
 
     gFootpathSelection.NormalSurface = surfaceIndex;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -821,8 +821,8 @@ static void window_new_ride_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         {
             if (rideEntry->ride_type[i] == listItem->Type)
                 break;
-            else
-                imageId++;
+
+            imageId++;
         }
 
         gfx_draw_sprite_raw_masked(dpi, coords + ScreenCoordsXY{ 2, 2 }, SPR_NEW_RIDE_MASK, imageId);

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -139,12 +139,12 @@ public:
                     buttonIndex = 0;
                     break;
                 }
-                else if (mutableScreenCoords.x < 351 && newsItem.TypeHasSubject())
+                if (mutableScreenCoords.x < 351 && newsItem.TypeHasSubject())
                 {
                     buttonIndex = 1;
                     break;
                 }
-                else if (mutableScreenCoords.x < 376 && newsItem.TypeHasLocation())
+                if (mutableScreenCoords.x < 376 && newsItem.TypeHasLocation())
                 {
                     buttonIndex = 2;
                     break;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2172,12 +2172,10 @@ static OpenRCT2String window_options_advanced_tooltip(
             // No tooltip if the path is empty
             return { STR_NONE, {} };
         }
-        else
-        {
-            auto ft = Formatter();
-            ft.Add<utf8*>(gConfigGeneral.rct1_path);
-            return { fallback, ft };
-        }
+
+        auto ft = Formatter();
+        ft.Add<utf8*>(gConfigGeneral.rct1_path);
+        return { fallback, ft };
     }
     return { fallback, {} };
 }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1911,14 +1911,11 @@ static RideStatus window_ride_get_next_default_status(const Ride* ride)
             {
                 return RideStatus::Closed;
             }
-            else if (ride->SupportsStatus(RideStatus::Testing) && !(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
+            if (ride->SupportsStatus(RideStatus::Testing) && !(ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED))
             {
                 return RideStatus::Testing;
             }
-            else
-            {
-                return RideStatus::Open;
-            }
+            return RideStatus::Open;
         case RideStatus::Simulating:
             return RideStatus::Testing;
         case RideStatus::Testing:
@@ -6023,10 +6020,8 @@ static OpenRCT2String window_ride_graphs_tooltip(rct_window* w, const rct_widget
                 ft.Add<uint16_t>(measurement->vehicle_index + 1);
                 return { fallback, ft };
             }
-            else
-            {
-                return message;
-            }
+
+            return message;
         }
     }
     else

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1315,21 +1315,21 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
+                if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
                 {
                     _currentTrackCurve = TrackElemType::RightHalfBankedHelixDownLarge | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_LEFT_SMALL && _currentTrackBankEnd == TRACK_BANK_LEFT)
+                if (_currentTrackCurve == TRACK_CURVE_LEFT_SMALL && _currentTrackBankEnd == TRACK_BANK_LEFT)
                 {
                     _currentTrackCurve = TrackElemType::LeftHalfBankedHelixDownSmall | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_RIGHT_SMALL && _currentTrackBankEnd == TRACK_BANK_RIGHT)
+                if (_currentTrackCurve == TRACK_CURVE_RIGHT_SMALL && _currentTrackBankEnd == TRACK_BANK_RIGHT)
                 {
                     _currentTrackCurve = TrackElemType::RightHalfBankedHelixDownSmall | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1346,7 +1346,7 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
+                if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
                 {
                     _currentTrackCurve = TrackElemType::RightQuarterBankedHelixLargeDown | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1365,7 +1365,7 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
                         window_ride_construction_update_active_elements();
                         break;
                     }
-                    else if (_currentTrackCurve == TRACK_CURVE_RIGHT)
+                    if (_currentTrackCurve == TRACK_CURVE_RIGHT)
                     {
                         _currentTrackCurve = TrackElemType::RightQuarterHelixLargeDown | RideConstructionSpecialPieceSelected;
                         _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1447,21 +1447,21 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
+                if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
                 {
                     _currentTrackCurve = TrackElemType::RightHalfBankedHelixUpLarge | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_LEFT_SMALL && _currentTrackBankEnd == TRACK_BANK_LEFT)
+                if (_currentTrackCurve == TRACK_CURVE_LEFT_SMALL && _currentTrackBankEnd == TRACK_BANK_LEFT)
                 {
                     _currentTrackCurve = TrackElemType::LeftHalfBankedHelixUpSmall | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_RIGHT_SMALL && _currentTrackBankEnd == TRACK_BANK_RIGHT)
+                if (_currentTrackCurve == TRACK_CURVE_RIGHT_SMALL && _currentTrackBankEnd == TRACK_BANK_RIGHT)
                 {
                     _currentTrackCurve = TrackElemType::RightHalfBankedHelixUpSmall | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1478,7 +1478,7 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
                     window_ride_construction_update_active_elements();
                     break;
                 }
-                else if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
+                if (_currentTrackCurve == TRACK_CURVE_RIGHT && _currentTrackBankEnd == TRACK_BANK_RIGHT)
                 {
                     _currentTrackCurve = TrackElemType::RightQuarterBankedHelixLargeUp | RideConstructionSpecialPieceSelected;
                     _currentTrackPrice = MONEY32_UNDEFINED;
@@ -1497,7 +1497,7 @@ static void window_ride_construction_mousedown(rct_window* w, rct_widgetindex wi
                         window_ride_construction_update_active_elements();
                         break;
                     }
-                    else if (_currentTrackCurve == TRACK_CURVE_RIGHT)
+                    if (_currentTrackCurve == TRACK_CURVE_RIGHT)
                     {
                         _currentTrackCurve = TrackElemType::RightQuarterHelixLargeUp | RideConstructionSpecialPieceSelected;
                         _currentTrackPrice = MONEY32_UNDEFINED;

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -208,38 +208,36 @@ static void window_save_prompt_mouseup(rct_window* w, rct_widgetindex widgetInde
         }
         return;
     }
-    else
-    {
-        switch (widgetIndex)
-        {
-            case WIDX_SAVE:
-            {
-                Intent* intent;
 
-                if (gScreenFlags & (SCREEN_FLAGS_EDITOR))
-                {
-                    intent = new Intent(WC_LOADSAVE);
-                    intent->putExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE);
-                    intent->putExtra(INTENT_EXTRA_PATH, gScenarioName);
-                }
-                else
-                {
-                    intent = static_cast<Intent*>(create_save_game_as_intent());
-                }
-                window_close(w);
-                intent->putExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(window_save_prompt_callback));
-                context_open_intent(intent);
-                delete intent;
-                break;
+    switch (widgetIndex)
+    {
+        case WIDX_SAVE:
+        {
+            Intent* intent;
+
+            if (gScreenFlags & (SCREEN_FLAGS_EDITOR))
+            {
+                intent = new Intent(WC_LOADSAVE);
+                intent->putExtra(INTENT_EXTRA_LOADSAVE_TYPE, LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE);
+                intent->putExtra(INTENT_EXTRA_PATH, gScenarioName);
             }
-            case WIDX_DONT_SAVE:
-                game_load_or_quit_no_save_prompt();
-                return;
-            case WIDX_CLOSE:
-            case WIDX_CANCEL:
-                window_close(w);
-                return;
+            else
+            {
+                intent = static_cast<Intent*>(create_save_game_as_intent());
+            }
+            window_close(w);
+            intent->putExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(window_save_prompt_callback));
+            context_open_intent(intent);
+            delete intent;
+            break;
         }
+        case WIDX_DONT_SAVE:
+            game_load_or_quit_no_save_prompt();
+            return;
+        case WIDX_CLOSE:
+        case WIDX_CANCEL:
+            window_close(w);
+            return;
     }
 }
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -147,8 +147,8 @@ static int32_t ScenarioSelectGetWindowWidth()
     // Shrink the window if we're showing scenarios by difficulty level.
     if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_DIFFICULTY && !_titleEditor)
         return 610;
-    else
-        return WW;
+
+    return WW;
 }
 
 rct_window* window_scenarioselect_open(scenarioselect_callback callback, bool titleEditor)

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -350,10 +350,8 @@ private:
             }
             return true;
         }
-        else
-        {
-            return group == groupFilter;
-        }
+
+        return group == groupFilter;
     }
 
     void InitialiseList()

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1706,7 +1706,8 @@ static void window_top_toolbar_scenery_tool_down(const ScreenCoordsXY& windowPos
         repaint_scenery_tool_down(windowPos, widgetIndex);
         return;
     }
-    else if (gWindowSceneryEyedropperEnabled)
+
+    if (gWindowSceneryEyedropperEnabled)
     {
         scenery_eyedropper_tool_down(windowPos, widgetIndex);
         return;
@@ -3008,16 +3009,14 @@ static money64 selection_raise_land(uint8_t flags)
                                                      : GameActions::Query(&landSmoothAction);
         return res->Error == GameActions::Status::Ok ? res->Cost : MONEY64_UNDEFINED;
     }
-    else
-    {
-        auto landRaiseAction = LandRaiseAction(
-            { centreX, centreY },
-            { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y }, gMapSelectType);
-        auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landRaiseAction)
-                                                     : GameActions::Query(&landRaiseAction);
 
-        return res->Error == GameActions::Status::Ok ? res->Cost : MONEY64_UNDEFINED;
-    }
+    auto landRaiseAction = LandRaiseAction(
+        { centreX, centreY }, { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+        gMapSelectType);
+    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landRaiseAction)
+                                                 : GameActions::Query(&landRaiseAction);
+
+    return res->Error == GameActions::Status::Ok ? res->Cost : MONEY64_UNDEFINED;
 }
 
 /**
@@ -3041,16 +3040,14 @@ static money64 selection_lower_land(uint8_t flags)
                                                      : GameActions::Query(&landSmoothAction);
         return res->Error == GameActions::Status::Ok ? res->Cost : MONEY64_UNDEFINED;
     }
-    else
-    {
-        auto landLowerAction = LandLowerAction(
-            { centreX, centreY },
-            { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y }, gMapSelectType);
-        auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landLowerAction)
-                                                     : GameActions::Query(&landLowerAction);
 
-        return res->Error == GameActions::Status::Ok ? res->Cost : MONEY64_UNDEFINED;
-    }
+    auto landLowerAction = LandLowerAction(
+        { centreX, centreY }, { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+        gMapSelectType);
+    auto res = (flags & GAME_COMMAND_FLAG_APPLY) ? GameActions::Execute(&landLowerAction)
+                                                 : GameActions::Query(&landLowerAction);
+
+    return res->Error == GameActions::Status::Ok ? res->Cost : MONEY64_UNDEFINED;
 }
 
 /**

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -267,7 +267,8 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
             fprintf(stdout, "usage: sprite details <spritefile> [idx]\n");
             return -1;
         }
-        else if (argc == 2)
+
+        if (argc == 2)
         {
             const char* spriteFilePath = argv[1];
             auto spriteFile = SpriteFile::Open(spriteFilePath);
@@ -281,33 +282,32 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
             printf("data size: %u\n", spriteFile->Header.total_size);
             return 1;
         }
-        else
+
+        const char* spriteFilePath = argv[1];
+        int32_t spriteIndex = atoi(argv[2]);
+        auto spriteFile = SpriteFile::Open(spriteFilePath);
+        if (!spriteFile.has_value())
         {
-            const char* spriteFilePath = argv[1];
-            int32_t spriteIndex = atoi(argv[2]);
-            auto spriteFile = SpriteFile::Open(spriteFilePath);
-            if (!spriteFile.has_value())
-            {
-                fprintf(stderr, "Unable to open input sprite file.\n");
-                return -1;
-            }
-
-            if (spriteIndex < 0 || spriteIndex >= static_cast<int32_t>(spriteFile->Header.num_entries))
-            {
-                fprintf(stderr, "Sprite #%d does not exist in sprite file.\n", spriteIndex);
-                return -1;
-            }
-
-            rct_g1_element* g1 = &spriteFile->Entries[spriteIndex];
-            printf("width: %d\n", g1->width);
-            printf("height: %d\n", g1->height);
-            printf("x offset: %d\n", g1->x_offset);
-            printf("y offset: %d\n", g1->y_offset);
-            printf("data offset: %p\n", g1->offset);
-            return 1;
+            fprintf(stderr, "Unable to open input sprite file.\n");
+            return -1;
         }
+
+        if (spriteIndex < 0 || spriteIndex >= static_cast<int32_t>(spriteFile->Header.num_entries))
+        {
+            fprintf(stderr, "Sprite #%d does not exist in sprite file.\n", spriteIndex);
+            return -1;
+        }
+
+        rct_g1_element* g1 = &spriteFile->Entries[spriteIndex];
+        printf("width: %d\n", g1->width);
+        printf("height: %d\n", g1->height);
+        printf("x offset: %d\n", g1->x_offset);
+        printf("y offset: %d\n", g1->y_offset);
+        printf("data offset: %p\n", g1->offset);
+        return 1;
     }
-    else if (_strcmpi(argv[0], "export") == 0)
+
+    if (_strcmpi(argv[0], "export") == 0)
     {
         if (argc < 4)
         {
@@ -339,7 +339,8 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         }
         return 1;
     }
-    else if (_strcmpi(argv[0], "exportall") == 0)
+
+    if (_strcmpi(argv[0], "exportall") == 0)
     {
         if (argc < 3)
         {
@@ -409,7 +410,8 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         }
         return 1;
     }
-    else if (_strcmpi(argv[0], "exportalldat") == 0)
+
+    if (_strcmpi(argv[0], "exportalldat") == 0)
     {
         if (argc < 3)
         {
@@ -498,7 +500,8 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         }
         return 1;
     }
-    else if (_strcmpi(argv[0], "create") == 0)
+
+    if (_strcmpi(argv[0], "create") == 0)
     {
         if (argc < 2)
         {
@@ -512,7 +515,8 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         spriteFile.Save(spriteFilePath);
         return 1;
     }
-    else if (_strcmpi(argv[0], "append") == 0)
+
+    if (_strcmpi(argv[0], "append") == 0)
     {
         if (argc != 3 && argc != 5)
         {
@@ -562,7 +566,8 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
 
         return 1;
     }
-    else if (_strcmpi(argv[0], "build") == 0)
+
+    if (_strcmpi(argv[0], "build") == 0)
     {
         if (argc < 3)
         {
@@ -650,9 +655,7 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         fprintf(stdout, "Finished\n");
         return 1;
     }
-    else
-    {
-        fprintf(stderr, "Unknown sprite command.\n");
-        return 1;
-    }
+
+    fprintf(stderr, "Unknown sprite command.\n");
+    return 1;
 }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -588,15 +588,13 @@ namespace OpenRCT2
                     }
                     return true;
                 }
-                else
+
+                auto fs = FileStream(path, FILE_MODE_OPEN);
+                if (!LoadParkFromStream(&fs, path, loadTitleScreenOnFail))
                 {
-                    auto fs = FileStream(path, FILE_MODE_OPEN);
-                    if (!LoadParkFromStream(&fs, path, loadTitleScreenOnFail))
-                    {
-                        return false;
-                    }
-                    return true;
+                    return false;
                 }
+                return true;
             }
             catch (const std::exception& e)
             {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -503,12 +503,14 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
         {
             return true;
         }
-        else if (*selectionFlags & OBJECT_SELECTION_FLAG_IN_USE)
+
+        if (*selectionFlags & OBJECT_SELECTION_FLAG_IN_USE)
         {
             set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_CURRENTLY_IN_USE);
             return false;
         }
-        else if (*selectionFlags & OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED)
+
+        if (*selectionFlags & OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED)
         {
             set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_ALWAYS_REQUIRED);
             return false;
@@ -527,66 +529,65 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
         *selectionFlags &= ~OBJECT_SELECTION_FLAG_SELECTED;
         return true;
     }
-    else
+
+    if (isMasterObject == 0)
     {
-        if (isMasterObject == 0)
+        if (flags & INPUT_FLAG_EDITOR_OBJECT_ALWAYS_REQUIRED)
         {
-            if (flags & INPUT_FLAG_EDITOR_OBJECT_ALWAYS_REQUIRED)
-            {
-                *selectionFlags |= OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED;
-            }
+            *selectionFlags |= OBJECT_SELECTION_FLAG_ALWAYS_REQUIRED;
         }
-        if (*selectionFlags & OBJECT_SELECTION_FLAG_SELECTED)
-        {
-            return true;
-        }
+    }
 
-        ObjectType objectType = item->Type;
-        uint16_t maxObjects = object_entry_group_counts[EnumValue(objectType)];
-
-        if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
-        {
-            set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED);
-            return false;
-        }
-
-        if (objectType == ObjectType::SceneryGroup && (flags & INPUT_FLAG_EDITOR_OBJECT_SELECT_OBJECTS_IN_SCENERY_GROUP))
-        {
-            for (const auto& sgEntry : item->SceneryGroupInfo.Entries)
-            {
-                if (!window_editor_object_selection_select_object(++isMasterObject, flags, sgEntry))
-                {
-                    _maxObjectsWasHit = true;
-                }
-            }
-        }
-        else if (objectType == ObjectType::Water)
-        {
-            // Replace old palette with newly selected palette immediately.
-            ReplaceSelectedWaterPalette(item);
-        }
-
-        if (isMasterObject != 0 && !(flags & INPUT_FLAG_EDITOR_OBJECT_1))
-        {
-            char objectName[64];
-            object_create_identifier_name(objectName, 64, &item->ObjectEntry);
-            auto ft = Formatter::Common();
-            ft.Add<const char*>(objectName);
-            set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_SHOULD_SELECT_X_FIRST);
-            return false;
-        }
-
-        if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
-        {
-            set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED);
-            return false;
-        }
-
-        _numSelectedObjectsForType[EnumValue(objectType)]++;
-
-        *selectionFlags |= OBJECT_SELECTION_FLAG_SELECTED;
+    if (*selectionFlags & OBJECT_SELECTION_FLAG_SELECTED)
+    {
         return true;
     }
+
+    ObjectType objectType = item->Type;
+    uint16_t maxObjects = object_entry_group_counts[EnumValue(objectType)];
+
+    if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
+    {
+        set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED);
+        return false;
+    }
+
+    if (objectType == ObjectType::SceneryGroup && (flags & INPUT_FLAG_EDITOR_OBJECT_SELECT_OBJECTS_IN_SCENERY_GROUP))
+    {
+        for (const auto& sgEntry : item->SceneryGroupInfo.Entries)
+        {
+            if (!window_editor_object_selection_select_object(++isMasterObject, flags, sgEntry))
+            {
+                _maxObjectsWasHit = true;
+            }
+        }
+    }
+    else if (objectType == ObjectType::Water)
+    {
+        // Replace old palette with newly selected palette immediately.
+        ReplaceSelectedWaterPalette(item);
+    }
+
+    if (isMasterObject != 0 && !(flags & INPUT_FLAG_EDITOR_OBJECT_1))
+    {
+        char objectName[64];
+        object_create_identifier_name(objectName, 64, &item->ObjectEntry);
+        auto ft = Formatter::Common();
+        ft.Add<const char*>(objectName);
+        set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_SHOULD_SELECT_X_FIRST);
+        return false;
+    }
+
+    if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
+    {
+        set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED);
+        return false;
+    }
+
+    _numSelectedObjectsForType[EnumValue(objectType)]++;
+
+    *selectionFlags |= OBJECT_SELECTION_FLAG_SELECTED;
+    return true;
 }
 
 bool window_editor_object_selection_select_object(

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -106,10 +106,7 @@ GameActions::Result::Ptr FootpathPlaceAction::Query() const
     {
         return ElementInsertQuery(std::move(res));
     }
-    else
-    {
-        return ElementUpdateQuery(tileElement, std::move(res));
-    }
+    return ElementUpdateQuery(tileElement, std::move(res));
 }
 
 GameActions::Result::Ptr FootpathPlaceAction::Execute() const
@@ -150,10 +147,7 @@ GameActions::Result::Ptr FootpathPlaceAction::Execute() const
     {
         return ElementInsertExecute(std::move(res));
     }
-    else
-    {
-        return ElementUpdateExecute(tileElement, std::move(res));
-    }
+    return ElementUpdateExecute(tileElement, std::move(res));
 }
 
 bool FootpathPlaceAction::IsSameAsPathElement(const PathElement* pathElement) const
@@ -169,22 +163,16 @@ bool FootpathPlaceAction::IsSameAsPathElement(const PathElement* pathElement) co
         {
             return false;
         }
-        else
-        {
-            return pathElement->GetSurfaceEntryIndex() == _type && pathElement->GetRailingsEntryIndex() == _railingsType;
-        }
+
+        return pathElement->GetSurfaceEntryIndex() == _type && pathElement->GetRailingsEntryIndex() == _railingsType;
     }
-    else
+
+    if (_constructFlags & PathConstructFlag::IsLegacyPathObject)
     {
-        if (_constructFlags & PathConstructFlag::IsLegacyPathObject)
-        {
-            return pathElement->GetLegacyPathEntryIndex() == _type;
-        }
-        else
-        {
-            return false;
-        }
+        return pathElement->GetLegacyPathEntryIndex() == _type;
     }
+
+    return false;
 }
 
 bool FootpathPlaceAction::IsSameAsEntranceElement(const EntranceElement& entranceElement) const
@@ -195,20 +183,16 @@ bool FootpathPlaceAction::IsSameAsEntranceElement(const EntranceElement& entranc
         {
             return entranceElement.GetLegacyPathEntryIndex() == _type;
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     }
 
     if (_constructFlags & PathConstructFlag::IsLegacyPathObject)
     {
         return false;
     }
-    else
-    {
-        return entranceElement.GetSurfaceEntryIndex() == _type;
-    }
+
+    return entranceElement.GetSurfaceEntryIndex() == _type;
 }
 
 GameActions::Result::Ptr FootpathPlaceAction::ElementUpdateQuery(PathElement* pathElement, GameActions::Result::Ptr res) const

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.cpp
@@ -281,18 +281,14 @@ bool FootpathPlaceFromTrackAction::IsSameAsEntranceElement(const EntranceElement
         {
             return entranceElement.GetLegacyPathEntryIndex() == _type;
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     }
 
     if (_constructFlags & PathConstructFlag::IsLegacyPathObject)
     {
         return false;
     }
-    else
-    {
-        return entranceElement.GetSurfaceEntryIndex() == _type;
-    }
+
+    return entranceElement.GetSurfaceEntryIndex() == _type;
 }

--- a/src/openrct2/actions/FootpathRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathRemoveAction.cpp
@@ -165,7 +165,8 @@ GameActions::Result::Ptr FootpathRemoveAction::RemoveBannersAtElement(const Coor
     {
         if (tileElement->GetType() == TILE_ELEMENT_TYPE_PATH)
             return result;
-        else if (tileElement->GetType() != TILE_ELEMENT_TYPE_BANNER)
+
+        if (tileElement->GetType() != TILE_ELEMENT_TYPE_BANNER)
             continue;
 
         auto bannerRemoveAction = BannerRemoveAction({ loc, tileElement->GetBaseZ(), tileElement->AsBanner()->GetPosition() });

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -335,7 +335,7 @@ namespace GameActions
     {
         if (network_get_mode() == NETWORK_MODE_CLIENT)
             return "cl";
-        else if (network_get_mode() == NETWORK_MODE_SERVER)
+        if (network_get_mode() == NETWORK_MODE_SERVER)
             return "sv";
         return "sp";
     }

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -198,7 +198,8 @@ rct_string_id LandSetHeightAction::CheckParameters() const
     {
         return STR_TOO_HIGH;
     }
-    else if (_height > MAXIMUM_LAND_HEIGHT - 2 && (_style & TILE_ELEMENT_SURFACE_SLOPE_MASK) != 0)
+
+    if (_height > MAXIMUM_LAND_HEIGHT - 2 && (_style & TILE_ELEMENT_SURFACE_SLOPE_MASK) != 0)
     {
         return STR_TOO_HIGH;
     }

--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -291,9 +291,6 @@ rct_string_id RideSetSettingAction::GetOperationErrorMessage(Ride* ride) const
             {
                 return STR_CANT_CHANGE_THIS;
             }
-            else
-            {
-                return STR_CANT_CHANGE_LAUNCH_SPEED;
-            }
+            return STR_CANT_CHANGE_LAUNCH_SPEED;
     }
 }

--- a/src/openrct2/actions/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/RideSetStatusAction.cpp
@@ -89,7 +89,8 @@ GameActions::Result::Ptr RideSetStatusAction::Query() const
             res->ErrorMessage = STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING;
             return res;
         }
-        else if (_status == RideStatus::Testing || _status == RideStatus::Simulating)
+
+        if (_status == RideStatus::Testing || _status == RideStatus::Simulating)
         {
             if (!ride->Test(_status, false))
             {

--- a/src/openrct2/cmdline/CommandLine.cpp
+++ b/src/openrct2/cmdline/CommandLine.cpp
@@ -38,10 +38,8 @@ bool CommandLineArgEnumerator::Backtrack()
         _index--;
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool CommandLineArgEnumerator::TryPop()
@@ -51,10 +49,8 @@ bool CommandLineArgEnumerator::TryPop()
         _index++;
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool CommandLineArgEnumerator::TryPopInteger(int32_t* result)
@@ -89,10 +85,8 @@ bool CommandLineArgEnumerator::TryPopString(const char** result)
         _index++;
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 #pragma endregion
@@ -317,11 +311,9 @@ namespace CommandLine
                     // Found matching command
                     return command;
                 }
-                else
-                {
-                    // Recurse for the sub command table
-                    return FindCommandFor(command->SubCommands, argEnumerator);
-                }
+
+                // Recurse for the sub command table
+                return FindCommandFor(command->SubCommands, argEnumerator);
             }
         }
 
@@ -364,10 +356,8 @@ namespace CommandLine
                 Console::Error::WriteLine("All options must be passed at the end of the command line.");
                 return false;
             }
-            else
-            {
-                continue;
-            }
+
+            continue;
         }
 
         return true;
@@ -424,12 +414,10 @@ namespace CommandLine
                 Console::Error::WriteLine("Option is a switch: %s", optionName);
                 return false;
             }
-            else
+
+            if (!ParseOptionValue(option, equalsCh + 1))
             {
-                if (!ParseOptionValue(option, equalsCh + 1))
-                {
-                    return false;
-                }
+                return false;
             }
         }
 
@@ -563,8 +551,6 @@ int32_t cmdline_run(const char** argv, int32_t argc)
     {
         return CommandLine::HandleCommandDefault();
     }
-    else
-    {
-        return command->Func(&argEnumerator);
-    }
+
+    return command->Func(&argEnumerator);
 }

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -387,11 +387,9 @@ static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator* enumerator)
         Console::WriteLine("Updated config.ini");
         return EXITCODE_OK;
     }
-    else
-    {
-        Console::Error::WriteLine("Unable to update config.ini");
-        return EXITCODE_FAIL;
-    }
+
+    Console::Error::WriteLine("Unable to update config.ini");
+    return EXITCODE_FAIL;
 }
 
 static exitcode_t HandleCommandScanObjects([[maybe_unused]] CommandLineArgEnumerator* enumerator)

--- a/src/openrct2/cmdline/UriHandler.cpp
+++ b/src/openrct2/cmdline/UriHandler.cpp
@@ -68,11 +68,9 @@ static exitcode_t HandleUriJoin(const std::vector<std::string>& args)
         gNetworkStartPort = port;
         return EXITCODE_CONTINUE;
     }
-    else
-    {
-        Console::Error::WriteLine("Expected hostname:port after join");
-        return EXITCODE_FAIL;
-    }
+
+    Console::Error::WriteLine("Expected hostname:port after join");
+    return EXITCODE_FAIL;
 }
 
 static bool TryParseHostnamePort(

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -327,7 +327,8 @@ private:
             {
                 return s.substr(0, i);
             }
-            else if (c == inQuotes && !escaped)
+
+            if (c == inQuotes && !escaped)
             {
                 inQuotes = 0;
             }

--- a/src/openrct2/core/EnumMap.hpp
+++ b/src/openrct2/core/EnumMap.hpp
@@ -31,7 +31,8 @@ private:
             return true;
         else if constexpr (std::is_integral_v<T>)
             return true;
-        return false;
+        else
+            return false;
     }
 
     static constexpr auto ValueDistance(T a, T b)
@@ -134,10 +135,8 @@ public:
                 auto index = static_cast<size_t>(k);
                 return _map.begin() + index;
             }
-            else
-            {
-                return binarySearchValue();
-            }
+
+            return binarySearchValue();
         }
         else
         {

--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -257,14 +257,13 @@ namespace Imaging
         {
             return IMAGE_FORMAT::PNG;
         }
-        else if (String::EndsWith(path, ".bmp", true))
+
+        if (String::EndsWith(path, ".bmp", true))
         {
             return IMAGE_FORMAT::BITMAP;
         }
-        else
-        {
-            return IMAGE_FORMAT::UNKNOWN;
-        }
+
+        return IMAGE_FORMAT::UNKNOWN;
     }
 
     static ImageReaderFunc GetReader(IMAGE_FORMAT format)

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -42,22 +42,16 @@ namespace Path
             {
                 return std::string(a) + std::string(b.substr(1));
             }
-            else
-            {
-                return std::string(a) + std::string(b);
-            }
+
+            return std::string(a) + std::string(b);
         }
-        else
+
+        if (Platform::IsPathSeparator(bBegin))
         {
-            if (Platform::IsPathSeparator(bBegin))
-            {
-                return std::string(a) + std::string(b);
-            }
-            else
-            {
-                return std::string(a) + PATH_SEPARATOR + std::string(b);
-            }
+            return std::string(a) + std::string(b);
         }
+
+        return std::string(a) + PATH_SEPARATOR + std::string(b);
     }
 
     std::string GetDirectory(const std::string& path)

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -45,8 +45,8 @@ namespace String
     {
         if (str == nullptr)
             return std::string();
-        else
-            return std::string(str);
+
+        return std::string(str);
     }
 
     std::string StdFormat_VA(const utf8* format, va_list args)
@@ -138,10 +138,8 @@ namespace String
             {
                 break;
             }
-            else
-            {
-                len++;
-            }
+
+            len++;
         }
         return std::string_view(ch, len);
     }
@@ -168,10 +166,8 @@ namespace String
         {
             return _stricmp(a, b);
         }
-        else
-        {
-            return strcmp(a, b);
-        }
+
+        return strcmp(a, b);
     }
 
     bool Equals(std::string_view a, std::string_view b, bool ignoreCase)
@@ -189,15 +185,11 @@ namespace String
                 }
                 return true;
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
-        else
-        {
-            return a == b;
-        }
+
+        return a == b;
     }
 
     bool Equals(const std::string& a, const std::string& b, bool ignoreCase)
@@ -251,10 +243,8 @@ namespace String
         {
             return _stricmp(a, b) == 0;
         }
-        else
-        {
-            return strcmp(a, b) == 0;
-        }
+
+        return strcmp(a, b) == 0;
     }
 
     bool StartsWith(std::string_view str, std::string_view match, bool ignoreCase)
@@ -306,10 +296,8 @@ namespace String
         {
             return -1;
         }
-        else
-        {
-            return lastOccurance - str;
-        }
+
+        return lastOccurance - str;
     }
 
     size_t LengthOf(const utf8* str)
@@ -791,10 +779,8 @@ namespace String
             log_warning("LCMapStringEx failed with %d", error);
             return std::string(src);
         }
-        else
-        {
-            return String::ToUtf8(dstW);
-        }
+
+        return String::ToUtf8(dstW);
 #    else
         std::string dst = std::string(src);
         std::transform(dst.begin(), dst.end(), dst.begin(), [](unsigned char c) { return std::toupper(c); });

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -157,15 +157,15 @@ namespace String
         {
             return { 1 };
         }
-        else if (v.size() >= 2 && ((v[0] & 0xE0) == 0xC0))
+        if (v.size() >= 2 && ((v[0] & 0xE0) == 0xC0))
         {
             return { 2 };
         }
-        else if (v.size() >= 3 && ((v[0] & 0xF0) == 0xE0))
+        if (v.size() >= 3 && ((v[0] & 0xF0) == 0xE0))
         {
             return { 3 };
         }
-        else if (v.size() >= 4 && ((v[0] & 0xF8) == 0xF0))
+        if (v.size() >= 4 && ((v[0] & 0xF8) == 0xF0))
         {
             return { 4 };
         }

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -121,10 +121,8 @@ public:
         {
             return zipFileStat.size;
         }
-        else
-        {
-            return 0;
-        }
+
+        return 0;
     }
 
     std::vector<uint8_t> GetFileData(std::string_view path) const override
@@ -306,11 +304,9 @@ private:
             {
                 return 0;
             }
-            else
-            {
-                _pos += readBytes;
-                return static_cast<uint64_t>(readBytes);
-            }
+
+            _pos += readBytes;
+            return static_cast<uint64_t>(readBytes);
         }
 
         const void* GetData() const override

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -56,15 +56,15 @@ sprite_peep_pickup_starts[15] =
 
 static inline uint32_t rctc_to_rct2_index(uint32_t image)
 {
-    if      (                  image <  1542) return image;
-    else if (image >=  1574 && image <  4983) return image - 32;
-    else if (image >=  4986 && image < 17189) return image - 35;
-    else if (image >= 17191 && image < 18121) return image - 37;
-    else if (image >= 18123 && image < 23800) return image - 39;
-    else if (image >= 23804 && image < 24670) return image - 43;
-    else if (image >= 24674 && image < 28244) return image - 47;
-    else if (image >= 28246                 ) return image - 49;
-    else throw std::runtime_error("Invalid RCTC g1.dat file");
+    if (                  image <  1542) return image;
+    if (image >=  1574 && image <  4983) return image - 32;
+    if (image >=  4986 && image < 17189) return image - 35;
+    if (image >= 17191 && image < 18121) return image - 37;
+    if (image >= 18123 && image < 23800) return image - 39;
+    if (image >= 23804 && image < 24670) return image - 43;
+    if (image >= 24674 && image < 28244) return image - 47;
+    if (image >= 28246                 ) return image - 49;
+    throw std::runtime_error("Invalid RCTC g1.dat file");
 }
 // clang-format on
 
@@ -371,38 +371,34 @@ static std::optional<PaletteMap> FASTCALL gfx_draw_sprite_get_palette(ImageId im
         }
         return GetPaletteMapForColour(paletteId);
     }
-    else
+
+    auto paletteMap = PaletteMap(gPeepPalette);
+    if (imageId.HasTertiary())
     {
-        auto paletteMap = PaletteMap(gPeepPalette);
-        if (imageId.HasTertiary())
-        {
-            paletteMap = PaletteMap(gOtherPalette);
-            auto tertiaryPaletteMap = GetPaletteMapForColour(imageId.GetTertiary());
-            if (tertiaryPaletteMap.has_value())
-            {
-                paletteMap.Copy(
-                    PALETTE_OFFSET_REMAP_TERTIARY, tertiaryPaletteMap.value(), PALETTE_OFFSET_REMAP_PRIMARY,
-                    PALETTE_LENGTH_REMAP);
-            }
-        }
-
-        auto primaryPaletteMap = GetPaletteMapForColour(imageId.GetPrimary());
-        if (primaryPaletteMap.has_value())
+        paletteMap = PaletteMap(gOtherPalette);
+        auto tertiaryPaletteMap = GetPaletteMapForColour(imageId.GetTertiary());
+        if (tertiaryPaletteMap.has_value())
         {
             paletteMap.Copy(
-                PALETTE_OFFSET_REMAP_PRIMARY, primaryPaletteMap.value(), PALETTE_OFFSET_REMAP_PRIMARY, PALETTE_LENGTH_REMAP);
+                PALETTE_OFFSET_REMAP_TERTIARY, tertiaryPaletteMap.value(), PALETTE_OFFSET_REMAP_PRIMARY, PALETTE_LENGTH_REMAP);
         }
-
-        auto secondaryPaletteMap = GetPaletteMapForColour(imageId.GetSecondary());
-        if (secondaryPaletteMap.has_value())
-        {
-            paletteMap.Copy(
-                PALETTE_OFFSET_REMAP_SECONDARY, secondaryPaletteMap.value(), PALETTE_OFFSET_REMAP_PRIMARY,
-                PALETTE_LENGTH_REMAP);
-        }
-
-        return paletteMap;
     }
+
+    auto primaryPaletteMap = GetPaletteMapForColour(imageId.GetPrimary());
+    if (primaryPaletteMap.has_value())
+    {
+        paletteMap.Copy(
+            PALETTE_OFFSET_REMAP_PRIMARY, primaryPaletteMap.value(), PALETTE_OFFSET_REMAP_PRIMARY, PALETTE_LENGTH_REMAP);
+    }
+
+    auto secondaryPaletteMap = GetPaletteMapForColour(imageId.GetSecondary());
+    if (secondaryPaletteMap.has_value())
+    {
+        paletteMap.Copy(
+            PALETTE_OFFSET_REMAP_SECONDARY, secondaryPaletteMap.value(), PALETTE_OFFSET_REMAP_PRIMARY, PALETTE_LENGTH_REMAP);
+    }
+
+    return paletteMap;
 }
 
 void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, ImageId imageId, const ScreenCoordsXY& spriteCoords)
@@ -667,11 +663,13 @@ const rct_g1_element* gfx_get_g1_element(int32_t image_id)
     {
         return nullptr;
     }
-    else if (offset == SPR_TEMP)
+
+    if (offset == SPR_TEMP)
     {
         return &_g1Temp;
     }
-    else if (offset < SPR_RCTC_G1_END)
+
+    if (offset < SPR_RCTC_G1_END)
     {
         if (offset < _g1.elements.size())
         {
@@ -685,10 +683,8 @@ const rct_g1_element* gfx_get_g1_element(int32_t image_id)
         {
             return &_g2.elements[idx];
         }
-        else
-        {
-            log_warning("Invalid entry in g2.dat requested, idx = %u. You may have to update your g2.dat.", idx);
-        }
+
+        log_warning("Invalid entry in g2.dat requested, idx = %u. You may have to update your g2.dat.", idx);
     }
     else if (offset < SPR_CSG_END)
     {
@@ -699,10 +695,8 @@ const rct_g1_element* gfx_get_g1_element(int32_t image_id)
             {
                 return &_csg.elements[idx];
             }
-            else
-            {
-                log_warning("Invalid entry in csg.dat requested, idx = %u.", idx);
-            }
+
+            log_warning("Invalid entry in csg.dat requested, idx = %u.", idx);
         }
     }
     else if (offset < SPR_SCROLLING_TEXT_END)
@@ -796,31 +790,28 @@ size_t g1_calculate_data_size(const rct_g1_element* g1)
     {
         return g1->width * 3;
     }
-    else if (g1->flags & G1_FLAG_RLE_COMPRESSION)
+
+    if (g1->flags & G1_FLAG_RLE_COMPRESSION)
     {
         if (g1->offset == nullptr)
         {
             return 0;
         }
-        else
+
+        auto idx = (g1->height - 1) * 2;
+        uint16_t offset = g1->offset[idx] | (g1->offset[idx + 1] << 8);
+        uint8_t* ptr = g1->offset + offset;
+        bool endOfLine = false;
+        do
         {
-            auto idx = (g1->height - 1) * 2;
-            uint16_t offset = g1->offset[idx] | (g1->offset[idx + 1] << 8);
-            uint8_t* ptr = g1->offset + offset;
-            bool endOfLine = false;
-            do
-            {
-                uint8_t chunk0 = *ptr++;
-                ptr++; // offset
-                uint8_t chunkSize = chunk0 & 0x7F;
-                ptr += chunkSize;
-                endOfLine = (chunk0 & 0x80) != 0;
-            } while (!endOfLine);
-            return ptr - g1->offset;
-        }
+            uint8_t chunk0 = *ptr++;
+            ptr++; // offset
+            uint8_t chunkSize = chunk0 & 0x7F;
+            ptr += chunkSize;
+            endOfLine = (chunk0 & 0x80) != 0;
+        } while (!endOfLine);
+        return ptr - g1->offset;
     }
-    else
-    {
-        return g1->width * g1->height;
-    }
+
+    return g1->width * g1->height;
 }

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -528,19 +528,19 @@ ImageCatalogue ImageId::GetCatalogue() const
     {
         return ImageCatalogue::TEMPORARY;
     }
-    else if (index < SPR_RCTC_G1_END)
+    if (index < SPR_RCTC_G1_END)
     {
         return ImageCatalogue::G1;
     }
-    else if (index < SPR_G2_END)
+    if (index < SPR_G2_END)
     {
         return ImageCatalogue::G2;
     }
-    else if (index < SPR_CSG_END)
+    if (index < SPR_CSG_END)
     {
         return ImageCatalogue::CSG;
     }
-    else if (index < SPR_IMAGE_LIST_END)
+    if (index < SPR_IMAGE_LIST_END)
     {
         return ImageCatalogue::OBJECT;
     }

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -306,7 +306,8 @@ int32_t font_sprite_get_codepoint_width(FontSpriteBase fontSpriteBase, int32_t c
         }
         return _additionalSpriteFontCharacterWidth[baseFontIndex][glyphIndex];
     }
-    else if (glyphIndex < 0 || glyphIndex >= static_cast<int32_t>(FONT_SPRITE_GLYPH_COUNT))
+
+    if (glyphIndex < 0 || glyphIndex >= static_cast<int32_t>(FONT_SPRITE_GLYPH_COUNT))
     {
         log_warning("Invalid glyph index %u", glyphIndex);
         glyphIndex = 0;
@@ -362,13 +363,8 @@ int32_t font_get_line_height(FontSpriteBase fontSpriteBase)
     {
         return gCurrentTTFFontSet->size[fontSize].line_height;
     }
-    else
-    {
 #endif // NO_TTF
-        return SpriteFontLineHeight[fontSize];
-#ifndef NO_TTF
-    }
-#endif // NO_TTF
+    return SpriteFontLineHeight[fontSize];
 }
 
 int32_t font_get_line_height_small(FontSpriteBase fontSpriteBase)
@@ -434,8 +430,6 @@ bool font_supports_string(const utf8* text, int32_t fontSize)
     {
         return font_supports_string_ttf(text, fontSize);
     }
-    else
-    {
-        return font_supports_string_sprite(text);
-    }
+
+    return font_supports_string_sprite(text);
 }

--- a/src/openrct2/drawing/Image.cpp
+++ b/src/openrct2/drawing/Image.cpp
@@ -178,7 +178,8 @@ static void FreeImageList(uint32_t baseImageId, uint32_t count)
             it->Count += count;
             return;
         }
-        else if (baseImageId + count == it->BaseId)
+
+        if (baseImageId + count == it->BaseId)
         {
             it->BaseId = baseImageId;
             it->Count += count;

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -40,10 +40,8 @@ void gfx_fill_rect_inset(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t
             assert(false);
             return;
         }
-        else
-        {
-            palette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
-        }
+
+        palette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
 
         if (flags & INSET_RECT_FLAG_BORDER_NONE)
         {

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -128,10 +128,8 @@ static uint8_t* font_sprite_get_codepoint_bitmap(int32_t codepoint)
     {
         return _characterBitmaps[offset - (SPR_G2_CHAR_BEGIN - SPR_CHAR_START) + FONT_SPRITE_GLYPH_COUNT];
     }
-    else
-    {
-        return _characterBitmaps[offset];
-    }
+
+    return _characterBitmaps[offset];
 }
 
 static int32_t scrolling_text_get_matching_or_oldest(

--- a/src/openrct2/drawing/TTF.cpp
+++ b/src/openrct2/drawing/TTF.cpp
@@ -373,10 +373,8 @@ static TTFSurface* ttf_render(TTF_Font* font, std::string_view text)
     {
         return TTF_RenderUTF8_Shaded(font, buffer.c_str(), 0x000000FF, 0x000000FF);
     }
-    else
-    {
-        return TTF_RenderUTF8_Solid(font, buffer.c_str(), 0x000000FF);
-    }
+
+    return TTF_RenderUTF8_Solid(font, buffer.c_str(), 0x000000FF);
 }
 
 void ttf_free_surface(TTFSurface* surface)

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -1553,9 +1553,9 @@ int TTF_GetFontHinting(const TTF_Font* font)
 {
     if (font->hinting == FT_LOAD_TARGET_ALT(FT_RENDER_MODE_LIGHT))
         return TTF_HINTING_LIGHT;
-    else if (font->hinting == FT_LOAD_TARGET_ALT(FT_RENDER_MODE_MONO))
+    if (font->hinting == FT_LOAD_TARGET_ALT(FT_RENDER_MODE_MONO))
         return TTF_HINTING_MONO;
-    else if (font->hinting == FT_LOAD_NO_HINTING)
+    if (font->hinting == FT_LOAD_NO_HINTING)
         return TTF_HINTING_NONE;
     return 0;
 }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1403,19 +1403,15 @@ static int32_t cc_say(InteractiveConsole& console, const arguments_t& argv)
         console.WriteFormatLine("This command only works in multiplayer mode.");
         return 0;
     }
-    else
+
+    if (!argv.empty())
     {
-        if (!argv.empty())
-        {
-            network_send_chat(argv[0].c_str());
-            return 1;
-        }
-        else
-        {
-            console.WriteFormatLine("Input your message");
-            return 0;
-        }
+        network_send_chat(argv[0].c_str());
+        return 1;
     }
+
+    console.WriteFormatLine("Input your message");
+    return 0;
 }
 
 static int32_t cc_replay_startrecord(InteractiveConsole& console, const arguments_t& argv)

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -170,10 +170,8 @@ std::string screenshot_dump_png(rct_drawpixelinfo* dpi)
     {
         return path.value();
     }
-    else
-    {
-        return "";
-    }
+
+    return "";
 }
 
 std::string screenshot_dump_png_32bpp(int32_t width, int32_t height, const void* pixels)
@@ -765,28 +763,26 @@ static std::string ResolveFilenameForCapture(const fs::path& filename)
         }
         return *path;
     }
-    else
+
+    auto screenshotDirectory = fs::u8path(screenshot_get_directory());
+    auto screenshotPath = fs::absolute(screenshotDirectory / filename);
+
+    // Check the filename isn't attempting to leave the screenshot directory for security
+    if (!IsPathChildOf(screenshotPath, screenshotDirectory))
     {
-        auto screenshotDirectory = fs::u8path(screenshot_get_directory());
-        auto screenshotPath = fs::absolute(screenshotDirectory / filename);
-
-        // Check the filename isn't attempting to leave the screenshot directory for security
-        if (!IsPathChildOf(screenshotPath, screenshotDirectory))
-        {
-            throw std::runtime_error("Filename is not a child of the screenshot directory.");
-        }
-
-        auto directory = screenshotPath.parent_path();
-        if (!fs::is_directory(directory))
-        {
-            if (!fs::create_directory(directory, screenshotDirectory))
-            {
-                throw std::runtime_error("Unable to create directory.");
-            }
-        }
-
-        return screenshotPath.string();
+        throw std::runtime_error("Filename is not a child of the screenshot directory.");
     }
+
+    auto directory = screenshotPath.parent_path();
+    if (!fs::is_directory(directory))
+    {
+        if (!fs::create_directory(directory, screenshotDirectory))
+        {
+            throw std::runtime_error("Unable to create directory.");
+        }
+    }
+
+    return screenshotPath.string();
 }
 
 void CaptureImage(const CaptureOptions& options)

--- a/src/openrct2/interface/StdInOutConsole.cpp
+++ b/src/openrct2/interface/StdInOutConsole.cpp
@@ -50,11 +50,9 @@ void StdInOutConsole::Start()
                     openrct2_finish();
                     break;
                 }
-                else
-                {
-                    lastPromptQuit = true;
-                    std::puts("(To exit, press ^C again)");
-                }
+
+                lastPromptQuit = true;
+                std::puts("(To exit, press ^C again)");
             }
             else
             {

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1972,8 +1972,6 @@ ZoomLevel ZoomLevel::min()
     {
         return -2;
     }
-    else
-    {
-        return 0;
-    }
+
+    return 0;
 }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -432,7 +432,8 @@ rct_widgetindex window_find_widget_from_point(rct_window* w, const ScreenCoordsX
         {
             break;
         }
-        else if (widget->type != WindowWidgetType::Empty && widget->IsVisible())
+
+        if (widget->type != WindowWidgetType::Empty && widget->IsVisible())
         {
             if (screenCoords.x >= w->windowPos.x + widget->left && screenCoords.x <= w->windowPos.x + widget->right
                 && screenCoords.y >= w->windowPos.y + widget->top && screenCoords.y <= w->windowPos.y + widget->bottom)
@@ -1337,10 +1338,8 @@ bool tool_set(rct_window* w, rct_widgetindex widgetIndex, Tool tool)
             tool_cancel();
             return true;
         }
-        else
-        {
-            tool_cancel();
-        }
+
+        tool_cancel();
     }
 
     input_set_flag(INPUT_FLAG_TOOL_ACTIVE, true);
@@ -1580,14 +1579,13 @@ OpenRCT2String window_event_tooltip_call(rct_window* w, const rct_widgetindex wi
     {
         return w->OnTooltip(widgetIndex, fallback);
     }
-    else if (w->event_handlers->tooltip != nullptr)
+
+    if (w->event_handlers->tooltip != nullptr)
     {
         return w->event_handlers->tooltip(w, widgetIndex, fallback);
     }
-    else
-    {
-        return { fallback, {} };
-    }
+
+    return { fallback, {} };
 }
 
 CursorID window_event_cursor_call(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -130,8 +130,8 @@ struct rct_widget
     {
         if (height() >= 10)
             return std::max<int32_t>(top, top + (height() / 2) - 5);
-        else
-            return top - 1;
+
+        return top - 1;
     }
 
     bool IsVisible() const

--- a/src/openrct2/interface/ZoomLevel.h
+++ b/src/openrct2/interface/ZoomLevel.h
@@ -51,16 +51,16 @@ public:
     {
         if (rhs._level < 0)
             return lhs >> -rhs._level;
-        else
-            return lhs << rhs._level;
+
+        return lhs << rhs._level;
     }
 
     template<typename T> friend T operator/(const T& lhs, const ZoomLevel& rhs)
     {
         if (rhs._level < 0)
             return lhs << -rhs._level;
-        else
-            return lhs >> rhs._level;
+
+        return lhs >> rhs._level;
     }
 
     static ZoomLevel min();

--- a/src/openrct2/localisation/ConversionTables.cpp
+++ b/src/openrct2/localisation/ConversionTables.cpp
@@ -111,8 +111,9 @@ static int32_t encoding_search_compare(const void *pKey, const void *pEntry)
 static wchar_t encoding_convert_x_to_unicode(wchar_t code, const encoding_convert_entry *table, size_t count)
 {
     encoding_convert_entry * entry = static_cast<encoding_convert_entry *>(std::bsearch(&code, table, count, sizeof(encoding_convert_entry), encoding_search_compare));
-    if (entry == nullptr) return code;
-    else return entry->unicode;
+    if (entry == nullptr)
+        return code;
+    return entry->unicode;
 }
 
 wchar_t encoding_convert_rct2_to_unicode(wchar_t rct2str)

--- a/src/openrct2/localisation/Convert.cpp
+++ b/src/openrct2/localisation/Convert.cpp
@@ -149,11 +149,9 @@ std::string rct2_to_utf8(std::string_view src, RCT2LanguageId languageId)
         // The code page used by RCT2 was not quite 1252 as some codes were used for Polish characters.
         return DecodeConvertWithTable(src, encoding_convert_rct2_to_unicode);
     }
-    else
-    {
-        auto decoded = DecodeToMultiByte(src);
-        return String::Convert(decoded, codePage, CODE_PAGE::CP_UTF8);
-    }
+
+    auto decoded = DecodeToMultiByte(src);
+    return String::Convert(decoded, codePage, CODE_PAGE::CP_UTF8);
 }
 
 std::string utf8_to_rct2(std::string_view src)

--- a/src/openrct2/localisation/FormatCodes.cpp
+++ b/src/openrct2/localisation/FormatCodes.cpp
@@ -96,14 +96,12 @@ std::string_view FormatTokenToString(FormatToken token, bool withBraces)
     {
         return GetFormatTokenStringWithBraces(token);
     }
-    else
-    {
-        auto it = FormatTokenMap.find(token);
-        if (it != FormatTokenMap.end())
-            return it->first;
 
-        return {};
-    }
+    auto it = FormatTokenMap.find(token);
+    if (it != FormatTokenMap.end())
+        return it->first;
+
+    return {};
 }
 
 bool FormatTokenTakesArgument(FormatToken token)

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -131,7 +131,8 @@ namespace OpenRCT2
                     current = token(FormatToken::Move, str.substr(startIndex, i - startIndex), p);
                     return;
                 }
-                else if (inner == "INLINE_SPRITE")
+
+                if (inner == "INLINE_SPRITE")
                 {
                     uint32_t p = 0;
                     auto p0 = ParseNumericToken(str, i);
@@ -178,12 +179,12 @@ namespace OpenRCT2
         {
             return token(FormatToken::Escaped, sztoken);
         }
-        else if (sztoken.size() >= 2 && sztoken[0] == '{' && sztoken[1] != '{')
+        if (sztoken.size() >= 2 && sztoken[0] == '{' && sztoken[1] != '{')
         {
             auto kind = FormatTokenFromString(sztoken.substr(1, len - 2));
             return token(kind, sztoken);
         }
-        else if (sztoken == "\n" || sztoken == "\r")
+        if (sztoken == "\n" || sztoken == "\r")
         {
             return token(FormatToken::Newline, sztoken);
         }

--- a/src/openrct2/localisation/Formatting.h
+++ b/src/openrct2/localisation/Formatting.h
@@ -243,13 +243,11 @@ namespace OpenRCT2
                             FormatRealName(ss, stringId);
                             return FormatString(ss, stack, argN...);
                         }
-                        else
-                        {
-                            auto subfmt = GetFmtStringById(stringId);
-                            auto subit = subfmt.begin();
-                            stack.push(subit);
-                            return FormatString(ss, stack, argN...);
-                        }
+
+                        auto subfmt = GetFmtStringById(stringId);
+                        auto subit = subfmt.begin();
+                        stack.push(subit);
+                        return FormatString(ss, stack, argN...);
                     }
                 }
                 else if (FormatTokenTakesArgument(token.kind))
@@ -257,10 +255,8 @@ namespace OpenRCT2
                     FormatArgument(ss, token.kind, arg0);
                     return FormatString(ss, stack, argN...);
                 }
-                else
-                {
-                    ss << token.text;
-                }
+
+                ss << token.text;
             }
             stack.pop();
         }

--- a/src/openrct2/localisation/Language.h
+++ b/src/openrct2/localisation/Language.h
@@ -114,25 +114,23 @@ constexpr utf8* utf8_write_codepoint(utf8* dst, uint32_t codepoint)
         dst[0] = static_cast<utf8>(codepoint);
         return dst + 1;
     }
-    else if (codepoint <= 0x7FF)
+    if (codepoint <= 0x7FF)
     {
         dst[0] = 0xC0 | ((codepoint >> 6) & 0x1F);
         dst[1] = 0x80 | (codepoint & 0x3F);
         return dst + 2;
     }
-    else if (codepoint <= 0xFFFF)
+    if (codepoint <= 0xFFFF)
     {
         dst[0] = 0xE0 | ((codepoint >> 12) & 0x0F);
         dst[1] = 0x80 | ((codepoint >> 6) & 0x3F);
         dst[2] = 0x80 | (codepoint & 0x3F);
         return dst + 3;
     }
-    else
-    {
-        dst[0] = 0xF0 | ((codepoint >> 18) & 0x07);
-        dst[1] = 0x80 | ((codepoint >> 12) & 0x3F);
-        dst[2] = 0x80 | ((codepoint >> 6) & 0x3F);
-        dst[3] = 0x80 | (codepoint & 0x3F);
-        return dst + 4;
-    }
+
+    dst[0] = 0xF0 | ((codepoint >> 18) & 0x07);
+    dst[1] = 0x80 | ((codepoint >> 12) & 0x3F);
+    dst[2] = 0x80 | ((codepoint >> 6) & 0x3F);
+    dst[3] = 0x80 | (codepoint & 0x3F);
+    return dst + 4;
 }

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -158,12 +158,11 @@ public:
             {
                 return _scenarioOverrides[ooIndex].strings[ooStringIndex].c_str();
             }
-            else
-            {
-                return nullptr;
-            }
+
+            return nullptr;
         }
-        else if (stringId >= ObjectOverrideBase)
+
+        if (stringId >= ObjectOverrideBase)
         {
             int32_t offset = stringId - ObjectOverrideBase;
             int32_t ooIndex = offset / ObjectOverrideMaxStringCount;
@@ -174,22 +173,16 @@ public:
             {
                 return _objectOverrides[ooIndex].strings[ooStringIndex].c_str();
             }
-            else
-            {
-                return nullptr;
-            }
+
+            return nullptr;
         }
-        else
+
+        if ((_strings.size() > static_cast<size_t>(stringId)) && !_strings[stringId].empty())
         {
-            if ((_strings.size() > static_cast<size_t>(stringId)) && !_strings[stringId].empty())
-            {
-                return _strings[stringId].c_str();
-            }
-            else
-            {
-                return nullptr;
-            }
+            return _strings[stringId].c_str();
         }
+
+        return nullptr;
     }
 
     rct_string_id GetObjectOverrideStringId(std::string_view legacyIdentifier, uint8_t index) override
@@ -469,7 +462,8 @@ private:
                 // Unexpected new line, ignore line entirely
                 return;
             }
-            else if (!IsWhitespace(codepoint) && codepoint != ':')
+
+            if (!IsWhitespace(codepoint) && codepoint != ':')
             {
                 reader->Skip();
                 sb.Append(codepoint);

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -445,8 +445,7 @@ money32 string_to_money(const char* string_to_monetise)
         {
             if (hasDecSep)
                 return MONEY32_UNDEFINED;
-            else
-                hasDecSep = true;
+            hasDecSep = true;
 
             // Replace localised decimal separator with an English one.
             *dst_ptr++ = '.';
@@ -457,8 +456,7 @@ money32 string_to_money(const char* string_to_monetise)
         {
             if (hasMinus)
                 return MONEY32_UNDEFINED;
-            else
-                hasMinus = true;
+            hasMinus = true;
         }
         else
         {

--- a/src/openrct2/localisation/UTF8.cpp
+++ b/src/openrct2/localisation/UTF8.cpp
@@ -77,18 +77,15 @@ int32_t utf8_get_codepoint_length(char32_t codepoint)
     {
         return 1;
     }
-    else if (codepoint <= 0x7FF)
+    if (codepoint <= 0x7FF)
     {
         return 2;
     }
-    else if (codepoint <= 0xFFFF)
+    if (codepoint <= 0xFFFF)
     {
         return 3;
     }
-    else
-    {
-        return 4;
-    }
+    return 4;
 }
 
 /**

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -62,8 +62,8 @@ const News::Item& News::ItemQueues::operator[](size_t index) const
 {
     if (index < Recent.capacity())
         return Recent[index];
-    else
-        return Archived[index - Recent.capacity()];
+
+    return Archived[index - Recent.capacity()];
 }
 
 News::Item* News::ItemQueues::At(int32_t index)
@@ -77,10 +77,8 @@ const News::Item* News::ItemQueues::At(int32_t index) const
     {
         return &(*this)[index];
     }
-    else
-    {
-        return nullptr;
-    }
+
+    return nullptr;
 }
 
 bool News::IsQueueEmpty()

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -159,13 +159,12 @@ static void research_next_design()
                 it = gResearchItemsUninvented.begin();
                 continue;
             }
-            else
-            {
-                research_mark_as_fully_completed();
-                return;
-            }
+
+            research_mark_as_fully_completed();
+            return;
         }
-        else if (ignoreActiveResearchTypes || (gResearchPriorities & EnumToFlag(researchItem.category)))
+
+        if (ignoreActiveResearchTypes || (gResearchPriorities & EnumToFlag(researchItem.category)))
         {
             break;
         }
@@ -561,11 +560,9 @@ bool scenery_is_invented(const ScenerySelection& sceneryItem)
     {
         return _researchedSceneryItems[sceneryItem.SceneryType][sceneryItem.EntryIndex];
     }
-    else
-    {
-        log_warning("Invalid Scenery Type");
-        return false;
-    }
+
+    log_warning("Invalid Scenery Type");
+    return false;
 }
 
 void scenery_set_invented(const ScenerySelection& sceneryItem)
@@ -697,23 +694,17 @@ rct_string_id ResearchItem::GetName() const
         {
             return STR_EMPTY;
         }
-        else
-        {
-            return rideEntry->naming.Name;
-        }
+
+        return rideEntry->naming.Name;
     }
-    else
+
+    rct_scenery_group_entry* sceneryEntry = get_scenery_group_entry(entryIndex);
+    if (sceneryEntry == nullptr)
     {
-        rct_scenery_group_entry* sceneryEntry = get_scenery_group_entry(entryIndex);
-        if (sceneryEntry == nullptr)
-        {
-            return STR_EMPTY;
-        }
-        else
-        {
-            return sceneryEntry->name;
-        }
+        return STR_EMPTY;
     }
+
+    return sceneryEntry->name;
 }
 
 /**

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -421,7 +421,7 @@ NetworkAuth NetworkBase::GetAuthStatus()
     {
         return _serverConnection->AuthStatus;
     }
-    else if (GetMode() == NETWORK_MODE_SERVER)
+    if (GetMode() == NETWORK_MODE_SERVER)
     {
         return NetworkAuth::Ok;
     }
@@ -858,10 +858,8 @@ std::string NetworkBase::GetMasterServerUrl()
     {
         return OPENRCT2_MASTER_SERVER_URL;
     }
-    else
-    {
-        return gConfigNetwork.master_server_url;
-    }
+
+    return gConfigNetwork.master_server_url;
 }
 
 NetworkGroup* NetworkBase::AddGroup()
@@ -3742,10 +3740,8 @@ rct_string_id network_get_action_name_string_id(uint32_t index)
     {
         return NetworkActions::Actions[index].Name;
     }
-    else
-    {
-        return STR_NONE;
-    }
+
+    return STR_NONE;
 }
 
 int32_t network_can_perform_action(uint32_t groupindex, NetworkPermission index)
@@ -3788,15 +3784,13 @@ Peep* network_get_pickup_peep(uint8_t playerid)
     {
         return _pickup_peep;
     }
-    else
+
+    NetworkPlayer* player = network.GetPlayerByID(playerid);
+    if (player)
     {
-        NetworkPlayer* player = network.GetPlayerByID(playerid);
-        if (player)
-        {
-            return player->PickupPeep;
-        }
-        return nullptr;
+        return player->PickupPeep;
     }
+    return nullptr;
 }
 
 void network_set_pickup_peep_old_x(uint8_t playerid, int32_t x)
@@ -3823,15 +3817,13 @@ int32_t network_get_pickup_peep_old_x(uint8_t playerid)
     {
         return _pickup_peep_old_x;
     }
-    else
+
+    NetworkPlayer* player = network.GetPlayerByID(playerid);
+    if (player)
     {
-        NetworkPlayer* player = network.GetPlayerByID(playerid);
-        if (player)
-        {
-            return player->PickupPeepOldX;
-        }
-        return -1;
+        return player->PickupPeepOldX;
     }
+    return -1;
 }
 
 int32_t network_get_current_player_group_index()

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -54,7 +54,7 @@ bool NetworkKey::LoadPrivate(OpenRCT2::IStream* stream)
         log_error("unknown size, refusing to load key");
         return false;
     }
-    else if (size > 4 * 1024 * 1024)
+    if (size > 4 * 1024 * 1024)
     {
         log_error("Key file suspiciously large, refusing to load it");
         return false;
@@ -86,7 +86,7 @@ bool NetworkKey::LoadPublic(OpenRCT2::IStream* stream)
         log_error("unknown size, refusing to load key");
         return false;
     }
-    else if (size > 4 * 1024 * 1024)
+    if (size > 4 * 1024 * 1024)
     {
         log_error("Key file suspiciously large, refusing to load it");
         return false;

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -77,12 +77,10 @@ const uint8_t* NetworkPacket::Read(size_t size)
     {
         return nullptr;
     }
-    else
-    {
-        const uint8_t* data = Data.data() + BytesRead;
-        BytesRead += size;
-        return data;
-    }
+
+    const uint8_t* data = Data.data() + BytesRead;
+    BytesRead += size;
+    return data;
 }
 
 const utf8* NetworkPacket::ReadString()

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -143,12 +143,10 @@ void NetworkUserManager::Save()
                 // erase advances the iterator so make sure we don't do it again
                 continue;
             }
-            else
-            {
-                // replace the existing element in jsonUsers
-                *it = networkUser->ToJson();
-                savedHashes.insert(hashString);
-            }
+
+            // replace the existing element in jsonUsers
+            *it = networkUser->ToJson();
+            savedHashes.insert(hashString);
         }
 
         it++;

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -95,20 +95,18 @@ std::optional<ServerListEntry> ServerListEntry::FromJson(json_t& server)
 
         return std::nullopt;
     }
-    else
-    {
-        ServerListEntry entry;
 
-        entry.Address = ip + ":" + std::to_string(port);
-        entry.Name = name;
-        entry.Description = description;
-        entry.Version = version;
-        entry.RequiresPassword = requiresPassword;
-        entry.Players = players;
-        entry.MaxPlayers = maxPlayers;
+    ServerListEntry entry;
 
-        return entry;
-    }
+    entry.Address = ip + ":" + std::to_string(port);
+    entry.Name = name;
+    entry.Description = description;
+    entry.Version = version;
+    entry.RequiresPassword = requiresPassword;
+    entry.Players = players;
+    entry.MaxPlayers = maxPlayers;
+
+    return entry;
 }
 
 void ServerList::Sort()

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -164,10 +164,8 @@ public:
         {
             return reinterpret_cast<const sockaddr_in*>(&_address)->sin_port;
         }
-        else
-        {
-            return reinterpret_cast<const sockaddr_in6*>(&_address)->sin6_port;
-        }
+
+        return reinterpret_cast<const sockaddr_in6*>(&_address)->sin6_port;
     }
 
     std::string GetHostname() const override
@@ -233,17 +231,16 @@ private:
             log_error("Resolution error message: %s.", gai_strerror(errorcode));
             return false;
         }
+
         if (result == nullptr)
         {
             return false;
         }
-        else
-        {
-            std::memcpy(ss, result->ai_addr, result->ai_addrlen);
-            *ss_len = static_cast<socklen_t>(result->ai_addrlen);
-            freeaddrinfo(result);
-            return true;
-        }
+
+        std::memcpy(ss, result->ai_addr, result->ai_addrlen);
+        *ss_len = static_cast<socklen_t>(result->ai_addrlen);
+        freeaddrinfo(result);
+        return true;
     }
 };
 
@@ -579,7 +576,8 @@ public:
             *sizeReceived = 0;
             return NetworkReadPacket::Disconnected;
         }
-        else if (readBytes == SOCKET_ERROR)
+
+        if (readBytes == SOCKET_ERROR)
         {
             *sizeReceived = 0;
 #    ifndef _WIN32
@@ -598,16 +596,12 @@ public:
             {
                 return NetworkReadPacket::Disconnected;
             }
-            else
-            {
-                return NetworkReadPacket::NoData;
-            }
+
+            return NetworkReadPacket::NoData;
         }
-        else
-        {
-            *sizeReceived = readBytes;
-            return NetworkReadPacket::Success;
-        }
+
+        *sizeReceived = readBytes;
+        return NetworkReadPacket::Success;
     }
 
     void Close() override
@@ -810,15 +804,13 @@ public:
             *sizeReceived = 0;
             return NetworkReadPacket::NoData;
         }
-        else
+
+        *sizeReceived = readBytes;
+        if (sender != nullptr)
         {
-            *sizeReceived = readBytes;
-            if (sender != nullptr)
-            {
-                *sender = std::make_unique<NetworkEndpoint>(reinterpret_cast<sockaddr*>(&senderAddr), senderAddrLen);
-            }
-            return NetworkReadPacket::Success;
+            *sender = std::make_unique<NetworkEndpoint>(reinterpret_cast<sockaddr*>(&senderAddr), senderAddrLen);
         }
+        return NetworkReadPacket::Success;
     }
 
     void Close() override

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -133,11 +133,9 @@ bool MusicObject::SupportsRideType(uint8_t rideType)
         // Default behaviour for music is to only exclude from merry-go-round
         return rideType != RIDE_TYPE_MERRY_GO_ROUND;
     }
-    else
-    {
-        auto it = std::find(_rideTypes.begin(), _rideTypes.end(), rideType);
-        return it != _rideTypes.end();
-    }
+
+    auto it = std::find(_rideTypes.begin(), _rideTypes.end(), rideType);
+    return it != _rideTypes.end();
 }
 
 size_t MusicObject::GetTrackCount() const
@@ -163,8 +161,6 @@ ObjectAsset MusicObject::GetAsset(IReadObjectContext& context, std::string_view 
         auto path2 = Path::Combine(dir, std::string(path.substr(11)));
         return ObjectAsset(path2);
     }
-    else
-    {
-        return context.GetAsset(path);
-    }
+
+    return context.GetAsset(path);
 }

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -414,7 +414,7 @@ private:
                 _loadedObjects.resize(i + 1);
                 return static_cast<int32_t>(i);
             }
-            else if (_loadedObjects[i] == nullptr)
+            if (_loadedObjects[i] == nullptr)
             {
                 return static_cast<int32_t>(i);
             }

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -264,14 +264,12 @@ public:
         {
             return ObjectFactory::CreateObjectFromJsonFile(*this, ori->Path);
         }
-        else if (String::Equals(extension, ".parkobj", true))
+        if (String::Equals(extension, ".parkobj", true))
         {
             return ObjectFactory::CreateObjectFromZipFile(*this, ori->Path);
         }
-        else
-        {
-            return ObjectFactory::CreateObjectFromLegacyFile(*this, ori->Path.c_str());
-        }
+
+        return ObjectFactory::CreateObjectFromLegacyFile(*this, ori->Path.c_str());
     }
 
     void RegisterLoadedObject(const ObjectRepositoryItem* ori, std::unique_ptr<Object>&& object) override
@@ -447,12 +445,10 @@ private:
             }
             return true;
         }
-        else
-        {
-            Console::Error::WriteLine("Object conflict: '%s'", conflict->Path.c_str());
-            Console::Error::WriteLine("               : '%s'", item.Path.c_str());
-            return false;
-        }
+
+        Console::Error::WriteLine("Object conflict: '%s'", conflict->Path.c_str());
+        Console::Error::WriteLine("               : '%s'", item.Path.c_str());
+        return false;
     }
 
     void ScanObject(const std::string& path)

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -65,8 +65,8 @@ struct ObjectRepositoryItem
     {
         if (Sources.empty())
             return ObjectSourceGame::Custom;
-        else
-            return static_cast<ObjectSourceGame>(Sources[0]);
+
+        return static_cast<ObjectSourceGame>(Sources[0]);
     }
 };
 

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -387,8 +387,8 @@ void RideObject::DrawPreview(rct_drawpixelinfo* dpi, [[maybe_unused]] int32_t wi
     {
         if (rideType != RIDE_TYPE_NULL)
             break;
-        else
-            imageId++;
+
+        imageId++;
     }
 
     gfx_draw_sprite(dpi, imageId, { 0, 0 }, 0);

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -21,12 +21,9 @@ paint_struct* PaintAddImageAsParentRotated(
             session, image_id, { y_offset, x_offset, z_offset },
             { bound_box_length_y, bound_box_length_x, bound_box_length_z });
     }
-    else
-    {
-        return PaintAddImageAsParent(
-            session, image_id, { x_offset, y_offset, z_offset },
-            { bound_box_length_x, bound_box_length_y, bound_box_length_z });
-    }
+
+    return PaintAddImageAsParent(
+        session, image_id, { x_offset, y_offset, z_offset }, { bound_box_length_x, bound_box_length_y, bound_box_length_z });
 }
 
 paint_struct* PaintAddImageAsParentRotated(
@@ -40,12 +37,10 @@ paint_struct* PaintAddImageAsParentRotated(
             session, image_id, { y_offset, x_offset, z_offset }, { bound_box_length_y, bound_box_length_x, bound_box_length_z },
             { bound_box_offset_y, bound_box_offset_x, bound_box_offset_z });
     }
-    else
-    {
-        return PaintAddImageAsParent(
-            session, image_id, { x_offset, y_offset, z_offset }, { bound_box_length_x, bound_box_length_y, bound_box_length_z },
-            { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });
-    }
+
+    return PaintAddImageAsParent(
+        session, image_id, { x_offset, y_offset, z_offset }, { bound_box_length_x, bound_box_length_y, bound_box_length_z },
+        { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });
 }
 
 paint_struct* PaintAddImageAsParentRotated(
@@ -58,10 +53,8 @@ paint_struct* PaintAddImageAsParentRotated(
             session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z },
             { boundBoxOffset.y, boundBoxOffset.x, boundBoxOffset.z });
     }
-    else
-    {
-        return PaintAddImageAsParent(session, image_id, offset, boundBoxSize, boundBoxOffset);
-    }
+
+    return PaintAddImageAsParent(session, image_id, offset, boundBoxSize, boundBoxOffset);
 }
 
 paint_struct* PaintAddImageAsParentRotated(
@@ -73,10 +66,8 @@ paint_struct* PaintAddImageAsParentRotated(
         return PaintAddImageAsParent(
             session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z });
     }
-    else
-    {
-        return PaintAddImageAsParent(session, image_id, offset, boundBoxSize);
-    }
+
+    return PaintAddImageAsParent(session, image_id, offset, boundBoxSize);
 }
 
 paint_struct* PaintAddImageAsChildRotated(
@@ -90,12 +81,10 @@ paint_struct* PaintAddImageAsChildRotated(
             session, image_id, y_offset, x_offset, bound_box_length_y, bound_box_length_x, bound_box_length_z, z_offset,
             bound_box_offset_y, bound_box_offset_x, bound_box_offset_z);
     }
-    else
-    {
-        return PaintAddImageAsChild(
-            session, image_id, x_offset, y_offset, bound_box_length_x, bound_box_length_y, bound_box_length_z, z_offset,
-            bound_box_offset_x, bound_box_offset_y, bound_box_offset_z);
-    }
+
+    return PaintAddImageAsChild(
+        session, image_id, x_offset, y_offset, bound_box_length_x, bound_box_length_y, bound_box_length_z, z_offset,
+        bound_box_offset_x, bound_box_offset_y, bound_box_offset_z);
 }
 
 paint_struct* PaintAddImageAsChildRotated(
@@ -108,10 +97,8 @@ paint_struct* PaintAddImageAsChildRotated(
             session, image_id, { offset.y, offset.x, offset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z },
             { boundBoxOffset.y, boundBoxOffset.x, boundBoxOffset.z });
     }
-    else
-    {
-        return PaintAddImageAsChild(session, image_id, offset, boundBoxSize, boundBoxOffset);
-    }
+
+    return PaintAddImageAsChild(session, image_id, offset, boundBoxSize, boundBoxOffset);
 }
 
 void paint_util_push_tunnel_rotated(paint_session* session, uint8_t direction, uint16_t height, uint8_t type)

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -186,7 +186,8 @@ bool virtual_floor_tile_is_floor(const CoordsXY& loc)
     {
         return true;
     }
-    else if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT)
+
+    if (gMapSelectFlags & MAP_SELECT_FLAG_ENABLE_CONSTRUCT)
     {
         // Check if we are anywhere near the selection tiles (larger scenery / rides)
         for (const auto& tile : gMapSelectionTiles)

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1669,8 +1669,8 @@ static int32_t guest_path_find_entering_park(Peep* peep, uint8_t edges)
 
     if (chosenDirection == INVALID_DIRECTION)
         return guest_path_find_aimless(peep, edges);
-    else
-        return peep_move_one_tile(chosenDirection, peep);
+
+    return peep_move_one_tile(chosenDirection, peep);
 }
 
 /**
@@ -1724,8 +1724,8 @@ static int32_t guest_path_find_leaving_park(Peep* peep, uint8_t edges)
     direction = peep_pathfind_choose_direction(TileCoordsXYZ{ peep->NextLoc }, peep);
     if (direction == INVALID_DIRECTION)
         return guest_path_find_aimless(peep, edges);
-    else
-        return peep_move_one_tile(direction, peep);
+
+    return peep_move_one_tile(direction, peep);
 }
 
 /**
@@ -1782,8 +1782,8 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
 
     if (chosenDirection == INVALID_DIRECTION)
         return guest_path_find_aimless(peep, edges);
-    else
-        return peep_move_one_tile(chosenDirection, peep);
+
+    return peep_move_one_tile(chosenDirection, peep);
 }
 
 /**

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -313,17 +313,16 @@ PeepActionSpriteType Peep::GetActionSpriteType()
     { // PeepActionType::None1 or PeepActionType::None2
         return PeepSpecialSpriteToSpriteTypeMap[SpecialSprite];
     }
-    else if (EnumValue(Action) < std::size(PeepActionToSpriteTypeMap))
+
+    if (EnumValue(Action) < std::size(PeepActionToSpriteTypeMap))
     {
         return PeepActionToSpriteTypeMap[EnumValue(Action)];
     }
-    else
-    {
-        openrct2_assert(
-            EnumValue(Action) >= std::size(PeepActionToSpriteTypeMap) && Action < PeepActionType::Idle,
-            "Invalid peep action %u", EnumValue(Action));
-        return PeepActionSpriteType::None;
-    }
+
+    openrct2_assert(
+        EnumValue(Action) >= std::size(PeepActionToSpriteTypeMap) && Action < PeepActionType::Idle, "Invalid peep action %u",
+        EnumValue(Action));
+    return PeepActionSpriteType::None;
 }
 
 /*
@@ -1513,17 +1512,15 @@ bool Peep::SetName(std::string_view value)
         Name = nullptr;
         return true;
     }
-    else
+
+    auto newNameMemory = static_cast<char*>(std::malloc(value.size() + 1));
+    if (newNameMemory != nullptr)
     {
-        auto newNameMemory = static_cast<char*>(std::malloc(value.size() + 1));
-        if (newNameMemory != nullptr)
-        {
-            std::memcpy(newNameMemory, value.data(), value.size());
-            newNameMemory[value.size()] = '\0';
-            std::free(Name);
-            Name = newNameMemory;
-            return true;
-        }
+        std::memcpy(newNameMemory, value.data(), value.size());
+        newNameMemory[value.size()] = '\0';
+        std::free(Name);
+        Name = newNameMemory;
+        return true;
     }
     return false;
 }
@@ -1835,15 +1832,13 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
                     found = true;
                     break;
                 }
-                else
+
+                if (z != nextTileElement->base_height)
                 {
-                    if (z != nextTileElement->base_height)
-                    {
-                        continue;
-                    }
-                    found = true;
-                    break;
+                    continue;
                 }
+                found = true;
+                break;
             } while (!(nextTileElement++)->IsLastForTile());
         }
 
@@ -1963,7 +1958,8 @@ static void peep_footpath_move_forward(Peep* peep, const CoordsXYE& coords, bool
             crowded++;
             continue;
         }
-        else if (auto litter = entity->As<Litter>(); litter != nullptr)
+
+        if (auto litter = entity->As<Litter>(); litter != nullptr)
         {
             if (abs(litter->z - guest->NextLoc.z) > 16)
                 continue;
@@ -2359,7 +2355,8 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
             tile_result = tileElement;
             return;
         }
-        else if (tileElement->GetType() == TILE_ELEMENT_TYPE_TRACK)
+
+        if (tileElement->GetType() == TILE_ELEMENT_TYPE_TRACK)
         {
             if (peep_interact_with_shop(this, { newLoc, tileElement }))
             {

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -1495,7 +1495,7 @@ void Staff::UpdateAnswering()
         peep_window_state_update(this);
         return;
     }
-    else if (SubState == 1)
+    if (SubState == 1)
     {
         if (IsActionWalking())
         {
@@ -1509,7 +1509,7 @@ void Staff::UpdateAnswering()
         Invalidate();
         return;
     }
-    else if (SubState <= 3)
+    if (SubState <= 3)
     {
         MechanicTimeSinceCall++;
         if (MechanicTimeSinceCall > 2500)
@@ -2529,10 +2529,8 @@ bool Staff::UpdateFixingMoveToStationExit(bool firstRun, const Ride* ride)
         MoveTo({ loc.value(), z });
         return false;
     }
-    else
-    {
-        return true;
-    }
+
+    return true;
 }
 
 /**

--- a/src/openrct2/platform/Linux.cpp
+++ b/src/openrct2/platform/Linux.cpp
@@ -83,11 +83,11 @@ uint16_t platform_get_locale_language()
         {
             return LANGUAGE_ENGLISH_US;
         }
-        else if (!fnmatch(pattern, "zh_CN", 0))
+        if (!fnmatch(pattern, "zh_CN", 0))
         {
             return LANGUAGE_CHINESE_SIMPLIFIED;
         }
-        else if (!fnmatch(pattern, "zh_TW", 0))
+        if (!fnmatch(pattern, "zh_TW", 0))
         {
             return LANGUAGE_CHINESE_TRADITIONAL;
         }

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -42,18 +42,14 @@ namespace Platform
         {
             return std::string();
         }
-        else
+
+        auto colon = std::strchr(value, ':');
+        if (colon == nullptr)
         {
-            auto colon = std::strchr(value, ':');
-            if (colon == nullptr)
-            {
-                return std::string(value);
-            }
-            else
-            {
-                return std::string(value, colon);
-            }
+            return std::string(value);
         }
+
+        return std::string(value, colon);
     }
 
     std::string GetHomePath()
@@ -207,12 +203,10 @@ namespace Platform
         {
             return String::Set(buffer, bufferSize, relativePath);
         }
-        else
-        {
-            String::Set(buffer, bufferSize, absolutePath);
-            Memory::Free(absolutePath);
-            return buffer;
-        }
+
+        String::Set(buffer, bufferSize, absolutePath);
+        Memory::Free(absolutePath);
+        return buffer;
     }
 
     std::string ResolveCasing(const std::string& path, bool fileExists)

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -589,12 +589,10 @@ namespace Platform
         {
             return String::Set(buffer, bufferSize, relativePath);
         }
-        else
-        {
-            auto absolutePath = String::ToUtf8(absolutePathW);
-            String::Set(buffer, bufferSize, absolutePath.c_str());
-            return buffer;
-        }
+
+        auto absolutePath = String::ToUtf8(absolutePathW);
+        String::Set(buffer, bufferSize, absolutePath.c_str());
+        return buffer;
     }
 
     std::string ResolveCasing(const std::string& path, bool fileExists)

--- a/src/openrct2/platform/Windows.cpp
+++ b/src/openrct2/platform/Windows.cpp
@@ -120,12 +120,10 @@ bool platform_lock_single_instance()
 
         return true;
     }
-    else
-    {
-        // Already running
-        CloseHandle(mutex);
-        return false;
-    }
+
+    // Already running
+    CloseHandle(mutex);
+    return false;
 }
 
 int32_t platform_get_drives()
@@ -223,55 +221,55 @@ uint16_t platform_get_locale_language()
     {
         return LANGUAGE_ENGLISH_UK;
     }
-    else if (strcmp(langCode, "ENU") == 0)
+    if (strcmp(langCode, "ENU") == 0)
     {
         return LANGUAGE_ENGLISH_US;
     }
-    else if (strcmp(langCode, "DEU") == 0)
+    if (strcmp(langCode, "DEU") == 0)
     {
         return LANGUAGE_GERMAN;
     }
-    else if (strcmp(langCode, "NLD") == 0)
+    if (strcmp(langCode, "NLD") == 0)
     {
         return LANGUAGE_DUTCH;
     }
-    else if (strcmp(langCode, "FRA") == 0)
+    if (strcmp(langCode, "FRA") == 0)
     {
         return LANGUAGE_FRENCH;
     }
-    else if (strcmp(langCode, "HUN") == 0)
+    if (strcmp(langCode, "HUN") == 0)
     {
         return LANGUAGE_HUNGARIAN;
     }
-    else if (strcmp(langCode, "PLK") == 0)
+    if (strcmp(langCode, "PLK") == 0)
     {
         return LANGUAGE_POLISH;
     }
-    else if (strcmp(langCode, "ESP") == 0)
+    if (strcmp(langCode, "ESP") == 0)
     {
         return LANGUAGE_SPANISH;
     }
-    else if (strcmp(langCode, "SVE") == 0)
+    if (strcmp(langCode, "SVE") == 0)
     {
         return LANGUAGE_SWEDISH;
     }
-    else if (strcmp(langCode, "ITA") == 0)
+    if (strcmp(langCode, "ITA") == 0)
     {
         return LANGUAGE_ITALIAN;
     }
-    else if (strcmp(langCode, "POR") == 0)
+    if (strcmp(langCode, "POR") == 0)
     {
         return LANGUAGE_PORTUGUESE_BR;
     }
-    else if (strcmp(langCode, "FIN") == 0)
+    if (strcmp(langCode, "FIN") == 0)
     {
         return LANGUAGE_FINNISH;
     }
-    else if (strcmp(langCode, "NOR") == 0)
+    if (strcmp(langCode, "NOR") == 0)
     {
         return LANGUAGE_NORWEGIAN;
     }
-    else if (strcmp(langCode, "DAN") == 0)
+    if (strcmp(langCode, "DAN") == 0)
     {
         return LANGUAGE_DANISH;
     }
@@ -347,8 +345,8 @@ TemperatureUnit platform_get_locale_temperature_format()
 
     if (fahrenheit)
         return TemperatureUnit::Fahrenheit;
-    else
-        return TemperatureUnit::Celsius;
+
+    return TemperatureUnit::Celsius;
 }
 
 uint8_t platform_get_locale_date_format()
@@ -381,21 +379,19 @@ uint8_t platform_get_locale_date_format()
     {
         return DATE_FORMAT_DAY_MONTH_YEAR;
     }
-    else if (wcsncmp(L"M", first, 1) == 0)
+    if (wcsncmp(L"M", first, 1) == 0)
     {
         return DATE_FORMAT_MONTH_DAY_YEAR;
     }
-    else if (wcsncmp(L"y", first, 1) == 0)
+    if (wcsncmp(L"y", first, 1) == 0)
     {
         if (wcsncmp(L"d", second, 1) == 0)
         {
             return DATE_FORMAT_YEAR_DAY_MONTH;
         }
-        else
-        {
-            // Closest possible option
-            return DATE_FORMAT_YEAR_MONTH_DAY;
-        }
+
+        // Closest possible option
+        return DATE_FORMAT_YEAR_MONTH_DAY;
     }
 #    endif
 
@@ -421,10 +417,8 @@ bool platform_get_font_path(TTFFontDescriptor* font, utf8* buffer, size_t size)
         safe_strcat_path(buffer, font->filename, size);
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 #        else
     log_warning("Compatibility hack: falling back to C:\\Windows\\Fonts");
     safe_strcpy(buffer, "C:\\Windows\\Fonts\\", size);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -157,14 +157,12 @@ namespace RCT1
             {
                 return LoadScenario(path);
             }
-            else if (String::Equals(extension, ".sv4", true))
+            if (String::Equals(extension, ".sv4", true))
             {
                 return LoadSavedGame(path);
             }
-            else
-            {
-                throw std::runtime_error("Invalid RCT1 park extension.");
-            }
+
+            throw std::runtime_error("Invalid RCT1 park extension.");
         }
 
         ParkLoadResult LoadSavedGame(const utf8* path, bool skipObjectCheck = false) override
@@ -333,10 +331,8 @@ namespace RCT1
                 std::memcpy(s4.get(), decodedData.get(), sizeof(S4));
                 return s4;
             }
-            else
-            {
-                throw std::runtime_error("Unable to decode park.");
-            }
+
+            throw std::runtime_error("Unable to decode park.");
         }
 
         void Initialise()
@@ -364,10 +360,8 @@ namespace RCT1
             {
                 return "";
             }
-            else
-            {
-                return path_get_filename(scenarioEntry->path);
-            }
+
+            return path_get_filename(scenarioEntry->path);
         }
 
         void InitialiseEntryMaps()
@@ -2051,7 +2045,7 @@ namespace RCT1
                     {
                         continue;
                     }
-                    else if (researchItem.item == RCT1_RESEARCH_END)
+                    if (researchItem.item == RCT1_RESEARCH_END)
                     {
                         break;
                     }
@@ -2433,11 +2427,9 @@ namespace RCT1
                 *count = std::size(_s4.research_items_LL);
                 return _s4.research_items_LL;
             }
-            else
-            {
-                *count = std::size(_s4.research_items);
-                return _s4.research_items;
-            }
+
+            *count = std::size(_s4.research_items);
+            return _s4.research_items;
         }
 
         std::string GetUserString(rct_string_id stringId)

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -47,10 +47,8 @@ namespace RCT1
                 auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
                 return LoadFromStream(&fs);
             }
-            else
-            {
-                throw std::runtime_error("Invalid RCT1 track extension.");
-            }
+
+            throw std::runtime_error("Invalid RCT1 track extension.");
         }
 
         bool LoadFromStream(OpenRCT2::IStream* stream) override
@@ -85,10 +83,8 @@ namespace RCT1
             {
                 return ImportAA();
             }
-            else
-            {
-                return ImportTD4();
-            }
+
+            return ImportTD4();
         }
 
     private:

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -1252,8 +1252,8 @@ namespace RCT1
         };
         if (wallType < std::size(map))
             return map[wallType];
-        else
-            return map[0];
+
+        return map[0];
     }
 
     const char * GetPathObject(uint8_t pathType)

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -436,10 +436,8 @@ int32_t RCT12WallElement::GetRCT1WallType(int32_t edge) const
     {
         return typeA | (typeB << 2);
     }
-    else
-    {
-        return -1;
-    }
+
+    return -1;
 }
 
 colour_t RCT12WallElement::GetRCT1WallColour() const
@@ -1282,11 +1280,9 @@ std::string GetTruncatedRCT2String(std::string_view src, size_t maxLength)
                     rct2encoded.resize(i);
                     break;
                 }
-                else
-                {
-                    // Skip the next two bytes which represent the unicode character
-                    i += 2;
-                }
+
+                // Skip the next two bytes which represent the unicode character
+                i += 2;
             }
         }
     }

--- a/src/openrct2/rct12/SawyerEncoding.cpp
+++ b/src/openrct2/rct12/SawyerEncoding.cpp
@@ -90,12 +90,12 @@ namespace SawyerEncoding
 
             if (checksum - 0x1D4C1 == fileChecksum)
                 return RCT12TrackDesignVersion::TD6;
-            else if (checksum - 0x1A67C == fileChecksum)
+            if (checksum - 0x1A67C == fileChecksum)
                 return RCT12TrackDesignVersion::TD4;
-            else if (checksum - 0x1A650 == fileChecksum)
+            if (checksum - 0x1A650 == fileChecksum)
                 return RCT12TrackDesignVersion::TD4;
-            else
-                return RCT12TrackDesignVersion::unknown;
+
+            return RCT12TrackDesignVersion::unknown;
         }
         catch (const std::exception&)
         {

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -21,28 +21,23 @@ ObjectEntryIndex RCT2RideTypeToOpenRCT2RideType(uint8_t rct2RideType, const rct_
         case RIDE_TYPE_CORKSCREW_ROLLER_COASTER:
             if (rideEntry != nullptr && !(ride_entry_get_supported_track_pieces(rideEntry) & (1ULL << TRACK_VERTICAL_LOOP)))
                 return RIDE_TYPE_HYPERCOASTER;
-            else
-                return RIDE_TYPE_CORKSCREW_ROLLER_COASTER;
+            return RIDE_TYPE_CORKSCREW_ROLLER_COASTER;
         case RIDE_TYPE_JUNIOR_ROLLER_COASTER:
             if (rideEntry != nullptr && ride_entry_get_supported_track_pieces(rideEntry) & (1ULL << TRACK_SLOPE_STEEP))
                 return RIDE_TYPE_CLASSIC_MINI_ROLLER_COASTER;
-            else
-                return RIDE_TYPE_JUNIOR_ROLLER_COASTER;
+            return RIDE_TYPE_JUNIOR_ROLLER_COASTER;
         case RIDE_TYPE_CAR_RIDE:
             if (rideEntry != nullptr && ride_entry_get_supported_track_pieces(rideEntry) & (1ULL << TRACK_SLOPE_STEEP))
                 return RIDE_TYPE_MONSTER_TRUCKS;
-            else
-                return RIDE_TYPE_CAR_RIDE;
+            return RIDE_TYPE_CAR_RIDE;
         case RIDE_TYPE_TWISTER_ROLLER_COASTER:
             if (rideEntry != nullptr && rideEntry->flags & RIDE_ENTRY_FLAG_NO_INVERSIONS)
                 return RIDE_TYPE_HYPER_TWISTER;
-            else
-                return RIDE_TYPE_TWISTER_ROLLER_COASTER;
+            return RIDE_TYPE_TWISTER_ROLLER_COASTER;
         case RIDE_TYPE_STEEL_WILD_MOUSE:
             if (rideEntry != nullptr && !(ride_entry_get_supported_track_pieces(rideEntry) & (1ULL << TRACK_SLOPE_STEEP)))
                 return RIDE_TYPE_SPINNING_WILD_MOUSE;
-            else
-                return RIDE_TYPE_STEEL_WILD_MOUSE;
+            return RIDE_TYPE_STEEL_WILD_MOUSE;
 
         default:
             return rct2RideType;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -100,14 +100,12 @@ public:
         {
             return LoadScenario(path);
         }
-        else if (String::Equals(extension, ".sv6", true))
+        if (String::Equals(extension, ".sv6", true))
         {
             return LoadSavedGame(path);
         }
-        else
-        {
-            throw std::runtime_error("Invalid RCT2 park extension.");
-        }
+
+        throw std::runtime_error("Invalid RCT2 park extension.");
     }
 
     ParkLoadResult LoadSavedGame(const utf8* path, bool skipObjectCheck = false) override
@@ -970,7 +968,7 @@ public:
                 invented = false;
                 continue;
             }
-            else if (researchItem.IsUninventedEndMarker() || researchItem.IsRandomEndMarker())
+            if (researchItem.IsUninventedEndMarker() || researchItem.IsRandomEndMarker())
             {
                 break;
             }

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -49,10 +49,8 @@ public:
             auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
             return LoadFromStream(&fs);
         }
-        else
-        {
-            throw std::runtime_error("Invalid RCT2 track extension.");
-        }
+
+        throw std::runtime_error("Invalid RCT2 track extension.");
     }
 
     bool LoadFromStream(OpenRCT2::IStream* stream) override

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -404,31 +404,25 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
                     {
                         break;
                     }
-                    else
-                    {
-                        _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
-                        _vehicleVelocityF64E0C -= vehicle->remaining_distance - 13962;
-                        vehicle->remaining_distance = 13962;
-                        vehicle->acceleration += dword_9A2970[vehicle->Pitch];
-                        _vehicleUnkF64E10++;
-                        continue;
-                    }
+
+                    _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
+                    _vehicleVelocityF64E0C -= vehicle->remaining_distance - 13962;
+                    vehicle->remaining_distance = 13962;
+                    vehicle->acceleration += dword_9A2970[vehicle->Pitch];
+                    _vehicleUnkF64E10++;
+                    continue;
                 }
-                else
+
+                if (vehicle->CableLiftUpdateTrackMotionForwards())
                 {
-                    if (vehicle->CableLiftUpdateTrackMotionForwards())
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
-                        _vehicleVelocityF64E0C -= vehicle->remaining_distance + 1;
-                        vehicle->remaining_distance = -1;
-                        vehicle->acceleration += dword_9A2970[vehicle->Pitch];
-                        _vehicleUnkF64E10++;
-                    }
+                    break;
                 }
+
+                _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
+                _vehicleVelocityF64E0C -= vehicle->remaining_distance + 1;
+                vehicle->remaining_distance = -1;
+                vehicle->acceleration += dword_9A2970[vehicle->Pitch];
+                _vehicleUnkF64E10++;
             }
             vehicle->MoveTo(unk_F64E20);
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2015,13 +2015,11 @@ std::pair<RideMeasurement*, OpenRCT2String> Ride::GetMeasurement()
     {
         return { measurement.get(), { STR_EMPTY, {} } };
     }
-    else
-    {
-        auto ft = Formatter();
-        ft.Add<rct_string_id>(GetRideComponentName(GetRideTypeDescriptor().NameConvention.vehicle).singular);
-        ft.Add<rct_string_id>(GetRideComponentName(GetRideTypeDescriptor().NameConvention.station).singular);
-        return { nullptr, { STR_DATA_LOGGING_WILL_START_WHEN_NEXT_LEAVES, ft } };
-    }
+
+    auto ft = Formatter();
+    ft.Add<rct_string_id>(GetRideComponentName(GetRideTypeDescriptor().NameConvention.vehicle).singular);
+    ft.Add<rct_string_id>(GetRideComponentName(GetRideTypeDescriptor().NameConvention.station).singular);
+    return { nullptr, { STR_DATA_LOGGING_WILL_START_WHEN_NEXT_LEAVES, ft } };
 }
 
 #pragma endregion
@@ -4255,10 +4253,8 @@ RideNaming get_ride_naming(const uint8_t rideType, rct_ride_entry* rideEntry)
     {
         return GetRideTypeDescriptor(rideType).Naming;
     }
-    else
-    {
-        return rideEntry->naming;
-    }
+
+    return rideEntry->naming;
 }
 
 /*
@@ -4741,22 +4737,20 @@ uint8_t ride_entry_get_vehicle_at_position(int32_t rideEntryIndex, int32_t numCa
     {
         return rideEntry->front_vehicle;
     }
-    else if (position == 1 && rideEntry->second_vehicle != 255)
+    if (position == 1 && rideEntry->second_vehicle != 255)
     {
         return rideEntry->second_vehicle;
     }
-    else if (position == 2 && rideEntry->third_vehicle != 255)
+    if (position == 2 && rideEntry->third_vehicle != 255)
     {
         return rideEntry->third_vehicle;
     }
-    else if (position == numCarsPerTrain - 1 && rideEntry->rear_vehicle != 255)
+    if (position == numCarsPerTrain - 1 && rideEntry->rear_vehicle != 255)
     {
         return rideEntry->rear_vehicle;
     }
-    else
-    {
-        return rideEntry->default_vehicle;
-    }
+
+    return rideEntry->default_vehicle;
 }
 
 // Finds track pieces that a given ride entry has sprites for
@@ -5401,16 +5395,14 @@ int32_t get_booster_speed(uint8_t rideType, int32_t rawSpeed)
     {
         return rawSpeed;
     }
-    else if (shiftFactor > 0)
+    if (shiftFactor > 0)
     {
         return (rawSpeed << shiftFactor);
     }
-    else
-    {
-        // Workaround for an issue with older compilers (GCC 6, Clang 4) which would fail the build
-        int8_t shiftFactorAbs = std::abs(shiftFactor);
-        return (rawSpeed >> shiftFactorAbs);
-    }
+
+    // Workaround for an issue with older compilers (GCC 6, Clang 4) which would fail the build
+    int8_t shiftFactorAbs = std::abs(shiftFactor);
+    return (rawSpeed >> shiftFactorAbs);
 }
 
 void fix_invalid_vehicle_sprite_sizes()

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -221,10 +221,8 @@ namespace OpenRCT2::RideAudio
                     {
                         return true;
                     }
-                    else
-                    {
-                        return false;
-                    }
+
+                    return false;
                 }),
             _musicChannels.end());
     }
@@ -272,18 +270,16 @@ namespace OpenRCT2::RideAudio
         {
             return { 1378, 12427456 };
         }
-        else
+
+        auto& objManager = GetContext()->GetObjectManager();
+        auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride.music));
+        if (musicObj != nullptr)
         {
-            auto& objManager = GetContext()->GetObjectManager();
-            auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride.music));
-            if (musicObj != nullptr)
+            auto numTracks = musicObj->GetTrackCount();
+            if (ride.music_tune_id < numTracks)
             {
-                auto numTracks = musicObj->GetTrackCount();
-                if (ride.music_tune_id < numTracks)
-                {
-                    auto track = musicObj->GetTrack(ride.music_tune_id);
-                    return { track->BytesPerTick, track->Size };
-                }
+                auto track = musicObj->GetTrack(ride.music_tune_id);
+                return { track->BytesPerTick, track->Size };
             }
         }
         return { 0, 0 };

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -335,10 +335,8 @@ bool track_remove_station_element(const CoordsXYZD& loc, ride_id_t rideIndex, in
             gGameCommandErrorText = STR_NO_MORE_STATIONS_ALLOWED_ON_THIS_RIDE;
             return false;
         }
-        else
-        {
-            return true;
-        }
+
+        return true;
     }
 
     currentLoc = stationFrontLoc;
@@ -432,31 +430,27 @@ bool track_circuit_iterator_previous(track_circuit_iterator* it)
         it->first = it->current.element;
         return true;
     }
-    else
+
+    if (!it->firstIteration && it->first == it->current.element)
     {
-        if (!it->firstIteration && it->first == it->current.element)
-        {
-            it->looped = true;
-            return false;
-        }
-
-        it->firstIteration = false;
-        it->last = it->current;
-
-        if (track_block_get_previous({ it->last.x, it->last.y, it->last.element }, &trackBeginEnd))
-        {
-            it->current.x = trackBeginEnd.end_x;
-            it->current.y = trackBeginEnd.end_y;
-            it->current.element = trackBeginEnd.begin_element;
-            it->currentZ = trackBeginEnd.begin_z;
-            it->currentDirection = trackBeginEnd.begin_direction;
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        it->looped = true;
+        return false;
     }
+
+    it->firstIteration = false;
+    it->last = it->current;
+
+    if (track_block_get_previous({ it->last.x, it->last.y, it->last.element }, &trackBeginEnd))
+    {
+        it->current.x = trackBeginEnd.end_x;
+        it->current.y = trackBeginEnd.end_y;
+        it->current.element = trackBeginEnd.begin_element;
+        it->currentZ = trackBeginEnd.begin_z;
+        it->currentDirection = trackBeginEnd.begin_direction;
+        return true;
+    }
+
+    return false;
 }
 
 bool track_circuit_iterator_next(track_circuit_iterator* it)
@@ -469,18 +463,16 @@ bool track_circuit_iterator_next(track_circuit_iterator* it)
         it->first = it->current.element;
         return true;
     }
-    else
-    {
-        if (!it->firstIteration && it->first == it->current.element)
-        {
-            it->looped = true;
-            return false;
-        }
 
-        it->firstIteration = false;
-        it->last = it->current;
-        return track_block_get_next(&it->last, &it->current, &it->currentZ, &it->currentDirection);
+    if (!it->firstIteration && it->first == it->current.element)
+    {
+        it->looped = true;
+        return false;
     }
+
+    it->firstIteration = false;
+    it->last = it->current;
+    return track_block_get_next(&it->last, &it->current, &it->currentZ, &it->currentDirection);
 }
 
 bool track_circuit_iterators_match(const track_circuit_iterator* firstIt, const track_circuit_iterator* secondIt)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -163,10 +163,8 @@ rct_string_id TrackDesign::CreateTrackDesign(const Ride& ride)
     {
         return CreateTrackDesignMaze(ride);
     }
-    else
-    {
-        return CreateTrackDesignTrack(ride);
-    }
+
+    return CreateTrackDesignTrack(ride);
 }
 
 rct_string_id TrackDesign::CreateTrackDesignTrack(const Ride& ride)
@@ -1771,11 +1769,9 @@ static std::optional<money32> track_design_place_ride(TrackDesign* td6, const Co
                     {
                         return std::nullopt;
                     }
-                    else
-                    {
-                        totalCost += res->Cost;
-                        _trackDesignPlaceStateEntranceExitPlaced = true;
-                    }
+
+                    totalCost += res->Cost;
+                    _trackDesignPlaceStateEntranceExitPlaced = true;
                 }
                 break;
             }
@@ -1977,13 +1973,11 @@ static bool track_design_place_preview(TrackDesign* td6, money32* cost, Ride** o
         *outRide = ride;
         return true;
     }
-    else
-    {
-        _currentTrackPieceDirection = backup_rotation;
-        ride->Delete();
-        _trackDesignDrawingPreview = false;
-        return false;
-    }
+
+    _currentTrackPieceDirection = backup_rotation;
+    ride->Delete();
+    _trackDesignDrawingPreview = false;
+    return false;
 }
 
 #pragma region Track Design Preview

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -90,10 +90,8 @@ public:
             }
             return std::make_tuple(true, item);
         }
-        else
-        {
-            return std::make_tuple(true, TrackRepositoryItem());
-        }
+
+        return std::make_tuple(true, TrackRepositoryItem());
     }
 
 protected:

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1983,12 +1983,10 @@ static SoundIdVolume sub_6D7AC0(
             currentVolume = std::min<int32_t>(currentVolume + 15, targetVolume);
             return { currentSoundId, currentVolume };
         }
-        else
-        {
-            currentVolume -= 9;
-            if (currentVolume >= 80)
-                return { currentSoundId, currentVolume };
-        }
+
+        currentVolume -= 9;
+        if (currentVolume >= 80)
+            return { currentSoundId, currentVolume };
     }
 
     // Begin sound at quarter volume
@@ -2307,7 +2305,7 @@ static std::optional<uint32_t> ride_get_train_index_from_vehicle(Ride* ride, uin
             // track type to, e.g., Crooked House
             break;
         }
-        else if (trainIndex >= std::size(ride->vehicles))
+        if (trainIndex >= std::size(ride->vehicles))
         {
             return std::nullopt;
         }
@@ -2355,7 +2353,7 @@ void Vehicle::UpdateWaitingForPassengers()
         Invalidate();
         return;
     }
-    else if (sub_state == 1)
+    if (sub_state == 1)
     {
         if (time_waiting != 0xFFFF)
             time_waiting++;
@@ -3030,13 +3028,11 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
                          * trains can depart! */
                         return false;
                     }
-                    else
-                    {
-                        /* Sync exception - train is not arriving at the station
-                         * and there are less than half the trains for the ride
-                         * travelling. */
-                        continue;
-                    }
+
+                    /* Sync exception - train is not arriving at the station
+                     * and there are less than half the trains for the ride
+                     * travelling. */
+                    continue;
                 }
             }
         }
@@ -3377,13 +3373,13 @@ void Vehicle::UpdateDeparting()
             UpdateDepartingBoatHire();
             return;
         }
-        else if (curRide->mode == RideMode::ReverseInclineLaunchedShuttle)
+        if (curRide->mode == RideMode::ReverseInclineLaunchedShuttle)
         {
             velocity = -velocity;
             FinishDeparting();
             return;
         }
-        else if (curRide->mode == RideMode::Shuttle)
+        if (curRide->mode == RideMode::Shuttle)
         {
             update_flags ^= VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE;
             velocity = 0;
@@ -3827,7 +3823,7 @@ void Vehicle::UpdateTravelling()
                 UpdateTravellingBoatHireSetup();
                 return;
             }
-            else if (curRide->mode == RideMode::Shuttle)
+            if (curRide->mode == RideMode::Shuttle)
             {
                 update_flags ^= VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE;
                 velocity = 0;
@@ -6922,10 +6918,7 @@ int32_t Vehicle::GetSwingAmount() const
             {
                 return 14;
             }
-            else
-            {
-                return -15;
-            }
+            return -15;
 
         case TrackElemType::SBendRight:
         case TrackElemType::SBendRightCovered:
@@ -6934,10 +6927,7 @@ int32_t Vehicle::GetSwingAmount() const
             {
                 return -14;
             }
-            else
-            {
-                return 15;
-            }
+            return 15;
 
         case TrackElemType::LeftQuarterTurn3Tiles:
         case TrackElemType::LeftBankedQuarterTurn3Tiles:
@@ -7002,32 +6992,32 @@ static uint8_t GetSwingSprite(int16_t swingPosition)
 {
     if (swingPosition < -10012)
         return 11;
-    else if (swingPosition > 10012)
+    if (swingPosition > 10012)
         return 12;
 
     if (swingPosition < -8191)
         return 9;
-    else if (swingPosition > 8191)
+    if (swingPosition > 8191)
         return 10;
 
     if (swingPosition < -6371)
         return 7;
-    else if (swingPosition > 6371)
+    if (swingPosition > 6371)
         return 8;
 
     if (swingPosition < -4550)
         return 5;
-    else if (swingPosition > 4550)
+    if (swingPosition > 4550)
         return 6;
 
     if (swingPosition < -2730)
         return 3;
-    else if (swingPosition > 2730)
+    if (swingPosition > 2730)
         return 4;
 
     if (swingPosition < -910)
         return 1;
-    else if (swingPosition > 910)
+    if (swingPosition > 910)
         return 2;
 
     return 0;
@@ -7247,30 +7237,28 @@ void Vehicle::UpdateAnimationAnimalFlying()
         animationState--;
         return;
     }
-    else
+
+    if (animation_frame == 0)
     {
-        if (animation_frame == 0)
+        auto trackType = GetTrackType();
+        TileElement* trackElement = map_get_track_element_at_of_type_seq(TrackLocation, trackType, 0);
+        if (trackElement != nullptr && trackElement->AsTrack()->HasChain())
         {
-            auto trackType = GetTrackType();
-            TileElement* trackElement = map_get_track_element_at_of_type_seq(TrackLocation, trackType, 0);
-            if (trackElement != nullptr && trackElement->AsTrack()->HasChain())
-            {
-                // start flapping, bird
-                animation_frame = 1;
-                animationState = 5;
-                Invalidate();
-            }
-        }
-        else
-        {
-            // continue flapping until reaching frame 0
-            animation_frame = (animation_frame + 1) % 4;
+            // start flapping, bird
+            animation_frame = 1;
+            animationState = 5;
             Invalidate();
         }
-        // number of frames to skip before updating again
-        constexpr std::array<uint8_t, 4> frameWaitTimes = { 5, 3, 5, 3 };
-        animationState = frameWaitTimes[animation_frame];
     }
+    else
+    {
+        // continue flapping until reaching frame 0
+        animation_frame = (animation_frame + 1) % 4;
+        Invalidate();
+    }
+    // number of frames to skip before updating again
+    constexpr std::array<uint8_t, 4> frameWaitTimes = { 5, 3, 5, 3 };
+    animationState = frameWaitTimes[animation_frame];
 }
 
 /**
@@ -9276,10 +9264,8 @@ static constexpr int32_t GetAccelerationDecrease2(const int32_t velocity, const 
     {
         return accelerationDecrease2 / totalMass;
     }
-    else
-    {
-        return accelerationDecrease2;
-    }
+
+    return accelerationDecrease2;
 }
 
 int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const rct_ride_entry_vehicle& vehicleEntry)
@@ -9610,16 +9596,14 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
                 {
                     break;
                 }
-                else
+
+                if (car->remaining_distance < 0x368A)
                 {
-                    if (car->remaining_distance < 0x368A)
-                    {
-                        break;
-                    }
-                    car->acceleration += dword_9A2970[car->Pitch];
-                    _vehicleUnkF64E10++;
-                    continue;
+                    break;
                 }
+                car->acceleration += dword_9A2970[car->Pitch];
+                _vehicleUnkF64E10++;
+                continue;
             }
             if (car->remaining_distance < 0x368A)
             {
@@ -9630,16 +9614,14 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
             {
                 break;
             }
-            else
+
+            if (car->remaining_distance >= 0)
             {
-                if (car->remaining_distance >= 0)
-                {
-                    break;
-                }
-                car->acceleration = dword_9A2970[car->Pitch];
-                _vehicleUnkF64E10++;
-                continue;
+                break;
             }
+            car->acceleration = dword_9A2970[car->Pitch];
+            _vehicleUnkF64E10++;
+            continue;
         }
         // loc_6DBF20
         car->MoveTo(unk_F64E20);

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -609,7 +609,8 @@ ObjectiveStatus Objective::CheckGuestsBy() const
         {
             return ObjectiveStatus::Success;
         }
-        else if (currentMonthYear == MONTH_COUNT * Year)
+
+        if (currentMonthYear == MONTH_COUNT * Year)
         {
             return ObjectiveStatus::Failure;
         }
@@ -630,7 +631,8 @@ ObjectiveStatus Objective::CheckParkValueBy() const
         {
             return ObjectiveStatus::Success;
         }
-        else if (currentMonthYear == MONTH_COUNT * Year)
+
+        if (currentMonthYear == MONTH_COUNT * Year)
         {
             return ObjectiveStatus::Failure;
         }

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -51,8 +51,7 @@ static int32_t ScenarioCategoryCompare(int32_t categoryA, int32_t categoryB)
         return 1;
     if (categoryA < categoryB)
         return -1;
-    else
-        return 1;
+    return 1;
 }
 
 static int32_t scenario_index_entry_CompareByCategory(const scenario_index_entry& entryA, const scenario_index_entry& entryB)
@@ -97,23 +96,19 @@ static int32_t scenario_index_entry_CompareByIndex(const scenario_index_entry& e
                 {
                     return scenario_index_entry_CompareByCategory(entryA, entryB);
                 }
-                else
-                {
-                    return ScenarioCategoryCompare(entryA.category, entryB.category);
-                }
+
+                return ScenarioCategoryCompare(entryA.category, entryB.category);
             }
-            else if (entryA.source_index == -1)
+            if (entryA.source_index == -1)
             {
                 return 1;
             }
-            else if (entryB.source_index == -1)
+            if (entryB.source_index == -1)
             {
                 return -1;
             }
-            else
-            {
-                return entryA.source_index - entryB.source_index;
-            }
+            return entryA.source_index - entryB.source_index;
+
         case ScenarioSource::Real:
             return scenario_index_entry_CompareByCategory(entryA, entryB);
     }
@@ -154,10 +149,8 @@ protected:
         {
             return std::make_tuple(true, entry);
         }
-        else
-        {
-            return std::make_tuple(true, scenario_index_entry());
-        }
+
+        return std::make_tuple(true, scenario_index_entry());
     }
 
     void Serialise(DataSerialiser& ds, scenario_index_entry& item) const override
@@ -224,32 +217,28 @@ private:
                 }
                 return result;
             }
-            else
+
+            // RCT2 or RCTC scenario
+            auto stream = GetStreamFromRCT2Scenario(path);
+            auto chunkReader = SawyerChunkReader(stream.get());
+
+            rct_s6_header header = chunkReader.ReadChunkAs<rct_s6_header>();
+            if (header.type == S6_TYPE_SCENARIO)
             {
-                // RCT2 or RCTC scenario
-                auto stream = GetStreamFromRCT2Scenario(path);
-                auto chunkReader = SawyerChunkReader(stream.get());
-
-                rct_s6_header header = chunkReader.ReadChunkAs<rct_s6_header>();
-                if (header.type == S6_TYPE_SCENARIO)
+                rct_s6_info info = chunkReader.ReadChunkAs<rct_s6_info>();
+                // If the name or the details contain a colour code, they might be in UTF-8 already.
+                // This is caused by a bug that was in OpenRCT2 for 3 years.
+                if (!IsLikelyUTF8(info.name) && !IsLikelyUTF8(info.details))
                 {
-                    rct_s6_info info = chunkReader.ReadChunkAs<rct_s6_info>();
-                    // If the name or the details contain a colour code, they might be in UTF-8 already.
-                    // This is caused by a bug that was in OpenRCT2 for 3 years.
-                    if (!IsLikelyUTF8(info.name) && !IsLikelyUTF8(info.details))
-                    {
-                        rct2_to_utf8_self(info.name, sizeof(info.name));
-                        rct2_to_utf8_self(info.details, sizeof(info.details));
-                    }
+                    rct2_to_utf8_self(info.name, sizeof(info.name));
+                    rct2_to_utf8_self(info.details, sizeof(info.details));
+                }
 
-                    *entry = CreateNewScenarioEntry(path, timestamp, &info);
-                    return true;
-                }
-                else
-                {
-                    log_verbose("%s is not a scenario", path.c_str());
-                }
+                *entry = CreateNewScenarioEntry(path, timestamp, &info);
+                return true;
             }
+
+            log_verbose("%s is not a scenario", path.c_str());
         }
         catch (const std::exception&)
         {

--- a/src/openrct2/scripting/Duktape.hpp
+++ b/src/openrct2/scripting/Duktape.hpp
@@ -244,12 +244,10 @@ namespace OpenRCT2::Scripting
         {
             return DukValue::take_from_stack(ctx);
         }
-        else
-        {
-            // Pop error off stack
-            duk_pop(ctx);
-            return std::nullopt;
-        }
+
+        // Pop error off stack
+        duk_pop(ctx);
+        return std::nullopt;
     }
 
     std::string ProcessString(const DukValue& value);
@@ -345,14 +343,12 @@ namespace OpenRCT2::Scripting
         {
             return ToDuk(ctx, nullptr);
         }
-        else
-        {
-            DukObject dukCoords(ctx);
-            dukCoords.Set("x", value.x);
-            dukCoords.Set("y", value.y);
-            dukCoords.Set("z", value.z);
-            return dukCoords.Take();
-        }
+
+        DukObject dukCoords(ctx);
+        dukCoords.Set("x", value.x);
+        dukCoords.Set("y", value.y);
+        dukCoords.Set("z", value.z);
+        return dukCoords.Take();
     }
 
     template<> inline CoordsXYZ FromDuk(const DukValue& value)
@@ -377,15 +373,13 @@ namespace OpenRCT2::Scripting
         {
             return ToDuk(ctx, nullptr);
         }
-        else
-        {
-            DukObject dukCoords(ctx);
-            dukCoords.Set("x", value.x);
-            dukCoords.Set("y", value.y);
-            dukCoords.Set("z", value.z);
-            dukCoords.Set("direction", value.direction);
-            return dukCoords.Take();
-        }
+
+        DukObject dukCoords(ctx);
+        dukCoords.Set("x", value.x);
+        dukCoords.Set("y", value.y);
+        dukCoords.Set("z", value.z);
+        dukCoords.Set("direction", value.direction);
+        return dukCoords.Take();
     }
 
     template<> inline DukValue ToDuk(duk_context* ctx, const GForces& value)

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -58,13 +58,11 @@ namespace OpenRCT2::Scripting
                     case EntityType::Guest:
                         if (targetApiVersion <= API_VERSION_33_PEEP_DEPRECATION)
                             return "peep";
-                        else
-                            return "guest";
+                        return "guest";
                     case EntityType::Staff:
                         if (targetApiVersion <= API_VERSION_33_PEEP_DEPRECATION)
                             return "peep";
-                        else
-                            return "staff";
+                        return "staff";
                     case EntityType::SteamParticle:
                         return "steam_particle";
                     case EntityType::MoneyEffect:

--- a/src/openrct2/scripting/bindings/game/ScConfiguration.hpp
+++ b/src/openrct2/scripting/bindings/game/ScConfiguration.hpp
@@ -54,10 +54,8 @@ namespace OpenRCT2::Scripting
             {
                 return std::make_pair(input, std::string_view());
             }
-            else
-            {
-                return std::make_pair(input.substr(0, pos), input.substr(pos + 1));
-            }
+
+            return std::make_pair(input.substr(0, pos), input.substr(pos + 1));
         }
 
         std::pair<std::string_view, std::string_view> GetNamespaceAndKey(std::string_view input) const
@@ -179,7 +177,7 @@ namespace OpenRCT2::Scripting
                     duk_push_string(ctx, locale);
                     return DukValue::take_from_stack(ctx);
                 }
-                else if (key == "general.showFps")
+                if (key == "general.showFps")
                 {
                     duk_push_boolean(ctx, gConfigGeneral.show_fps);
                     return DukValue::take_from_stack(ctx);

--- a/src/openrct2/scripting/bindings/world/ScScenario.hpp
+++ b/src/openrct2/scripting/bindings/world/ScScenario.hpp
@@ -263,7 +263,7 @@ namespace OpenRCT2::Scripting
         {
             if (gScenarioCompletedCompanyValue == MONEY64_UNDEFINED)
                 return "inProgress";
-            else if (gScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
+            if (gScenarioCompletedCompanyValue == COMPANY_VALUE_ON_FAILED_OBJECTIVE)
                 return "failed";
             return "completed";
         }

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -425,7 +425,7 @@ static void LegacyScriptGetLine(OpenRCT2::IStream* stream, char* parts)
             parts[part * 128 + cindex] = 0;
             return;
         }
-        else if (c == '#')
+        if (c == '#')
         {
             parts[part * 128 + cindex] = 0;
             comment = 1;

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -185,7 +185,7 @@ namespace TitleSequenceManager
                 {
                     return true;
                 }
-                else if (a.PredefinedIndex > b.PredefinedIndex)
+                if (a.PredefinedIndex > b.PredefinedIndex)
                 {
                     return false;
                 }

--- a/src/openrct2/util/SawyerCoding.cpp
+++ b/src/openrct2/util/SawyerCoding.cpp
@@ -415,12 +415,12 @@ int32_t sawyercoding_detect_rct1_version(int32_t gameVersion)
 
     if (gameVersion >= 108000 && gameVersion < 110000)
         return (FILE_VERSION_RCT1 | fileType);
-    else if (gameVersion >= 110000 && gameVersion < 120000)
+    if (gameVersion >= 110000 && gameVersion < 120000)
         return (FILE_VERSION_RCT1_AA | fileType);
-    else if (gameVersion >= 120000 && gameVersion < 130000)
+    if (gameVersion >= 120000 && gameVersion < 130000)
         return (FILE_VERSION_RCT1_LL | fileType);
     // RCTOA Acres sets this, and possibly some other user-created scenarios as well
-    else if (gameVersion == 0)
+    if (gameVersion == 0)
         return (FILE_VERSION_RCT1_LL | fileType);
 
     return -1;

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -351,17 +351,15 @@ int32_t strlogicalcmp(const char* s1, const char* s2)
     {
         if (*s2 == '\0')
             return *s1 != '\0';
-        else if (*s1 == '\0')
+        if (*s1 == '\0')
             return -1;
-        else if (!(isdigit(*s1) && isdigit(*s2)))
+        if (!(isdigit(*s1) && isdigit(*s2)))
         {
             if (toupper(*s1) != toupper(*s2))
                 return toupper(*s1) - toupper(*s2);
-            else
-            {
-                ++s1;
-                ++s2;
-            }
+
+            ++s1;
+            ++s2;
         }
         else
         {
@@ -370,8 +368,9 @@ int32_t strlogicalcmp(const char* s1, const char* s2)
             unsigned long n2 = strtoul(s2, &lim2, 10);
             if (n1 > n2)
                 return 1;
-            else if (n1 < n2)
+            if (n1 < n2)
                 return -1;
+
             s1 = lim1;
             s2 = lim2;
         }
@@ -458,10 +457,8 @@ char* safe_strcat(char* destination, const char* source, size_t size)
         {
             break;
         }
-        else
-        {
-            destination++;
-        }
+
+        destination++;
     }
 
     bool terminated = false;

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -222,10 +222,8 @@ bool climate_is_raining()
     {
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool climate_is_snowing()
@@ -235,10 +233,8 @@ bool climate_is_snowing()
     {
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool WeatherIsDry(WeatherType weatherType)
@@ -274,10 +270,8 @@ static int8_t climate_step_weather_level(int8_t currentWeatherLevel, int8_t next
     {
         return currentWeatherLevel + 1;
     }
-    else
-    {
-        return currentWeatherLevel - 1;
-    }
+
+    return currentWeatherLevel - 1;
 }
 
 /**

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -267,8 +267,8 @@ ObjectEntryIndex EntranceElement::GetLegacyPathEntryIndex() const
 {
     if (HasLegacyPathEntry())
         return PathType;
-    else
-        return OBJECT_ENTRY_INDEX_NULL;
+
+    return OBJECT_ENTRY_INDEX_NULL;
 }
 
 const FootpathObject* EntranceElement::GetLegacyPathEntry() const
@@ -287,8 +287,8 @@ ObjectEntryIndex EntranceElement::GetSurfaceEntryIndex() const
 {
     if (HasLegacyPathEntry())
         return OBJECT_ENTRY_INDEX_NULL;
-    else
-        return PathType;
+
+    return PathType;
 }
 
 const FootpathSurfaceObject* EntranceElement::GetSurfaceEntry() const

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -586,19 +586,16 @@ static int32_t rct_neighbour_compare(const void* a, const void* b)
     uint8_t vb = (static_cast<const rct_neighbour*>(b))->order;
     if (va < vb)
         return 1;
-    else if (va > vb)
+    if (va > vb)
         return -1;
-    else
-    {
-        uint8_t da = (static_cast<const rct_neighbour*>(a))->direction;
-        uint8_t db = (static_cast<const rct_neighbour*>(b))->direction;
-        if (da < db)
-            return -1;
-        else if (da > db)
-            return 1;
-        else
-            return 0;
-    }
+
+    uint8_t da = (static_cast<const rct_neighbour*>(a))->direction;
+    uint8_t db = (static_cast<const rct_neighbour*>(b))->direction;
+    if (da < db)
+        return -1;
+    if (da > db)
+        return 1;
+    return 0;
 }
 
 static void neighbour_list_init(rct_neighbour_list* neighbourList)
@@ -860,7 +857,7 @@ static void loc_6A6D7E(
                         }
                         return;
                     }
-                    else if (tileElement->GetBaseZ() == initialTileElementPos.z - LAND_HEIGHT_STEP)
+                    if (tileElement->GetBaseZ() == initialTileElementPos.z - LAND_HEIGHT_STEP)
                     {
                         if (tileElement->AsPath()->IsSloped()
                             && tileElement->AsPath()->GetSlopeDirection() == direction_reverse(direction))
@@ -1653,8 +1650,8 @@ ObjectEntryIndex PathElement::GetLegacyPathEntryIndex() const
 {
     if (Flags2 & FOOTPATH_ELEMENT_FLAGS2_LEGACY_PATH_ENTRY)
         return SurfaceIndex;
-    else
-        return OBJECT_ENTRY_INDEX_NULL;
+
+    return OBJECT_ENTRY_INDEX_NULL;
 }
 
 const FootpathObject* PathElement::GetLegacyPathEntry() const
@@ -1717,8 +1714,8 @@ ObjectEntryIndex PathElement::GetSurfaceEntryIndex() const
 {
     if (Flags2 & FOOTPATH_ELEMENT_FLAGS2_LEGACY_PATH_ENTRY)
         return OBJECT_ENTRY_INDEX_NULL;
-    else
-        return SurfaceIndex;
+
+    return SurfaceIndex;
 }
 
 const FootpathSurfaceObject* PathElement::GetSurfaceEntry() const
@@ -1737,8 +1734,8 @@ ObjectEntryIndex PathElement::GetRailingsEntryIndex() const
 {
     if (Flags2 & FOOTPATH_ELEMENT_FLAGS2_LEGACY_PATH_ENTRY)
         return OBJECT_ENTRY_INDEX_NULL;
-    else
-        return RailingsIndex;
+
+    return RailingsIndex;
 }
 
 const FootpathRailingsObject* PathElement::GetRailingsEntry() const
@@ -2163,7 +2160,7 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
                     if (!tileElement->AsPath()->IsSloped())
                         // The footpath is flat, it can be connected to from any direction
                         return true;
-                    else if (tileElement->AsPath()->GetSlopeDirection() == direction_reverse(coords.direction))
+                    if (tileElement->AsPath()->GetSlopeDirection() == direction_reverse(coords.direction))
                         // The footpath is sloped and its lowest point matches the edge connection
                         return true;
                 }

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -539,10 +539,8 @@ inline constexpr Direction DirectionFromTo(const CoordsXY& from, const CoordsXY&
     {
         return y_diff < 0 ? 3 : 1;
     }
-    else
-    {
-        return x_diff < 0 ? 0 : 2;
-    }
+
+    return x_diff < 0 ? 0 : 2;
 }
 
 /*

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -207,25 +207,23 @@ static bool map_check_free_elements_and_reorganise(size_t numElementsOnTile, siz
     {
         return true;
     }
-    else
-    {
-        // if space issue is due to fragmentation then Reorg Tiles without increasing capacity
-        if (_tileElements.size() > totalElementsRequired + _tileElementsInUse)
-        {
-            ReorganiseTileElements();
-            // This check is not expected to fail
-            freeElements = _tileElements.capacity() - _tileElements.size();
-            if (freeElements >= totalElementsRequired)
-            {
-                return true;
-            }
-        }
 
-        // Capacity must increase to handle the space (Note capacity can go above MAX_TILE_ELEMENTS)
-        auto newCapacity = _tileElements.capacity() * 2;
-        ReorganiseTileElements(newCapacity);
-        return true;
+    // if space issue is due to fragmentation then Reorg Tiles without increasing capacity
+    if (_tileElements.size() > totalElementsRequired + _tileElementsInUse)
+    {
+        ReorganiseTileElements();
+        // This check is not expected to fail
+        freeElements = _tileElements.capacity() - _tileElements.size();
+        if (freeElements >= totalElementsRequired)
+        {
+            return true;
+        }
     }
+
+    // Capacity must increase to handle the space (Note capacity can go above MAX_TILE_ELEMENTS)
+    auto newCapacity = _tileElements.capacity() * 2;
+    ReorganiseTileElements(newCapacity);
+    return true;
 }
 
 static size_t CountElementsOnTile(const CoordsXY& loc);

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -337,10 +337,8 @@ static bool map_animation_invalidate_track_onridephoto(const CoordsXYZ& loc)
                 tileElement->AsTrack()->DecrementPhotoTimeout();
                 return false;
             }
-            else
-            {
-                return true;
-            }
+
+            return true;
         }
     } while (!(tileElement++)->IsLastForTile());
 

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -102,8 +102,8 @@ static int32_t get_height(int32_t x, int32_t y)
 {
     if (x >= 0 && y >= 0 && x < _heightSize && y < _heightSize)
         return _height[x + y * _heightSize];
-    else
-        return 0;
+
+    return 0;
 }
 
 static void set_height(int32_t x, int32_t y, int32_t height)

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -88,10 +88,8 @@ static PeepSpawn* get_random_peep_spawn()
     {
         return &gPeepSpawns[scenario_rand() % gPeepSpawns.size()];
     }
-    else
-    {
-        return nullptr;
-    }
+
+    return nullptr;
 }
 
 void park_set_open(bool open)

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -482,17 +482,17 @@ namespace OpenRCT2::TileInspector
         {
             return std::make_unique<GameActions::Result>(GameActions::Status::TooLow, STR_CANT_LOWER_ELEMENT_HERE, STR_TOO_LOW);
         }
-        else if (newBaseHeight > MAX_ELEMENT_HEIGHT)
+        if (newBaseHeight > MAX_ELEMENT_HEIGHT)
         {
             return std::make_unique<GameActions::Result>(
                 GameActions::Status::TooHigh, STR_CANT_RAISE_ELEMENT_HERE, STR_TOO_HIGH);
         }
-        else if (newClearanceHeight < 0)
+        if (newClearanceHeight < 0)
         {
             return std::make_unique<GameActions::Result>(
                 GameActions::Status::NoClearance, STR_CANT_LOWER_ELEMENT_HERE, STR_NO_CLEARANCE);
         }
-        else if (newClearanceHeight > MAX_ELEMENT_HEIGHT)
+        if (newClearanceHeight > MAX_ELEMENT_HEIGHT)
         {
             return std::make_unique<GameActions::Result>(
                 GameActions::Status::NoClearance, STR_CANT_RAISE_ELEMENT_HERE, STR_NO_CLEARANCE);


### PR DESCRIPTION
This PR removes unnecessary `else` bocks that are placed directly after an `if` block that ends with `return`, `continue` or `break`. This does not change the flow in any way, but cleans up the unnecessary lines and reduces the indention quite a lot in some cases.