### PR TITLE
Fix #12981: New vehicles do not appear in vehicle type dropdown

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Feature: [#15194] [Plugin] Add guest properties, ride downtime and park casualty penalty.
 - Feature: [#15195] Added a bug-report item in file dropdown menu.
 - Feature: [#15294] New vehicle animation type: flying animal.
+- Fix: [#12981] New vehicles do not appear in vehicle type dropdown.
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
 - Fix: [#13912] “Dome park” no longer renders dome correctly.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -65,6 +65,8 @@ static constexpr const rct_string_id WINDOW_TITLE = STR_RIDE_WINDOW_TITLE;
 static constexpr const int32_t WH = 207;
 static constexpr const int32_t WW = 316;
 
+static void populate_vehicle_type_dropdown(Ride* ride, bool forceRefresh = false);
+
 enum
 {
     WINDOW_RIDE_PAGE_MAIN,
@@ -1249,6 +1251,8 @@ static rct_window* window_ride_open(Ride* ride)
 
     window_ride_update_overall_view(ride);
 
+    populate_vehicle_type_dropdown(ride, true);
+
     return w;
 }
 
@@ -2066,7 +2070,7 @@ static void window_ride_main_follow_ride(rct_window* w)
     }
 }
 
-static void populate_vehicle_type_dropdown(Ride* ride)
+static void populate_vehicle_type_dropdown(Ride* ride, bool forceRefresh)
 {
     auto& objManager = GetContext()->GetObjectManager();
     rct_ride_entry* rideEntry = ride->GetRideEntry();
@@ -2091,7 +2095,7 @@ static void populate_vehicle_type_dropdown(Ride* ride)
 
     // Don't repopulate the list if we just did.
     auto& ls = OpenRCT2::GetContext()->GetLocalisationService();
-    if (VehicleDropdownExpanded == selectionShouldBeExpanded && VehicleDropdownRideType == rideEntry
+    if (!forceRefresh && VehicleDropdownExpanded == selectionShouldBeExpanded && VehicleDropdownRideType == rideEntry
         && VehicleDropdownDataLanguage == ls.GetCurrentLanguage())
         return;
 


### PR DESCRIPTION
This forcibly refreshes the list on opening the window, while keeping the existing mechanism that expands the list when cheats are used when the window is already open.