### PR TITLE
Remove focus union and replace with typed focus

### DIFF
--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -274,7 +274,7 @@ rct_window* WindowCreate(
     w->min_height = height;
     w->max_height = height;
 
-    w->focus2 = Focus2();
+    w->focus2 = std::nullopt;
     w->page = 0;
     w->var_48C = 0;
     w->var_492 = 0;

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -274,11 +274,7 @@ rct_window* WindowCreate(
     w->min_height = height;
     w->max_height = height;
 
-    w->viewport_focus_coordinates.var_480 = 0;
-    w->viewport_focus_coordinates.x = 0;
-    w->viewport_focus_coordinates.y = 0;
-    w->viewport_focus_coordinates.z = 0;
-    w->viewport_focus_coordinates.rotation = 0;
+    w->focus2 = Focus2();
     w->page = 0;
     w->var_48C = 0;
     w->var_492 = 0;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -788,12 +788,10 @@ namespace OpenRCT2::Ui::Windows
                     auto wheight = viewportWidget->height() - 1;
                     if (viewport == nullptr)
                     {
-                        auto mapX = 0;
-                        auto mapY = 0;
-                        auto mapZ = 0;
-                        viewport_create(
-                            this, { left, top }, wwidth, wheight, 0, { mapX, mapY, mapZ }, VIEWPORT_FOCUS_TYPE_COORDINATE,
-                            SPRITE_INDEX_NULL);
+                        Focus2 focus;
+                        focus.type = Focus2::Type::Coordinate;
+                        focus.data = CoordsXYZ(0, 0, 0);
+                        viewport_create(this, { left, top }, wwidth, wheight, focus);
                         flags |= WF_NO_SCROLLING;
                         Invalidate();
                     }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -788,9 +788,7 @@ namespace OpenRCT2::Ui::Windows
                     auto wheight = viewportWidget->height() - 1;
                     if (viewport == nullptr)
                     {
-                        Focus2 focus;
-                        focus.type = Focus2::Type::Coordinate;
-                        focus.data = CoordsXYZ(0, 0, 0);
+                        const auto focus = Focus2(CoordsXYZ(0, 0, 0));
                         viewport_create(this, { left, top }, wwidth, wheight, focus);
                         flags |= WF_NO_SCROLLING;
                         Invalidate();

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -79,9 +79,12 @@ private:
     void CreateViewport()
     {
         rct_widget* viewportWidget = &window_banner_widgets[WIDX_VIEWPORT];
+        Focus2 focus;
+        focus.type = Focus2::Type::Coordinate;
+        focus.data = _bannerViewPos;
         viewport_create(
             this, windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-            (viewportWidget->width()) - 1, (viewportWidget->height()) - 1, 0, _bannerViewPos, 0, SPRITE_INDEX_NULL);
+            (viewportWidget->width()) - 1, (viewportWidget->height()) - 1, focus);
 
         if (viewport != nullptr)
             viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -79,9 +79,7 @@ private:
     void CreateViewport()
     {
         rct_widget* viewportWidget = &window_banner_widgets[WIDX_VIEWPORT];
-        Focus2 focus;
-        focus.type = Focus2::Type::Coordinate;
-        focus.data = _bannerViewPos;
+        const auto focus = Focus2(_bannerViewPos);
         viewport_create(
             this, windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
             (viewportWidget->width()) - 1, (viewportWidget->height()) - 1, focus);

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -40,9 +40,7 @@ rct_window* window_editor_main_open()
         &window_editor_main_events, WC_MAIN_WINDOW, WF_STICK_TO_BACK);
     window->widgets = window_editor_main_widgets;
 
-    Focus2 focus;
-    focus.type = Focus2::Type::Coordinate;
-    focus.data = CoordsXYZ(0x0FFF, 0x0FFF, 0);
+    const auto focus = Focus2(CoordsXYZ(0x0FFF, 0x0FFF, 0));
     viewport_create(window, window->windowPos, window->width, window->height, focus);
     window->viewport->flags |= 0x0400;
 

--- a/src/openrct2-ui/windows/EditorMain.cpp
+++ b/src/openrct2-ui/windows/EditorMain.cpp
@@ -40,7 +40,10 @@ rct_window* window_editor_main_open()
         &window_editor_main_events, WC_MAIN_WINDOW, WF_STICK_TO_BACK);
     window->widgets = window_editor_main_widgets;
 
-    viewport_create(window, window->windowPos, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
+    Focus2 focus;
+    focus.type = Focus2::Type::Coordinate;
+    focus.data = CoordsXYZ(0x0FFF, 0x0FFF, 0);
+    viewport_create(window, window->windowPos, window->width, window->height, focus);
     window->viewport->flags |= 0x0400;
 
     gCurrentRotation = 0;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -750,17 +750,7 @@ void window_guest_viewport_init(rct_window* w)
         int32_t width = view_widget->width() - 1;
         int32_t height = view_widget->height() - 1;
 
-        if (w->focus2.GetFocus() == Focus2::Type::Coordinate)
-        {
-            viewport_create(
-                w, screenPos, width, height, 0, std::get<Focus2::CoordinateFocus>(w->focus2.data),
-                VIEWPORT_FOCUS_TYPE_COORDINATE, SPRITE_INDEX_NULL);
-        }
-        else
-        {
-            viewport_create(
-                w, screenPos, width, height, 0, {}, VIEWPORT_FOCUS_TYPE_SPRITE, std::get<Focus2::EntityFocus>(w->focus2.data));
-        }
+        viewport_create(w, screenPos, width, height, w->focus2);
         if (w->viewport != nullptr && reCreateViewport)
         {
             w->viewport->flags = origViewportFlags;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -398,7 +398,6 @@ rct_window* window_guest_open(Peep* peep)
         window->enabled_widgets = window_guest_page_enabled_widgets[0];
         window->number = peep->sprite_index;
         window->page = 0;
-        window->viewport_focus_coordinates.y = 0;
         window->frame_no = 0;
         window->list_information_type = 0;
         window->picked_peep_frame = 0;
@@ -410,8 +409,6 @@ rct_window* window_guest_open(Peep* peep)
         window->max_height = 450;
         window->no_list_items = 0;
         window->selected_list_item = -1;
-
-        window->viewport_focus_coordinates.y = -1;
     }
 
     window->page = 0;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -732,7 +732,7 @@ void window_guest_viewport_init(rct_window* w)
     uint16_t origViewportFlags{};
     if (w->viewport != nullptr)
     {
-        if (w->focus2.HasFocus())
+        if (w->focus2.has_value())
             return;
 
         origViewportFlags = w->viewport->flags;
@@ -750,7 +750,7 @@ void window_guest_viewport_init(rct_window* w)
         int32_t width = view_widget->width() - 1;
         int32_t height = view_widget->height() - 1;
 
-        viewport_create(w, screenPos, width, height, w->focus2);
+        viewport_create(w, screenPos, width, height, w->focus2.value());
         if (w->viewport != nullptr && reCreateViewport)
         {
             w->viewport->flags = origViewportFlags;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -730,16 +730,12 @@ void window_guest_viewport_init(rct_window* w)
         return;
     }
 
-    auto focus = viewport_update_smart_guest_follow(w, peep);
+    viewport_update_smart_guest_follow(w, peep);
     bool reCreateViewport = false;
     uint16_t origViewportFlags{};
     if (w->viewport != nullptr)
     {
-        // Check all combos, for now skipping y and rot
-        if (focus.coordinate.x == w->viewport_focus_coordinates.x
-            && (focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK) == w->viewport_focus_coordinates.y
-            && focus.coordinate.z == w->viewport_focus_coordinates.z
-            && focus.coordinate.rotation == w->viewport_focus_coordinates.rotation)
+        if (w->focus2.HasFocus())
             return;
 
         origViewportFlags = w->viewport->flags;
@@ -750,11 +746,6 @@ void window_guest_viewport_init(rct_window* w)
 
     window_event_invalidate_call(w);
 
-    w->viewport_focus_coordinates.x = focus.coordinate.x;
-    w->viewport_focus_coordinates.y = focus.coordinate.y;
-    w->viewport_focus_coordinates.z = focus.coordinate.z;
-    w->viewport_focus_coordinates.rotation = focus.coordinate.rotation;
-
     if (peep->State != PeepState::Picked && w->viewport == nullptr)
     {
         auto view_widget = &w->widgets[WIDX_VIEWPORT];
@@ -762,10 +753,17 @@ void window_guest_viewport_init(rct_window* w)
         int32_t width = view_widget->width() - 1;
         int32_t height = view_widget->height() - 1;
 
-        viewport_create(
-            w, screenPos, width, height, 0,
-            { focus.coordinate.x, focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK, focus.coordinate.z },
-            focus.sprite.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite.sprite_id);
+        if (w->focus2.GetFocus() == Focus2::Type::Coordinate)
+        {
+            viewport_create(
+                w, screenPos, width, height, 0, std::get<Focus2::CoordinateFocus>(w->focus2.data),
+                VIEWPORT_FOCUS_TYPE_COORDINATE, SPRITE_INDEX_NULL);
+        }
+        else
+        {
+            viewport_create(
+                w, screenPos, width, height, 0, {}, VIEWPORT_FOCUS_TYPE_SPRITE, std::get<Focus2::EntityFocus>(w->focus2.data));
+        }
         if (w->viewport != nullptr && reCreateViewport)
         {
             w->viewport->flags = origViewportFlags;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -41,9 +41,7 @@ rct_window* window_main_open()
         WF_STICK_TO_BACK);
     window->widgets = window_main_widgets;
 
-    Focus2 focus;
-    focus.type = Focus2::Type::Coordinate;
-    focus.data = CoordsXYZ(0x0FFF, 0x0FFF, 0);
+    const auto focus = Focus2(CoordsXYZ(0x0FFF, 0x0FFF, 0));
     viewport_create(window, window->windowPos, window->width, window->height, focus);
     window->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
     gCurrentRotation = 0;

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -41,7 +41,10 @@ rct_window* window_main_open()
         WF_STICK_TO_BACK);
     window->widgets = window_main_widgets;
 
-    viewport_create(window, window->windowPos, window->width, window->height, 0, { 0x0FFF, 0x0FFF, 0 }, 0x1, SPRITE_INDEX_NULL);
+    Focus2 focus;
+    focus.type = Focus2::Type::Coordinate;
+    focus.data = CoordsXYZ(0x0FFF, 0x0FFF, 0);
+    viewport_create(window, window->windowPos, window->width, window->height, focus);
     window->viewport->flags |= VIEWPORT_FLAG_SOUND_ON;
     gCurrentRotation = 0;
     gShowGridLinesRefCount = 0;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -772,8 +772,7 @@ static void window_park_init_viewport(rct_window* w)
             rct_widget* viewportWidget = &window_park_entrance_widgets[WIDX_VIEWPORT];
             viewport_create(
                 w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-                viewportWidget->width() - 1, viewportWidget->height() - 1, 0, std::get<Focus2::CoordinateFocus>(focus.data),
-                VIEWPORT_FOCUS_TYPE_COORDINATE, SPRITE_INDEX_NULL);
+                viewportWidget->width() - 1, viewportWidget->height() - 1, focus);
             w->flags |= (1 << 2);
             w->Invalidate();
         }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -415,7 +415,6 @@ static rct_window* window_park_open()
     w->enabled_widgets = window_park_page_enabled_widgets[WINDOW_PARK_PAGE_ENTRANCE];
     w->number = 0;
     w->page = WINDOW_PARK_PAGE_ENTRANCE;
-    w->viewport_focus_coordinates.y = 0;
     w->frame_no = 0;
     w->list_information_type = std::numeric_limits<uint16_t>::max();
     w->numberOfStaff = -1;
@@ -459,8 +458,6 @@ rct_window* window_park_entrance_open()
     if (window == nullptr)
     {
         window = window_park_open();
-        window->viewport_focus_coordinates.y = -1;
-        window->viewport_focus_coordinates.x = -1;
     }
 
     window->page = WINDOW_PARK_PAGE_ENTRANCE;
@@ -738,22 +735,18 @@ static void window_park_entrance_paint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void window_park_init_viewport(rct_window* w)
 {
-    int32_t x, y, z, r, xy, zr, viewportFlags;
-    x = y = z = r = xy = zr = 0;
+    int32_t viewportFlags;
 
     if (w->page != WINDOW_PARK_PAGE_ENTRANCE)
         return;
 
+    Focus2 focus;
     if (!gParkEntrances.empty())
     {
         const auto& entrance = gParkEntrances[0];
-        x = entrance.x + 16;
-        y = entrance.y + 16;
-        z = entrance.z + 32;
-        r = get_current_rotation();
-
-        xy = IMAGE_TYPE_TRANSPARENT | (y << 16) | x;
-        zr = (z << 16) | (r << 8);
+        focus.type = Focus2::Type::Coordinate;
+        focus.data = CoordsXYZ{ entrance.x + 16, entrance.y + 16, entrance.z + 32 };
+        focus.rotation = get_current_rotation();
     }
 
     if (w->viewport == nullptr)
@@ -769,13 +762,9 @@ static void window_park_init_viewport(rct_window* w)
     // Call invalidate event
     window_event_invalidate_call(w);
 
-    w->viewport_focus_coordinates.x = x;
-    w->viewport_focus_coordinates.y = y;
-    w->viewport_focus_sprite.type |= VIEWPORT_FOCUS_TYPE_COORDINATE;
-    w->viewport_focus_coordinates.z = z;
-    w->viewport_focus_coordinates.rotation = r;
+    w->focus2 = focus;
 
-    if (zr != 0xFFFF)
+    if (focus.HasFocus())
     {
         // Create viewport
         if (w->viewport == nullptr)
@@ -783,8 +772,8 @@ static void window_park_init_viewport(rct_window* w)
             rct_widget* viewportWidget = &window_park_entrance_widgets[WIDX_VIEWPORT];
             viewport_create(
                 w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-                viewportWidget->width() - 1, viewportWidget->height() - 1, 0, { x, y, z },
-                w->viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_MASK, SPRITE_INDEX_NULL);
+                viewportWidget->width() - 1, viewportWidget->height() - 1, 0, std::get<Focus2::CoordinateFocus>(focus.data),
+                VIEWPORT_FOCUS_TYPE_COORDINATE, SPRITE_INDEX_NULL);
             w->flags |= (1 << 2);
             w->Invalidate();
         }
@@ -811,8 +800,6 @@ rct_window* window_park_rating_open()
     if (window == nullptr)
     {
         window = window_park_open();
-        window->viewport_focus_coordinates.x = -1;
-        window->viewport_focus_coordinates.y = -1;
     }
 
     if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE))
@@ -947,8 +934,6 @@ rct_window* window_park_guests_open()
     if (window == nullptr)
     {
         window = window_park_open();
-        window->viewport_focus_coordinates.x = -1;
-        window->viewport_focus_coordinates.y = -1;
     }
 
     if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE))
