### PR TITLE
Fix 15851: Katie Smith cheat

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -50,6 +50,7 @@
 - Fix: [#15582] [Plugin] Litter properties return incorrect values.
 - Fix: [#15584] Ride income underflows when on-ride photos are making losses.
 - Fix: [#15612] Crash when placing walls beside certain scenery objects.
+- Fix: [#15851] Incorrect percentage chance of jumping with Katie Smith cheat.
 - Improved: [#3417] Crash dumps are now placed in their own folder.
 - Improved: [#13524] macOS arm64 native (universal) app
 - Improved: [#15538] Software rendering can now draw in parallel when Multithreading is enabled.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -38,7 +38,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -556,7 +556,7 @@ void Guest::UpdateEasterEggInteractions()
 
     if (PeepFlags & PEEP_FLAGS_JOY)
     {
-        if (scenario_rand() <= 1456)
+        if ((scenario_rand() & 0xFFFF) <= 1456)
         {
             if (IsActionInterruptable())
             {


### PR DESCRIPTION
Instead of a 2% chance of jumping for joy it was a 3x10^-5% chance of jumping for joy when the cheat was active. (okay those numbers arent quite true but good enough for explanation)

Checked this against the vanilla assembly.