### PR TITLE
Use (const) references to widgets and scrolls where possible

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -194,14 +194,14 @@ static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, rct_wind
     rct_widgetindex widgetIndex = _dragWidget.widget_index;
     uint8_t scrollIndex = _dragScrollIndex;
 
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
     rct_scroll* scroll = &w->scrolls[scrollIndex];
 
     ScreenCoordsXY differentialCoords = screenCoords - gInputDragLast;
 
     if (scroll->flags & HSCROLLBAR_VISIBLE)
     {
-        int16_t size = widget->width() - 1;
+        int16_t size = widget.width() - 1;
         if (scroll->flags & VSCROLLBAR_VISIBLE)
             size -= 11;
         size = std::max(0, scroll->h_right - size);
@@ -210,7 +210,7 @@ static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, rct_wind
 
     if (scroll->flags & VSCROLLBAR_VISIBLE)
     {
-        int16_t size = widget->height() - 1;
+        int16_t size = widget.height() - 1;
         if (scroll->flags & HSCROLLBAR_VISIBLE)
             size -= 11;
         size = std::max(0, scroll->v_bottom - size);
@@ -604,9 +604,7 @@ static void InputViewportDragEnd()
 
 static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
-    rct_widget* widget;
-
-    widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     _inputState = InputState::ScrollLeft;
     gPressedWidget.window_classification = w->classification;
@@ -617,7 +615,7 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
     int32_t scroll_area, scroll_id;
     ScreenCoordsXY scrollCoords;
     scroll_id = 0; // safety
-    WidgetScrollGetPart(w, widget, screenCoords, scrollCoords, &scroll_area, &scroll_id);
+    WidgetScrollGetPart(w, &widget, screenCoords, scrollCoords, &scroll_area, &scroll_id);
 
     _currentScrollArea = scroll_area;
     _currentScrollIndex = scroll_id;
@@ -628,15 +626,15 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
         return;
     }
 
-    rct_widget* widg = &w->widgets[widgetIndex];
+    const auto& widg = w->widgets[widgetIndex];
     rct_scroll* scroll = &w->scrolls[scroll_id];
 
-    int32_t widget_width = widg->width() - 1;
+    int32_t widget_width = widg.width() - 1;
     if (scroll->flags & VSCROLLBAR_VISIBLE)
         widget_width -= SCROLLBAR_WIDTH + 1;
     int32_t widget_content_width = std::max(scroll->h_right - widget_width, 0);
 
-    int32_t widget_height = widg->bottom - widg->top - 1;
+    int32_t widget_height = widg.bottom - widg.top - 1;
     if (scroll->flags & HSCROLLBAR_VISIBLE)
         widget_height -= SCROLLBAR_WIDTH + 1;
     int32_t widget_content_height = std::max(scroll->v_bottom - widget_height, 0);
@@ -676,12 +674,11 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
 
 static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
-    rct_widget* widget;
     int32_t scroll_part, scroll_id;
 
     assert(w != nullptr);
 
-    widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
     if (w->classification != gPressedWidget.window_classification || w->number != gPressedWidget.window_number
         || widgetIndex != gPressedWidget.widget_index)
     {
@@ -690,7 +687,7 @@ static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, cons
     }
 
     ScreenCoordsXY newScreenCoords;
-    WidgetScrollGetPart(w, widget, screenCoords, newScreenCoords, &scroll_part, &scroll_id);
+    WidgetScrollGetPart(w, &widget, screenCoords, newScreenCoords, &scroll_part, &scroll_id);
 
     if (_currentScrollArea == SCROLL_PART_HSCROLLBAR_THUMB)
     {
@@ -746,14 +743,14 @@ static void InputScrollEnd()
  */
 static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id)
 {
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
         int32_t newLeft;
         newLeft = w->scrolls[scroll_id].h_right;
         newLeft *= x;
-        x = widget->width() - 21;
+        x = widget.width() - 21;
         if (w->scrolls[scroll_id].flags & VSCROLLBAR_VISIBLE)
             x -= SCROLLBAR_WIDTH + 1;
         newLeft /= x;
@@ -763,7 +760,7 @@ static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetInd
         newLeft += x;
         if (newLeft < 0)
             newLeft = 0;
-        x = widget->width() - 1;
+        x = widget.width() - 1;
         if (w->scrolls[scroll_id].flags & VSCROLLBAR_VISIBLE)
             x -= SCROLLBAR_WIDTH + 1;
         x *= -1;
@@ -785,14 +782,14 @@ static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetInd
 static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id)
 {
     assert(w != nullptr);
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
         int32_t newTop;
         newTop = w->scrolls[scroll_id].v_bottom;
         newTop *= y;
-        y = widget->height() - 21;
+        y = widget.height() - 21;
         if (w->scrolls[scroll_id].flags & HSCROLLBAR_VISIBLE)
             y -= SCROLLBAR_WIDTH + 1;
         newTop /= y;
@@ -802,7 +799,7 @@ static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetInd
         newTop += y;
         if (newTop < 0)
             newTop = 0;
-        y = widget->height() - 1;
+        y = widget.height() - 1;
         if (w->scrolls[scroll_id].flags & HSCROLLBAR_VISIBLE)
             y -= SCROLLBAR_WIDTH + 1;
         y *= -1;
@@ -841,12 +838,12 @@ static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetInde
 static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
     assert(w != nullptr);
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
         w->scrolls[scroll_id].flags |= HSCROLLBAR_RIGHT_PRESSED;
         w->scrolls[scroll_id].h_left += 3;
-        int32_t newLeft = widget->width() - 1;
+        int32_t newLeft = widget.width() - 1;
         if (w->scrolls[scroll_id].flags & VSCROLLBAR_VISIBLE)
             newLeft -= SCROLLBAR_WIDTH + 1;
         newLeft *= -1;
@@ -884,12 +881,12 @@ static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex
 static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
     assert(w != nullptr);
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
         w->scrolls[scroll_id].flags |= VSCROLLBAR_DOWN_PRESSED;
         w->scrolls[scroll_id].v_top += 3;
-        int32_t newTop = widget->height() - 1;
+        int32_t newTop = widget.height() - 1;
         if (w->scrolls[scroll_id].flags & HSCROLLBAR_VISIBLE)
             newTop -= SCROLLBAR_WIDTH + 1;
         newTop *= -1;
@@ -1000,7 +997,6 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
 {
     rct_windowclass windowClass = WC_NULL;
     rct_windownumber windowNumber = 0;
-    rct_widget* widget;
 
     if (w != nullptr)
     {
@@ -1026,9 +1022,9 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
         window_cancel_textbox();
     }
 
-    widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
-    switch (widget->type)
+    switch (widget.type)
     {
         case WindowWidgetType::Frame:
         case WindowWidgetType::Resize:
@@ -1060,7 +1056,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
         default:
             if (WidgetIsEnabled(w, widgetIndex) && !WidgetIsDisabled(w, widgetIndex))
             {
-                OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, w->windowPos.x + widget->midX());
+                OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, w->windowPos.x + widget.midX());
 
                 // Set new cursor down widget
                 gPressedWidget.window_classification = windowClass;

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -195,26 +195,26 @@ static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, rct_wind
     uint8_t scrollIndex = _dragScrollIndex;
 
     const auto& widget = w->widgets[widgetIndex];
-    rct_scroll* scroll = &w->scrolls[scrollIndex];
+    auto& scroll = w->scrolls[scrollIndex];
 
     ScreenCoordsXY differentialCoords = screenCoords - gInputDragLast;
 
-    if (scroll->flags & HSCROLLBAR_VISIBLE)
+    if (scroll.flags & HSCROLLBAR_VISIBLE)
     {
         int16_t size = widget.width() - 1;
-        if (scroll->flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll->h_right - size);
-        scroll->h_left = std::min<uint16_t>(std::max(0, scroll->h_left + differentialCoords.x), size);
+        size = std::max(0, scroll.h_right - size);
+        scroll.h_left = std::min<uint16_t>(std::max(0, scroll.h_left + differentialCoords.x), size);
     }
 
-    if (scroll->flags & VSCROLLBAR_VISIBLE)
+    if (scroll.flags & VSCROLLBAR_VISIBLE)
     {
         int16_t size = widget.height() - 1;
-        if (scroll->flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll->v_bottom - size);
-        scroll->v_top = std::min<uint16_t>(std::max(0, scroll->v_top + differentialCoords.y), size);
+        size = std::max(0, scroll.v_bottom - size);
+        scroll.v_top = std::min<uint16_t>(std::max(0, scroll.v_top + differentialCoords.y), size);
     }
 
     WidgetScrollUpdateThumbs(w, widgetIndex);
@@ -627,43 +627,43 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
     }
 
     const auto& widg = w->widgets[widgetIndex];
-    rct_scroll* scroll = &w->scrolls[scroll_id];
+    auto& scroll = w->scrolls[scroll_id];
 
     int32_t widget_width = widg.width() - 1;
-    if (scroll->flags & VSCROLLBAR_VISIBLE)
+    if (scroll.flags & VSCROLLBAR_VISIBLE)
         widget_width -= SCROLLBAR_WIDTH + 1;
-    int32_t widget_content_width = std::max(scroll->h_right - widget_width, 0);
+    int32_t widget_content_width = std::max(scroll.h_right - widget_width, 0);
 
     int32_t widget_height = widg.bottom - widg.top - 1;
-    if (scroll->flags & HSCROLLBAR_VISIBLE)
+    if (scroll.flags & HSCROLLBAR_VISIBLE)
         widget_height -= SCROLLBAR_WIDTH + 1;
-    int32_t widget_content_height = std::max(scroll->v_bottom - widget_height, 0);
+    int32_t widget_content_height = std::max(scroll.v_bottom - widget_height, 0);
 
     switch (scroll_area)
     {
         case SCROLL_PART_HSCROLLBAR_LEFT:
-            scroll->h_left = std::max(scroll->h_left - 3, 0);
+            scroll.h_left = std::max(scroll.h_left - 3, 0);
             break;
         case SCROLL_PART_HSCROLLBAR_RIGHT:
-            scroll->h_left = std::min(scroll->h_left + 3, widget_content_width);
+            scroll.h_left = std::min(scroll.h_left + 3, widget_content_width);
             break;
         case SCROLL_PART_HSCROLLBAR_LEFT_TROUGH:
-            scroll->h_left = std::max(scroll->h_left - widget_width, 0);
+            scroll.h_left = std::max(scroll.h_left - widget_width, 0);
             break;
         case SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH:
-            scroll->h_left = std::min(scroll->h_left + widget_width, widget_content_width);
+            scroll.h_left = std::min(scroll.h_left + widget_width, widget_content_width);
             break;
         case SCROLL_PART_VSCROLLBAR_TOP:
-            scroll->v_top = std::max(scroll->v_top - 3, 0);
+            scroll.v_top = std::max(scroll.v_top - 3, 0);
             break;
         case SCROLL_PART_VSCROLLBAR_BOTTOM:
-            scroll->v_top = std::min(scroll->v_top + 3, widget_content_height);
+            scroll.v_top = std::min(scroll.v_top + 3, widget_content_height);
             break;
         case SCROLL_PART_VSCROLLBAR_TOP_TROUGH:
-            scroll->v_top = std::max(scroll->v_top - widget_height, 0);
+            scroll.v_top = std::max(scroll.v_top - widget_height, 0);
             break;
         case SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH:
-            scroll->v_top = std::min(scroll->v_top + widget_height, widget_content_height);
+            scroll.v_top = std::min(scroll.v_top + widget_height, widget_content_height);
             break;
         default:
             break;
@@ -744,32 +744,33 @@ static void InputScrollEnd()
 static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id)
 {
     const auto& widget = w->widgets[widgetIndex];
+    auto& scroll = w->scrolls[scroll_id];
 
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
         int32_t newLeft;
-        newLeft = w->scrolls[scroll_id].h_right;
+        newLeft = scroll.h_right;
         newLeft *= x;
         x = widget.width() - 21;
-        if (w->scrolls[scroll_id].flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             x -= SCROLLBAR_WIDTH + 1;
         newLeft /= x;
         x = newLeft;
-        w->scrolls[scroll_id].flags |= HSCROLLBAR_THUMB_PRESSED;
-        newLeft = w->scrolls[scroll_id].h_left;
+        scroll.flags |= HSCROLLBAR_THUMB_PRESSED;
+        newLeft = scroll.h_left;
         newLeft += x;
         if (newLeft < 0)
             newLeft = 0;
         x = widget.width() - 1;
-        if (w->scrolls[scroll_id].flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             x -= SCROLLBAR_WIDTH + 1;
         x *= -1;
-        x += w->scrolls[scroll_id].h_right;
+        x += scroll.h_right;
         if (x < 0)
             x = 0;
         if (newLeft > x)
             newLeft = x;
-        w->scrolls[scroll_id].h_left = newLeft;
+        scroll.h_left = newLeft;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
@@ -783,32 +784,33 @@ static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetInd
 {
     assert(w != nullptr);
     const auto& widget = w->widgets[widgetIndex];
+    auto& scroll = w->scrolls[scroll_id];
 
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
         int32_t newTop;
-        newTop = w->scrolls[scroll_id].v_bottom;
+        newTop = scroll.v_bottom;
         newTop *= y;
         y = widget.height() - 21;
-        if (w->scrolls[scroll_id].flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             y -= SCROLLBAR_WIDTH + 1;
         newTop /= y;
         y = newTop;
-        w->scrolls[scroll_id].flags |= VSCROLLBAR_THUMB_PRESSED;
-        newTop = w->scrolls[scroll_id].v_top;
+        scroll.flags |= VSCROLLBAR_THUMB_PRESSED;
+        newTop = scroll.v_top;
         newTop += y;
         if (newTop < 0)
             newTop = 0;
         y = widget.height() - 1;
-        if (w->scrolls[scroll_id].flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             y -= SCROLLBAR_WIDTH + 1;
         y *= -1;
-        y += w->scrolls[scroll_id].v_bottom;
+        y += scroll.v_bottom;
         if (y < 0)
             y = 0;
         if (newTop > y)
             newTop = y;
-        w->scrolls[scroll_id].v_top = newTop;
+        scroll.v_top = newTop;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
@@ -823,9 +825,10 @@ static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetInde
     assert(w != nullptr);
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
-        w->scrolls[scroll_id].flags |= HSCROLLBAR_LEFT_PRESSED;
-        if (w->scrolls[scroll_id].h_left >= 3)
-            w->scrolls[scroll_id].h_left -= 3;
+        auto& scroll = w->scrolls[scroll_id];
+        scroll.flags |= HSCROLLBAR_LEFT_PRESSED;
+        if (scroll.h_left >= 3)
+            scroll.h_left -= 3;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
@@ -841,17 +844,18 @@ static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetInd
     const auto& widget = w->widgets[widgetIndex];
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
-        w->scrolls[scroll_id].flags |= HSCROLLBAR_RIGHT_PRESSED;
-        w->scrolls[scroll_id].h_left += 3;
+        auto& scroll = w->scrolls[scroll_id];
+        scroll.flags |= HSCROLLBAR_RIGHT_PRESSED;
+        scroll.h_left += 3;
         int32_t newLeft = widget.width() - 1;
-        if (w->scrolls[scroll_id].flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             newLeft -= SCROLLBAR_WIDTH + 1;
         newLeft *= -1;
-        newLeft += w->scrolls[scroll_id].h_right;
+        newLeft += scroll.h_right;
         if (newLeft < 0)
             newLeft = 0;
-        if (w->scrolls[scroll_id].h_left > newLeft)
-            w->scrolls[scroll_id].h_left = newLeft;
+        if (scroll.h_left > newLeft)
+            scroll.h_left = newLeft;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
@@ -866,9 +870,10 @@ static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex
     assert(w != nullptr);
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
-        w->scrolls[scroll_id].flags |= VSCROLLBAR_UP_PRESSED;
-        if (w->scrolls[scroll_id].v_top >= 3)
-            w->scrolls[scroll_id].v_top -= 3;
+        auto& scroll = w->scrolls[scroll_id];
+        scroll.flags |= VSCROLLBAR_UP_PRESSED;
+        if (scroll.v_top >= 3)
+            scroll.v_top -= 3;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
@@ -884,17 +889,18 @@ static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIn
     const auto& widget = w->widgets[widgetIndex];
     if (window_find_by_number(w->classification, w->number) != nullptr)
     {
-        w->scrolls[scroll_id].flags |= VSCROLLBAR_DOWN_PRESSED;
-        w->scrolls[scroll_id].v_top += 3;
+        auto& scroll = w->scrolls[scroll_id];
+        scroll.flags |= VSCROLLBAR_DOWN_PRESSED;
+        scroll.v_top += 3;
         int32_t newTop = widget.height() - 1;
-        if (w->scrolls[scroll_id].flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             newTop -= SCROLLBAR_WIDTH + 1;
         newTop *= -1;
-        newTop += w->scrolls[scroll_id].v_bottom;
+        newTop += scroll.v_bottom;
         if (newTop < 0)
             newTop = 0;
-        if (w->scrolls[scroll_id].v_top > newTop)
-            w->scrolls[scroll_id].v_top = newTop;
+        if (scroll.v_top > newTop)
+            scroll.v_top = newTop;
         WidgetScrollUpdateThumbs(w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -47,7 +47,8 @@ static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
  */
 void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
-    switch (w->widgets[widgetIndex].type)
+    const auto& widget = w->widgets[widgetIndex];
+    switch (widget.type)
     {
         case WindowWidgetType::Frame:
             WidgetFrameDraw(dpi, w, widgetIndex);
@@ -111,18 +112,18 @@ void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetInd
 static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto leftTop = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
-    int32_t r = w->windowPos.x + widget->right;
-    int32_t b = w->windowPos.y + widget->bottom;
+    auto leftTop = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    int32_t r = w->windowPos.x + widget.right;
+    int32_t b = w->windowPos.y + widget.bottom;
 
     //
     uint8_t press = ((w->flags & WF_10) ? INSET_RECT_FLAG_FILL_MID_LIGHT : 0);
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     // Draw the frame
     gfx_fill_rect_inset(dpi, { leftTop, { r, b } }, colour, press);
@@ -134,7 +135,7 @@ static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
         return;
 
     // Draw the resize sprite at the bottom right corner
-    leftTop = w->windowPos + ScreenCoordsXY{ widget->right - 18, widget->bottom - 18 };
+    leftTop = w->windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
     gfx_draw_sprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
@@ -145,15 +146,15 @@ static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
 static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto leftTop = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
-    int32_t r = w->windowPos.x + widget->right;
-    int32_t b = w->windowPos.y + widget->bottom;
+    auto leftTop = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    int32_t r = w->windowPos.x + widget.right;
+    int32_t b = w->windowPos.y + widget.bottom;
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     // Draw the panel
     gfx_fill_rect_inset(dpi, { leftTop, { r, b } }, colour, 0);
@@ -165,7 +166,7 @@ static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
         return;
 
     // Draw the resize sprite at the bottom right corner
-    leftTop = w->windowPos + ScreenCoordsXY{ widget->right - 18, widget->bottom - 18 };
+    leftTop = w->windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
     gfx_draw_sprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
@@ -176,19 +177,19 @@ static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
 static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget->left, widget->top },
-                     w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom } };
+    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Check if the button is pressed down
     uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
-    if (static_cast<int32_t>(widget->image) == -2)
+    if (static_cast<int32_t>(widget.image) == -2)
     {
         // Draw border with no fill
         gfx_fill_rect_inset(dpi, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
@@ -208,20 +209,20 @@ static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
 static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    auto& widget = w->widgets[widgetIndex];
 
-    if (widget->type != WindowWidgetType::Tab && static_cast<int32_t>(widget->image) == -1)
+    if (widget.type != WindowWidgetType::Tab && static_cast<int32_t>(widget.image) == -1)
         return;
 
-    if (widget->type == WindowWidgetType::Tab)
+    if (widget.type == WindowWidgetType::Tab)
     {
         if (WidgetIsDisabled(w, widgetIndex))
             return;
 
-        if (widget->image == static_cast<uint32_t>(SPR_NONE))
+        if (widget.image == static_cast<uint32_t>(SPR_NONE))
         {
             // Set standard tab sprite to use.
-            widget->image = IMAGE_TYPE_REMAP | SPR_TAB;
+            widget.image = IMAGE_TYPE_REMAP | SPR_TAB;
         }
     }
 
@@ -232,18 +233,18 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
         return;
     }
 
-    if (widget->type != WindowWidgetType::TrnBtn)
+    if (widget.type != WindowWidgetType::TrnBtn)
     {
         WidgetDrawImage(dpi, w, widgetIndex);
         return;
     }
 
     // Resolve the absolute ltrb
-    auto leftTop = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    auto leftTop = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     // Get the colour and disabled image
-    uint8_t colour = w->colours[widget->colour] & 0x7F;
-    uint32_t image = widget->image + 2;
+    uint8_t colour = w->colours[widget.colour] & 0x7F;
+    uint32_t image = widget.image + 2;
 
     // Draw disabled image
     gfx_draw_sprite(dpi, ImageId(image, colour), leftTop);
@@ -262,19 +263,19 @@ static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     }
 
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget->left, widget->top },
-                     w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom } };
+    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     // Check if the button is pressed down
     if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
     {
-        if (static_cast<int32_t>(widget->image) == -2)
+        if (static_cast<int32_t>(widget.image) == -2)
         {
             // Draw border with no fill
             gfx_fill_rect_inset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
@@ -296,21 +297,21 @@ static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
 static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget->left, widget->top },
-                     w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom } };
+    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     // Border
     uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
     gfx_fill_rect_inset(dpi, rect, colour, press);
 
     // Button caption
-    if (widget->type != WindowWidgetType::TableHeader)
+    if (widget.type != WindowWidgetType::TableHeader)
     {
         WidgetTextCentred(dpi, w, widgetIndex);
     }
@@ -327,42 +328,42 @@ static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
 static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
-    if (widget->text == STR_NONE)
+    if (widget.text == STR_NONE)
         return;
 
     // Get the colour
-    colour_t colour = w->colours[widget->colour];
+    colour_t colour = w->colours[widget.colour];
     colour &= ~(COLOUR_FLAG_TRANSLUCENT);
     if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, 0 };
-    int32_t r = w->windowPos.x + widget->right;
+    auto topLeft = w->windowPos + ScreenCoordsXY{ widget.left, 0 };
+    int32_t r = w->windowPos.x + widget.right;
 
-    if (widget->type == WindowWidgetType::Button || widget->type == WindowWidgetType::TableHeader)
-        topLeft.y += widget->textTop();
+    if (widget.type == WindowWidgetType::Button || widget.type == WindowWidgetType::TableHeader)
+        topLeft.y += widget.textTop();
     else
-        topLeft.y += widget->top;
+        topLeft.y += widget.top;
 
-    auto stringId = widget->text;
+    auto stringId = widget.text;
     auto ft = Formatter::Common();
-    if (widget->flags & WIDGET_FLAGS::TEXT_IS_STRING)
+    if (widget.flags & WIDGET_FLAGS::TEXT_IS_STRING)
     {
         stringId = STR_STRING;
-        ft.Add<utf8*>(widget->string);
+        ft.Add<utf8*>(widget.string);
     }
 
     ScreenCoordsXY coords = { (topLeft.x + r + 1) / 2 - 1, topLeft.y };
-    if (widget->type == WindowWidgetType::LabelCentred)
+    if (widget.type == WindowWidgetType::LabelCentred)
     {
-        DrawTextWrapped(dpi, coords, widget->width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
     }
     else
     {
-        DrawTextEllipsised(dpi, coords, widget->width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextEllipsised(dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 }
 
@@ -373,39 +374,39 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
 static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
-    if (widget->text == STR_NONE || widget->text == STR_VIEWPORT)
+    if (widget.text == STR_NONE || widget.text == STR_VIEWPORT)
         return;
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
     if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    int32_t l = w->windowPos.x + widget->left;
-    int32_t r = w->windowPos.x + widget->right;
+    int32_t l = w->windowPos.x + widget.left;
+    int32_t r = w->windowPos.x + widget.right;
     int32_t t;
 
-    if (widget->type == WindowWidgetType::Button || widget->type == WindowWidgetType::DropdownMenu
-        || widget->type == WindowWidgetType::Spinner || widget->type == WindowWidgetType::TableHeader)
+    if (widget.type == WindowWidgetType::Button || widget.type == WindowWidgetType::DropdownMenu
+        || widget.type == WindowWidgetType::Spinner || widget.type == WindowWidgetType::TableHeader)
     {
-        t = w->windowPos.y + widget->textTop();
+        t = w->windowPos.y + widget.textTop();
     }
     else
-        t = w->windowPos.y + widget->top;
+        t = w->windowPos.y + widget.top;
 
-    auto stringId = widget->text;
+    auto stringId = widget.text;
     auto ft = Formatter::Common();
-    if (widget->flags & WIDGET_FLAGS::TEXT_IS_STRING)
+    if (widget.flags & WIDGET_FLAGS::TEXT_IS_STRING)
     {
         stringId = STR_STRING;
-        ft.Add<utf8*>(widget->string);
+        ft.Add<utf8*>(widget.string);
     }
 
     ScreenCoordsXY coords = { l + 1, t };
-    if (widget->type == WindowWidgetType::LabelCentred)
+    if (widget.type == WindowWidgetType::LabelCentred)
     {
         DrawTextWrapped(dpi, coords, r - l, stringId, ft, { colour, TextAlignment::CENTRE });
     }
@@ -422,26 +423,26 @@ static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex wi
 static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget->left, widget->top },
-                     w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom } };
+    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     gfx_fill_rect_inset(dpi, rect, colour, INSET_RECT_F_60);
     WidgetText(dpi, w, widgetIndex);
 }
 
-static std::pair<rct_string_id, void*> widget_get_stringid_and_args(const rct_widget* widget)
+static std::pair<rct_string_id, void*> widget_get_stringid_and_args(const rct_widget& widget)
 {
-    auto stringId = widget->text;
+    auto stringId = widget.text;
     void* formatArgs = gCommonFormatArgs;
-    if (widget->flags & WIDGET_FLAGS::TEXT_IS_STRING)
+    if (widget.flags & WIDGET_FLAGS::TEXT_IS_STRING)
     {
-        if (widget->string == nullptr || widget->string[0] == '\0')
+        if (widget.string == nullptr || widget.string[0] == '\0')
         {
             stringId = STR_NONE;
             formatArgs = nullptr;
@@ -449,7 +450,7 @@ static std::pair<rct_string_id, void*> widget_get_stringid_and_args(const rct_wi
         else
         {
             stringId = STR_STRING;
-            formatArgs = const_cast<void*>(reinterpret_cast<const void*>(&widget->string));
+            formatArgs = const_cast<void*>(reinterpret_cast<const void*>(&widget.string));
         }
     }
     return std::make_pair(stringId, formatArgs);
@@ -462,18 +463,18 @@ static std::pair<rct_string_id, void*> widget_get_stringid_and_args(const rct_wi
 static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto l = w->windowPos.x + widget->left + 5;
-    auto t = w->windowPos.y + widget->top;
+    auto l = w->windowPos.x + widget.left + 5;
+    auto t = w->windowPos.y + widget.top;
     auto textRight = l;
 
     // Text
     auto [stringId, formatArgs] = widget_get_stringid_and_args(widget);
     if (stringId != STR_NONE)
     {
-        uint8_t colour = w->colours[widget->colour] & 0x7F;
+        uint8_t colour = w->colours[widget.colour] & 0x7F;
         if (WidgetIsDisabled(w, widgetIndex))
             colour |= COLOUR_FLAG_INSET;
 
@@ -487,13 +488,13 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
 
     // Border
     // Resolve the absolute ltrb
-    l = w->windowPos.x + widget->left;
-    t = w->windowPos.y + widget->top + 4;
-    const auto r = w->windowPos.x + widget->right;
-    const auto b = w->windowPos.y + widget->bottom;
+    l = w->windowPos.x + widget.left;
+    t = w->windowPos.y + widget.top + 4;
+    const auto r = w->windowPos.x + widget.right;
+    const auto b = w->windowPos.y + widget.bottom;
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour] & 0x7F;
+    uint8_t colour = w->colours[widget.colour] & 0x7F;
 
     // Border left of text
     gfx_fill_rect(dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
@@ -523,7 +524,7 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
 static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto* widget = &w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
     auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
@@ -571,11 +572,11 @@ static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
 static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
-    auto bottomRight = w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
+    auto topLeft = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    auto bottomRight = w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
 
     // Check if the button is pressed down
     uint8_t press = 0;
@@ -585,20 +586,20 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
         press |= INSET_RECT_FLAG_BORDER_INSET;
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     // Draw the button
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, press);
 
-    if (widget->text == STR_NONE)
+    if (widget.text == STR_NONE)
         return;
 
-    topLeft = w->windowPos + ScreenCoordsXY{ widget->midX() - 1, std::max<int32_t>(widget->top, widget->midY() - 5) };
+    topLeft = w->windowPos + ScreenCoordsXY{ widget.midX() - 1, std::max<int32_t>(widget.top, widget.midY() - 5) };
 
     if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
-    DrawTextEllipsised(dpi, topLeft, widget->width() - 2, widget->text, Formatter::Common(), { colour, TextAlignment::CENTRE });
+    DrawTextEllipsised(dpi, topLeft, widget.width() - 2, widget.text, Formatter::Common(), { colour, TextAlignment::CENTRE });
 }
 
 /**
@@ -608,15 +609,15 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
 static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltb
-    ScreenCoordsXY topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
-    ScreenCoordsXY bottomRight = w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
+    ScreenCoordsXY topLeft = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    ScreenCoordsXY bottomRight = w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
     ScreenCoordsXY midLeft = { topLeft.x, (topLeft.y + bottomRight.y) / 2 };
 
     // Get the colour
-    colour_t colour = w->colours[widget->colour];
+    colour_t colour = w->colours[widget.colour];
 
     // checkbox
     gfx_fill_rect_inset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
@@ -635,7 +636,7 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     }
 
     // draw the text
-    if (widget->text == STR_NONE)
+    if (widget.text == STR_NONE)
         return;
 
     auto [stringId, formatArgs] = widget_get_stringid_and_args(widget);
@@ -650,15 +651,15 @@ static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
 {
     // Get the widget
     int32_t scrollIndex = window_get_scroll_data_index(w, widgetIndex);
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
     rct_scroll* scroll = &w->scrolls[scrollIndex];
 
     // Resolve the absolute ltrb
-    ScreenCoordsXY topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
-    ScreenCoordsXY bottomRight = w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
+    ScreenCoordsXY topLeft = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    ScreenCoordsXY bottomRight = w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     // Draw the border
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
@@ -791,33 +792,33 @@ static void WidgetVScrollbarDraw(
 static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Get the image
-    int32_t image = widget->image;
+    int32_t image = widget.image;
     if (image == SPR_NONE)
         return;
 
     // Resolve the absolute ltrb
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     // Get the colour
-    uint8_t colour = NOT_TRANSLUCENT(w->colours[widget->colour]);
+    uint8_t colour = NOT_TRANSLUCENT(w->colours[widget.colour]);
 
-    if (widget->type == WindowWidgetType::ColourBtn || widget->type == WindowWidgetType::TrnBtn
-        || widget->type == WindowWidgetType::Tab)
+    if (widget.type == WindowWidgetType::ColourBtn || widget.type == WindowWidgetType::TrnBtn
+        || widget.type == WindowWidgetType::Tab)
         if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
             image++;
 
     if (WidgetIsDisabled(w, widgetIndex))
     {
         // Draw greyed out (light border bottom right shadow)
-        colour = w->colours[widget->colour];
+        colour = w->colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].lighter;
         gfx_draw_sprite_solid(dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, colour);
 
         // Draw greyed out (dark)
-        colour = w->colours[widget->colour];
+        colour = w->colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].mid_light;
         gfx_draw_sprite_solid(dpi, image, screenCoords, colour);
     }
@@ -916,7 +917,7 @@ bool WidgetIsActiveTool(rct_window* w, rct_widgetindex widgetIndex)
  *  edi: widget
  */
 void WidgetScrollGetPart(
-    rct_window* w, rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
+    rct_window* w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
     int32_t* output_scroll_area, int32_t* scroll_id)
 {
     *scroll_id = 0;
@@ -1086,14 +1087,14 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     char wrapped_string[TEXT_INPUT_SIZE];
 
     // Get the widget
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenCoordsXY topLeft{ w->windowPos + ScreenCoordsXY{ widget->left, widget->top } };
-    ScreenCoordsXY bottomRight{ w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom } };
+    ScreenCoordsXY topLeft{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top } };
+    ScreenCoordsXY bottomRight{ w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w->colours[widget.colour];
 
     bool active = w->classification == gCurrentTextBox.window.classification && w->number == gCurrentTextBox.window.number
         && widgetIndex == gCurrentTextBox.widget_index;
@@ -1102,13 +1103,13 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
     // Figure out where the text should be positioned vertically.
-    topLeft.y = w->windowPos.y + widget->textTop();
+    topLeft.y = w->windowPos.y + widget.textTop();
 
     if (!active || gTextInput == nullptr)
     {
-        if (w->widgets[widgetIndex].text != 0)
+        if (widget.text != 0)
         {
-            safe_strcpy(wrapped_string, w->widgets[widgetIndex].string, 512);
+            safe_strcpy(wrapped_string, widget.string, 512);
             gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5, FontSpriteBase::MEDIUM, &no_lines);
             gfx_draw_string_no_formatting(
                 dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w->colours[1], FontSpriteBase::MEDIUM });
@@ -1144,7 +1145,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     if (gTextBoxFrameNo <= 15)
     {
         colour = ColourMapA[w->colours[1]].mid_light;
-        auto y = topLeft.y + (widget->height() - 1);
+        auto y = topLeft.y + (widget.height() - 1);
         gfx_fill_rect(dpi, { { cur_x, y }, { cur_x + width, y } }, colour + 5);
     }
 }

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -356,25 +356,25 @@ static rct_widget* WindowGetScrollWidget(rct_window* w, int32_t scrollIndex)
  */
 static void WindowScrollWheelInput(rct_window* w, int32_t scrollIndex, int32_t wheel)
 {
-    rct_scroll* scroll = &w->scrolls[scrollIndex];
+    auto& scroll = w->scrolls[scrollIndex];
     rct_widget* widget = WindowGetScrollWidget(w, scrollIndex);
     rct_widgetindex widgetIndex = WindowGetWidgetIndex(w, widget);
 
-    if (scroll->flags & VSCROLLBAR_VISIBLE)
+    if (scroll.flags & VSCROLLBAR_VISIBLE)
     {
         int32_t size = widget->height() - 1;
-        if (scroll->flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll->v_bottom - size);
-        scroll->v_top = std::min(std::max(0, scroll->v_top + wheel), size);
+        size = std::max(0, scroll.v_bottom - size);
+        scroll.v_top = std::min(std::max(0, scroll.v_top + wheel), size);
     }
     else
     {
         int32_t size = widget->width() - 1;
-        if (scroll->flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             size -= 11;
-        size = std::max(0, scroll->h_right - size);
-        scroll->h_left = std::min(std::max(0, scroll->h_left + wheel), size);
+        size = std::max(0, scroll.h_right - size);
+        scroll.h_left = std::min(std::max(0, scroll.h_left + wheel), size);
     }
 
     WidgetScrollUpdateThumbs(w, widgetIndex);
@@ -394,8 +394,8 @@ static int32_t WindowWheelInput(rct_window* w, int32_t wheel)
             continue;
 
         // Originally always checked first scroll view, bug maybe?
-        rct_scroll* scroll = &w->scrolls[i];
-        if (scroll->flags & (HSCROLLBAR_VISIBLE | VSCROLLBAR_VISIBLE))
+        const auto& scroll = w->scrolls[i];
+        if (scroll.flags & (HSCROLLBAR_VISIBLE | VSCROLLBAR_VISIBLE))
         {
             WindowScrollWheelInput(w, i, wheel);
             return 1;
@@ -542,8 +542,8 @@ void WindowAllWheelInput()
                 if (widget.type == WindowWidgetType::Scroll)
                 {
                     int32_t scrollIndex = WindowGetScrollIndex(w, widgetIndex);
-                    rct_scroll* scroll = &w->scrolls[scrollIndex];
-                    if (scroll->flags & (HSCROLLBAR_VISIBLE | VSCROLLBAR_VISIBLE))
+                    const auto& scroll = w->scrolls[scrollIndex];
+                    if (scroll.flags & (HSCROLLBAR_VISIBLE | VSCROLLBAR_VISIBLE))
                     {
                         WindowScrollWheelInput(w, WindowGetScrollIndex(w, widgetIndex), pixel_scroll);
                         return;
@@ -577,7 +577,6 @@ void ApplyScreenSaverLockSetting()
 void WindowInitScrollWidgets(rct_window* w)
 {
     rct_widget* widget;
-    rct_scroll* scroll;
     int32_t widget_index, scroll_index;
     int32_t width, height;
 
@@ -591,20 +590,20 @@ void WindowInitScrollWidgets(rct_window* w)
             continue;
         }
 
-        scroll = &w->scrolls[scroll_index];
-        scroll->flags = 0;
+        auto& scroll = w->scrolls[scroll_index];
+        scroll.flags = 0;
         width = 0;
         height = 0;
         window_get_scroll_size(w, scroll_index, &width, &height);
-        scroll->h_left = 0;
-        scroll->h_right = width + 1;
-        scroll->v_top = 0;
-        scroll->v_bottom = height + 1;
+        scroll.h_left = 0;
+        scroll.h_right = width + 1;
+        scroll.v_top = 0;
+        scroll.v_bottom = height + 1;
 
         if (widget->content & SCROLL_HORIZONTAL)
-            scroll->flags |= HSCROLLBAR_VISIBLE;
+            scroll.flags |= HSCROLLBAR_VISIBLE;
         if (widget->content & SCROLL_VERTICAL)
-            scroll->flags |= VSCROLLBAR_VISIBLE;
+            scroll.flags |= VSCROLLBAR_VISIBLE;
 
         WidgetScrollUpdateThumbs(w, widget_index);
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -538,8 +538,8 @@ void WindowAllWheelInput()
             rct_widgetindex widgetIndex = window_find_widget_from_point(w, cursorState->position);
             if (widgetIndex != -1)
             {
-                rct_widget* widget = &w->widgets[widgetIndex];
-                if (widget->type == WindowWidgetType::Scroll)
+                const auto& widget = w->widgets[widgetIndex];
+                if (widget.type == WindowWidgetType::Scroll)
                 {
                     int32_t scrollIndex = WindowGetScrollIndex(w, widgetIndex);
                     rct_scroll* scroll = &w->scrolls[scrollIndex];

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -826,20 +826,22 @@ static void window_editor_object_selection_invalidate(rct_window* w)
     // Set window title and buttons
     auto ft = Formatter::Common();
     ft.Add<rct_string_id>(ObjectSelectionPages[w->selected_tab].Caption);
+    auto& titleWidget = w->widgets[WIDX_TITLE];
+    auto& installTrackWidget = w->widgets[WIDX_INSTALL_TRACK];
     if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
     {
-        w->widgets[WIDX_TITLE].text = STR_TRACK_DESIGNS_MANAGER_SELECT_RIDE_TYPE;
-        w->widgets[WIDX_INSTALL_TRACK].type = WindowWidgetType::Button;
+        titleWidget.text = STR_TRACK_DESIGNS_MANAGER_SELECT_RIDE_TYPE;
+        installTrackWidget.type = WindowWidgetType::Button;
     }
     else if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
     {
-        w->widgets[WIDX_TITLE].text = STR_ROLLER_COASTER_DESIGNER_SELECT_RIDE_TYPES_VEHICLES;
-        w->widgets[WIDX_INSTALL_TRACK].type = WindowWidgetType::Empty;
+        titleWidget.text = STR_ROLLER_COASTER_DESIGNER_SELECT_RIDE_TYPES_VEHICLES;
+        installTrackWidget.type = WindowWidgetType::Empty;
     }
     else
     {
-        w->widgets[WIDX_TITLE].text = STR_OBJECT_SELECTION;
-        w->widgets[WIDX_INSTALL_TRACK].type = WindowWidgetType::Empty;
+        titleWidget.text = STR_OBJECT_SELECTION;
+        installTrackWidget.type = WindowWidgetType::Empty;
     }
 
     // Align tabs, hide advanced ones
@@ -847,16 +849,16 @@ static void window_editor_object_selection_invalidate(rct_window* w)
     int32_t x = 3;
     for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
     {
-        auto widget = &w->widgets[WIDX_TAB_1 + i];
+        auto& widget = w->widgets[WIDX_TAB_1 + i];
         if (!advancedMode && ObjectSelectionPages[i].IsAdvanced)
         {
-            widget->type = WindowWidgetType::Empty;
+            widget.type = WindowWidgetType::Empty;
         }
         else
         {
-            widget->type = WindowWidgetType::Tab;
-            widget->left = x;
-            widget->right = x + 30;
+            widget.type = WindowWidgetType::Tab;
+            widget.left = x;
+            widget.right = x + 30;
             x += 31;
         }
     }
@@ -950,8 +952,8 @@ static void window_editor_object_selection_invalidate(rct_window* w)
 
 static void window_editor_object_selection_paint_descriptions(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    auto widget = &w->widgets[WIDX_PREVIEW];
-    auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LIST].right + 4, widget->bottom + 23 };
+    const auto& widget = w->widgets[WIDX_PREVIEW];
+    auto screenPos = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LIST].right + 4, widget.bottom + 23 };
     auto width = w->windowPos.x + w->width - screenPos.x - 4;
 
     auto description = object_get_description(_loadedObject.get());
@@ -1069,18 +1071,17 @@ static void window_editor_object_selection_paint_debug_data(rct_window* w, rct_d
 static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     int32_t width;
-    rct_widget* widget;
 
     WindowDrawWidgets(w, dpi);
 
     // Draw tabs
     for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
     {
-        widget = &w->widgets[WIDX_TAB_1 + i];
-        if (widget->type != WindowWidgetType::Empty)
+        const auto& widget = w->widgets[WIDX_TAB_1 + i];
+        if (widget.type != WindowWidgetType::Empty)
         {
             auto image = ImageId(ObjectSelectionPages[i].Image);
-            auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+            auto screenPos = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
             gfx_draw_sprite(dpi, image, screenPos);
         }
     }
@@ -1096,8 +1097,8 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     {
         for (int32_t i = 0; i < 7; i++)
         {
-            widget = &w->widgets[WIDX_FILTER_RIDE_TAB_ALL + i];
-            if (widget->type == WindowWidgetType::Empty)
+            const auto& widget = w->widgets[WIDX_FILTER_RIDE_TAB_ALL + i];
+            if (widget.type == WindowWidgetType::Empty)
                 continue;
 
             int32_t spriteIndex = ride_tabs[i];
@@ -1108,17 +1109,17 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
             }
             spriteIndex += (i == 4 ? ThrillRidesTabAnimationSequence[frame] : frame);
 
-            auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+            auto screenPos = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
             gfx_draw_sprite(dpi, ImageId(spriteIndex, w->colours[1]), screenPos);
         }
     }
 
     // Preview background
-    widget = &w->widgets[WIDX_PREVIEW];
+    const auto& previewWidget = w->widgets[WIDX_PREVIEW];
     gfx_fill_rect(
         dpi,
-        { w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 },
-          w->windowPos + ScreenCoordsXY{ widget->right - 1, widget->bottom - 1 } },
+        { w->windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 },
+          w->windowPos + ScreenCoordsXY{ previewWidget.right - 1, previewWidget.bottom - 1 } },
         ColourMapA[w->colours[1]].darkest);
 
     // Draw number of selected items
@@ -1136,25 +1137,25 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     }
 
     // Draw sort button text
-    widget = &w->widgets[WIDX_LIST_SORT_TYPE];
-    if (widget->type != WindowWidgetType::Empty)
+    const auto& listSortTypeWidget = w->widgets[WIDX_LIST_SORT_TYPE];
+    if (listSortTypeWidget.type != WindowWidgetType::Empty)
     {
         auto ft = Formatter();
         auto stringId = _listSortType == RIDE_SORT_TYPE ? static_cast<rct_string_id>(_listSortDescending ? STR_DOWN : STR_UP)
                                                         : STR_NONE;
         ft.Add<rct_string_id>(stringId);
-        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
-        DrawTextEllipsised(dpi, screenPos, widget->width(), STR_OBJECTS_SORT_TYPE, ft, { w->colours[1] });
+        auto screenPos = w->windowPos + ScreenCoordsXY{ listSortTypeWidget.left + 1, listSortTypeWidget.top + 1 };
+        DrawTextEllipsised(dpi, screenPos, listSortTypeWidget.width(), STR_OBJECTS_SORT_TYPE, ft, { w->colours[1] });
     }
-    widget = &w->widgets[WIDX_LIST_SORT_RIDE];
-    if (widget->type != WindowWidgetType::Empty)
+    const auto& listSortRideWidget = w->widgets[WIDX_LIST_SORT_RIDE];
+    if (listSortRideWidget.type != WindowWidgetType::Empty)
     {
         auto ft = Formatter();
         auto stringId = _listSortType == RIDE_SORT_RIDE ? static_cast<rct_string_id>(_listSortDescending ? STR_DOWN : STR_UP)
                                                         : STR_NONE;
         ft.Add<rct_string_id>(stringId);
-        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
-        DrawTextEllipsised(dpi, screenPos, widget->width(), STR_OBJECTS_SORT_RIDE, ft, { w->colours[1] });
+        auto screenPos = w->windowPos + ScreenCoordsXY{ listSortRideWidget.left + 1, listSortRideWidget.top + 1 };
+        DrawTextEllipsised(dpi, screenPos, listSortRideWidget.width(), STR_OBJECTS_SORT_RIDE, ft, { w->colours[1] });
     }
 
     if (w->selected_list_item == -1 || _loadedObject == nullptr)
@@ -1163,12 +1164,11 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     list_item* listItem = &_listItems[w->selected_list_item];
 
     // Draw preview
-    widget = &w->widgets[WIDX_PREVIEW];
     {
         rct_drawpixelinfo clipDPI;
-        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
-        width = widget->width() - 1;
-        int32_t height = widget->height() - 1;
+        auto screenPos = w->windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
+        width = previewWidget.width() - 1;
+        int32_t height = previewWidget.height() - 1;
         if (clip_drawpixelinfo(&clipDPI, dpi, screenPos, width, height))
         {
             _loadedObject->DrawPreview(&clipDPI, width, height);
@@ -1177,7 +1177,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
 
     // Draw name of object
     {
-        auto screenPos = w->windowPos + ScreenCoordsXY{ widget->midX() + 1, widget->bottom + 3 };
+        auto screenPos = w->windowPos + ScreenCoordsXY{ previewWidget.midX() + 1, previewWidget.bottom + 3 };
         width = w->width - w->widgets[WIDX_LIST].right - 6;
         auto ft = Formatter();
         ft.Add<rct_string_id>(STR_STRING);
@@ -1188,6 +1188,7 @@ static void window_editor_object_selection_paint(rct_window* w, rct_drawpixelinf
     window_editor_object_selection_paint_descriptions(w, dpi);
     window_editor_object_selection_paint_debug_data(w, dpi);
 }
+
 /**
  *
  *  rct2: 0x006AADA3

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -474,9 +474,8 @@ static void window_editor_scenario_options_financial_resize(rct_window* w)
 static void window_editor_scenario_options_show_climate_dropdown(rct_window* w)
 {
     int32_t i;
-    rct_widget* dropdownWidget;
 
-    dropdownWidget = &w->widgets[WIDX_CLIMATE];
+    const auto& dropdownWidget = w->widgets[WIDX_CLIMATE];
 
     for (i = 0; i < static_cast<uint8_t>(ClimateType::Count); i++)
     {
@@ -484,8 +483,8 @@ static void window_editor_scenario_options_show_climate_dropdown(rct_window* w)
         gDropdownItemsArgs[i] = ClimateNames[i];
     }
     WindowDropdownShowTextCustomWidth(
-        { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, Dropdown::Flag::StayOpen, static_cast<uint8_t>(ClimateType::Count), dropdownWidget->width() - 3);
+        { w->windowPos.x + dropdownWidget.left, w->windowPos.y + dropdownWidget.top }, dropdownWidget.height() + 1,
+        w->colours[1], 0, Dropdown::Flag::StayOpen, static_cast<uint8_t>(ClimateType::Count), dropdownWidget.width() - 3);
     Dropdown::SetChecked(static_cast<uint8_t>(gClimate), true);
 }
 
@@ -683,49 +682,49 @@ static void window_editor_scenario_options_financial_paint(rct_window* w, rct_dr
     WindowDrawWidgets(w, dpi);
     window_editor_scenario_options_draw_tab_images(w, dpi);
 
-    if (w->widgets[WIDX_INITIAL_CASH].type != WindowWidgetType::Empty)
+    const auto& initialCashWidget = w->widgets[WIDX_INITIAL_CASH];
+    if (initialCashWidget.type != WindowWidgetType::Empty)
     {
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_INITIAL_CASH].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, initialCashWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_INIT_CASH_LABEL);
 
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_INITIAL_CASH].left + 1, w->widgets[WIDX_INITIAL_CASH].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ initialCashWidget.left + 1, initialCashWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gInitialCash);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
-    if (w->widgets[WIDX_INITIAL_LOAN].type != WindowWidgetType::Empty)
+    const auto& initialLoanWidget = w->widgets[WIDX_INITIAL_LOAN];
+    if (initialLoanWidget.type != WindowWidgetType::Empty)
     {
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_INITIAL_LOAN].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, initialLoanWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_INIT_LOAN_LABEL);
 
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_INITIAL_LOAN].left + 1, w->widgets[WIDX_INITIAL_LOAN].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ initialLoanWidget.left + 1, initialLoanWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gBankLoan);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
-    if (w->widgets[WIDX_MAXIMUM_LOAN].type != WindowWidgetType::Empty)
+    const auto& maximumLoanWidget = w->widgets[WIDX_MAXIMUM_LOAN];
+    if (maximumLoanWidget.type != WindowWidgetType::Empty)
     {
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_MAXIMUM_LOAN].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, maximumLoanWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_MAX_LOAN_LABEL);
 
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_MAXIMUM_LOAN].left + 1, w->widgets[WIDX_MAXIMUM_LOAN].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ maximumLoanWidget.left + 1, maximumLoanWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gMaxBankLoan);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
-    if (w->widgets[WIDX_INTEREST_RATE].type != WindowWidgetType::Empty)
+    const auto& interestRateWidget = w->widgets[WIDX_INTEREST_RATE];
+    if (interestRateWidget.type != WindowWidgetType::Empty)
     {
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_INTEREST_RATE].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, interestRateWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_INTEREST_RATE_LABEL);
 
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_INTEREST_RATE].left + 1, w->widgets[WIDX_INTEREST_RATE].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ interestRateWidget.left + 1, interestRateWidget.top };
 
         auto ft = Formatter();
         ft.Add<int16_t>(std::clamp<int16_t>(static_cast<int16_t>(gBankLoanInterestRate), INT16_MIN, INT16_MAX));
@@ -967,49 +966,49 @@ static void window_editor_scenario_options_guests_paint(rct_window* w, rct_drawp
     WindowDrawWidgets(w, dpi);
     window_editor_scenario_options_draw_tab_images(w, dpi);
 
-    if (w->widgets[WIDX_CASH_PER_GUEST].type != WindowWidgetType::Empty)
+    const auto& cashPerGuestWidget = w->widgets[WIDX_CASH_PER_GUEST];
+    if (cashPerGuestWidget.type != WindowWidgetType::Empty)
     {
         // Cash per guest label
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CASH_PER_GUEST].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, cashPerGuestWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_CASH_PER_GUEST_LABEL);
 
         // Cash per guest value
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_CASH_PER_GUEST].left + 1, w->widgets[WIDX_CASH_PER_GUEST].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ cashPerGuestWidget.left + 1, cashPerGuestWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gGuestInitialCash);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
     // Guest initial happiness label
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top };
+    const auto& initialHappinessWidget = w->widgets[WIDX_GUEST_INITIAL_HAPPINESS];
+    screenCoords = w->windowPos + ScreenCoordsXY{ 8, initialHappinessWidget.top };
     DrawTextBasic(dpi, screenCoords, STR_GUEST_INIT_HAPPINESS);
 
     // Guest initial happiness value
-    screenCoords = w->windowPos
-        + ScreenCoordsXY{ w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].left + 1, w->widgets[WIDX_GUEST_INITIAL_HAPPINESS].top };
+    screenCoords = w->windowPos + ScreenCoordsXY{ initialHappinessWidget.left + 1, initialHappinessWidget.top };
     auto ft = Formatter();
     ft.Add<uint16_t>((gGuestInitialHappiness * 100) / 255);
     DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
 
     // Guest initial hunger label
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_GUEST_INITIAL_HUNGER].top };
+    const auto& initialHungerWidget = w->widgets[WIDX_GUEST_INITIAL_HUNGER];
+    screenCoords = w->windowPos + ScreenCoordsXY{ 8, initialHungerWidget.top };
     DrawTextBasic(dpi, screenCoords, STR_GUEST_INIT_HUNGER);
 
     // Guest initial hunger value
-    screenCoords = w->windowPos
-        + ScreenCoordsXY{ w->widgets[WIDX_GUEST_INITIAL_HUNGER].left + 1, w->widgets[WIDX_GUEST_INITIAL_HUNGER].top };
+    screenCoords = w->windowPos + ScreenCoordsXY{ initialHungerWidget.left + 1, initialHungerWidget.top };
     ft = Formatter();
     ft.Add<uint16_t>(((255 - gGuestInitialHunger) * 100) / 255);
     DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
 
     // Guest initial thirst label
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_GUEST_INITIAL_THIRST].top };
+    const auto& initialThirstWidget = w->widgets[WIDX_GUEST_INITIAL_THIRST];
+    screenCoords = w->windowPos + ScreenCoordsXY{ 8, initialThirstWidget.top };
     DrawTextBasic(dpi, screenCoords, STR_GUEST_INIT_THIRST);
 
     // Guest initial thirst value
-    screenCoords = w->windowPos
-        + ScreenCoordsXY{ w->widgets[WIDX_GUEST_INITIAL_THIRST].left + 1, w->widgets[WIDX_GUEST_INITIAL_THIRST].top };
+    screenCoords = w->windowPos + ScreenCoordsXY{ initialThirstWidget.left + 1, initialThirstWidget.top };
     ft = Formatter();
     ft.Add<uint16_t>(((255 - gGuestInitialThirst) * 100) / 255);
     DrawTextBasic(dpi, screenCoords, STR_PERCENT_FORMAT_LABEL, ft);
@@ -1331,39 +1330,39 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
     WindowDrawWidgets(w, dpi);
     window_editor_scenario_options_draw_tab_images(w, dpi);
 
-    if (w->widgets[WIDX_LAND_COST].type != WindowWidgetType::Empty)
+    const auto& landCostWidget = w->widgets[WIDX_LAND_COST];
+    if (landCostWidget.type != WindowWidgetType::Empty)
     {
         // Cost to buy land label
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_LAND_COST].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, landCostWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_LAND_COST_LABEL);
 
         // Cost to buy land value
-        screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_LAND_COST].left + 1, w->widgets[WIDX_LAND_COST].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ landCostWidget.left + 1, landCostWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gLandPrice);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
-    if (w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].type != WindowWidgetType::Empty)
+    const auto& constructionRightsCostWidget = w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST];
+    if (constructionRightsCostWidget.type != WindowWidgetType::Empty)
     {
         // Cost to buy construction rights label
-        screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ 8, constructionRightsCostWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_RIGHTS_COST_LABEL);
 
         // Cost to buy construction rights value
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].left + 1,
-                              w->widgets[WIDX_CONSTRUCTION_RIGHTS_COST].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ constructionRightsCostWidget.left + 1, constructionRightsCostWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gConstructionRightsPrice);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
-    if (w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].type != WindowWidgetType::Empty)
+    const auto& payForParkOrRidesWidget = w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES];
+    if (payForParkOrRidesWidget.type != WindowWidgetType::Empty)
     {
         // Pay for park or rides label
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].left + 1, w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ payForParkOrRidesWidget.left + 1, payForParkOrRidesWidget.top };
 
         auto ft = Formatter();
         // Pay for park and/or rides value
@@ -1377,26 +1376,27 @@ static void window_editor_scenario_options_park_paint(rct_window* w, rct_drawpix
         DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
     }
 
-    if (w->widgets[WIDX_ENTRY_PRICE].type != WindowWidgetType::Empty)
+    const auto& entryPriceWidget = w->widgets[WIDX_ENTRY_PRICE];
+    if (entryPriceWidget.type != WindowWidgetType::Empty)
     {
         // Entry price label
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES].right + 8, w->widgets[WIDX_ENTRY_PRICE].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ entryPriceWidget.right + 8, entryPriceWidget.top };
         DrawTextBasic(dpi, screenCoords, STR_ENTRY_PRICE_LABEL);
 
         // Entry price value
-        screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_ENTRY_PRICE].left + 1, w->widgets[WIDX_ENTRY_PRICE].top };
+        screenCoords = w->windowPos + ScreenCoordsXY{ entryPriceWidget.left + 1, entryPriceWidget.top };
         auto ft = Formatter();
         ft.Add<money64>(gParkEntranceFee);
         DrawTextBasic(dpi, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft);
     }
 
     // Climate label
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CLIMATE].top };
+    const auto& climateWidget = w->widgets[WIDX_CLIMATE];
+    screenCoords = w->windowPos + ScreenCoordsXY{ 8, climateWidget.top };
     DrawTextBasic(dpi, screenCoords, STR_CLIMATE_LABEL);
 
     // Climate value
-    screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_CLIMATE].left + 1, w->widgets[WIDX_CLIMATE].top };
+    screenCoords = w->windowPos + ScreenCoordsXY{ climateWidget.left + 1, climateWidget.top };
     auto ft = Formatter();
     ft.Add<rct_string_id>(ClimateNames[static_cast<uint8_t>(gClimate)]);
     DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -745,10 +745,10 @@ void window_guest_viewport_init(rct_window* w)
 
     if (peep->State != PeepState::Picked && w->viewport == nullptr)
     {
-        auto view_widget = &w->widgets[WIDX_VIEWPORT];
-        auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->windowPos.x, view_widget->top + 1 + w->windowPos.y };
-        int32_t width = view_widget->width() - 1;
-        int32_t height = view_widget->height() - 1;
+        const auto& view_widget = w->widgets[WIDX_VIEWPORT];
+        auto screenPos = ScreenCoordsXY{ view_widget.left + 1 + w->windowPos.x, view_widget.top + 1 + w->windowPos.y };
+        int32_t width = view_widget.width() - 1;
+        int32_t height = view_widget.height() - 1;
 
         viewport_create(w, screenPos, width, height, w->focus.value());
         if (w->viewport != nullptr && reCreateViewport)
@@ -771,10 +771,10 @@ static void window_guest_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     if (w->disabled_widgets & (1ULL << WIDX_TAB_1))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_1];
-    int32_t width = widget->width() - 1;
-    int32_t height = widget->height() - 1;
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
+    const auto& widget = w->widgets[WIDX_TAB_1];
+    int32_t width = widget.width() - 1;
+    int32_t height = widget.height() - 1;
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
     if (w->page == WINDOW_GUEST_OVERVIEW)
         height++;
 
@@ -843,8 +843,8 @@ static void window_guest_stats_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->disabled_widgets & (1ULL << WIDX_TAB_2))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_2];
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_2];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     const auto peep = GetGuest(w);
     if (peep == nullptr)
@@ -881,8 +881,8 @@ static void window_guest_rides_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->disabled_widgets & (1ULL << WIDX_TAB_3))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_3];
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_3];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     int32_t image_id = SPR_TAB_RIDE_0;
 
@@ -903,8 +903,8 @@ static void window_guest_finance_tab_paint(rct_window* w, rct_drawpixelinfo* dpi
     if (w->disabled_widgets & (1ULL << WIDX_TAB_4))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_4];
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_4];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     int32_t image_id = SPR_TAB_FINANCES_SUMMARY_0;
 
@@ -925,8 +925,8 @@ static void window_guest_thoughts_tab_paint(rct_window* w, rct_drawpixelinfo* dp
     if (w->disabled_widgets & (1ULL << WIDX_TAB_5))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_5];
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_5];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     int32_t image_id = SPR_TAB_THOUGHTS_0;
 
@@ -947,8 +947,8 @@ static void window_guest_inventory_tab_paint(rct_window* w, rct_drawpixelinfo* d
     if (w->disabled_widgets & (1ULL << WIDX_TAB_6))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_6];
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_6];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     gfx_draw_sprite(dpi, ImageId(SPR_TAB_GUEST_INVENTORY), screenCoords);
 }
@@ -958,8 +958,8 @@ static void window_guest_debug_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->disabled_widgets & (1ULL << WIDX_TAB_7))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_7];
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_7];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     int32_t image_id = SPR_TAB_GEARS_0;
     if (w->page == WINDOW_GUEST_DEBUG)
@@ -1003,22 +1003,22 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    rct_widget* widget = &w->widgets[WIDX_ACTION_LBL];
-    auto screenPos = w->windowPos + ScreenCoordsXY{ widget->midX(), widget->top - 1 };
+    const auto& actionLabelWidget = w->widgets[WIDX_ACTION_LBL];
+    auto screenPos = w->windowPos + ScreenCoordsXY{ actionLabelWidget.midX(), actionLabelWidget.top - 1 };
 
     {
         auto ft = Formatter();
         peep->FormatActionTo(ft);
-        int32_t width = widget->width();
+        int32_t width = actionLabelWidget.width();
         DrawTextEllipsised(dpi, screenPos, width, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
     }
 
     // Draw the marquee thought
-    widget = &w->widgets[WIDX_MARQUEE];
-    auto width = widget->width() - 3;
-    int32_t left = widget->left + 2 + w->windowPos.x;
-    int32_t top = widget->top + w->windowPos.y;
-    int32_t height = widget->height();
+    const auto& marqueeWidget = w->widgets[WIDX_MARQUEE];
+    auto width = marqueeWidget.width() - 3;
+    int32_t left = marqueeWidget.left + 2 + w->windowPos.x;
+    int32_t top = marqueeWidget.top + w->windowPos.y;
+    int32_t height = marqueeWidget.height();
     rct_drawpixelinfo dpi_marquee;
     if (!clip_drawpixelinfo(&dpi_marquee, dpi, { left, top }, width, height))
     {
@@ -1044,7 +1044,7 @@ void window_guest_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
         return;
     }
 
-    screenPos.x = widget->width() - w->list_information_type;
+    screenPos.x = marqueeWidget.width() - w->list_information_type;
     {
         auto ft = Formatter();
         peep_thought_set_format_args(&peep->Thoughts[i], ft);

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -180,8 +180,8 @@ static void window_news_options_invalidate(rct_window* w)
     w->pressed_widgets |= (1ULL << (WIDX_TAB_PARK + w->page));
 
     // Set checkboxes
-    rct_widget* baseCheckBox = &w->widgets[WIDX_CHECKBOX_0];
-    int32_t y = baseCheckBox->top;
+    const auto& baseCheckBox = w->widgets[WIDX_CHECKBOX_0];
+    int32_t y = baseCheckBox.top;
 
     int32_t checkboxWidgetIndex = WIDX_CHECKBOX_0;
     rct_widget* checkboxWidget = &w->widgets[checkboxWidgetIndex];
@@ -194,8 +194,8 @@ static void window_news_options_invalidate(rct_window* w)
         w->enabled_widgets |= (1ULL << checkboxWidgetIndex);
 
         checkboxWidget->type = WindowWidgetType::Checkbox;
-        checkboxWidget->left = baseCheckBox->left;
-        checkboxWidget->right = baseCheckBox->right;
+        checkboxWidget->left = baseCheckBox.left;
+        checkboxWidget->right = baseCheckBox.right;
         checkboxWidget->top = y;
         checkboxWidget->bottom = checkboxWidget->top + LIST_ROW_HEIGHT + 3;
         checkboxWidget->text = ndef->caption;
@@ -266,9 +266,8 @@ static void window_news_options_draw_tab_image(rct_window* w, rct_drawpixelinfo*
             }
         }
 
-        gfx_draw_sprite(
-            dpi, ImageId(spriteIndex),
-            w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
+        const auto& widget = w->widgets[widgetIndex];
+        gfx_draw_sprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
     }
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1474,10 +1474,10 @@ static void window_options_audio_dropdown(rct_window* w, rct_widgetindex widgetI
     }
 }
 
-static uint8_t get_scroll_percentage(rct_widget* widget, rct_scroll* scroll)
+static uint8_t get_scroll_percentage(const rct_widget& widget, const rct_scroll& scroll)
 {
-    uint8_t width = widget->width() - 1;
-    return static_cast<float>(scroll->h_left) / (scroll->h_right - width) * 100;
+    uint8_t width = widget.width() - 1;
+    return static_cast<float>(scroll.h_left) / (scroll.h_right - width) * 100;
 }
 
 static void window_options_audio_update(rct_window* w)
@@ -1486,10 +1486,9 @@ static void window_options_audio_update(rct_window* w)
 
     if (w->page == WINDOW_OPTIONS_PAGE_AUDIO)
     {
-        rct_widget* widget;
-
-        widget = &window_options_audio_widgets[WIDX_MASTER_VOLUME];
-        uint8_t master_volume = get_scroll_percentage(widget, &w->scrolls[0]);
+        const auto& masterVolumeWidget = window_options_audio_widgets[WIDX_MASTER_VOLUME];
+        const auto& masterVolumeScroll = w->scrolls[0];
+        uint8_t master_volume = get_scroll_percentage(masterVolumeWidget, masterVolumeScroll);
         if (master_volume != gConfigSound.master_volume)
         {
             gConfigSound.master_volume = master_volume;
@@ -1497,8 +1496,9 @@ static void window_options_audio_update(rct_window* w)
             widget_invalidate(w, WIDX_MASTER_VOLUME);
         }
 
-        widget = &window_options_audio_widgets[WIDX_SOUND_VOLUME];
-        uint8_t sound_volume = get_scroll_percentage(widget, &w->scrolls[1]);
+        const auto& soundVolumeWidget = window_options_audio_widgets[WIDX_MASTER_VOLUME];
+        const auto& soundVolumeScroll = w->scrolls[1];
+        uint8_t sound_volume = get_scroll_percentage(soundVolumeWidget, soundVolumeScroll);
         if (sound_volume != gConfigSound.sound_volume)
         {
             gConfigSound.sound_volume = sound_volume;
@@ -1506,8 +1506,9 @@ static void window_options_audio_update(rct_window* w)
             widget_invalidate(w, WIDX_SOUND_VOLUME);
         }
 
-        widget = &window_options_audio_widgets[WIDX_MUSIC_VOLUME];
-        uint8_t ride_music_volume = get_scroll_percentage(widget, &w->scrolls[2]);
+        const auto& musicVolumeWidget = window_options_audio_widgets[WIDX_MASTER_VOLUME];
+        const auto& musicVolumeScroll = w->scrolls[2];
+        uint8_t ride_music_volume = get_scroll_percentage(musicVolumeWidget, musicVolumeScroll);
         if (ride_music_volume != gConfigSound.ride_music_volume)
         {
             gConfigSound.ride_music_volume = ride_music_volume;
@@ -1524,11 +1525,11 @@ static void window_options_audio_scrollgetsize(rct_window* w, int32_t scrollInde
 
 static void initialize_scroll_position(rct_window* w, rct_widgetindex widget_index, int32_t scroll_id, uint8_t volume)
 {
-    rct_widget* widget = &window_options_audio_widgets[widget_index];
-    rct_scroll* scroll = &w->scrolls[scroll_id];
+    const auto& widget = window_options_audio_widgets[widget_index];
+    auto& scroll = w->scrolls[scroll_id];
 
-    int widget_size = scroll->h_right - (widget->width() - 1);
-    scroll->h_left = ceil(volume / 100.0f * widget_size);
+    int32_t widget_size = scroll.h_right - (widget.width() - 1);
+    scroll.h_left = ceil(volume / 100.0f * widget_size);
 
     WidgetScrollUpdateThumbs(w, widget_index);
 }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -944,9 +944,8 @@ static void window_ride_draw_tab_image(rct_drawpixelinfo* dpi, rct_window* w, in
             spriteIndex += (frame % window_ride_tab_animation_frames[w->page]);
         }
 
-        gfx_draw_sprite(
-            dpi, ImageId(spriteIndex),
-            w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
+        const auto& widget = w->widgets[widgetIndex];
+        gfx_draw_sprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
     }
 }
 
@@ -981,9 +980,9 @@ static void window_ride_draw_tab_main(rct_drawpixelinfo* dpi, rct_window* w)
                         spriteIndex += (w->frame_no / 4) % 8;
                     break;
             }
-            gfx_draw_sprite(
-                dpi, ImageId(spriteIndex),
-                w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
+
+            const auto& widget = w->widgets[widgetIndex];
+            gfx_draw_sprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
         }
     }
 }
@@ -995,13 +994,13 @@ static void window_ride_draw_tab_main(rct_drawpixelinfo* dpi, rct_window* w)
 static void window_ride_draw_tab_vehicle(rct_drawpixelinfo* dpi, rct_window* w)
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_VEHICLE;
-    rct_widget* widget = &w->widgets[widgetIndex];
+    const auto& widget = w->widgets[widgetIndex];
 
     if (!(w->disabled_widgets & (1LL << widgetIndex)))
     {
-        auto screenCoords = ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
-        int32_t width = widget->right - screenCoords.x;
-        int32_t height = widget->bottom - 3 - screenCoords.y;
+        auto screenCoords = ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
+        int32_t width = widget.right - screenCoords.x;
+        int32_t height = widget.bottom - 3 - screenCoords.y;
         if (w->page == WINDOW_RIDE_PAGE_VEHICLE)
             height += 4;
 
@@ -1013,7 +1012,7 @@ static void window_ride_draw_tab_vehicle(rct_drawpixelinfo* dpi, rct_window* w)
             return;
         }
 
-        screenCoords = ScreenCoordsXY{ widget->width() / 2, widget->height() - 12 };
+        screenCoords = ScreenCoordsXY{ widget.width() / 2, widget.height() - 12 };
 
         auto ride = get_ride(w->rideId);
         if (ride == nullptr)
@@ -1070,7 +1069,7 @@ static void window_ride_draw_tab_customer(rct_drawpixelinfo* dpi, rct_window* w)
 
     if (!(w->disabled_widgets & (1LL << widgetIndex)))
     {
-        rct_widget* widget = &w->widgets[widgetIndex];
+        const auto& widget = w->widgets[widgetIndex];
         int32_t spriteIndex = 0;
         if (w->page == WINDOW_RIDE_PAGE_CUSTOMER)
             spriteIndex = w->picked_peep_frame & ~3;
@@ -1080,7 +1079,7 @@ static void window_ride_draw_tab_customer(rct_drawpixelinfo* dpi, rct_window* w)
         spriteIndex |= 0xA9E00000;
 
         gfx_draw_sprite(
-            dpi, ImageId::FromUInt32(spriteIndex), w->windowPos + ScreenCoordsXY{ widget->midX(), widget->bottom - 6 });
+            dpi, ImageId::FromUInt32(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.midX(), widget.bottom - 6 });
     }
 }
 
@@ -1656,11 +1655,11 @@ static void window_ride_init_viewport(rct_window* w)
     // rct2: 0x006aec9c only used here so brought it into the function
     if (w->viewport == nullptr && !ride->overall_view.IsNull())
     {
-        rct_widget* view_widget = &w->widgets[WIDX_VIEWPORT];
+        const auto& view_widget = w->widgets[WIDX_VIEWPORT];
 
-        auto screenPos = w->windowPos + ScreenCoordsXY{ view_widget->left + 1, view_widget->top + 1 };
-        int32_t width = view_widget->width() - 1;
-        int32_t height = view_widget->height() - 1;
+        auto screenPos = w->windowPos + ScreenCoordsXY{ view_widget.left + 1, view_widget.top + 1 };
+        int32_t width = view_widget.width() - 1;
+        int32_t height = view_widget.height() - 1;
 
         viewport_create(w, screenPos, width, height, w->focus.value());
 
@@ -4807,7 +4806,6 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     // TODO: This should use lists and identified sprites
     rct_drawpixelinfo clippedDpi;
-    rct_widget* widget;
 
     auto ride = get_ride(w->rideId);
     if (ride == nullptr)
@@ -4817,12 +4815,12 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     window_ride_draw_tab_images(dpi, w);
 
     // Track / shop item preview
-    widget = &window_ride_colour_widgets[WIDX_TRACK_PREVIEW];
-    if (widget->type != WindowWidgetType::Empty)
+    const auto& trackPreviewWidget = window_ride_colour_widgets[WIDX_TRACK_PREVIEW];
+    if (trackPreviewWidget.type != WindowWidgetType::Empty)
         gfx_fill_rect(
             dpi,
-            { { w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 } },
-              { w->windowPos + ScreenCoordsXY{ widget->right - 1, widget->bottom - 1 } } },
+            { { w->windowPos + ScreenCoordsXY{ trackPreviewWidget.left + 1, trackPreviewWidget.top + 1 } },
+              { w->windowPos + ScreenCoordsXY{ trackPreviewWidget.right - 1, trackPreviewWidget.bottom - 1 } } },
             PALETTE_INDEX_12);
 
     auto trackColour = ride_get_track_colour(ride, w->ride_colour);
@@ -4831,7 +4829,7 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr || rideEntry->shop_item[0] == ShopItem::None)
     {
-        auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+        auto screenCoords = w->windowPos + ScreenCoordsXY{ trackPreviewWidget.left, trackPreviewWidget.top };
 
         // Track
         if (ride->type == RIDE_TYPE_MAZE)
@@ -4858,7 +4856,8 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
     else
     {
         auto screenCoords = w->windowPos
-            + ScreenCoordsXY{ (widget->left + widget->right) / 2 - 8, (widget->bottom + widget->top) / 2 - 6 };
+            + ScreenCoordsXY{ (trackPreviewWidget.left + trackPreviewWidget.right) / 2 - 8,
+                              (trackPreviewWidget.bottom + trackPreviewWidget.top) / 2 - 6 };
 
         ShopItem shopItem = rideEntry->shop_item[1] == ShopItem::None ? rideEntry->shop_item[0] : rideEntry->shop_item[1];
         gfx_draw_sprite(dpi, ImageId(GetShopItemDescriptor(shopItem).Image, ride->track_colour[0].main), screenCoords);
@@ -4866,12 +4865,13 @@ static void window_ride_colour_paint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Entrance preview
     trackColour = ride_get_track_colour(ride, 0);
-    widget = &w->widgets[WIDX_ENTRANCE_PREVIEW];
-    if (widget->type != WindowWidgetType::Empty)
+    const auto& entrancePreviewWidget = w->widgets[WIDX_ENTRANCE_PREVIEW];
+    if (entrancePreviewWidget.type != WindowWidgetType::Empty)
     {
         if (clip_drawpixelinfo(
-                &clippedDpi, dpi, w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 }, widget->width(),
-                widget->height()))
+                &clippedDpi, dpi,
+                w->windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
+                entrancePreviewWidget.width(), entrancePreviewWidget.height()))
         {
             gfx_clear(&clippedDpi, PALETTE_INDEX_12);
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -245,16 +245,16 @@ static void window_scenarioselect_init_tabs(rct_window* w)
     int32_t x = 3;
     for (int32_t i = 0; i < NumTabs; i++)
     {
-        rct_widget* widget = &w->widgets[i + WIDX_TAB1];
+        auto& widget = w->widgets[i + WIDX_TAB1];
         if (!(showPages & (1 << i)))
         {
-            widget->type = WindowWidgetType::Empty;
+            widget.type = WindowWidgetType::Empty;
             continue;
         }
 
-        widget->type = WindowWidgetType::Tab;
-        widget->left = x;
-        widget->right = x + 90;
+        widget.type = WindowWidgetType::Tab;
+        widget.left = x;
+        widget.right = x + 90;
         x += 91;
     }
 }
@@ -563,8 +563,8 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
     rct_string_id highlighted_format = ScenarioSelectUseSmallFont() ? STR_WHITE_STRING : STR_WINDOW_COLOUR_2_STRINGID;
     rct_string_id unhighlighted_format = ScenarioSelectUseSmallFont() ? STR_WHITE_STRING : STR_BLACK_STRING;
 
-    rct_widget* listWidget = &w->widgets[WIDX_SCENARIOLIST];
-    int32_t listWidth = listWidget->width() - 12;
+    const auto& listWidget = w->widgets[WIDX_SCENARIOLIST];
+    int32_t listWidth = listWidget.width() - 12;
 
     const int32_t scenarioItemHeight = get_scenario_list_item_size();
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -260,7 +260,7 @@ static void window_server_list_scroll_mousedown(rct_window* w, int32_t scrollInd
     {
         const auto& server = _serverList.GetServer(serverIndex);
 
-        auto listWidget = &w->widgets[WIDX_LIST];
+        const auto& listWidget = w->widgets[WIDX_LIST];
 
         gDropdownItemsFormat[0] = STR_JOIN_GAME;
         if (server.Favourite)
@@ -271,8 +271,8 @@ static void window_server_list_scroll_mousedown(rct_window* w, int32_t scrollInd
         {
             gDropdownItemsFormat[1] = STR_ADD_TO_FAVOURITES;
         }
-        auto dropdownPos = ScreenCoordsXY{ w->windowPos.x + listWidget->left + screenCoords.x + 2 - w->scrolls[0].h_left,
-                                           w->windowPos.y + listWidget->top + screenCoords.y + 2 - w->scrolls[0].v_top };
+        auto dropdownPos = ScreenCoordsXY{ w->windowPos.x + listWidget.left + screenCoords.x + 2 - w->scrolls[0].h_left,
+                                           w->windowPos.y + listWidget.top + screenCoords.y + 2 - w->scrolls[0].v_top };
         WindowDropdownShowText(dropdownPos, 0, COLOUR_GREY, 0, 2);
     }
 }
@@ -287,9 +287,10 @@ static void window_server_list_scroll_mouseover(rct_window* w, int32_t scrollInd
     }
 
     int32_t hoverButtonIndex = -1;
+    auto& listWidget = w->widgets[WIDX_LIST];
     if (index != -1)
     {
-        int32_t width = w->widgets[WIDX_LIST].width();
+        int32_t width = listWidget.width();
         int32_t sy = index * ITEM_HEIGHT;
         for (int32_t i = 0; i < 2; i++)
         {
@@ -304,11 +305,11 @@ static void window_server_list_scroll_mouseover(rct_window* w, int32_t scrollInd
         }
     }
 
-    int32_t width = w->widgets[WIDX_LIST].width();
+    int32_t width = listWidget.width();
     int32_t right = width - 3 - 14 - 10;
     if (screenCoords.x < right)
     {
-        w->widgets[WIDX_LIST].tooltip = STR_NONE;
+        listWidget.tooltip = STR_NONE;
         window_tooltip_close();
     }
 
@@ -421,11 +422,12 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     gfx_clear(dpi, paletteIndex);
 
-    int32_t width = w->widgets[WIDX_LIST].width();
+    auto& listWidget = w->widgets[WIDX_LIST];
+    int32_t width = listWidget.width();
 
     ScreenCoordsXY screenCoords;
     screenCoords.y = 0;
-    w->widgets[WIDX_LIST].tooltip = STR_NONE;
+    listWidget.tooltip = STR_NONE;
     for (int32_t i = 0; i < w->no_list_items; i++)
     {
         if (screenCoords.y >= dpi->y + dpi->height)
@@ -439,7 +441,7 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         {
             gfx_filter_rect(dpi, 0, screenCoords.y, width, screenCoords.y + ITEM_HEIGHT, FilterPaletteID::PaletteDarken1);
             _version = serverDetails.Version;
-            w->widgets[WIDX_LIST].tooltip = STR_NETWORK_VERSION_TIP;
+            listWidget.tooltip = STR_NETWORK_VERSION_TIP;
         }
 
         colour_t colour = w->colours[1];

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -967,9 +967,9 @@ void window_staff_overview_paint(rct_window* w, rct_drawpixelinfo* dpi)
     }
     auto ft = Formatter();
     peep->FormatActionTo(ft);
-    rct_widget* widget = &w->widgets[WIDX_BTM_LABEL];
-    auto screenPos = w->windowPos + ScreenCoordsXY{ widget->midX(), widget->top };
-    int32_t width = widget->width();
+    const auto& widget = w->widgets[WIDX_BTM_LABEL];
+    auto screenPos = w->windowPos + ScreenCoordsXY{ widget.midX(), widget.top };
+    int32_t width = widget.width();
     DrawTextEllipsised(dpi, screenPos, width, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
 }
 
@@ -982,16 +982,14 @@ void window_staff_options_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->disabled_widgets & (1ULL << WIDX_TAB_2))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_2];
-
     int32_t image_id = SPR_TAB_STAFF_OPTIONS_0;
-
     if (w->page == WINDOW_STAFF_OPTIONS)
     {
         image_id += (w->frame_no / 2) % 7;
     }
 
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_2];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
     gfx_draw_sprite(dpi, ImageId(image_id), screenCoords);
 }
 
@@ -1004,16 +1002,14 @@ void window_staff_stats_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->disabled_widgets & (1ULL << WIDX_TAB_3))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_3];
-
     int32_t image_id = SPR_TAB_STATS_0;
-
     if (w->page == WINDOW_STAFF_STATISTICS)
     {
         image_id += (w->frame_no / 4) % 7;
     }
 
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    const auto& widget = w->widgets[WIDX_TAB_3];
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
     gfx_draw_sprite(dpi, ImageId(image_id), screenCoords);
 }
 
@@ -1025,10 +1021,10 @@ void window_staff_overview_tab_paint(rct_window* w, rct_drawpixelinfo* dpi)
     if (w->disabled_widgets & (1ULL << WIDX_TAB_1))
         return;
 
-    rct_widget* widget = &w->widgets[WIDX_TAB_1];
-    int32_t width = widget->width() - 1;
-    int32_t height = widget->height() - 1;
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
+    const auto& widget = w->widgets[WIDX_TAB_1];
+    int32_t width = widget.width() - 1;
+    int32_t height = widget.height() - 1;
+    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
     if (w->page == WINDOW_STAFF_OVERVIEW)
         height++;
 
@@ -1379,11 +1375,11 @@ void window_staff_viewport_init(rct_window* w)
     {
         if (w->viewport == nullptr)
         {
-            rct_widget* view_widget = &w->widgets[WIDX_VIEWPORT];
+            const auto& view_widget = w->widgets[WIDX_VIEWPORT];
 
-            auto screenPos = ScreenCoordsXY{ view_widget->left + 1 + w->windowPos.x, view_widget->top + 1 + w->windowPos.y };
-            int32_t width = view_widget->width() - 1;
-            int32_t height = view_widget->height() - 1;
+            auto screenPos = ScreenCoordsXY{ view_widget.left + 1 + w->windowPos.x, view_widget.top + 1 + w->windowPos.y };
+            int32_t width = view_widget.width() - 1;
+            int32_t height = view_widget.height() - 1;
 
             viewport_create(w, screenPos, width, height, focus.value());
             w->flags |= WF_NO_SCROLLING;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3063,8 +3063,8 @@ static void window_top_toolbar_land_tool_drag(const ScreenCoordsXY& screenPos)
     rct_widgetindex widget_index = window_find_widget_from_point(window, screenPos);
     if (widget_index == -1)
         return;
-    rct_widget* widget = &window->widgets[widget_index];
-    if (widget->type != WindowWidgetType::Viewport)
+    const auto& widget = window->widgets[widget_index];
+    if (widget.type != WindowWidgetType::Viewport)
         return;
     rct_viewport* viewport = window->viewport;
     if (viewport == nullptr)
@@ -3106,8 +3106,8 @@ static void window_top_toolbar_water_tool_drag(const ScreenCoordsXY& screenPos)
     rct_widgetindex widget_index = window_find_widget_from_point(window, screenPos);
     if (widget_index == -1)
         return;
-    rct_widget* widget = &window->widgets[widget_index];
-    if (widget->type != WindowWidgetType::Viewport)
+    const auto& widget = window->widgets[widget_index];
+    if (widget.type != WindowWidgetType::Viewport)
         return;
     rct_viewport* viewport = window->viewport;
     if (viewport == nullptr)

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -143,7 +143,7 @@ bool WidgetIsPressed(rct_window* w, rct_widgetindex widgetIndex);
 bool WidgetIsHighlighted(rct_window* w, rct_widgetindex widgetIndex);
 bool WidgetIsActiveTool(rct_window* w, rct_widgetindex widgetIndex);
 void WidgetScrollGetPart(
-    rct_window* w, rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
+    rct_window* w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
     int32_t* output_scroll_area, int32_t* scroll_id);
 
 void WidgetSetEnabled(rct_window* w, rct_widgetindex widgetIndex, bool enabled);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -568,7 +568,6 @@ void window_update_scroll_widgets(rct_window* w)
 {
     int32_t scrollIndex, width, height, scrollPositionChanged;
     rct_widgetindex widgetIndex;
-    rct_scroll* scroll;
     rct_widget* widget;
 
     widgetIndex = 0;
@@ -579,32 +578,32 @@ void window_update_scroll_widgets(rct_window* w)
         if (widget->type != WindowWidgetType::Scroll)
             continue;
 
-        scroll = &w->scrolls[scrollIndex];
+        auto& scroll = w->scrolls[scrollIndex];
         width = 0;
         height = 0;
         window_get_scroll_size(w, scrollIndex, &width, &height);
         if (height == 0)
         {
-            scroll->v_top = 0;
+            scroll.v_top = 0;
         }
         else if (width == 0)
         {
-            scroll->h_left = 0;
+            scroll.h_left = 0;
         }
         width++;
         height++;
 
         scrollPositionChanged = 0;
-        if ((widget->content & SCROLL_HORIZONTAL) && width != scroll->h_right)
+        if ((widget->content & SCROLL_HORIZONTAL) && width != scroll.h_right)
         {
             scrollPositionChanged = 1;
-            scroll->h_right = width;
+            scroll.h_right = width;
         }
 
-        if ((widget->content & SCROLL_VERTICAL) && height != scroll->v_bottom)
+        if ((widget->content & SCROLL_VERTICAL) && height != scroll.v_bottom)
         {
             scrollPositionChanged = 1;
-            scroll->v_bottom = height;
+            scroll.v_bottom = height;
         }
 
         if (scrollPositionChanged)
@@ -1292,8 +1291,9 @@ void window_resize(rct_window* w, int32_t dw, int32_t dh)
     // Update scroll widgets
     for (int32_t i = 0; i < 3; i++)
     {
-        w->scrolls[i].h_right = WINDOW_SCROLL_UNDEFINED;
-        w->scrolls[i].v_bottom = WINDOW_SCROLL_UNDEFINED;
+        auto& scroll = w->scrolls[i];
+        scroll.h_right = WINDOW_SCROLL_UNDEFINED;
+        scroll.v_bottom = WINDOW_SCROLL_UNDEFINED;
     }
     window_update_scroll_widgets(w);
 
@@ -2183,63 +2183,63 @@ rct_windowclass window_get_classification(rct_window* window)
 void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index)
 {
     const auto& widget = w->widgets[widget_index];
-    rct_scroll* scroll = &w->scrolls[window_get_scroll_data_index(w, widget_index)];
+    auto& scroll = w->scrolls[window_get_scroll_data_index(w, widget_index)];
 
-    if (scroll->flags & HSCROLLBAR_VISIBLE)
+    if (scroll.flags & HSCROLLBAR_VISIBLE)
     {
         int32_t view_size = widget.width() - 21;
-        if (scroll->flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             view_size -= 11;
-        int32_t x = scroll->h_left * view_size;
-        if (scroll->h_right != 0)
-            x /= scroll->h_right;
-        scroll->h_thumb_left = x + 11;
+        int32_t x = scroll.h_left * view_size;
+        if (scroll.h_right != 0)
+            x /= scroll.h_right;
+        scroll.h_thumb_left = x + 11;
 
         x = widget.width() - 2;
-        if (scroll->flags & VSCROLLBAR_VISIBLE)
+        if (scroll.flags & VSCROLLBAR_VISIBLE)
             x -= 11;
-        x += scroll->h_left;
-        if (scroll->h_right != 0)
-            x = (x * view_size) / scroll->h_right;
+        x += scroll.h_left;
+        if (scroll.h_right != 0)
+            x = (x * view_size) / scroll.h_right;
         x += 11;
         view_size += 10;
-        scroll->h_thumb_right = std::min(x, view_size);
+        scroll.h_thumb_right = std::min(x, view_size);
 
-        if (scroll->h_thumb_right - scroll->h_thumb_left < 20)
+        if (scroll.h_thumb_right - scroll.h_thumb_left < 20)
         {
-            double barPosition = (scroll->h_thumb_right * 1.0) / view_size;
+            double barPosition = (scroll.h_thumb_right * 1.0) / view_size;
 
-            scroll->h_thumb_left = static_cast<uint16_t>(std::lround(scroll->h_thumb_left - (20 * barPosition)));
-            scroll->h_thumb_right = static_cast<uint16_t>(std::lround(scroll->h_thumb_right + (20 * (1 - barPosition))));
+            scroll.h_thumb_left = static_cast<uint16_t>(std::lround(scroll.h_thumb_left - (20 * barPosition)));
+            scroll.h_thumb_right = static_cast<uint16_t>(std::lround(scroll.h_thumb_right + (20 * (1 - barPosition))));
         }
     }
 
-    if (scroll->flags & VSCROLLBAR_VISIBLE)
+    if (scroll.flags & VSCROLLBAR_VISIBLE)
     {
         int32_t view_size = widget.height() - 21;
-        if (scroll->flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             view_size -= 11;
-        int32_t y = scroll->v_top * view_size;
-        if (scroll->v_bottom != 0)
-            y /= scroll->v_bottom;
-        scroll->v_thumb_top = y + 11;
+        int32_t y = scroll.v_top * view_size;
+        if (scroll.v_bottom != 0)
+            y /= scroll.v_bottom;
+        scroll.v_thumb_top = y + 11;
 
         y = widget.height() - 2;
-        if (scroll->flags & HSCROLLBAR_VISIBLE)
+        if (scroll.flags & HSCROLLBAR_VISIBLE)
             y -= 11;
-        y += scroll->v_top;
-        if (scroll->v_bottom != 0)
-            y = (y * view_size) / scroll->v_bottom;
+        y += scroll.v_top;
+        if (scroll.v_bottom != 0)
+            y = (y * view_size) / scroll.v_bottom;
         y += 11;
         view_size += 10;
-        scroll->v_thumb_bottom = std::min(y, view_size);
+        scroll.v_thumb_bottom = std::min(y, view_size);
 
-        if (scroll->v_thumb_bottom - scroll->v_thumb_top < 20)
+        if (scroll.v_thumb_bottom - scroll.v_thumb_top < 20)
         {
-            double barPosition = (scroll->v_thumb_bottom * 1.0) / view_size;
+            double barPosition = (scroll.v_thumb_bottom * 1.0) / view_size;
 
-            scroll->v_thumb_top = static_cast<uint16_t>(std::lround(scroll->v_thumb_top - (20 * barPosition)));
-            scroll->v_thumb_bottom = static_cast<uint16_t>(std::lround(scroll->v_thumb_bottom + (20 * (1 - barPosition))));
+            scroll.v_thumb_top = static_cast<uint16_t>(std::lround(scroll.v_thumb_top - (20 * barPosition)));
+            scroll.v_thumb_bottom = static_cast<uint16_t>(std::lround(scroll.v_thumb_bottom + (20 * (1 - barPosition))));
         }
     }
 }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -427,16 +427,16 @@ rct_widgetindex window_find_widget_from_point(rct_window* w, const ScreenCoordsX
     rct_widgetindex widget_index = -1;
     for (int32_t i = 0;; i++)
     {
-        rct_widget* widget = &w->widgets[i];
-        if (widget->type == WindowWidgetType::Last)
+        const auto& widget = w->widgets[i];
+        if (widget.type == WindowWidgetType::Last)
         {
             break;
         }
 
-        if (widget->type != WindowWidgetType::Empty && widget->IsVisible())
+        if (widget.type != WindowWidgetType::Empty && widget.IsVisible())
         {
-            if (screenCoords.x >= w->windowPos.x + widget->left && screenCoords.x <= w->windowPos.x + widget->right
-                && screenCoords.y >= w->windowPos.y + widget->top && screenCoords.y <= w->windowPos.y + widget->bottom)
+            if (screenCoords.x >= w->windowPos.x + widget.left && screenCoords.x <= w->windowPos.x + widget.right
+                && screenCoords.y >= w->windowPos.y + widget.top && screenCoords.y <= w->windowPos.y + widget.bottom)
             {
                 widget_index = i;
             }
@@ -445,8 +445,11 @@ rct_widgetindex window_find_widget_from_point(rct_window* w, const ScreenCoordsX
 
     // Return next widget if a dropdown
     if (widget_index != -1)
-        if (w->widgets[widget_index].type == WindowWidgetType::DropdownMenu)
+    {
+        const auto& widget = w->widgets[widget_index];
+        if (widget.type == WindowWidgetType::DropdownMenu)
             widget_index++;
+    }
 
     // Return the widget index
     return widget_index;
@@ -502,8 +505,6 @@ void window_invalidate_all()
  */
 void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex)
 {
-    rct_widget* widget;
-
     assert(w != nullptr);
 #ifdef DEBUG
     for (int32_t i = 0; i <= widgetIndex; i++)
@@ -512,12 +513,12 @@ void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex)
     }
 #endif
 
-    widget = &w->widgets[widgetIndex];
-    if (widget->left == -2)
+    const auto& widget = w->widgets[widgetIndex];
+    if (widget.left == -2)
         return;
 
-    gfx_set_dirty_blocks({ { w->windowPos + ScreenCoordsXY{ widget->left, widget->top } },
-                           { w->windowPos + ScreenCoordsXY{ widget->right + 1, widget->bottom + 1 } } });
+    gfx_set_dirty_blocks({ { w->windowPos + ScreenCoordsXY{ widget.left, widget.top } },
+                           { w->windowPos + ScreenCoordsXY{ widget.right + 1, widget.bottom + 1 } } });
 }
 
 template<typename _TPred> static void widget_invalidate_by_condition(_TPred pred)
@@ -623,7 +624,8 @@ int32_t window_get_scroll_data_index(rct_window* w, rct_widgetindex widget_index
     assert(w != nullptr);
     for (i = 0; i < widget_index; i++)
     {
-        if (w->widgets[i].type == WindowWidgetType::Scroll)
+        const auto& widget = w->widgets[i];
+        if (widget.type == WindowWidgetType::Scroll)
             result++;
     }
     return result;
@@ -1747,8 +1749,9 @@ void window_align_tabs(rct_window* w, rct_widgetindex start_tab_id, rct_widgetin
     {
         if (!(w->disabled_widgets & (1LL << i)))
         {
-            w->widgets[i].left = x;
-            w->widgets[i].right = x + tab_width;
+            auto& widget = w->widgets[i];
+            widget.left = x;
+            widget.right = x + tab_width;
             x += tab_width + 1;
         }
     }
@@ -2179,12 +2182,12 @@ rct_windowclass window_get_classification(rct_window* window)
  */
 void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index)
 {
-    rct_widget* widget = &w->widgets[widget_index];
+    const auto& widget = w->widgets[widget_index];
     rct_scroll* scroll = &w->scrolls[window_get_scroll_data_index(w, widget_index)];
 
     if (scroll->flags & HSCROLLBAR_VISIBLE)
     {
-        int32_t view_size = widget->width() - 21;
+        int32_t view_size = widget.width() - 21;
         if (scroll->flags & VSCROLLBAR_VISIBLE)
             view_size -= 11;
         int32_t x = scroll->h_left * view_size;
@@ -2192,7 +2195,7 @@ void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index)
             x /= scroll->h_right;
         scroll->h_thumb_left = x + 11;
 
-        x = widget->width() - 2;
+        x = widget.width() - 2;
         if (scroll->flags & VSCROLLBAR_VISIBLE)
             x -= 11;
         x += scroll->h_left;
@@ -2213,7 +2216,7 @@ void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index)
 
     if (scroll->flags & VSCROLLBAR_VISIBLE)
     {
-        int32_t view_size = widget->height() - 21;
+        int32_t view_size = widget.height() - 21;
         if (scroll->flags & HSCROLLBAR_VISIBLE)
             view_size -= 11;
         int32_t y = scroll->v_top * view_size;
@@ -2221,7 +2224,7 @@ void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index)
             y /= scroll->v_bottom;
         scroll->v_thumb_top = y + 11;
 
-        y = widget->height() - 2;
+        y = widget.height() - 2;
         if (scroll->flags & HSCROLLBAR_VISIBLE)
             y -= 11;
         y += scroll->v_top;


### PR DESCRIPTION
This is a start of a larger refactor where all `rct_window` functions take a (const) reference where it should never be Null. Often there is not even any validation. The null-checks should be outside the functions, and the functions should not be called at all when null.

Note: The change from `w->widgets[WIDX_PAY_FOR_PARK_OR_RIDES]` to `entryPriceWidget` is intended. It was using the wrong widget before.