### PR TITLE
Fix #15213: Freeze when reading a partially cut unicode character 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
 - Fix: [#15193] Crash when rides/stalls are demolished.
 - Fix: [#15199] Construction window is not closed when a ride gets demolished.
+- Fix: [#15213] Freeze when hovering over Reverse Freefall Coaster in Russian.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -18,56 +18,67 @@ static void DrawText(
 static void DrawText(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, rct_string_id format, const void* args);
 
-StaticLayout::StaticLayout(utf8string source, const TextPaint& paint, int32_t width)
+class StaticLayout
 {
-    Buffer = source;
-    Paint = paint;
+private:
+    utf8string Buffer;
+    TextPaint Paint;
+    int32_t LineCount = 0;
+    int32_t LineHeight;
+    int32_t MaxWidth;
 
-    MaxWidth = gfx_wrap_string(Buffer, width, paint.SpriteBase, &LineCount);
-    LineCount += 1;
-    LineHeight = font_get_line_height(paint.SpriteBase);
-}
-
-void StaticLayout::Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords)
-{
-    TextPaint tempPaint = Paint;
-
-    auto lineCoords = coords;
-    switch (Paint.Alignment)
+public:
+    StaticLayout(utf8string source, const TextPaint& paint, int32_t width)
     {
-        case TextAlignment::LEFT:
-            break;
-        case TextAlignment::CENTRE:
-            lineCoords.x += MaxWidth / 2;
-            break;
-        case TextAlignment::RIGHT:
-            lineCoords.x += MaxWidth;
-            break;
+        Buffer = source;
+        Paint = paint;
+
+        MaxWidth = gfx_wrap_string(Buffer, width, paint.SpriteBase, &LineCount);
+        LineCount += 1;
+        LineHeight = font_get_line_height(paint.SpriteBase);
     }
-    utf8* buffer = Buffer;
-    for (int32_t line = 0; line < LineCount; ++line)
+
+    void Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords)
     {
-        DrawText(dpi, lineCoords, tempPaint, buffer);
-        tempPaint.Colour = TEXT_COLOUR_254;
-        buffer = get_string_end(buffer) + 1;
-        lineCoords.y += LineHeight;
+        TextPaint tempPaint = Paint;
+
+        auto lineCoords = coords;
+        switch (Paint.Alignment)
+        {
+            case TextAlignment::LEFT:
+                break;
+            case TextAlignment::CENTRE:
+                lineCoords.x += MaxWidth / 2;
+                break;
+            case TextAlignment::RIGHT:
+                lineCoords.x += MaxWidth;
+                break;
+        }
+        utf8* buffer = Buffer;
+        for (int32_t line = 0; line < LineCount; ++line)
+        {
+            DrawText(dpi, lineCoords, tempPaint, buffer);
+            tempPaint.Colour = TEXT_COLOUR_254;
+            buffer = get_string_end(buffer) + 1;
+            lineCoords.y += LineHeight;
+        }
     }
-}
 
-int32_t StaticLayout::GetHeight()
-{
-    return LineHeight * LineCount;
-}
+    int32_t GetHeight() const
+    {
+        return LineHeight * LineCount;
+    }
 
-int32_t StaticLayout::GetWidth()
-{
-    return MaxWidth;
-}
+    int32_t GetWidth() const
+    {
+        return MaxWidth;
+    }
 
-int32_t StaticLayout::GetLineCount()
-{
-    return LineCount;
-}
+    int32_t GetLineCount() const
+    {
+        return LineCount;
+    }
+};
 
 static void DrawText(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -157,10 +157,9 @@ int32_t DrawTextWrapped(
 {
     const void* args = ft.Data();
 
-    utf8 buffer[512];
-    format_string(buffer, sizeof(buffer), format, args);
-
-    StaticLayout layout(buffer, textPaint, width);
+    // TODO: Refactor StaticLayout to take a std::string_view instead. It shouldn't have to write to the buffer.
+    const std::string buffer = format_string(format, args);
+    StaticLayout layout(const_cast<char*>(buffer.c_str()), textPaint, width);
 
     if (textPaint.Alignment == TextAlignment::CENTRE)
     {

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -124,26 +124,6 @@ struct TextPaint
     }
 };
 
-class StaticLayout
-{
-private:
-    utf8string Buffer;
-    TextPaint Paint;
-    int32_t LineCount = 0;
-    int32_t LineHeight;
-    int32_t MaxWidth;
-
-    StaticLayout();
-    StaticLayout(const StaticLayout&);
-
-public:
-    StaticLayout(utf8string source, const TextPaint& paint, int32_t width);
-    void Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords);
-    int32_t GetHeight();
-    int32_t GetWidth();
-    int32_t GetLineCount();
-};
-
 void DrawTextBasic(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, rct_string_id format, const Formatter& ft = {},
     TextPaint textPaint = {});


### PR DESCRIPTION
This is the main change:
```diff
-    utf8 buffer[512];
-    format_string(buffer, sizeof(buffer), format, args);
-
-    StaticLayout layout(buffer, textPaint, width);
+    // TODO: Refactor StaticLayout to take a std::string_view instead. It shouldn't have to write to the buffer.
+    const std::string buffer = format_string(format, args);
+    StaticLayout layout(const_cast<char*>(buffer.c_str()), textPaint, width);
```
The main problem was that it is possible for unicode characters that take up multiple bytes to only get partly written to the buffer. The codepoint iterator then breaks on this.

The `const_cast` is safe, since the `std::string` cannot be optimized away to static data, thought it should really be refactored out. I've made a start with this, but it turns into a way bigger refactor than what is needed to solve this crash.