### PR TITLE
Fix #15197: Cannot place flat ride after removing it in construction window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#15170] Plugin: incorrect label text alignment.
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
 - Fix: [#15193] Crash when rides/stalls are demolished.
+- Fix: [#15197] Cannot place flat ride after removing it in construction window.
 - Fix: [#15199] Construction window is not closed when a ride gets demolished.
 - Fix: [#15213] Freeze when hovering over Reverse Freefall Coaster in Russian.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1931,6 +1931,14 @@ static void window_ride_construction_mouseup_demolish(rct_window* w)
         const rct_preview_track* trackBlock = ted.Block;
         newCoords->z = (tileElement->GetBaseZ()) - trackBlock->z;
         gGotoStartPlacementMode = true;
+
+        // When flat rides are deleted, the window should be reset so the ride can be placed again.
+        const auto rideId = w->rideId;
+        auto ride = get_ride(rideId);
+        if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_FLAT_RIDE))
+        {
+            ride_initialise_construction_window(ride);
+        }
     }
 
     auto trackRemoveAction = TrackRemoveAction(


### PR DESCRIPTION
Fixes #15197 

Demolishing a flat ride (using the bulldozer icon in the construction menu) will now reopen the construction window to it's default state.

As a side note, when the ride menu is open, if you right click on the ride, the construction window opens. If you click the bulldozer icon, the ride will delete, but the ride window is still open. This happens on the develop version, not just this branch. Should that have a separate issue or should I try to roll a fix into this issue?