### PR TITLE
Fix incorrect staff costumes being available

### DIFF
--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -591,28 +591,20 @@ void scenery_set_not_invented(const ScenerySelection& sceneryItem)
 
 bool scenery_group_is_invented(int32_t sgIndex)
 {
-    auto invented = false;
     const auto sgEntry = get_scenery_group_entry(sgIndex);
     if (sgEntry != nullptr && sgEntry->entry_count > 0)
     {
         if (gCheatsIgnoreResearchStatus)
         {
-            invented = true;
+            return true;
         }
-        else
-        {
-            for (auto i = 0; i < sgEntry->entry_count; i++)
-            {
-                auto sceneryEntry = sgEntry->scenery_entries[i];
-                if (scenery_is_invented(sceneryEntry))
-                {
-                    invented = true;
-                    break;
-                }
-            }
-        }
+
+        return std::none_of(
+            std::begin(gResearchItemsUninvented), std::end(gResearchItemsUninvented), [sgIndex](const ResearchItem& item) {
+                return item.type == Research::EntryType::Scenery && item.entryIndex == sgIndex;
+            });
     }
-    return invented;
+    return false;
 }
 
 void scenery_group_set_invented(int32_t sgIndex)

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -592,19 +592,20 @@ void scenery_set_not_invented(const ScenerySelection& sceneryItem)
 bool scenery_group_is_invented(int32_t sgIndex)
 {
     const auto sgEntry = get_scenery_group_entry(sgIndex);
-    if (sgEntry != nullptr && sgEntry->entry_count > 0)
+    if (sgEntry == nullptr || sgEntry->entry_count == 0)
     {
-        if (gCheatsIgnoreResearchStatus)
-        {
-            return true;
-        }
-
-        return std::none_of(
-            std::begin(gResearchItemsUninvented), std::end(gResearchItemsUninvented), [sgIndex](const ResearchItem& item) {
-                return item.type == Research::EntryType::Scenery && item.entryIndex == sgIndex;
-            });
+        return false;
     }
-    return false;
+
+    if (gCheatsIgnoreResearchStatus)
+    {
+        return true;
+    }
+
+    return std::none_of(
+        std::begin(gResearchItemsUninvented), std::end(gResearchItemsUninvented), [sgIndex](const ResearchItem& item) {
+            return item.type == Research::EntryType::Scenery && item.entryIndex == sgIndex;
+        });
 }
 
 void scenery_group_set_invented(int32_t sgIndex)


### PR DESCRIPTION
Noticed this when trying to fix an NSF scenery window issue. The previous code meant that if any single scenery item in a set was researched then the costume was available but I'm pretty sure its meant to be tied to if the whole scenery set is invented.