### PR TITLE
Avoid drawing over elements that are higher

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
+- Improved: [#15462] Ghost elements do no longer overrule higher elements' colours in the map window.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1463,7 +1463,7 @@ static uint16_t map_window_get_pixel_colour_peep(const CoordsXY& c)
         if (tileElement->IsGhost())
         {
             colour = MapColour(PALETTE_INDEX_21);
-            break;
+            continue;
         }
 
         int32_t tileElementType = tileElement->GetType() >> 2;
@@ -1494,7 +1494,7 @@ static uint16_t map_window_get_pixel_colour_ride(const CoordsXY& c)
         if (tileElement->IsGhost())
         {
             colourA = MapColour(PALETTE_INDEX_21);
-            break;
+            continue;
         }
 
         switch (tileElement->GetType())


### PR DESCRIPTION
Ghost elements would always draw on top of everything in the map window, even when built under other elements.