@@ -1356,8 +1341,6 @@ rct_window* window_park_objective_open()
     if (window == nullptr)
     {
         window = window_park_open();
-        window->viewport_focus_coordinates.x = -1;
-        window->viewport_focus_coordinates.y = -1;
     }
 
     if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE))
@@ -1549,8 +1532,6 @@ rct_window* window_park_awards_open()
     if (window == nullptr)
     {
         window = window_park_open();
-        window->viewport_focus_coordinates.x = -1;
-        window->viewport_focus_coordinates.y = -1;
     }
 
     if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE))

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -740,13 +740,11 @@ static void window_park_init_viewport(rct_window* w)
     if (w->page != WINDOW_PARK_PAGE_ENTRANCE)
         return;
 
-    Focus2 focus;
+    std::optional<Focus2> focus = std::nullopt;
     if (!gParkEntrances.empty())
     {
         const auto& entrance = gParkEntrances[0];
-        focus.type = Focus2::Type::Coordinate;
-        focus.data = CoordsXYZ{ entrance.x + 16, entrance.y + 16, entrance.z + 32 };
-        focus.rotation = get_current_rotation();
+        focus = Focus2(CoordsXYZ{ entrance.x + 16, entrance.y + 16, entrance.z + 32 });
     }
 
     if (w->viewport == nullptr)
