### PR TITLE
Fix #11354: Coding style causes undefined behaviour

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -177,6 +177,7 @@ The following people are not part of the development team, but have been contrib
 * Saad Rehman (SaadRehmanCS)
 * (ocalhoun6)
 * Sean Payne (seanmajorpayne)
+* Soham Roy (sohamroy19)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/core/CircularBuffer.h
+++ b/src/openrct2/core/CircularBuffer.h
@@ -12,14 +12,14 @@
 #include <array>
 #include <cstddef>
 
-template<typename _TType, size_t _TMax> class CircularBuffer
+template<typename TType, size_t TMax> class CircularBuffer
 {
 public:
-    using value_type = _TType;
-    using pointer = _TType*;
-    using const_pointer = const _TType*;
-    using reference = _TType&;
-    using const_reference = const _TType&;
+    using value_type = TType;
+    using pointer = TType*;
+    using const_pointer = const TType*;
+    using reference = TType&;
+    using const_reference = const TType&;
     using size_type = size_t;
     using difference_type = ptrdiff_t;
 
@@ -137,5 +137,5 @@ private:
     size_t _head = 0;
     size_t _tail = 0;
     size_t _size = 0;
-    std::array<_TType, _TMax> _elements;
+    std::array<TType, TMax> _elements;
 };

--- a/src/openrct2/core/Meta.hpp
+++ b/src/openrct2/core/Meta.hpp
@@ -16,15 +16,15 @@ namespace Meta
     /**
      * Meta function for checking that all Conditions are true types.
      */
-    template<typename... _TConditions> struct all : std::true_type
+    template<typename... TConditions> struct all : std::true_type
     {
     };
 
-    template<typename _TCondition, typename... _TConditions>
-    struct all<_TCondition, _TConditions...> : std::conditional<_TCondition::value, all<_TConditions...>, std::false_type>::type
+    template<typename TCondition, typename... TConditions>
+    struct all<TCondition, TConditions...> : std::conditional<TCondition::value, all<TConditions...>, std::false_type>::type
     {
     };
 
-    template<typename _TType, typename... _TTypes> using all_convertible = all<std::is_convertible<_TTypes, _TType>...>;
+    template<typename TType, typename... TTypes> using all_convertible = all<std::is_convertible<TTypes, TType>...>;
 
 } // namespace Meta

--- a/src/openrct2/core/Random.hpp
+++ b/src/openrct2/core/Random.hpp
@@ -27,12 +27,12 @@ namespace Random
     /**
      * FixedSeedSequence adheres to the _Named Requirement_ `SeedSequence`.
      */
-    template<size_t _TNum = 0> class FixedSeedSequence
+    template<size_t TNum = 0> class FixedSeedSequence
     {
     public:
         using result_type = uint32_t;
 
-        static constexpr size_t N = _TNum;
+        static constexpr size_t N = TNum;
         static constexpr result_type default_seed = 0x1234567F;
 
         explicit FixedSeedSequence()
@@ -41,26 +41,26 @@ namespace Random
         }
 
         template<
-            typename... _TTypes, typename std::enable_if<sizeof...(_TTypes) == N, int>::type = 0,
-            typename std::enable_if<Meta::all_convertible<result_type, _TTypes...>::value, int>::type = 0>
-        explicit FixedSeedSequence(_TTypes... s)
+            typename... TTypes, typename std::enable_if<sizeof...(TTypes) == N, int>::type = 0,
+            typename std::enable_if<Meta::all_convertible<result_type, TTypes...>::value, int>::type = 0>
+        explicit FixedSeedSequence(TTypes... s)
             : v{ static_cast<result_type>(s)... }
         {
         }
 
-        template<typename _TIt, typename = decltype(*std::declval<_TIt&>(), ++std::declval<_TIt&>(), void())>
-        explicit FixedSeedSequence(_TIt begin, _TIt end)
+        template<typename TIt, typename = decltype(*std::declval<TIt&>(), ++std::declval<TIt&>(), void())>
+        explicit FixedSeedSequence(TIt begin, TIt end)
         {
             std::copy(begin, end, v.begin());
         }
 
-        template<typename _TType>
-        explicit FixedSeedSequence(std::initializer_list<_TType> il)
+        template<typename TType>
+        explicit FixedSeedSequence(std::initializer_list<TType> il)
             : FixedSeedSequence(il.begin(), il.end())
         {
         }
 
-        template<typename _TIt> void generate(_TIt begin, _TIt end) const
+        template<typename TIt> void generate(TIt begin, TIt end) const
         {
             std::copy_n(v.begin(), std::min(static_cast<size_t>(end - begin), N), begin);
         }
@@ -70,7 +70,7 @@ namespace Random
             return N;
         }
 
-        template<typename _TIt> constexpr void param(_TIt ob) const
+        template<typename TIt> constexpr void param(TIt ob) const
         {
             std::copy(v.begin(), v.end(), ob);
         }
@@ -79,9 +79,9 @@ namespace Random
         std::array<result_type, N> v;
     };
 
