### PR TITLE
Fix #15006: Prevent allocating empty texture atlases

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -101,8 +101,8 @@ public:
         _atlasWidth = atlasWidth;
         _atlasHeight = atlasHeight;
 
-        _cols = _atlasWidth / _imageSize;
-        _rows = _atlasHeight / _imageSize;
+        _cols = std::max(1, _atlasWidth / _imageSize);
+        _rows = std::max(1, _atlasHeight / _imageSize);
 
         _freeSlots.resize(_cols * _rows);
         for (size_t i = 0; i < _freeSlots.size(); i++)


### PR DESCRIPTION
I looked into the issue and there was one image with 2080 pixels height, a single atlas only supports up to 2048 on each axis. In order to avoid a crash this will now allocate always a minimum of 1 row and 1 column. Images that are bigger than the entire atlas will be distorted since it normalizes the bounds to the atlas dimension. We could also increase the atlas size but I suspect this image is not supposed to be there.

Closes #15006