### PR TITLE
Fix undefined behaviour in cctype functions

### DIFF
--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -392,9 +392,10 @@ namespace OpenRCT2::Ui
                     {
                         filtersb << ' ';
                     }
-                    else if (isalpha(c))
+                    else if (isalpha(static_cast<unsigned char>(c)))
                     {
-                        filtersb << '[' << static_cast<char>(tolower(c)) << static_cast<char>(toupper(c)) << ']';
+                        auto uc = static_cast<unsigned char>(c);
+                        filtersb << '[' << static_cast<char>(tolower(uc)) << static_cast<char>(toupper(uc)) << ']';
                     }
                     else
                     {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1485,30 +1485,16 @@ static bool filter_string(const ObjectRepositoryItem* item)
     // Get ride type
     const char* rideTypeName = language_get_string(get_ride_type_string_id(item));
 
-    // Get object name (ride/vehicle for rides) and type name (rides only)
-    char name_lower[MAX_PATH];
-    char type_lower[MAX_PATH];
-    char object_path[MAX_PATH];
-    char filter_lower[sizeof(_filter_string)];
-    safe_strcpy(name_lower, item->Name.c_str(), MAX_PATH);
-    safe_strcpy(type_lower, rideTypeName, MAX_PATH);
-    safe_strcpy(object_path, item->Path.c_str(), MAX_PATH);
-    safe_strcpy(filter_lower, _filter_string, sizeof(_filter_string));
-
-    // Make use of lowercase characters only
-    for (int32_t i = 0; name_lower[i] != '\0'; i++)
-        name_lower[i] = static_cast<char>(tolower(static_cast<unsigned char>(name_lower[i])));
-    for (int32_t i = 0; type_lower[i] != '\0'; i++)
-        type_lower[i] = static_cast<char>(tolower(static_cast<unsigned char>(type_lower[i])));
-    for (int32_t i = 0; object_path[i] != '\0'; i++)
-        object_path[i] = static_cast<char>(tolower(static_cast<unsigned char>(object_path[i])));
-    for (int32_t i = 0; filter_lower[i] != '\0'; i++)
-        filter_lower[i] = static_cast<char>(tolower(static_cast<unsigned char>(filter_lower[i])));
+    // Get object name (ride/vehicle for rides) and type name (rides only) in uppercase
+    const auto nameUpper = String::ToUpper(item->Name);
+    const auto typeUpper = String::ToUpper(rideTypeName);
+    const auto pathUpper = String::ToUpper(item->Path);
+    const auto filterUpper = String::ToUpper(_filter_string);
 
     // Check if the searched string exists in the name, ride type, or filename
-    bool inName = strstr(name_lower, filter_lower) != nullptr;
-    bool inRideType = (item->ObjectEntry.GetType() == ObjectType::Ride) && strstr(type_lower, filter_lower) != nullptr;
-    bool inPath = strstr(object_path, filter_lower) != nullptr;
+    bool inName = nameUpper.find(filterUpper) != std::string::npos;
+    bool inRideType = (item->ObjectEntry.GetType() == ObjectType::Ride) && typeUpper.find(filterUpper) != std::string::npos;
+    bool inPath = pathUpper.find(filterUpper) != std::string::npos;
 
     return inName || inRideType || inPath;
 }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1497,13 +1497,13 @@ static bool filter_string(const ObjectRepositoryItem* item)
 
     // Make use of lowercase characters only
     for (int32_t i = 0; name_lower[i] != '\0'; i++)
-        name_lower[i] = static_cast<char>(tolower(name_lower[i]));
+        name_lower[i] = static_cast<char>(tolower(static_cast<unsigned char>(name_lower[i])));
     for (int32_t i = 0; type_lower[i] != '\0'; i++)
-        type_lower[i] = static_cast<char>(tolower(type_lower[i]));
+        type_lower[i] = static_cast<char>(tolower(static_cast<unsigned char>(type_lower[i])));
     for (int32_t i = 0; object_path[i] != '\0'; i++)
-        object_path[i] = static_cast<char>(tolower(object_path[i]));
+        object_path[i] = static_cast<char>(tolower(static_cast<unsigned char>(object_path[i])));
     for (int32_t i = 0; filter_lower[i] != '\0'; i++)
-        filter_lower[i] = static_cast<char>(tolower(filter_lower[i]));
+        filter_lower[i] = static_cast<char>(tolower(static_cast<unsigned char>(filter_lower[i])));
 
     // Check if the searched string exists in the name, ride type, or filename
     bool inName = strstr(name_lower, filter_lower) != nullptr;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -89,21 +89,14 @@ private:
             return;
         }
 
