### PR TITLE
Fix: Possible out-of-bounds read on group encoding

### DIFF
--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -44,21 +44,26 @@ int32_t object_entry_group_counts[] = {
 static_assert(std::size(object_entry_group_counts) == EnumValue(ObjectType::Count));
 
 // 98DA2C
-// clang-format off
 int32_t object_entry_group_encoding[] = {
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_RLE,
-    CHUNK_ENCODING_ROTATE,
+    CHUNK_ENCODING_RLE,    // Ride
+    CHUNK_ENCODING_RLE,    // SmallScenery
+    CHUNK_ENCODING_RLE,    // LargeScenery
+    CHUNK_ENCODING_RLE,    // Walls
+    CHUNK_ENCODING_RLE,    // Banners
+    CHUNK_ENCODING_RLE,    // Paths
+    CHUNK_ENCODING_RLE,    // PathBits
+    CHUNK_ENCODING_RLE,    // SceneryGroup
+    CHUNK_ENCODING_RLE,    // ParkEntrance
+    CHUNK_ENCODING_RLE,    // Water
+    CHUNK_ENCODING_ROTATE, // ScenarioText
+    CHUNK_ENCODING_NONE,   // TerrainSurface
+    CHUNK_ENCODING_NONE,   // TerrainEdge
+    CHUNK_ENCODING_NONE,   // Station
+    CHUNK_ENCODING_NONE,   // Music
+    CHUNK_ENCODING_NONE,   // FootpathSurface
+    CHUNK_ENCODING_NONE,   // FootpathRailings
 };
-// clang-format on
+static_assert(std::size(object_entry_group_encoding) == EnumValue(ObjectType::Count));
 
 ObjectList::const_iterator::const_iterator(const ObjectList* parent, bool end)
 {


### PR DESCRIPTION
This fills the array and ensures that the size matches the object type count. This array is used in the [`SaveObject` function](https://github.com/OpenRCT2/OpenRCT2/blob/77141f57b0a91aa4321bc6908027168fe883a784/src/openrct2/object/ObjectRepository.cpp#L520) without any checks beforehand on the object type.
https://github.com/OpenRCT2/OpenRCT2/blob/77141f57b0a91aa4321bc6908027168fe883a784/src/openrct2/object/ObjectRepository.cpp#L520

I'm not 100% sure how this is supposed to work for new object types (are Sawyer chunks even used for new object types?), hence this PR rather than a direct commit on the NSF branch. The only current call stack comes from `S6Importer`, so I guess that's why it never caused any issues.