### PR TITLE
Move function for NSF use

### DIFF
--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -217,25 +217,6 @@ void Object::SetAuthors(std::vector<std::string>&& authors)
     _authors = std::move(authors);
 }
 
-std::optional<uint8_t> rct_object_entry::GetSceneryType() const
-{
-    switch (GetType())
-    {
-        case ObjectType::SmallScenery:
-            return SCENERY_TYPE_SMALL;
-        case ObjectType::LargeScenery:
-            return SCENERY_TYPE_LARGE;
-        case ObjectType::Walls:
-            return SCENERY_TYPE_WALL;
-        case ObjectType::Banners:
-            return SCENERY_TYPE_BANNER;
-        case ObjectType::PathBits:
-            return SCENERY_TYPE_PATH_ITEM;
-        default:
-            return std::nullopt;
-    }
-}
-
 bool rct_object_entry::IsEmpty() const
 {
     uint64_t a, b;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -119,8 +119,6 @@ struct rct_object_entry
         flags |= (static_cast<uint8_t>(newType) & 0x0F);
     }
 
-    std::optional<uint8_t> GetSceneryType() const;
-
     ObjectSourceGame GetSourceGame() const
     {
         return static_cast<ObjectSourceGame>((flags & 0xF0) >> 4);

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -66,6 +66,25 @@ void SceneryGroupObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
     gfx_draw_sprite(dpi, imageId, screenCoords - ScreenCoordsXY{ 15, 14 }, 0);
 }
 
+static std::optional<uint8_t> GetSceneryType(const ObjectType type)
+{
+    switch (type)
+    {
+        case ObjectType::SmallScenery:
+            return SCENERY_TYPE_SMALL;
+        case ObjectType::LargeScenery:
+            return SCENERY_TYPE_LARGE;
+        case ObjectType::Walls:
+            return SCENERY_TYPE_WALL;
+        case ObjectType::Banners:
+            return SCENERY_TYPE_BANNER;
+        case ObjectType::PathBits:
+            return SCENERY_TYPE_PATH_ITEM;
+        default:
+            return std::nullopt;
+    }
+}
+
 void SceneryGroupObject::UpdateEntryIndexes()
 {
     auto context = GetContext();
@@ -84,7 +103,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
         auto entryIndex = objectManager.GetLoadedObjectEntryIndex(ori->LoadedObject.get());
         Guard::Assert(entryIndex != OBJECT_ENTRY_INDEX_NULL, GUARD_LINE);
 
-        auto sceneryType = ori->ObjectEntry.GetSceneryType();
+        auto sceneryType = GetSceneryType(ori->Type);
         if (sceneryType.has_value())
         {
             _legacyType.scenery_entries[_legacyType.entry_count] = { sceneryType.value(), entryIndex };


### PR DESCRIPTION
This function was moved as part of the NSF. As its standalone we can move it over with no issues.