### PR TITLE
Fix #15809: Assign a temporary result to avoid crashes

### DIFF
--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -119,6 +119,8 @@ GameActions::Result::Ptr MapCanConstructWithClearAt(
     auto res = std::make_unique<GameActions::Result>();
 
     uint8_t groundFlags = ELEMENT_IS_ABOVE_GROUND;
+    res->SetData(ConstructClearResult{ groundFlags });
+
     bool canBuildCrossing = false;
     if (map_is_edge(pos))
     {


### PR DESCRIPTION
This is rather a temporary fix for now. FootpathPlaceAction and FootpathPlaceFromTrackAction seem to ignore the error when the variable entrancePath is true, this might be wrong and should be checked.
