### PR TITLE
Fix hovering on scenery window showing incorrect hover for 1 tick

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -712,6 +712,8 @@ static void window_scenery_dropdown(rct_window* w, rct_widgetindex widgetIndex, 
     w->Invalidate();
 }
 
+static ScenerySelection get_scenery_id_by_cursor_pos(rct_window* w, const ScreenCoordsXY& screenCoords);
+
 /**
  *
  *  rct2: 0x006E1B9F
@@ -720,6 +722,28 @@ static void window_scenery_periodic_update(rct_window* w)
 {
     if (!_selectedScenery.IsUndefined())
     {
+        // Find out what scenery the cursor is over
+        const CursorState* state = context_get_cursor_state();
+        rct_widgetindex widgetIndex = window_find_widget_from_point(w, state->position);
+        if (widgetIndex == WIDX_SCENERY_LIST)
+        {
+            ScreenCoordsXY scrollPos = {};
+            int32_t scrollArea = 0;
+            int32_t scrollId = 0;
+            WidgetScrollGetPart(w, &w->widgets[WIDX_SCENERY_LIST], state->position, scrollPos, &scrollArea, &scrollId);
+            if (scrollArea == SCROLL_PART_VIEW)
+            {
+                const ScenerySelection scenery = get_scenery_id_by_cursor_pos(w, scrollPos);
+                if (scenery == _selectedScenery)
+                {
+                    return;
+                }
+            }
+        }
+
+        // Cursor was not over the currently hover selected scenery so reset hover selection.
+        // This will happen when the mouse leaves the scroll window and is required so that the cost and description switch to
+        // the tool scenery selection.
         _selectedScenery = {};
     }
 }


### PR DESCRIPTION
The scenery window will periodically reset the hover selection so that when you move the cursor out of the window it correctly switches to the actual selection. This leads to the price and description reseting for a singular tick which looks a bit odd and unexpected. To fix this instead when it tries to reset it first checks to see if the cursor is still over the hover selection and if it is does not reset the selection