-    template<typename _TUIntType> struct RotateEngineState
+    template<typename TUIntType> struct RotateEngineState
     {
-        using value_type = _TUIntType;
+        using value_type = TUIntType;
 
         value_type s0;
         value_type s1;
@@ -91,21 +91,21 @@ namespace Random
      * RotateEngine adheres to the _Named Requirement_ `RandomNumberEngine`
      * https://en.cppreference.com/w/cpp/named_req/RandomNumberEngine
      */
-    template<typename _TUIntType, _TUIntType _TX, size_t _TR1, size_t _TR2>
-    class RotateEngine : protected RotateEngineState<_TUIntType>
+    template<typename TUIntType, TUIntType TX, size_t TR1, size_t TR2>
+    class RotateEngine : protected RotateEngineState<TUIntType>
     {
-        static_assert(std::is_unsigned<_TUIntType>::value, "Type must be unsigned integral.");
+        static_assert(std::is_unsigned<TUIntType>::value, "Type must be unsigned integral.");
 
-        using RotateEngineState<_TUIntType>::s0;
-        using RotateEngineState<_TUIntType>::s1;
+        using RotateEngineState<TUIntType>::s0;
+        using RotateEngineState<TUIntType>::s1;
 
     public:
-        using result_type = _TUIntType;
-        using state_type = RotateEngineState<_TUIntType>;
+        using result_type = TUIntType;
+        using state_type = RotateEngineState<TUIntType>;
 
-        static constexpr result_type x = _TX;
-        static constexpr size_t r1 = _TR1;
-        static constexpr size_t r2 = _TR2;
+        static constexpr result_type x = TX;
+        static constexpr size_t r1 = TR1;
+        static constexpr size_t r2 = TR2;
         static constexpr result_type default_seed = 1;
 
         static constexpr result_type min()
@@ -129,8 +129,8 @@ namespace Random
             s1 = r.s1;
         }
 
-        template<typename _TSseq, typename = typename std::enable_if<!std::is_same<_TSseq, RotateEngine>::value>::type>
-        explicit RotateEngine(_TSseq& seed_seq)
+        template<typename TSseq, typename = typename std::enable_if<!std::is_same<TSseq, RotateEngine>::value>::type>
+        explicit RotateEngine(TSseq& seed_seq)
         {
             seed(seed_seq);
         }
@@ -141,7 +141,7 @@ namespace Random
             s1 = s;
         }
 
-        template<typename _TSseq> typename std::enable_if<std::is_class<_TSseq>::value, void>::type seed(_TSseq& seed_seq)
+        template<typename TSseq> typename std::enable_if<std::is_class<TSseq>::value, void>::type seed(TSseq& seed_seq)
         {
             std::array<result_type, 2> s;
             seed_seq.generate(s.begin(), s.end());

--- a/src/openrct2/drawing/Font.h
+++ b/src/openrct2/drawing/Font.h
@@ -33,8 +33,8 @@ enum class FontSpriteBase : int16_t
 
 #ifndef NO_TTF
 
-struct Internal_TTF_Font;
-using TTF_Font = Internal_TTF_Font;
+struct InternalTTFFont;
+using TTF_Font = InternalTTFFont;
 struct TTFFontDescriptor
 {
     const utf8* filename;

--- a/src/openrct2/drawing/Font.h
+++ b/src/openrct2/drawing/Font.h
@@ -33,8 +33,8 @@ enum class FontSpriteBase : int16_t
 
 #ifndef NO_TTF
 
-struct _TTF_Font;
-using TTF_Font = _TTF_Font;
+struct Internal_TTF_Font;
+using TTF_Font = Internal_TTF_Font;
 struct TTFFontDescriptor
 {
     const utf8* filename;

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -103,7 +103,7 @@ struct c_glyph
 };
 
 /* The structure used to hold internal font information */
-struct Internal_TTF_Font
+struct InternalTTFFont
 {
     /* Freetype2 maintains all sorts of useful info itself */
     FT_Face face;

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -103,7 +103,7 @@ struct c_glyph
 };
 
 /* The structure used to hold internal font information */
-struct _TTF_Font
+struct Internal_TTF_Font
 {
     /* Freetype2 maintains all sorts of useful info itself */
     FT_Face face;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -228,7 +228,7 @@ void window_close(rct_window* w)
         g_window_list.erase(itWindow);
 }
 
-template<typename _TPred> static void window_close_by_condition(_TPred pred, uint32_t flags = WindowCloseFlags::None)
+template<typename TPred> static void window_close_by_condition(TPred pred, uint32_t flags = WindowCloseFlags::None)
 {
     bool listUpdated;
     do
@@ -458,7 +458,7 @@ rct_widgetindex window_find_widget_from_point(rct_window* w, const ScreenCoordsX
  *
  * @param window The window to invalidate (esi).
  */
-template<typename _TPred> static void window_invalidate_by_condition(_TPred pred)
+template<typename TPred> static void window_invalidate_by_condition(TPred pred)
 {
     window_visit_each([pred](rct_window* w) {
         if (pred(w))
@@ -520,7 +520,7 @@ void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex)
                            { w->windowPos + ScreenCoordsXY{ widget->right + 1, widget->bottom + 1 } } });
 }
 
-template<typename _TPred> static void widget_invalidate_by_condition(_TPred pred)
+template<typename TPred> static void widget_invalidate_by_condition(TPred pred)
 {
     window_visit_each([pred](rct_window* w) {
         if (pred(w))

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -312,7 +312,7 @@ namespace PaintSortFlags
     static constexpr uint8_t OutsideQuadrant = (1U << 7);
 } // namespace PaintSortFlags
 
-template<uint8_t _TRotation>
+template<uint8_t TRotation>
 static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, uint16_t quadrantIndex, uint8_t flag)
 {
     paint_struct* ps;
@@ -403,7 +403,7 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
 
             const paint_struct_bound_box& currentBBox = ps_next->bounds;
 
-            const bool compareResult = CheckBoundingBox<_TRotation>(initialBBox, currentBBox);
+            const bool compareResult = CheckBoundingBox<TRotation>(initialBBox, currentBBox);
 
             if (compareResult)
             {


### PR DESCRIPTION
Referring #11354, an underscore followed by a capital letter used as a prefix might cause undefined behaviour.
Replaced variable or typename prefixes of type _T([A-Z]) with _T$1, essentially.