### PR TITLE
Refactor window_dropdown_paint (Part of #12098)

### DIFF
--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -293,13 +293,9 @@ static void window_dropdown_paint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         ScreenCoordsXY cellCoords;
         if (_dropdown_list_vertically)
-        {
             cellCoords = { i / _dropdown_num_rows, i % _dropdown_num_rows };
-        }
         else
-        {
             cellCoords = { i % _dropdown_num_columns, i / _dropdown_num_columns };
-        }
 
         ScreenCoordsXY screenCoords = w->windowPos
             + ScreenCoordsXY{ 2 + (cellCoords.x * _dropdown_item_width), 2 + (cellCoords.y * _dropdown_item_height) };


### PR DESCRIPTION
I set out to update another call of gfx_filter_rect to use ScreenRect, and cleaned up the code a bit while I was there

- Use ScreenRect (#12098) and ScreenCoordsXY
- Move variables to a more local scope, with the appropriate types
- Reduce nesting in if statements