### PR TITLE
Fix Windows compilation of OrcaStream

### DIFF
--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -512,10 +512,12 @@ namespace OpenRCT2
                         Read(&raw, sizeof(raw));
                         return static_cast<T>(raw);
                     }
-
-                    uint64_t raw{};
-                    Read(&raw, sizeof(raw));
-                    return static_cast<T>(raw);
+                    else
+                    {
+                        uint64_t raw{};
+                        Read(&raw, sizeof(raw));
+                        return static_cast<T>(raw);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Ported from the NSF.

It doesn’t fail compilation on develop, because it isn’t used there (yet).