@@ -764,7 +762,7 @@ static void window_park_init_viewport(rct_window* w)
 
     w->focus2 = focus;
 
-    if (focus.HasFocus())
+    if (focus.has_value())
     {
         // Create viewport
         if (w->viewport == nullptr)
@@ -772,7 +770,7 @@ static void window_park_init_viewport(rct_window* w)
             rct_widget* viewportWidget = &window_park_entrance_widgets[WIDX_VIEWPORT];
             viewport_create(
                 w, w->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-                viewportWidget->width() - 1, viewportWidget->height() - 1, focus);
+                viewportWidget->width() - 1, viewportWidget->height() - 1, focus.value());
             w->flags |= (1 << 2);
             w->Invalidate();
         }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -547,9 +547,7 @@ static void window_player_set_page(rct_window* w, int32_t page)
     {
         if (w->viewport == nullptr)
         {
-            Focus2 focus;
-            focus.type = Focus2::Type::Coordinate;
-            focus.data = TileCoordsXYZ(128, 128, 0).ToCoordsXYZ();
+            const auto focus = Focus2(TileCoordsXYZ(128, 128, 0).ToCoordsXYZ());
             viewport_create(w, w->windowPos, w->width, w->height, focus);
             w->flags |= WF_NO_SCROLLING;
             window_event_invalidate_call(w);

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -155,7 +155,6 @@ rct_window* window_player_open(uint8_t id)
         window = WindowCreateAutoPos(240, 170, &window_player_overview_events, WC_PLAYER, WF_RESIZABLE);
         window->number = id;
         window->page = 0;
-        window->viewport_focus_coordinates.y = 0;
         window->frame_no = 0;
         window->list_information_type = 0;
         window->picked_peep_frame = 0;
@@ -166,8 +165,6 @@ rct_window* window_player_open(uint8_t id)
         window->max_height = 450;
         window->no_list_items = 0;
         window->selected_list_item = -1;
-
-        window->viewport_focus_coordinates.y = -1;
     }
 
     window->page = 0;

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -163,6 +163,7 @@ rct_window* window_player_open(uint8_t id)
         window->min_height = 134;
         window->max_width = 500;
         window->max_height = 450;
+
         window->no_list_items = 0;
         window->selected_list_item = -1;
     }
