### PR TITLE
Remove unused server_list_get_item_button

### DIFF
--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -109,7 +109,7 @@ enum
     DDIDX_FAVOURITE
 };
 
-static bool _showVersionTooltip = false;
+static bool _showNetworkVersionTooltip = false;
 static std::string _version;
 
 static void join_server(std::string address);
@@ -283,26 +283,23 @@ static void window_server_list_scroll_mouseover(rct_window* w, int32_t scrollInd
     auto& listWidget = w->widgets[WIDX_LIST];
 
     int32_t itemIndex = screenCoords.y / ITEM_HEIGHT;
-    bool showVersionTooltip = false;
+    bool showNetworkVersionTooltip = false;
     if (itemIndex < 0 || itemIndex >= w->no_list_items)
     {
         itemIndex = -1;
     }
     else
     {
-        const int32_t iconX = listWidget.width() - SCROLLBAR_WIDTH - 17;
-        showVersionTooltip = screenCoords.x > iconX;
+        const int32_t iconX = listWidget.width() - SCROLLBAR_WIDTH - 7 - 10;
+        showNetworkVersionTooltip = screenCoords.x > iconX;
     }
 
-    if (w->selected_list_item != itemIndex || _showVersionTooltip != showVersionTooltip)
+    if (w->selected_list_item != itemIndex || _showNetworkVersionTooltip != showNetworkVersionTooltip)
     {
         w->selected_list_item = itemIndex;
-        _showVersionTooltip = showVersionTooltip;
+        _showNetworkVersionTooltip = showNetworkVersionTooltip;
 
-        if (showVersionTooltip)
-            listWidget.tooltip = STR_NETWORK_VERSION_TIP;
-        else
-            listWidget.tooltip = STR_NONE;
+        listWidget.tooltip = showNetworkVersionTooltip ? static_cast<rct_string_id>(STR_NETWORK_VERSION_TIP) : STR_NONE;
         window_tooltip_close();
 
         w->Invalidate();


### PR DESCRIPTION
When working on updating `server_list_get_item_button` to use `ScreenCoordsXY` (as @tupaschoal suggested in their [comment](https://github.com/OpenRCT2/OpenRCT2/pull/15605#pullrequestreview-782675300) on #15605), I noticed the result of the function's only reference wasn't used anywhere.

When removing the code, I did not notice a difference in behaviour, and the git history of the file doesn't seem to explain the point of the code either.

While I was in there I also cleaned up the `clang-format off` part of the code by realigning it, and applying clang-format's rules manually where they didn't break anything.