### PR TITLE
Part of #12098: Change several gfx_filter_rect calls to use ScreenRect

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1637,7 +1637,7 @@ void window_guest_rides_scroll_paint(rct_window* w, rct_drawpixelinfo* dpi, int3
         rct_string_id stringId = STR_BLACK_STRING;
         if (list_index == w->selected_list_item)
         {
-            gfx_filter_rect(dpi, 0, y, 800, y + 9, FilterPaletteID::PaletteDarken1);
+            gfx_filter_rect(dpi, { { 0, y }, { 800, y + 9 } }, FilterPaletteID::PaletteDarken1);
             stringId = STR_WINDOW_COLOUR_2_STRINGID;
         }
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -675,7 +675,8 @@ private:
                 rct_string_id format = STR_BLACK_STRING;
                 if (index == _highlightedIndex)
                 {
-                    gfx_filter_rect(&dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, FilterPaletteID::PaletteDarken1);
+                    const ScreenRect screenRect{ { 0, y }, { 800, y + SCROLLABLE_ROW_HEIGHT - 1 } };
+                    gfx_filter_rect(&dpi, screenRect, FilterPaletteID::PaletteDarken1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 
@@ -745,7 +746,8 @@ private:
                 rct_string_id format = STR_BLACK_STRING;
                 if (index == _highlightedIndex)
                 {
-                    gfx_filter_rect(&dpi, 0, y, 800, y + SUMMARISED_GUEST_ROW_HEIGHT, FilterPaletteID::PaletteDarken1);
+                    const ScreenRect screenRect{ { 0, y }, { 800, y + SUMMARISED_GUEST_ROW_HEIGHT } };
+                    gfx_filter_rect(&dpi, screenRect, FilterPaletteID::PaletteDarken1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -759,7 +759,7 @@ static void window_loadsave_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
         if (i == w->selected_list_item)
         {
             stringId = STR_WINDOW_COLOUR_2_STRINGID;
-            gfx_filter_rect(dpi, 0, y, listWidth, y + SCROLLABLE_ROW_HEIGHT, FilterPaletteID::PaletteDarken1);
+            gfx_filter_rect(dpi, { { 0, y }, { listWidth, y + SCROLLABLE_ROW_HEIGHT } }, FilterPaletteID::PaletteDarken1);
         }
         // display a marker next to the currently loaded game file
         if (_listItems[i].loaded)

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -592,8 +592,8 @@ static void window_multiplayer_players_scrollpaint(rct_window* w, rct_drawpixeli
             colour_t colour = COLOUR_BLACK;
             if (i == w->selected_list_item)
             {
-                gfx_filter_rect(
-                    dpi, 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, FilterPaletteID::PaletteDarken1);
+                const ScreenRect screenRect{ { 0, screenCoords.y }, { 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } };
+                gfx_filter_rect(dpi, screenRect, FilterPaletteID::PaletteDarken1);
                 buffer += network_get_player_name(i);
                 colour = w->colours[2];
             }
@@ -894,8 +894,8 @@ static void window_multiplayer_groups_scrollpaint(rct_window* w, rct_drawpixelin
     {
         if (i == w->selected_list_item)
         {
-            gfx_filter_rect(
-                dpi, 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1, FilterPaletteID::PaletteDarken1);
+            const ScreenRect screenRect{ { 0, screenCoords.y }, { 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } };
+            gfx_filter_rect(dpi, screenRect, FilterPaletteID::PaletteDarken1);
         }
         if (screenCoords.y > dpi->y + dpi->height)
         {

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -576,7 +576,7 @@ static void window_ride_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         if (i == static_cast<size_t>(w->selected_list_item))
         {
             // Background highlight
-            gfx_filter_rect(dpi, 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1, FilterPaletteID::PaletteDarken1);
+            gfx_filter_rect(dpi, { { 0, y }, { 800, y + SCROLLABLE_ROW_HEIGHT - 1 } }, FilterPaletteID::PaletteDarken1);
             format = (_quickDemolishMode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
         }
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -596,7 +596,8 @@ static void window_scenarioselect_scrollpaint(rct_window* w, rct_drawpixelinfo* 
                 bool isHighlighted = w->highlighted_scenario == scenario;
                 if (isHighlighted)
                 {
-                    gfx_filter_rect(dpi, 0, y, w->width, y + scenarioItemHeight - 1, FilterPaletteID::PaletteDarken1);
+                    const ScreenRect screenRect{ { 0, y }, { w->width, y + scenarioItemHeight - 1 } };
+                    gfx_filter_rect(dpi, screenRect, FilterPaletteID::PaletteDarken1);
                 }
 
                 bool isCompleted = scenario->highscore != nullptr;

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -439,7 +439,8 @@ static void window_server_list_scrollpaint(rct_window* w, rct_drawpixelinfo* dpi
         // Draw hover highlight
         if (highlighted)
         {
-            gfx_filter_rect(dpi, 0, screenCoords.y, width, screenCoords.y + ITEM_HEIGHT, FilterPaletteID::PaletteDarken1);
+            const ScreenRect screenRect{ { 0, screenCoords.y }, { width, screenCoords.y + ITEM_HEIGHT } };
+            gfx_filter_rect(dpi, screenRect, FilterPaletteID::PaletteDarken1);
             _version = serverDetails.Version;
             listWidget.tooltip = STR_NETWORK_VERSION_TIP;
         }

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -509,7 +509,8 @@ private:
         if (isHighlighted)
         {
             format = STR_WINDOW_COLOUR_2_STRINGID;
-            gfx_filter_rect(&dpi, 0, y - 1, scrollWidth, y + (SCROLLABLE_ROW_HEIGHT - 2), FilterPaletteID::PaletteDarken1);
+            const ScreenRect screenRect{ { 0, y - 1 }, { scrollWidth, y + SCROLLABLE_ROW_HEIGHT - 2 } };
+            gfx_filter_rect(&dpi, screenRect, FilterPaletteID::PaletteDarken1);
         }
 
         auto bindingOffset = (scrollWidth * 2) / 3;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -401,7 +401,8 @@ public:
 
                 if (i == _highlightedIndex)
                 {
-                    gfx_filter_rect(&dpi, 0, y, 800, y + (SCROLLABLE_ROW_HEIGHT - 1), FilterPaletteID::PaletteDarken1);
+                    const ScreenRect screenRect{ { 0, y }, { 800, y + SCROLLABLE_ROW_HEIGHT - 1 } };
+                    gfx_filter_rect(&dpi, screenRect, FilterPaletteID::PaletteDarken1);
                     format = (_quickFireMode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
                 }
 


### PR DESCRIPTION
Another few "refactors" of gfx_filter_rect calls!

I've extracted the initialisation to a separate variable depending on whether clang-format would add a newline after the opening parentheses, since I find a separate variable to be much easier to read

On another note, while testing I've found some off-by-one errors in the LoadSave and RideList files, where adding or subtracting 1 from y values makes them more consistent with other scrollpaints. Do you feel it's okay to include these in this PR, or should I start a new one for them? We're talking 3 lines of codes here (LoadSave.cpp:762, RideList.cpp:591 and RideList.cpp:743).