@@ -546,8 +547,10 @@ static void window_player_set_page(rct_window* w, int32_t page)
     {
         if (w->viewport == nullptr)
         {
-            viewport_create(
-                w, w->windowPos, w->width, w->height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
+            Focus2 focus;
+            focus.type = Focus2::Type::Coordinate;
+            focus.data = TileCoordsXYZ(128, 128, 0).ToCoordsXYZ();
+            viewport_create(w, w->windowPos, w->width, w->height, focus);
             w->flags |= WF_NO_SCROLLING;
             window_event_invalidate_call(w);
             window_player_update_viewport(w, false);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1593,8 +1593,7 @@ static void window_ride_init_viewport(rct_window* w)
 
     int32_t viewSelectionIndex = w->ride.view - 1;
 
-    Focus2 focus;
-    focus.rotation = get_current_rotation();
+    std::optional<Focus2> focus;
 
     if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->num_vehicles && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {
@@ -1614,8 +1613,7 @@ static void window_ride_init_viewport(rct_window* w)
         }
         if (vehId != SPRITE_INDEX_NULL)
         {
-            focus.type = Focus2::Type::Entity;
-            focus.data = vehId;
+            focus = Focus2(vehId);
         }
     }
     else if (viewSelectionIndex >= ride->num_vehicles && viewSelectionIndex < (ride->num_vehicles + ride->num_stations))
@@ -1623,9 +1621,8 @@ static void window_ride_init_viewport(rct_window* w)
         auto stationIndex = GetStationIndexFromViewSelection(*w);
         if (stationIndex)
         {
-            auto location = ride->stations[*stationIndex].GetStart();
-            focus.type = Focus2::Type::Coordinate;
-            focus.data = location;
+            const auto location = ride->stations[*stationIndex].GetStart();
+            focus = Focus2(location);
         }
     }
     else
@@ -1638,9 +1635,7 @@ static void window_ride_init_viewport(rct_window* w)
         {
             const auto& view = ride_overall_views[w->number];
             CoordsXYZ loc = { view.x, view.y, view.z };
-            focus.type = Focus2::Type::Coordinate;
-            focus.data = loc;
-            focus.zoom = view.zoom;
+            focus = Focus2(loc, view.zoom);
         }
     }
 
@@ -1672,7 +1667,7 @@ static void window_ride_init_viewport(rct_window* w)
         int32_t width = view_widget->width() - 1;
         int32_t height = view_widget->height() - 1;
 
-        viewport_create(w, screenPos, width, height, w->focus2);
+        viewport_create(w, screenPos, width, height, w->focus2.value());
 
         w->flags |= WF_NO_SCROLLING;
         w->Invalidate();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1591,42 +1591,31 @@ static void window_ride_init_viewport(rct_window* w)
     if (ride == nullptr)
         return;
 
-    int32_t viewSelectionIndex = w->viewport_focus_coordinates.var_480 - 1;
+    int32_t viewSelectionIndex = w->ride.view - 1;
 
-    union
-    {
-        sprite_focus sprite;
-        coordinate_focus coordinate;
-    } focus;
-
-    focus.coordinate.x = 0;
-    focus.coordinate.y = 0;
-    focus.coordinate.z = 0;
-    focus.sprite.sprite_id = SPRITE_INDEX_NULL;
-    focus.coordinate.zoom = 0;
-    focus.coordinate.rotation = get_current_rotation();
-    focus.coordinate.width = 0;
-    focus.coordinate.height = 0;
+    Focus2 focus;
+    focus.rotation = get_current_rotation();
 
     if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->num_vehicles && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {
-        focus.sprite.sprite_id = ride->vehicles[viewSelectionIndex];
+        uint16_t vehId = ride->vehicles[viewSelectionIndex];
         rct_ride_entry* ride_entry = ride->GetRideEntry();
         if (ride_entry && ride_entry->tab_vehicle != 0)
         {
-            Vehicle* vehicle = GetEntity<Vehicle>(focus.sprite.sprite_id);
+            Vehicle* vehicle = GetEntity<Vehicle>(vehId);
             if (vehicle == nullptr)
             {
-                focus.sprite.sprite_id = SPRITE_INDEX_NULL;
+                vehId = SPRITE_INDEX_NULL;
             }
             else if (vehicle->next_vehicle_on_train != SPRITE_INDEX_NULL)
             {
-                focus.sprite.sprite_id = vehicle->next_vehicle_on_train;
+                vehId = vehicle->next_vehicle_on_train;
             }
         }
-        if (focus.sprite.sprite_id != SPRITE_INDEX_NULL)
+        if (vehId != SPRITE_INDEX_NULL)
         {
-            focus.sprite.type |= VIEWPORT_FOCUS_TYPE_SPRITE;
+            focus.type = Focus2::Type::Entity;
+            focus.data = vehId;
         }
     }
     else if (viewSelectionIndex >= ride->num_vehicles && viewSelectionIndex < (ride->num_vehicles + ride->num_stations))
@@ -1635,40 +1624,30 @@ static void window_ride_init_viewport(rct_window* w)
         if (stationIndex)
         {
             auto location = ride->stations[*stationIndex].GetStart();
-            focus.coordinate.x = location.x;
-            focus.coordinate.y = location.y;
-            focus.coordinate.z = location.z;
-            focus.sprite.type |= VIEWPORT_FOCUS_TYPE_COORDINATE;
+            focus.type = Focus2::Type::Coordinate;
+            focus.data = location;
         }
     }
     else
     {
         if (viewSelectionIndex > 0)
         {
-            w->viewport_focus_coordinates.var_480 = 0;
+            w->ride.view = 0;
         }
         if (w->number < ride_overall_views.size())
         {
             const auto& view = ride_overall_views[w->number];
-            focus.coordinate.x = view.x;
-            focus.coordinate.y = view.y;
-            focus.coordinate.z = view.z;
-            focus.coordinate.zoom = view.zoom;
-            focus.sprite.type |= VIEWPORT_FOCUS_TYPE_COORDINATE;
+            CoordsXYZ loc = { view.x, view.y, view.z };
+            focus.type = Focus2::Type::Coordinate;
+            focus.data = loc;
+            focus.zoom = view.zoom;
         }
     }
-    focus.coordinate.var_480 = w->viewport_focus_coordinates.var_480;
 
     uint16_t viewport_flags = 0;
