### PR TITLE
Introduce templated identifier type

### DIFF
--- a/src/openrct2/Identifiers.h
+++ b/src/openrct2/Identifiers.h
@@ -1,0 +1,17 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "common.h"
+#include "core/Identifier.hpp"
+
+#include <limits>
+
+using ParkEntranceIndex = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkEntranceIndexTag>;

--- a/src/openrct2/core/Identifier.hpp
+++ b/src/openrct2/core/Identifier.hpp
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+template<typename T, T TNullValue, typename TTag> class TIdentifier
+{
+    enum class ValueType : T
+    {
+        Null = TNullValue,
+    } _handle;
+
+private:
+    explicit TIdentifier(const T index)
+        : _handle{ static_cast<ValueType>(index) }
+    {
+    }
+
+public:
+    static constexpr auto Null = ValueType::Null;
+
+    TIdentifier(const ValueType other)
+        : _handle{ other }
+    {
+    }
+
+    static constexpr TIdentifier FromUnderlying(const T val) noexcept
+    {
+        return TIdentifier{ val };
+    }
+
+    constexpr T ToUnderlying() const noexcept
+    {
+        return static_cast<T>(_handle);
+    }
+
+    constexpr bool IsNull() const noexcept
+    {
+        return _handle == ValueType::Null;
+    }
+
+    constexpr bool operator==(const ValueType other) const noexcept
+    {
+        return _handle == other;
+    }
+
+    constexpr bool operator!=(const ValueType other) const noexcept
+    {
+        return _handle != other;
+    }
+};

--- a/src/openrct2/core/Identifier.hpp
+++ b/src/openrct2/core/Identifier.hpp
@@ -34,6 +34,11 @@ public:
     {
     }
 
+    static constexpr TIdentifier GetNull() noexcept
+    {
+        return Null;
+    }
+
     static constexpr TIdentifier FromUnderlying(const T val) noexcept
     {
         return TIdentifier{ val };

--- a/src/openrct2/core/Identifier.hpp
+++ b/src/openrct2/core/Identifier.hpp
@@ -26,17 +26,15 @@ private:
     {
     }
 
-public:
-    static constexpr auto Null = ValueType::Null;
-
-    TIdentifier(const ValueType other)
+    explicit TIdentifier(const ValueType other)
         : _handle{ other }
     {
     }
 
+public:
     static constexpr TIdentifier GetNull() noexcept
     {
-        return Null;
+        return TIdentifier{ ValueType::Null };
     }
 
     static constexpr TIdentifier FromUnderlying(const T val) noexcept

--- a/src/openrct2/core/Identifier.hpp
+++ b/src/openrct2/core/Identifier.hpp
@@ -21,17 +21,19 @@ template<typename T, T TNullValue, typename TTag> class TIdentifier
     } _handle;
 
 private:
-    explicit TIdentifier(const T index)
+    explicit constexpr TIdentifier(const T index)
         : _handle{ static_cast<ValueType>(index) }
     {
     }
 
-    explicit TIdentifier(const ValueType other)
+    explicit constexpr TIdentifier(const ValueType other)
         : _handle{ other }
     {
     }
 
 public:
+    constexpr TIdentifier() = default;
+
     static constexpr TIdentifier GetNull() noexcept
     {
         return TIdentifier{ ValueType::Null };

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -209,6 +209,7 @@
     <ClInclude Include="Game.h" />
     <ClInclude Include="GameState.h" />
     <ClInclude Include="GameStateSnapshots.h" />
+    <ClInclude Include="Identifiers.h" />
     <ClInclude Include="Input.h" />
     <ClInclude Include="interface\Chat.h" />
     <ClInclude Include="interface\Colour.h" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -169,6 +169,7 @@
     <ClInclude Include="core\GroupVector.hpp" />
     <ClInclude Include="core\Guard.hpp" />
     <ClInclude Include="core\Http.h" />
+    <ClInclude Include="core\Identifier.hpp" />
     <ClInclude Include="core\Imaging.h" />
     <ClInclude Include="core\IStream.hpp" />
     <ClInclude Include="core\JobPool.h" />

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1738,7 +1738,7 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
     // If entrance no longer exists, choose a new one
     if ((peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN) && peep->ChosenParkEntrance.ToUnderlying() >= gParkEntrances.size())
     {
-        peep->ChosenParkEntrance = ParkEntranceIndex::Null;
+        peep->ChosenParkEntrance = ParkEntranceIndex::GetNull();
         peep->PeepFlags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
     }
 
@@ -1758,7 +1758,7 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
             entranceNum++;
         }
 
