### PR TITLE
Fix #15442: Use after free in object manager

### DIFF
--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -63,15 +63,18 @@ namespace Editor
 
     static void object_list_load()
     {
+        auto* context = GetContext();
+
+        // Unload objects first, the repository is re-populated which owns the objects.
+        auto& objectManager = context->GetObjectManager();
+        objectManager.UnloadAll();
+
         // Scan objects if necessary
-        auto context = GetContext();
         const auto& localisationService = context->GetLocalisationService();
         auto& objectRepository = context->GetObjectRepository();
         objectRepository.LoadOrConstruct(localisationService.GetCurrentLanguage());
 
         // Reset loaded objects to just defaults
-        auto& objectManager = context->GetObjectManager();
-        objectManager.UnloadAll();
         objectManager.LoadDefaultObjects();
     }
 


### PR DESCRIPTION
This fixes #15442 but its also in develop, the lines changed in NSF a bit.