### PR TITLE
Plugin API: Fix being unable to read litter information

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -40,6 +40,7 @@
 - Fix: [#15514] Two different “quit to menu” menu items are available in track designer and track design manager.
 - Fix: [#15560] Memory leak due to OpenGL Renderer not releasing a texture.
 - Fix: [#15567] Litter not being counted correctly during Park rating calculation (original bug).
+- Fix: [#15582] [Plugin] Litter properties return incorrect values.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Improved: [#13524] macOS arm64 native (universal) app
 - Improved: [#15538] Software rendering can now draw in parallel when Multithreading is enabled.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1504,7 +1504,7 @@ declare global {
         /**
          * The tick number this entity was created.
          */
-        creationTime: number;
+        creationTick: number;
     }
 
     type LitterType = "vomit" |

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -409,6 +409,7 @@ void ScriptEngine::Initialise()
     ScTile::Register(ctx);
     ScTileElement::Register(ctx);
     ScEntity::Register(ctx);
+    ScLitter::Register(ctx);
     ScVehicle::Register(ctx);
     ScPeep::Register(ctx);
     ScGuest::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 37;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 38;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -48,10 +48,15 @@ namespace OpenRCT2::Scripting
     std::string ScLitter::litterType_get() const
     {
         auto* litter = GetLitter();
-        auto it = LitterTypeMap.find(litter->SubType);
-        if (it == LitterTypeMap.end())
-            return "";
-        return std::string{ it->first };
+        if (litter != nullptr)
+        {
+            auto it = LitterTypeMap.find(litter->SubType);
+            if (it != LitterTypeMap.end())
+            {
+                return std::string{ it->first };
+            }
+        }
+        return "";
     }
 
     void ScLitter::litterType_set(const std::string& litterType)

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -122,7 +122,7 @@ namespace OpenRCT2::Scripting
         {
             for (auto sprite : EntityList<Litter>())
             {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScLitter>(sprite->sprite_index)));
             }
         }
         else if (type == "duck")


### PR DESCRIPTION
Hey all,

After the change in #15566 I tried to update my plugin but found out the plugin api for litter entities seems to be a bit incomplete. It seems the PR that introduced litter (#15165) was only partially tested. This PR aims to fix the problems.

If you'd like to test it, you can use this script to see the difference (in a park with at least 1 litter entity):
```js
var litter = map.getAllEntities("litter")[0];
console.log(`Entity type: ${litter.type}\nLitter type: ${litter.litterType}\nCreation tick: ${litter.creationTick}`);
```
The script prints this on the most recent develop:
```
Entity type: litter
Litter type: undefined
Creation tick: undefined
```
And this on my branch:
```
Entity type: litter
Litter type: vomit_alt
Creation tick: 640
```

Full list of changes:
- Updated `creationTime` to `creationTick` to match names in `ScLitter.cpp` (it'd try to read a not existing property otherwise).
- Register `ScLitter` class in the Scripting Engine, so its getters and setters can actually be used.
- Add a nullptr check to `litterType_get()` to fix a crash there if the entity does not exist.
- Allow `getAllEntities("litter")` to return instances of litter objects instead of base entities.

Thank you for your time! :)