-
     if (w->viewport != nullptr)
     {
-        if (focus.coordinate.x == w->viewport_focus_coordinates.x
-            && (focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK) == w->viewport_focus_coordinates.y
-            && focus.coordinate.z == w->viewport_focus_coordinates.z
-            && focus.coordinate.rotation == w->viewport_focus_coordinates.rotation
-            && focus.coordinate.zoom == w->viewport_focus_coordinates.zoom && focus.coordinate.width == w->width
-            && focus.coordinate.height == w->height)
+        if (focus == w->focus2)
         {
             return;
         }
@@ -1682,13 +1661,7 @@ static void window_ride_init_viewport(rct_window* w)
 
     window_event_invalidate_call(w);
 
-    w->viewport_focus_coordinates.x = focus.coordinate.x;
-    w->viewport_focus_coordinates.y = focus.coordinate.y;
-    w->viewport_focus_coordinates.z = focus.coordinate.z;
-    w->viewport_focus_coordinates.rotation = focus.coordinate.rotation;
-    w->viewport_focus_coordinates.zoom = focus.coordinate.zoom;
-    w->viewport_focus_coordinates.width = w->width;
-    w->viewport_focus_coordinates.height = w->height;
+    w->focus2 = focus;
 
     // rct2: 0x006aec9c only used here so brought it into the function
     if (!w->viewport && !ride->overall_view.IsNull())
@@ -1698,10 +1671,17 @@ static void window_ride_init_viewport(rct_window* w)
         auto screenPos = w->windowPos + ScreenCoordsXY{ view_widget->left + 1, view_widget->top + 1 };
         int32_t width = view_widget->width() - 1;
         int32_t height = view_widget->height() - 1;
-        viewport_create(
-            w, screenPos, width, height, focus.coordinate.zoom,
-            { focus.coordinate.x, focus.coordinate.y & VIEWPORT_FOCUS_Y_MASK, focus.coordinate.z },
-            focus.sprite.type & VIEWPORT_FOCUS_TYPE_MASK, focus.sprite.sprite_id);
+        if (w->focus2.GetFocus() == Focus2::Type::Coordinate)
+        {
+            viewport_create(
+                w, screenPos, width, height, 0, std::get<Focus2::CoordinateFocus>(w->focus2.data),
+                VIEWPORT_FOCUS_TYPE_COORDINATE, SPRITE_INDEX_NULL);
+        }
+        else
+        {
+            viewport_create(
+                w, screenPos, width, height, 0, {}, VIEWPORT_FOCUS_TYPE_SPRITE, std::get<Focus2::EntityFocus>(w->focus2.data));
+        }
 
         w->flags |= WF_NO_SCROLLING;
         w->Invalidate();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1671,17 +1671,8 @@ static void window_ride_init_viewport(rct_window* w)
         auto screenPos = w->windowPos + ScreenCoordsXY{ view_widget->left + 1, view_widget->top + 1 };
         int32_t width = view_widget->width() - 1;
         int32_t height = view_widget->height() - 1;
-        if (w->focus2.GetFocus() == Focus2::Type::Coordinate)
-        {
-            viewport_create(
-                w, screenPos, width, height, 0, std::get<Focus2::CoordinateFocus>(w->focus2.data),
-                VIEWPORT_FOCUS_TYPE_COORDINATE, SPRITE_INDEX_NULL);
-        }
-        else
-        {
-            viewport_create(
-                w, screenPos, width, height, 0, {}, VIEWPORT_FOCUS_TYPE_SPRITE, std::get<Focus2::EntityFocus>(w->focus2.data));
-        }
+
+        viewport_create(w, screenPos, width, height, w->focus2);
 
         w->flags |= WF_NO_SCROLLING;
         w->Invalidate();

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -196,7 +196,6 @@ rct_window* window_scenarioselect_open(std::function<void(std::string_view)> cal
     initialise_list_items(window);
 
     WindowInitScrollWidgets(window);
-    window->viewport_focus_coordinates.var_480 = -1;
     window->highlighted_scenario = nullptr;
 
     return window;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -127,10 +127,12 @@ public:
 
         // Create viewport
         rct_widget& viewportWidget = window_sign_widgets[WIDX_VIEWPORT];
-
+        Focus2 focus;
+        focus.type = Focus2::Type::Coordinate;
+        focus.data = CoordsXYZ{ signViewPosition, viewZ };
         viewport_create(
             this, windowPos + ScreenCoordsXY{ viewportWidget.left + 1, viewportWidget.top + 1 }, viewportWidget.width() - 1,
-            viewportWidget.height() - 1, 0, { signViewPosition, viewZ }, 0, SPRITE_INDEX_NULL);
+            viewportWidget.height() - 1, focus);
 
         viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
         Invalidate();
@@ -300,9 +302,12 @@ public:
 
         // Create viewport
         rct_widget* viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
+        Focus2 focus;
+        focus.type = Focus2::Type::Coordinate;
+        focus.data = signViewPos;
         viewport_create(
             this, windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 }, viewportWidget->width() - 1,
-            viewportWidget->height() - 1, 0, signViewPos, 0, SPRITE_INDEX_NULL);
+            viewportWidget->height() - 1, focus);
         if (viewport != nullptr)
             viewport->flags = gConfigGeneral.always_show_gridlines ? VIEWPORT_FLAG_GRIDLINES : 0;
         Invalidate();

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -127,9 +127,7 @@ public:
 
         // Create viewport
         rct_widget& viewportWidget = window_sign_widgets[WIDX_VIEWPORT];
-        Focus2 focus;
-        focus.type = Focus2::Type::Coordinate;
-        focus.data = CoordsXYZ{ signViewPosition, viewZ };
+        const auto focus = Focus2(CoordsXYZ{ signViewPosition, viewZ });
         viewport_create(
             this, windowPos + ScreenCoordsXY{ viewportWidget.left + 1, viewportWidget.top + 1 }, viewportWidget.width() - 1,
             viewportWidget.height() - 1, focus);
@@ -302,9 +300,7 @@ public:
 
         // Create viewport
         rct_widget* viewportWidget = &window_sign_widgets[WIDX_VIEWPORT];
-        Focus2 focus;
-        focus.type = Focus2::Type::Coordinate;
-        focus.data = signViewPos;
+        const auto focus = Focus2(CoordsXYZ{ signViewPos });
         viewport_create(
             this, windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 }, viewportWidget->width() - 1,
             viewportWidget->height() - 1, focus);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1396,9 +1396,7 @@ void window_staff_viewport_init(rct_window* w)
             int32_t width = view_widget->width() - 1;
             int32_t height = view_widget->height() - 1;
 
-            viewport_create(
-                w, screenPos, width, height, 0, { 0, 0, 0 }, VIEWPORT_FOCUS_TYPE_SPRITE,
-                std::get<Focus2::EntityFocus>(focus.data));
+            viewport_create(w, screenPos, width, height, focus);
             w->flags |= WF_NO_SCROLLING;
             w->Invalidate();
         }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1346,9 +1346,7 @@ void window_staff_viewport_init(rct_window* w)
     if (w->page != WINDOW_STAFF_OVERVIEW)
         return;
 
