### PR TITLE
Fix #15299: Breakpad crash dumps are created in game directory

### DIFF
--- a/src/openrct2/platform/Crash.cpp
+++ b/src/openrct2/platform/Crash.cpp
@@ -324,9 +324,9 @@ static bool OnCrash(
 static std::wstring GetDumpDirectory()
 {
     auto env = GetContext()->GetPlatformEnvironment();
-    auto crashPath = env->GetDirectoryPath(DIRBASE::OPENRCT2, DIRID::CRASH);
+    auto crashPath = env->GetDirectoryPath(DIRBASE::USER, DIRID::CRASH);
 
-    auto result = String::ToWideChar(crashPath.c_str());
+    auto result = String::ToWideChar(crashPath);
     return result;
 }
 


### PR DESCRIPTION
Possible regression from #15101. Crash dumps were set to create in the OpenRCT2 directory, which won't work if the user has installed OpenRCT2 in a protected directory like Program Files.

Additionally, `crash` directory wasn't created properly. `EnsureUserContentDirectoriesExist` does create it, but it does so in the User directory, not OpenRCT2 directory, further proving that it was intended to land there.

Should fix #15299.