### PR TITLE
Fix #15487: map animations do not work correctly in vanilla RCT2

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
 - Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
+- Fix: [#15487] Map animations do not work correctly when loading an exported SV6 file in vanilla RCT2.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
 - Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.

--- a/src/openrct2/rct2/S6Exporter.cpp
+++ b/src/openrct2/rct2/S6Exporter.cpp
@@ -1761,9 +1761,10 @@ void S6Exporter::ExportMapAnimations()
         auto& dst = _s6.map_animations[i];
 
         dst.type = src.type;
+        // In RCT12MapAnimation, the x and y coordinates use big coords, while the z coordinate uses small coords.
         dst.x = src.location.x;
         dst.y = src.location.y;
-        dst.baseZ = src.location.z;
+        dst.baseZ = src.location.z / COORDS_Z_STEP;
     }
 }
 


### PR DESCRIPTION
This only affected vanilla because we always automatically recreate map animations on import.

Make sure to include the Co-authored-by header if you squash merge! Or just use a regular merge.