-    Focus2 focus = {};
-    focus.type = Focus2::Type::Entity;
-    focus.data = w->number;
+    std::optional<Focus2> focus;
 
     const auto peep = GetStaff(w);
     if (peep == nullptr)
@@ -1356,13 +1354,9 @@ void window_staff_viewport_init(rct_window* w)
         return;
     }
 
-    if (peep->State == PeepState::Picked)
+    if (peep->State != PeepState::Picked)
     {
-        focus.type = Focus2::Type::None;
-    }
-    else
-    {
-        focus.rotation = get_current_rotation();
+        focus = Focus2(peep->sprite_index);
     }
 
     uint16_t viewport_flags;
@@ -1396,7 +1390,7 @@ void window_staff_viewport_init(rct_window* w)
             int32_t width = view_widget->width() - 1;
             int32_t height = view_widget->height() - 1;
 
-            viewport_create(w, screenPos, width, height, focus);
+            viewport_create(w, screenPos, width, height, focus.value());
             w->flags |= WF_NO_SCROLLING;
             w->Invalidate();
         }

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -227,9 +227,7 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
     WindowInitScrollWidgets(window);
 
     rct_widget* const viewportWidget = &window_title_command_editor_widgets[WIDX_VIEWPORT];
-    Focus2 focus;
-    focus.type = Focus2::Type::Coordinate;
-    focus.data = CoordsXYZ{ 0, 0, 0 };
+    const auto focus = Focus2(CoordsXYZ{ 0, 0, 0 });
     viewport_create(
         window, window->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
         viewportWidget->width() - 1, viewportWidget->height() - 1, focus);
@@ -479,7 +477,8 @@ static void window_title_command_editor_dropdown(rct_window* w, rct_widgetindex 
                     _command.SpriteIndex = SPRITE_INDEX_NULL;
                     _command.SpriteName[0] = '\0';
                     window_unfollow_sprite(w);
-                    w->viewport->flags &= ~VIEWPORT_FOCUS_TYPE_SPRITE;
+                    // This is incorrect
+                    w->viewport->flags &= ~VIEWPORT_FLAG_GRIDLINES;
                     break;
                 case TitleScript::Speed:
                     _command.Speed = 1;

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -227,9 +227,12 @@ void window_title_command_editor_open(TitleSequence* sequence, int32_t index, bo
     WindowInitScrollWidgets(window);
 
     rct_widget* const viewportWidget = &window_title_command_editor_widgets[WIDX_VIEWPORT];
+    Focus2 focus;
+    focus.type = Focus2::Type::Coordinate;
+    focus.data = CoordsXYZ{ 0, 0, 0 };
     viewport_create(
         window, window->windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-        viewportWidget->width() - 1, viewportWidget->height() - 1, 0, { 0, 0, 0 }, 0, SPRITE_INDEX_NULL);
+        viewportWidget->width() - 1, viewportWidget->height() - 1, focus);
 
     _window_title_command_editor_index = index;
     _window_title_command_editor_insert = insert;

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -76,9 +76,7 @@ public:
         enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_ZOOM_IN) | (1ULL << WIDX_ZOOM_OUT) | (1ULL << WIDX_LOCATE);
 
         // Create viewport
-        Focus2 focus;
-        focus.type = Focus2::Type::Coordinate;
-        focus.data = TileCoordsXYZ(128, 128, 0).ToCoordsXYZ();
+        const auto focus = Focus2(TileCoordsXYZ(128, 128, 0).ToCoordsXYZ());
         viewport_create(this, windowPos, width, height, focus);
         if (viewport == nullptr)
         {

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -76,7 +76,10 @@ public:
         enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_ZOOM_IN) | (1ULL << WIDX_ZOOM_OUT) | (1ULL << WIDX_LOCATE);
 
         // Create viewport