-        // Convert filter to lowercase
-        utf8 filterStringLower[sizeof(_filterString)];
-        String::Set(filterStringLower, sizeof(filterStringLower), _filterString);
-        for (int32_t i = 0; filterStringLower[i] != '\0'; i++)
-            filterStringLower[i] = static_cast<utf8>(tolower(static_cast<unsigned char>(filterStringLower[i])));
+        // Convert filter to uppercase
+        const auto filterStringUpper = String::ToUpper(_filterString);
 
         // Fill the set with indices for tracks that match the filter
         for (uint16_t i = 0; i < _trackDesigns.size(); i++)
         {
-            utf8 trackNameLower[USER_STRING_MAX_LENGTH];
-            String::Set(trackNameLower, sizeof(trackNameLower), _trackDesigns[i].name);
-            for (int32_t j = 0; trackNameLower[j] != '\0'; j++)
-                trackNameLower[j] = static_cast<utf8>(tolower(static_cast<unsigned char>(trackNameLower[j])));
-
-            if (strstr(trackNameLower, filterStringLower) != nullptr)
+            const auto trackNameUpper = String::ToUpper(_trackDesigns[i].name);
+            if (trackNameUpper.find(filterStringUpper) != std::string::npos)
             {
                 _filteredTrackIds.push_back(i);
             }

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -93,7 +93,7 @@ private:
         utf8 filterStringLower[sizeof(_filterString)];
         String::Set(filterStringLower, sizeof(filterStringLower), _filterString);
         for (int32_t i = 0; filterStringLower[i] != '\0'; i++)
-            filterStringLower[i] = static_cast<utf8>(tolower(filterStringLower[i]));
+            filterStringLower[i] = static_cast<utf8>(tolower(static_cast<unsigned char>(filterStringLower[i])));
 
         // Fill the set with indices for tracks that match the filter
         for (uint16_t i = 0; i < _trackDesigns.size(); i++)
@@ -101,7 +101,7 @@ private:
             utf8 trackNameLower[USER_STRING_MAX_LENGTH];
             String::Set(trackNameLower, sizeof(trackNameLower), _trackDesigns[i].name);
             for (int32_t j = 0; trackNameLower[j] != '\0'; j++)
-                trackNameLower[j] = static_cast<utf8>(tolower(trackNameLower[j]));
+                trackNameLower[j] = static_cast<utf8>(tolower(static_cast<unsigned char>(trackNameLower[j])));
 
             if (strstr(trackNameLower, filterStringLower) != nullptr)
             {

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -178,7 +178,7 @@ namespace String
             {
                 for (size_t i = 0; i < a.size(); i++)
                 {
-                    if (tolower(a[i]) != tolower(b[i]))
+                    if (tolower(static_cast<unsigned char>(a[i])) != tolower(static_cast<unsigned char>(b[i])))
                     {
                         return false;
                     }
@@ -212,7 +212,7 @@ namespace String
                         return false;
                     }
                 }
-                else if (tolower(ai) != tolower(bi))
+                else if (tolower(static_cast<unsigned char>(ai)) != tolower(static_cast<unsigned char>(bi)))
                 {
                     return false;
                 }
@@ -822,7 +822,7 @@ namespace String
         for (auto c : value)
         {
             // Keep alphanumeric and other accepted characters intact
-            if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            if (std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_' || c == '.' || c == '~')
             {
                 escaped << c;
             }

--- a/src/openrct2/scripting/bindings/network/ScPlayerGroup.cpp
+++ b/src/openrct2/scripting/bindings/network/ScPlayerGroup.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2::Scripting
         auto result = s.substr(sizeof("PERMISSION_") - 1);
         for (auto& c : result)
         {
-            c = std::tolower(c);
+            c = std::tolower(static_cast<unsigned char>(c));
         }
         return result;
     }

--- a/src/openrct2/scripting/bindings/network/ScPlayerGroup.cpp
+++ b/src/openrct2/scripting/bindings/network/ScPlayerGroup.cpp
@@ -14,6 +14,7 @@
 #    include "../../../Context.h"
 #    include "../../../actions/NetworkModifyGroupAction.h"
 #    include "../../../actions/PlayerSetGroupAction.h"
+#    include "../../../core/String.hpp"
 #    include "../../../network/NetworkAction.h"
 #    include "../../../network/network.h"
 #    include "../../Duktape.hpp"
@@ -63,12 +64,7 @@ namespace OpenRCT2::Scripting
 
     static std::string TransformPermissionKeyToInternal(const std::string& s)
     {
-        auto result = "PERMISSION_" + s;
-        for (auto& c : result)
-        {
-            c = std::toupper(c);
-        }
-        return result;
+        return "PERMISSION_" + String::ToUpper(s);
     }
 #    endif
 

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -332,7 +332,7 @@ int32_t strcicmp(char const* a, char const* b)
 {
     for (;; a++, b++)
     {
-        int32_t d = tolower(*a) - tolower(*b);
+        int32_t d = tolower(static_cast<unsigned char>(*a)) - tolower(static_cast<unsigned char>(*b));
         if (d != 0 || !*a)
             return d;
     }
@@ -353,7 +353,7 @@ int32_t strlogicalcmp(const char* s1, const char* s2)
             return *s1 != '\0';
         if (*s1 == '\0')
             return -1;
-        if (!(isdigit(*s1) && isdigit(*s2)))
+        if (!(isdigit(static_cast<unsigned char>(*s1)) && isdigit(static_cast<unsigned char>(*s2))))
         {
             if (toupper(*s1) != toupper(*s2))
                 return toupper(*s1) - toupper(*s2);

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -39,7 +39,7 @@ static std::string sanitizeTestName(const std::string& name)
     std::string res;
     for (char c : nameOnly)
     {
-        if (isalnum(c))
+        if (isalnum(static_cast<unsigned char>(c)))
             res += c;
     }
     return res;


### PR DESCRIPTION
These calls relied on undefined behaviour. Note from [cppreference](https://en.cppreference.com/w/cpp/string/byte/isalnum):

> Like all other functions from `<cctype>`, the behavior of `std::isalnum` is undefined if the argument's value is neither representable as `unsigned char` nor equal to EOF. To use these functions safely with plain `char`s (or `signed char`s), the argument should first be converted to `unsigned char`.

Multiple commits because changes are made via GitHub, squash on merge.