### PR TITLE
Small Staff Refactor from NSF

### DIFF
--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -530,7 +530,7 @@ void window_staff_overview_mousedown(rct_window* w, rct_widgetindex widgetIndex,
             }
 
             // Disable clear patrol area if no area is set.
-            if (gStaffModes[peep->StaffId] != StaffMode::Patrol)
+            if (!peep->HasPatrolArea())
             {
                 Dropdown::SetDisabled(1, true);
             }
@@ -568,12 +568,8 @@ void window_staff_overview_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
                 {
                     return;
                 }
-                for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
-                {
-                    gStaffPatrolAreas[peep->StaffId * STAFF_PATROL_AREA_SIZE + i] = 0;
-                }
-                assert(gStaffModes[peep->StaffId] == StaffMode::Patrol);
-                gStaffModes[peep->StaffId] = StaffMode::Walk;
+                // TODO: THIS SHOULD BE NETWORKED
+                peep->ClearPatrolArea();
 
                 gfx_invalidate_screen();
                 staff_update_greyed_patrol_areas();

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -414,7 +414,7 @@ public:
                 DrawTextEllipsised(&dpi, { actionOffset, y }, actionColumnSize, format, ft);
 
                 // True if a patrol path is set for the worker
-                if (gStaffModes[peep->StaffId] == StaffMode::Patrol)
+                if (peep->HasPatrolArea())
                 {
                     gfx_draw_sprite(&dpi, ImageId(SPR_STAFF_PATROL_PATH), { nameColumnSize + 5, y });
                 }
@@ -566,7 +566,7 @@ private:
 
             if (isPatrolAreaSet)
             {
-                if (gStaffModes[peep->StaffId] != StaffMode::Patrol)
+                if (!peep->HasPatrolArea())
                 {
                     continue;
                 }

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -57,5 +57,7 @@ GameActions::Result::Ptr StaffFireAction::Execute() const
     }
     window_close_by_class(WC_FIRE_PROMPT);
     peep_sprite_remove(staff);
+    // Due to patrol areas best to invalidate the whole screen on removal of staff
+    gfx_invalidate_screen();
     return MakeResult();
 }

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -226,7 +226,7 @@ GameActions::Result::Ptr StaffHireNewAction::QueryExecute(bool execute) const
 
         gStaffModes[staffIndex] = StaffMode::Walk;
 
-        for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
+        for (size_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
         {
             gStaffPatrolAreas[staffIndex * STAFF_PATROL_AREA_SIZE + i] = 0;
         }

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
@@ -63,14 +63,13 @@ GameActions::Result::Ptr StaffSetPatrolAreaAction::Execute() const
         return MakeResult(GameActions::Status::InvalidParameters, STR_NONE);
     }
 
-    int32_t patrolOffset = staff->StaffId * STAFF_PATROL_AREA_SIZE;
-
-    staff_toggle_patrol_area(staff->StaffId, _loc);
+    staff->TogglePatrolArea(_loc);
 
     bool isPatrolling = false;
