### PR TITLE
Fix #15451: Guest List Name Filter Remains After Group Selection

### DIFF
--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -321,8 +321,11 @@ public:
                 _selectedPage = 0;
                 _numPages = 1;
                 widgets[WIDX_TRACKING].type = WindowWidgetType::Empty;
-                widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::Empty;
-                if (_selectedTab == TabId::Individual)
+                if (_selectedTab == TabId::Summarised)
+                {
+                    widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::Empty;   
+                }
+                else if (_selectedTab == TabId::Individual)
                 {
                     widgets[WIDX_TRACKING].type = WindowWidgetType::FlatBtn;
                     widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::FlatBtn;
@@ -576,6 +579,10 @@ public:
                     _selectedTab = TabId::Individual;
                     widgets[WIDX_TRACKING].type = WindowWidgetType::FlatBtn;
                     Invalidate();
+                    if (!_filterName.empty())
+                    {
+                        widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::FlatBtn;
+                    }
                     scrolls[0].v_top = 0;
                     RefreshList();
                 }


### PR DESCRIPTION
Fixes #15451

Expected Behavior: 
1) Open the guest list
2) Apply a search filter by name (ex. Chris)
3) Click the summarized tab
4) Select one of the groups
5) The search filter will still be active (but now there is a pressed icon which can be deactivated to remove the filter)

Previously, the search filter would still be applied, but no hourglass icon would appear so the user would be unaware the filter was still applied.

Alternatively, we could make it so selecting a group deactivates the filter, but this seems like a more robust way for players to work with the guest list.