-        viewport_create(this, windowPos, width, height, 0, TileCoordsXYZ(128, 128, 0).ToCoordsXYZ(), 1, SPRITE_INDEX_NULL);
+        Focus2 focus;
+        focus.type = Focus2::Type::Coordinate;
+        focus.data = TileCoordsXYZ(128, 128, 0).ToCoordsXYZ();
+        viewport_create(this, windowPos, width, height, focus);
         if (viewport == nullptr)
         {
             Close();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -119,27 +119,26 @@ std::optional<ScreenCoordsXY> centre_2d_coordinates(const CoordsXYZ& loc, rct_vi
 
 CoordsXYZ Focus2::GetPos() const
 {
-    CoordsXYZ result;
-    std::visit(
-        [&result](auto&& arg) {
+    return std::visit(
+        [](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, Focus2::CoordinateFocus>)
-                result = arg;
+                return arg;
             else if constexpr (std::is_same_v<T, Focus2::EntityFocus>)
             {
                 auto* centreEntity = GetEntity(arg);
                 if (centreEntity != nullptr)
                 {
-                    result = { centreEntity->x, centreEntity->y, centreEntity->z };
+                    return CoordsXYZ{ centreEntity->x, centreEntity->y, centreEntity->z };
                 }
                 else
                 {
                     log_error("Invalid entity for focus.");
+                    return CoordsXYZ{};
                 }
             }
         },
         data);
-    return result;
 }
 
 /**

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -186,13 +186,13 @@ void viewport_create(rct_window* w, const ScreenCoordsXY& screenCoords, int32_t 
     w->viewport = viewport;
 
     CoordsXYZ centrePos = focus.GetPos();
-    std::visit(
-        [&w](auto&& arg) {
+    w->viewport_target_sprite = std::visit(
+        [](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, Focus2::CoordinateFocus>)
-                w->viewport_target_sprite = SPRITE_INDEX_NULL;
+                return SPRITE_INDEX_NULL;
             else if constexpr (std::is_same_v<T, Focus2::EntityFocus>)
-                w->viewport_target_sprite = arg;
+                return arg;
         },
         focus.data);
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -692,24 +692,26 @@ void viewport_update_smart_sprite_follow(rct_window* window)
             break;
 
         default: // All other types don't need any "smart" following; steam particle, duck, money effect, etc.
-            window->viewport_focus_sprite.sprite_id = window->viewport_smart_follow_sprite;
+            window->focus2.type = Focus2::Type::Entity;
+            window->focus2.data = window->viewport_smart_follow_sprite;
             window->viewport_target_sprite = window->viewport_smart_follow_sprite;
             break;
     }
 }
 
-viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Guest* peep)
+void viewport_update_smart_guest_follow(rct_window* window, const Guest* peep)
 {
-    viewport_focus focus{};
-    focus.type = VIEWPORT_FOCUS_TYPE_SPRITE;
-    focus.sprite.sprite_id = peep->sprite_index;
+    Focus2 focus{};
+    focus.type = Focus2::Type::Entity;
+    focus.data = peep->sprite_index;
+    window->viewport_target_sprite = peep->sprite_index;
 
     if (peep->State == PeepState::Picked)
     {
-        focus.sprite.sprite_id = SPRITE_INDEX_NULL;
         window->viewport_smart_follow_sprite = SPRITE_INDEX_NULL;
         window->viewport_target_sprite = SPRITE_INDEX_NULL;
-        return focus;
+        window->focus2 = Focus2(); // No focus
+        return;
     }
 
     bool overallFocus = true;
@@ -725,8 +727,9 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Gues
                 const auto car = train->GetCar(peep->CurrentCar);
                 if (car != nullptr)
                 {
-                    focus.sprite.sprite_id = car->sprite_index;
+                    focus.data = car->sprite_index;
                     overallFocus = false;
+                    window->viewport_target_sprite = car->sprite_index;
                 }
             }
         }
@@ -738,30 +741,25 @@ viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Gues
         if (ride != nullptr)
         {
             auto xy = ride->overall_view.ToTileCentre();
-            focus.type = VIEWPORT_FOCUS_TYPE_COORDINATE;
-            focus.coordinate.x = xy.x;
-            focus.coordinate.y = xy.y;
-            focus.coordinate.z = tile_element_height(xy) + (4 * COORDS_Z_STEP);
-            focus.sprite.type |= VIEWPORT_FOCUS_TYPE_COORDINATE;
+            focus.type = Focus2::Type::Coordinate;
+            CoordsXYZ coordFocus;
+            coordFocus.x = xy.x;
+            coordFocus.y = xy.y;
+            coordFocus.z = tile_element_height(xy) + (4 * COORDS_Z_STEP);
+            focus.data = coordFocus;
+            window->viewport_target_sprite = SPRITE_INDEX_NULL;
         }
     }
-    else
-    {
-        focus.sprite.type |= VIEWPORT_FOCUS_TYPE_SPRITE | VIEWPORT_FOCUS_TYPE_COORDINATE;
-        focus.sprite.pad_486 &= 0xFFFF;
-    }
-    focus.coordinate.rotation = get_current_rotation();
+    focus.rotation = get_current_rotation();
 
-    window->viewport_focus_sprite = focus.sprite;
-    window->viewport_target_sprite = window->viewport_focus_sprite.sprite_id;
-    return focus;
+    window->focus2 = focus;
 }
 
 void viewport_update_smart_staff_follow(rct_window* window, const Staff* peep)
 {
-    sprite_focus focus = {};
-
-    focus.sprite_id = window->viewport_smart_follow_sprite;
+    Focus2 focus{};
+    focus.type = Focus2::Type::Entity;
+    focus.data = window->viewport_smart_follow_sprite;
 
     if (peep->State == PeepState::Picked)
     {
@@ -770,19 +768,18 @@ void viewport_update_smart_staff_follow(rct_window* window, const Staff* peep)
         return;
     }
 
-    focus.type |= VIEWPORT_FOCUS_TYPE_SPRITE | VIEWPORT_FOCUS_TYPE_COORDINATE;
-
-    window->viewport_focus_sprite = focus;
-    window->viewport_target_sprite = window->viewport_focus_sprite.sprite_id;
+    window->focus2 = focus;
+    window->viewport_target_sprite = window->viewport_smart_follow_sprite;
 }
 
 void viewport_update_smart_vehicle_follow(rct_window* window)
 {
-    sprite_focus focus = {};
-    focus.sprite_id = window->viewport_smart_follow_sprite;
+    Focus2 focus{};
+    focus.type = Focus2::Type::Entity;
+    focus.data = window->viewport_smart_follow_sprite;
 
-    window->viewport_focus_sprite = focus;
-    window->viewport_target_sprite = window->viewport_focus_sprite.sprite_id;
+    window->focus2 = focus;
+    window->viewport_target_sprite = window->viewport_smart_follow_sprite;
 }
 
 /**

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -112,7 +112,7 @@ void viewports_invalidate(int32_t left, int32_t top, int32_t right, int32_t bott
 void viewport_update_position(rct_window* window);
 void viewport_update_sprite_follow(rct_window* window);
 void viewport_update_smart_sprite_follow(rct_window* window);
-viewport_focus viewport_update_smart_guest_follow(rct_window* window, const Guest* peep);
+void viewport_update_smart_guest_follow(rct_window* window, const Guest* peep);
 void viewport_update_smart_staff_follow(rct_window* window, const Staff* peep);
 void viewport_update_smart_vehicle_follow(rct_window* window);
 void viewport_render(

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -104,9 +104,7 @@ extern uint8_t gCurrentRotation;
 
 void viewport_init_all();
 std::optional<ScreenCoordsXY> centre_2d_coordinates(const CoordsXYZ& loc, rct_viewport* viewport);
-void viewport_create(
-    rct_window* w, const ScreenCoordsXY& screenCoords, int32_t width, int32_t height, int32_t zoom, CoordsXYZ centrePos,
-    char flags, uint16_t sprite);
+void viewport_create(rct_window* w, const ScreenCoordsXY& screenCoords, int32_t width, int32_t height, const Focus2& focus);
 void viewport_remove(rct_viewport* viewport);
 void viewports_invalidate(int32_t left, int32_t top, int32_t right, int32_t bottom, int32_t maxZoom = -1);
 void viewport_update_position(rct_window* window);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -195,35 +195,6 @@ struct rct_scroll
 
 constexpr auto WINDOW_SCROLL_UNDEFINED = std::numeric_limits<uint16_t>::max();
 
-/**
- * Viewport focus structure.
- * size: 0xA
- * Use sprite.type to work out type.
- */
-struct coordinate_focus
-{
-    int16_t var_480;
-    int16_t x;        // 0x482
-    int16_t y;        // 0x484 & VIEWPORT_FOCUS_Y_MASK
-    int16_t z;        // 0x486
-    uint8_t rotation; // 0x488
-    uint8_t zoom;     // 0x489
-    int16_t width;
-    int16_t height;
-};
-
-// Type is viewport_target_sprite_id & 0x80000000 != 0
-struct sprite_focus
-{
-    int16_t var_480;
-    uint16_t sprite_id; // 0x482
-    uint8_t pad_484;
-    uint8_t type; // 0x485 & VIEWPORT_FOCUS_TYPE_MASK
-    uint16_t pad_486;
-    uint8_t rotation; // 0x488
-    uint8_t zoom;     // 0x489
-};
-
 struct Focus2
 {
     enum class Type
@@ -277,17 +248,6 @@ enum VIEWPORT_FOCUS_TYPE : uint8_t
 {
     VIEWPORT_FOCUS_TYPE_COORDINATE = (1 << 6),
     VIEWPORT_FOCUS_TYPE_SPRITE = (1 << 7)
-};
-#define VIEWPORT_FOCUS_Y_MASK 0x3FFF
-
-struct viewport_focus
-{
-    VIEWPORT_FOCUS_TYPE type{};
-    union
-    {
-        sprite_focus sprite;
-        coordinate_focus coordinate;
-    };
 };
 
 struct rct_window_event_list

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -197,57 +197,32 @@ constexpr auto WINDOW_SCROLL_UNDEFINED = std::numeric_limits<uint16_t>::max();
 
 struct Focus2
 {
-    enum class Type
-    {
-        None,
-        Entity,
-        Coordinate,
-    };
     using CoordinateFocus = CoordsXYZ;
     using EntityFocus = uint16_t;
 
-    Type type = Type::None;
-    uint8_t rotation = 0;
     uint8_t zoom = 0;
-
     std::variant<CoordinateFocus, EntityFocus> data;
-    constexpr bool HasFocus() const
+
+    template<typename T> constexpr explicit Focus2(T newValue, uint8_t newZoom = 0)
     {
-        return type == Type::None;
+        data = newValue;
+        zoom = newZoom;
     }
-    constexpr Type GetFocus() const
-    {
-        return type;
-    }
+
+    CoordsXYZ GetPos() const;
+
     constexpr bool operator==(const Focus2& other) const
     {
-        if (type != other.type)
+        if (zoom != other.zoom)
         {
             return false;
         }
-        if (rotation != other.rotation || zoom != other.zoom)
-        {
-            return false;
-        }
-        if (type == Type::Coordinate)
-        {
-            const auto& thisCoordFocus = std::get<CoordinateFocus>(data);
-            const auto& otherCoordFocus = std::get<CoordinateFocus>(other.data);
-            return thisCoordFocus == otherCoordFocus;
-        }
-        else if (type == Type::Entity)
-        {
-            return std::get<EntityFocus>(data) == std::get<EntityFocus>(other.data);
-        }
-        return true;
+        return data == other.data;
     }
-};
-
-#define VIEWPORT_FOCUS_TYPE_MASK 0xC0
-enum VIEWPORT_FOCUS_TYPE : uint8_t
-{
-    VIEWPORT_FOCUS_TYPE_COORDINATE = (1 << 6),
-    VIEWPORT_FOCUS_TYPE_SPRITE = (1 << 7)
+    constexpr bool operator!=(const Focus2& other) const
+    {
+        return !(*this == other);
+    }
 };
 
 struct rct_window_event_list

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -12,26 +12,10 @@ void rct_window::SetLocation(const CoordsXYZ& coords)
 
 void rct_window::ScrollToViewport()
 {
-    if (viewport == nullptr || !focus2.HasFocus())
+    if (viewport == nullptr || !focus2.has_value())
         return;
 
-    CoordsXYZ newCoords = {};
-    if (focus2.GetFocus() == Focus2::Type::Entity)
-    {
-        auto* sprite = GetEntity(std::get<Focus2::EntityFocus>(focus2.data));
-        if (sprite == nullptr)
-        {
-            return;
-        }
-        newCoords.x = sprite->x;
-        newCoords.y = sprite->y;
-        newCoords.z = sprite->z;
-    }
-    else
-    {
-        auto& coordFocus = std::get<Focus2::CoordinateFocus>(focus2.data);
-        newCoords = coordFocus;
-    }
+    CoordsXYZ newCoords = focus2.value().GetPos();
 
     auto mainWindow = window_get_main();
     if (mainWindow != nullptr)

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -12,14 +12,13 @@ void rct_window::SetLocation(const CoordsXYZ& coords)
 
 void rct_window::ScrollToViewport()
 {
-    // In original checked to make sure x and y were not -1 as well.
-    if (viewport == nullptr || viewport_focus_coordinates.y == -1)
+    if (viewport == nullptr || !focus2.HasFocus())
         return;
 
     CoordsXYZ newCoords = {};
-    if (viewport_focus_sprite.type & VIEWPORT_FOCUS_TYPE_SPRITE)
+    if (focus2.GetFocus() == Focus2::Type::Entity)
     {
-        auto* sprite = GetEntity(viewport_focus_sprite.sprite_id);
+        auto* sprite = GetEntity(std::get<Focus2::EntityFocus>(focus2.data));
         if (sprite == nullptr)
         {
             return;
@@ -30,9 +29,8 @@ void rct_window::ScrollToViewport()
     }
     else
     {
-        newCoords.x = viewport_focus_coordinates.x;
-        newCoords.y = viewport_focus_coordinates.y & VIEWPORT_FOCUS_Y_MASK;
-        newCoords.z = viewport_focus_coordinates.z;
+        auto& coordFocus = std::get<Focus2::CoordinateFocus>(focus2.data);
+        newCoords = coordFocus;
     }
 
     auto mainWindow = window_get_main();

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -55,10 +55,9 @@ struct rct_window
     uint32_t list_item_positions[1024]{};
     uint16_t no_list_items{};     // 0 for no items
     int16_t selected_list_item{}; // -1 for none selected
+    Focus2 focus2;
     union
     {
-        coordinate_focus viewport_focus_coordinates;
-        sprite_focus viewport_focus_sprite;
         campaign_variables campaign;
         new_ride_variables new_ride;
         news_variables news;

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -55,7 +55,7 @@ struct rct_window
     uint32_t list_item_positions[1024]{};
     uint16_t no_list_items{};     // 0 for no items
     int16_t selected_list_item{}; // -1 for none selected
-    Focus2 focus2;
+    std::optional<Focus2> focus2;
     union
     {
         campaign_variables campaign;


### PR DESCRIPTION
This if for the NSF to allow for CoordsXYZ.

Names are pretty much placeholders in this as Focus2 is a rubbish name.