-    for (int32_t i = 0; i < 128; i++)
+    const auto peepOffset = staff->StaffId * STAFF_PATROL_AREA_SIZE;
+    for (int32_t i = peepOffset; i < peepOffset + STAFF_PATROL_AREA_SIZE; i++)
     {
-        if (gStaffPatrolAreas[patrolOffset + i])
+        if (gStaffPatrolAreas[i] != 0)
         {
             isPatrolling = true;
             break;

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
@@ -67,7 +67,7 @@ GameActions::Result::Ptr StaffSetPatrolAreaAction::Execute() const
 
     bool isPatrolling = false;
     const auto peepOffset = staff->StaffId * STAFF_PATROL_AREA_SIZE;
-    for (int32_t i = peepOffset; i < peepOffset + STAFF_PATROL_AREA_SIZE; i++)
+    for (size_t i = peepOffset; i < peepOffset + STAFF_PATROL_AREA_SIZE; i++)
     {
         if (gStaffPatrolAreas[i] != 0)
         {

--- a/src/openrct2/peep/Peep.cpp
+++ b/src/openrct2/peep/Peep.cpp
@@ -652,6 +652,7 @@ void peep_sprite_remove(Peep* peep)
     }
     else
     {
+        staff->ClearPatrolArea();
         gStaffModes[staff->StaffId] = StaffMode::None;
         staff_update_greyed_patrol_areas();
 

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -881,6 +881,11 @@ public:
     static void ResetStats();
     void Serialise(DataSerialiser& stream);
 
+    void ClearPatrolArea();
+    void TogglePatrolArea(const CoordsXY& coords);
+    void SetPatrolArea(const CoordsXY& coords, bool value);
+    bool HasPatrolArea() const;
+
 private:
     void UpdatePatrolling();
     void UpdateMowing();

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -151,6 +151,10 @@ void staff_update_greyed_patrol_areas()
 
         for (auto peep : EntityList<Staff>())
         {
+            if (!peep->HasPatrolArea())
+            {
+                continue;
+            }
             if (static_cast<uint8_t>(peep->AssignedStaffType) == staff_type)
             {
                 const size_t peepPatrolOffset = peep->StaffId * STAFF_PATROL_AREA_SIZE;

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -365,8 +365,13 @@ void Staff::ResetStats()
 static std::pair<int32_t, int32_t> getPatrolAreaOffsetIndex(const CoordsXY& coords)
 {
     // Patrol areas are 4 * 4 tiles (32 * 4) = 128 = 2^^7
-    auto hash = ((coords.x & 0x1F80) >> 7) | ((coords.y & 0x1F80) >> 1);
-    return { hash >> 5, hash & 0x1F };
+    auto tilePos = TileCoordsXY(coords);
+    auto x = tilePos.x / 4;
+    auto y = tilePos.y / 4;
+    auto bitIndex = (y * STAFF_PATROL_AREA_BLOCKS_PER_LINE) + x;
+    auto byteIndex = int32_t(bitIndex / 32);
+    auto byteBitIndex = int32_t(bitIndex % 32);
+    return { byteIndex, byteBitIndex };
 }
 
 static bool staff_is_patrol_area_set(int32_t staffIndex, const CoordsXY& coords)
@@ -423,20 +428,7 @@ void Staff::TogglePatrolArea(const CoordsXY& coords)
 
 bool Staff::HasPatrolArea() const
 {
-    if (gStaffModes[StaffId] != StaffMode::Patrol)
-    {
-        return false;
-    }
-
-    const auto peepOffset = StaffId * STAFF_PATROL_AREA_SIZE;
-    for (int32_t i = peepOffset; i < peepOffset + STAFF_PATROL_AREA_SIZE; i++)
-    {
-        if (gStaffPatrolAreas[i] != 0)
-        {
-            return true;
-        }
-    }
-    return false;
+    return gStaffModes[StaffId] == StaffMode::Patrol;
 }
 
 /**

--- a/src/openrct2/peep/Staff.cpp
+++ b/src/openrct2/peep/Staff.cpp
@@ -143,8 +143,8 @@ void staff_update_greyed_patrol_areas()
 {
     for (int32_t staff_type = 0; staff_type < static_cast<uint8_t>(StaffType::Count); ++staff_type)
     {
-        int32_t staffPatrolOffset = (staff_type + STAFF_MAX_COUNT) * STAFF_PATROL_AREA_SIZE;
-        for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
+        const size_t staffPatrolOffset = (staff_type + STAFF_MAX_COUNT) * STAFF_PATROL_AREA_SIZE;
+        for (size_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
         {
             gStaffPatrolAreas[staffPatrolOffset + i] = 0;
         }
@@ -153,8 +153,8 @@ void staff_update_greyed_patrol_areas()
         {
             if (static_cast<uint8_t>(peep->AssignedStaffType) == staff_type)
             {
-                int32_t peepPatrolOffset = peep->StaffId * STAFF_PATROL_AREA_SIZE;
-                for (int32_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
+                const size_t peepPatrolOffset = peep->StaffId * STAFF_PATROL_AREA_SIZE;
+                for (size_t i = 0; i < STAFF_PATROL_AREA_SIZE; i++)
                 {
                     gStaffPatrolAreas[staffPatrolOffset + i] |= gStaffPatrolAreas[peepPatrolOffset + i];
                 }

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -65,8 +65,6 @@ void staff_set_name(uint16_t spriteIndex, const char* name);
 bool staff_hire_new_member(StaffType staffType, EntertainerCostume entertainerType);
 void staff_update_greyed_patrol_areas();
 bool staff_is_patrol_area_set_for_type(StaffType type, const CoordsXY& coords);
-void staff_set_patrol_area(int32_t staffIndex, const CoordsXY& coords, bool value);
-void staff_toggle_patrol_area(int32_t staffIndex, const CoordsXY& coords);
 colour_t staff_get_colour(StaffType staffType);
 bool staff_set_colour(StaffType staffType, colour_t value);
 uint32_t staff_get_available_entertainer_costumes();

--- a/src/openrct2/peep/Staff.h
+++ b/src/openrct2/peep/Staff.h
@@ -15,7 +15,8 @@
 #define STAFF_MAX_COUNT 200
 // The number of elements in the gStaffPatrolAreas array per staff member. Every bit in the array represents a 4x4 square.
 // Right now, it's a 32-bit array like in RCT2. 32 * 128 = 4096 bits, which is also the number of 4x4 squares on a 256x256 map.
-#define STAFF_PATROL_AREA_SIZE 128
+constexpr size_t STAFF_PATROL_AREA_BLOCKS_PER_LINE = MAXIMUM_MAP_SIZE_TECHNICAL / 4;
+constexpr size_t STAFF_PATROL_AREA_SIZE = (STAFF_PATROL_AREA_BLOCKS_PER_LINE * STAFF_PATROL_AREA_BLOCKS_PER_LINE) / 32;
 
 enum class StaffMode : uint8_t
 {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1293,7 +1293,7 @@ namespace RCT1
                     x <<= 7;
                     int32_t y = val & 0x3E0;
                     y <<= 2;
-                    staff_set_patrol_area(staffmember->StaffId, { x, y }, true);
+                    staffmember->SetPatrolArea({ x, y }, true);
                 }
             }
         }


### PR DESCRIPTION
Just trying to make the actual change that modified the patrol areas easier to follow. So to start I've introduced all of the new methods added in the NSF then after this can modify the functionality. Also noticed that `peep->ClearPatrolArea();` is not network safe. 
I think we will need to modify StaffSetPatrolAreaAction to have three states: Set, Unset, Clear. That will be a follow on PR.