-        if (chosenEntrance == ParkEntranceIndex::Null)
+        if (chosenEntrance.IsNull())
             return guest_path_find_aimless(peep, edges);
 
         peep->ChosenParkEntrance = chosenEntrance;

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1736,15 +1736,15 @@ static int32_t guest_path_find_leaving_park(Peep* peep, uint8_t edges)
 static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
 {
     // If entrance no longer exists, choose a new one
-    if ((peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN) && peep->ChosenParkEntrance >= gParkEntrances.size())
+    if ((peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN) && peep->ChosenParkEntrance.ToUnderlying() >= gParkEntrances.size())
     {
-        peep->ChosenParkEntrance = PARK_ENTRANCE_INDEX_NULL;
+        peep->ChosenParkEntrance = ParkEntranceIndex::Null;
         peep->PeepFlags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
     }
 
     if (!(peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN))
     {
-        uint8_t chosenEntrance = PARK_ENTRANCE_INDEX_NULL;
+        ParkEntranceIndex chosenEntrance = ParkEntranceIndex::Null;
         uint16_t nearestDist = 0xFFFF;
         uint8_t entranceNum = 0;
         for (const auto& entrance : gParkEntrances)
@@ -1753,19 +1753,19 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
             if (dist < nearestDist)
             {
                 nearestDist = dist;
-                chosenEntrance = entranceNum;
+                chosenEntrance = ParkEntranceIndex::FromUnderlying(entranceNum);
             }
             entranceNum++;
         }
 
-        if (chosenEntrance == 0xFF)
+        if (chosenEntrance == ParkEntranceIndex::Null)
             return guest_path_find_aimless(peep, edges);
 
         peep->ChosenParkEntrance = chosenEntrance;
         peep->PeepFlags |= PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
     }
 
-    const auto& entrance = gParkEntrances[peep->ChosenParkEntrance];
+    const auto& entrance = gParkEntrances[peep->ChosenParkEntrance.ToUnderlying()];
 
     gPeepPathFindGoalPosition = TileCoordsXYZ(entrance);
     gPeepPathFindIgnoreForeignQueues = true;

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1744,7 +1744,7 @@ static int32_t guest_path_find_park_entrance(Peep* peep, uint8_t edges)
 
     if (!(peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN))
     {
-        ParkEntranceIndex chosenEntrance = ParkEntranceIndex::Null;
+        auto chosenEntrance = ParkEntranceIndex::GetNull();
         uint16_t nearestDist = 0xFFFF;
         uint8_t entranceNum = 0;
         for (const auto& entrance : gParkEntrances)

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/Identifier.hpp"
 #include "../ride/RideTypes.h"
 #include "../ride/Station.h"
 #include "../util/Util.h"
@@ -32,7 +33,7 @@ namespace GameActions
 {
     class Result;
 }
-using ParkEntranceIndex = uint8_t;
+using ParkEntranceIndex = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkEntranceIndexTag>;
 
 enum class StaffType : uint8_t
 {

--- a/src/openrct2/peep/Peep.h
+++ b/src/openrct2/peep/Peep.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
+#include "../Identifiers.h"
 #include "../common.h"
-#include "../core/Identifier.hpp"
 #include "../ride/RideTypes.h"
 #include "../ride/Station.h"
 #include "../util/Util.h"
@@ -33,7 +33,6 @@ namespace GameActions
 {
     class Result;
 }
-using ParkEntranceIndex = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkEntranceIndexTag>;
 
 enum class StaffType : uint8_t
 {

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
+#include "../Identifiers.h"
 #include "../common.h"
-#include "../core/Identifier.hpp"
 #include "Location.hpp"
 #include "Map.h"
 
@@ -44,8 +44,6 @@ extern CoordsXYZD gParkEntranceGhostPosition;
 #define MAX_PARK_ENTRANCES 256
 
 constexpr int32_t MaxRideEntranceOrExitHeight = 244 * COORDS_Z_STEP;
-
-using ParkEntranceIndex = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkEntranceIndexTag>;
 
 extern std::vector<CoordsXYZD> gParkEntrances;
 

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/Identifier.hpp"
 #include "Location.hpp"
 #include "Map.h"
 
@@ -44,8 +45,7 @@ extern CoordsXYZD gParkEntranceGhostPosition;
 
 constexpr int32_t MaxRideEntranceOrExitHeight = 244 * COORDS_Z_STEP;
 
-using ParkEntranceIndex = uint8_t;
-constexpr const ParkEntranceIndex PARK_ENTRANCE_INDEX_NULL = 255;
+using ParkEntranceIndex = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkEntranceIndexTag>;
 
 extern std::vector<CoordsXYZD> gParkEntrances;
 


### PR DESCRIPTION
We are basically re-inventing the wheel for each time we want to have a strong type for different indices based things.

Here is an overview to what this type promises:
```cpp
using EntityId = TIdentifier<
    uint16_t, 
    std::numeric_limits<uint16_t>::max(), 
    struct EntityIdTag
    >;

using PatrolAreaId = TIdentifier<
    uint32_t, 
    std::numeric_limits<uint32_t>::max(), 
    struct PatrolAreaIdTag
    >;

int main()
{
    // Won't compile.
    EntityId id0 = EntityId(0);

    // Construction from underlying value, explicit
    EntityId id = EntityId::FromUnderlying(0);

    // Nulled type
    EntityId idNull = EntityId::GetNull();

    // Check against null value.
    auto isNull2 = idNull.IsNull();

    // Copy
    EntityId id2 = id;

    // Get underlying value
    printf("%u\n", id2.ToUnderlying());
    
    // Won't compile.
    PatrolAreaId id3 = id2;
}
```
Since this type is basically an enum class with members it helps avoid using static_cast all over the place by using FromUnderlying/ToUnderlying. Another great benefit is that the type holds the Null value, we don't need to define this separately anymore. This type also has a member "IsNull" to reduce even more boilerplate code.

I've picked ParkEntranceIndex as its not heavily used for a smooth introduction of the type.