### PR TITLE
Show "Update available" in all game-options dropdowns

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -479,12 +479,14 @@ static void window_top_toolbar_mousedown(rct_window* w, rct_widgetindex widgetIn
                 gDropdownItemsFormat[numItems++] = STR_EMPTY;
                 gDropdownItemsFormat[numItems++] = STR_QUIT_TO_MENU;
                 gDropdownItemsFormat[numItems++] = STR_EXIT_OPENRCT2;
-                if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                {
-                    gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                    gDropdownItemsFormat[numItems++] = STR_UPDATE_AVAILABLE;
-                }
             }
+
+            if (OpenRCT2::GetContext()->HasNewVersionInfo())
+            {
+                gDropdownItemsFormat[numItems++] = STR_EMPTY;
+                gDropdownItemsFormat[numItems++] = STR_UPDATE_AVAILABLE;
+            }
+
             WindowDropdownShowText(
                 { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[0] | 0x80,
                 Dropdown::Flag::StayOpen, numItems);


### PR DESCRIPTION
Something I noticed when working on #15515: the "Update available" item in the game-options dropdown would only appear in scenario play - it would not appear in the scenario editor, track designer and track manager.