### PR TITLE
Fix #14741: crash on macOS exit

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#14649] ImageImporter incorrectly remaps colours outside the RCT2 palette.
 - Fix: [#14667] “Extreme Hawaiian Island” has unpurchaseable land tiles (original bug).
+- Fix: [#14741] Crash when exiting OpenRCT2 on macOS.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Fix: [#15136] Exported SV6 files cause vanilla RCT2 to hang.
 - Fix: [#15142] ToonTowner's mine roofs were moved into the pirate theme scenery group instead of the mine theme scenery group.

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -170,3 +170,12 @@ void Painter::ReleaseSession(paint_session* session)
     session->PaintEntryChain.Clear();
     _freePaintSessions.push_back(session);
 }
+
+Painter::~Painter()
+{
+    for (auto&& session : _paintSessionPool)
+    {
+        ReleaseSession(session.get());
+    }
+    _paintSessionPool.clear();
+}

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -49,6 +49,7 @@ namespace OpenRCT2
 
             paint_session* CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags);
             void ReleaseSession(paint_session* session);
+            ~Painter();
 
         private:
             void PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text);


### PR DESCRIPTION
See more details in #14741 for original issue description.

The issue was that any active paint sessions were never released in the shutdown process. Since unique_ptr was used, the destructors were simply called, and the default destructors do not call `Clear` on the PaintEntryChain until the mutex is destroyed. (At least, as best I was able to figure out...)

This little change seems to do the trick. I no longer any nasty shutdown issues. However, I haven't poked around in the paint code much before, so I may be missing a simpler way to resolve this. I don't see any downsides of moving away from unique_ptrs here, since it seems to me that both the `_paintSessionPool` and `_freePaintSessions` should be the same type.

@ZehMatt and @IntelOrca, do you mind taking a look at this? If one of you has a different solution (since you're both more familiar with this code), I'm happy to test it out if you can't reproduce the original issue.