### PR TITLE
Fix arbitrary ride type cheat not working

### DIFF
--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -223,6 +223,7 @@ GameActions::Result::Ptr RideSetSettingAction::Execute() const
             break;
         case RideSetSetting::RideType:
             ride->type = _value;
+            ride->UpdateRideTypeForAllPieces();
             gfx_invalidate_screen();
             break;
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5734,3 +5734,29 @@ void Ride::IncreaseNumShelteredSections()
     num_sheltered_sections &= ~ShelteredSectionsBits::NumShelteredSectionsMask;
     num_sheltered_sections |= newNumShelteredSections;
 }
+
+void Ride::UpdateRideTypeForAllPieces()
+{
+    for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
+    {
+        for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
+        {
+            auto* tileElement = map_get_first_element_at(TileCoordsXY(x, y));
+            if (tileElement == nullptr)
+                continue;
+
+            do
+            {
+                if (tileElement->GetType() != TILE_ELEMENT_TYPE_TRACK)
+                    continue;
+
+                auto* trackElement = tileElement->AsTrack();
+                if (trackElement->GetRideIndex() != id)
+                    continue;
+
+                trackElement->SetRideType(type);
+
+            } while (!(tileElement++)->IsLastForTile());
+        }
+    }
+}

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -468,6 +468,11 @@ public:
     void IncreaseNumShelteredSections();
 
     void RemoveVehicles();
+    /**
+     * Updates all pieces of the ride to match the internal ride type. (Track pieces can have different ride types from the ride
+     * they belong to, to enable “merging”.)
+     */
+    void UpdateRideTypeForAllPieces();
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
Bug introduced with https://github.com/OpenRCT2/OpenRCT2/pull/15414.

For the NSF, we should revisit this. It’s very well possible that people will want to change the "base" ride type while keeping the actual pieces the same.