### PR TITLE
Fix changelog order and quotation style

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -250,6 +250,7 @@
 - Improved: [#12806] Add Esperanto diacritics to the sprite font.
 - Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.
 - Improved: [#12890] Add stroke to lowercase ‘L’ to differentiate from capital ‘I’.
+- Change: [#12749] The required version of macOS has been lowered to 10.13 (High Sierra).
 - Fix: [#400] Unable to place some saved tracks flush to the ground (original bug).
 - Fix: [#5753] Entertainers make themselves happy instead of the guests.
 - Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
@@ -268,7 +269,6 @@
 - Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
 - Fix: [#12918] Cannot place vanilla TD6 tracks of the Hypercoaster, Monster Trucks, Classic Mini Roller Coaster, Spinning Wild Mouse and Hyper-Twister types.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
-- Technical: [#12749] The required version of macOS has been lowered to 10.13 (High Sierra).
 
 0.3.0 (2020-08-15)
 ------------------------------------------------------------------------
@@ -289,14 +289,17 @@
 - Feature: [#12347] Periodically check for new releases on GitHub, and show a notification on the title screen.
 - Feature: [#12347] The ‘About OpenRCT2’ window now has a link to the OpenRCT2 Discord Server.
 - Feature: [#12591] Show authors of an object on the object selection dialog.
-- Improved: [#6530] Allow water and land height changes on park borders.
-- Improved: [#11390] Build hash written to screenshot metadata.
 - Improved: [#3205] Make handymen less likely to get stuck in ride queues.
+- Improved: [#6530] Allow water and land height changes on park borders.
+- Improved: [#8110] OpenRCT2 now uses a single directory name for title sequences instead of three.
+- Improved: [#11390] Build hash written to screenshot metadata.
 - Change: [#11209] Warn when user is running OpenRCT2 through Wine.
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Change: [#11449] Remove complete circuit requirement from Air Powered Vertical Coaster (for RCT1 parity).
+- Change: [#11517] Windows Vista is supported again (libzip regression in the previous release).
 - Change: [#11898] The ‘openrct-data-path’ command-line argument has been renamed to ‘openrct2-data-path’.
 - Change: [#11944] The ride list sort mode is now remembered for the duration of the game.
+- Change: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.
 - Fix: [#1013] Negative length displayed in Ride window.
 - Fix: [#1148] Research funding dropdown not shown in finances window.
 - Fix: [#5451] Guests scream on every descent, no matter how small.
@@ -348,9 +351,6 @@
 - Fix: Brakes keep working during "Brakes failure".
 - Fix: Guests maze pathfinding prefers a specific direction (original bug).
 - Removed: [#11820] Twitch support (relied on a server that has been down for a few years).
-- Technical: [#8110] OpenRCT2 now uses a single directory name for title sequences instead of three.
-- Technical: [#11517] Windows Vista is supported again (libzip regression in the previous release).
-- Technical: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.
 
 0.2.6 (2020-04-17)
 ------------------------------------------------------------------------
@@ -794,6 +794,7 @@
 - Improved: Load/save window now refreshes list if native file dialog is closed/cancelled.
 - Improved: Major translation updates for Japanese and Polish.
 - Improved: Added 24x24, 48x48, and 96x96 icon resolutions.
+- Change: [#6384] On macOS, address ‘NSFileHandlingPanel’ deprecation by using ‘NSModalResponse’ instead.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#996, #2589, #2875] Viewport scrolling no longer shakes or gets stuck.
 - Fix: [#1185] Close button colour of prompt windows does not match.
@@ -880,8 +881,7 @@
 - Fix: Remove consecutive thoughts about a ride being demolished.
 - Fix: Water raft vehicles stop spinning when going up slopes.
 - Fix: Incorrect spin is applied to coasters on S-bends and other turns.
-- Technical: [#6384] On macOS, address NSFileHandlingPanel deprecation by using NSModalResponse instead.
-- Technical: [#6772] RCT2 interop removed.
+- Removed: [#6772] RCT2 interop removed.
 
 0.1.1 (2017-08-09)
 ------------------------------------------------------------------------
@@ -899,7 +899,7 @@
 - Improved: The land tool buttons can now be held down to increase/decrease size.
 - Improved: Dropdowns longer than 32 items overflow into columns.
 - Improved: Ride Type option in ride window is now a dropdown.
-- Improved: "About OpenRCT2" window redesigned, now contains OpenRCT2 info and access to changelog.
+- Improved: ‘About OpenRCT2’ window redesigned, now contains OpenRCT2 info and access to changelog.
 - Fix: [#2127, #2229, #5586] Mountain tool cost calculation.
 - Fix: [#3589] Crash due to invalid footpathEntry in path_paint.
 - Fix: [#3852] Constructing path not clearing scenery on server.
@@ -932,14 +932,18 @@
 - Feature: [#5056] Add cheat to own all land.
 - Feature: [#5133] Add option to display guest expenditure (as seen in RCTC).
 - Feature: [#5196] Add cheat to disable ride ageing.
+- Feature: [#5458] Begin offering headless build with reduced compile- and run-time dependencies.
 - Feature: [#5504] Group vehicles into ride groups.
 - Feature: [#5576] Add a persistent ‘display real names of guests’ setting.
 - Feature: [#5611] Add support for Android.
 - Feature: [#5706] Add support for OpenBSD.
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
 - Feature: Park entrance fee can now be set to amounts up to £200.
+- Improved: [#5047] Add ride ratings tests.
 - Improved: Construction rights can now be placed on park entrances.
 - Improved: Mouse can now be dragged to select scenery when saving track designs.
+- Improved: Fix many desync sources.
+- Change: [#5755] Title sequence wait periods use milliseconds.
 - Fix: [#259] Money making glitch involving swamps (original bug).
 - Fix: [#441] Construction rights over entrance path erased (original bug).
 - Fix: [#578] Ride ghosts show up in ride list during construction (original bug).
@@ -966,10 +970,6 @@
 - Fix: [#5819] Vertical multi-dimension coaster tunnels drawn incorrectly.
 - Fix: Non-invented vehicles can be used via track designs in select-by-track-type mode.
 - Fix: Track components added by OpenRCT2 are now usable in older scenarios.
-- Technical: [#5047] Add ride ratings tests.
-- Technical: [#5458] Begin offering headless build with reduced compile- and run-time dependencies.
-- Technical: [#5755] Title sequence wait periods use milliseconds.
-- Technical: Fix many desync sources.
 
 0.0.7 (2017-05-03)
 ------------------------------------------------------------------------
@@ -991,6 +991,7 @@
 - Improved: Scenario options are now synced in multiplayer.
 - Improved: Remove duplicate ride penalty for closed rides.
 - Improved: Make shortcut keys window larger and resizable.
+- Improved: INI configuration file now case-insensitive.
 - Fix: [#1992] Felicity Anderson Cheat can crash the game, as well as blocking queues.
 - Fix: [#4493] Provide tooltip for disabled price field.
 - Fix: [#4689] Object selection tabs sometimes flicker.
@@ -1023,8 +1024,7 @@
 - Fix: Potential for integer overflow in ride length.
 - Fix: Vehicles erroneously removed when removing all guests.
 - Removed: known_issues.txt no longer used, check issue tracker on GitHub.
-- Technical: INI configuration file now case-insensitive.
-- Technical: Remove version build from msbuild & NSIS.
+- Removed: version build from msbuild & NSIS.
 
 
 0.0.6 (2017-01-29)
@@ -1087,6 +1087,8 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Improved: In-game file dialog now shows more formats (sv6, sc6, sv4, etc.).
 - Improved: Joining multiplayer will not redownload custom objects.
 - Change: The maximum height of Junior Roller Coasters is now 14 units, like it was in RCT1.
+- Change: Multiplayer groups are now stored in JSON format.
+- Change: MinGW builds dropped support for Windows XP.
 - Fix: [#933] On-ride photo price sometimes gets reset to £2 when using ‘same price in whole park’ (original bug).
 - Fix: [#1038] Guest List is out of order.
 - Fix: [#1238] Track place window does not fully adjust to custom colour scheme.
@@ -1112,8 +1114,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: High lateral G-forces penalty applied too early (not reported).
 - Removed: BMP screenshots.
 - Removed: Intamin and Phoenix easter eggs.
-- Technical: Multiplayer groups are now stored in JSON format.
-- Technical: MinGW builds dropped support for Windows XP.
 
 0.0.4-beta (2016-04-15)
 ------------------------------------------------------------------------
@@ -1156,6 +1156,10 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Change: Sound controls re-worked to control sound effects and ride music separately.
 - Change: Use native line endings in config.ini.
 - Change: Remove default audio device from audio device dropdown in Linux.
+- Change: lodepng dropped in return for libpng.
+- Change: SDL2 upgraded from 2.0.3 to 2.0.4.
+- Change: argparse dropped in return for bespoke command line parsing implementation.
+- Change: Integrated breakpad for (manual) crash reporting.
 - Fix: Dated autosave files are not created on OSX and Linux.
 - Fix: Title sequence directories are not deleted when title sequence is deleted on OSX and Linux.
 - Fix: Tile not highlighted when placing staff members.
@@ -1183,10 +1187,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#3120] Negative cash in finance window is not red.
 - Fix: [#4134] Can’t enable park-wide photo price for log flume and river rapids.
 - Removed: Anti-cheat code that detected money hack attempts.
-- Technical: lodepng dropped in return for libpng.
-- Technical: SDL2 upgraded from 2.0.3 to 2.0.4.
-- Technical: argparse dropped in return for bespoke command line parsing implementation.
-- Technical: Integrated breakpad for (manual) crash reporting.
 
 0.0.3.1-beta (2015-12-04)
 ------------------------------------------------------------------------
@@ -1237,6 +1237,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Option to enable ‘mow grass’ by default for handymen (RCT1 style).
 - Feature: Option to ignore invalid checksums on loaded parks.
 - Feature: Option to scale game display for better compatibility with high DPI screens.
+- Improved: DirectDraw, DirectInput, DirectPlay and DirectSound dependencies are no longer used.
 - Change: Autosave is now measured in real-time rather than in-game date.
 - Change: Hacked rides no longer have their reliability set to 0.
 - Fix: When placing a track, the preview will now use the same orientation as the ghost.
@@ -1258,7 +1259,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: On-ride photos are now factored into the calculations of a ride’s income and profit per hour (original bug).
 - Removed: Six Flags branding and limitations.
 - Removed: Infogrames disclaimer.
-- Technical: DirectDraw, DirectInput, DirectPlay and DirectSound dependencies are no longer used.
 
 0.0.2-beta (2015-06-21)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,7 +20,7 @@
 - Improved: [#13524] macOS arm64 native (universal) app
 - Improved: [#15538] Software rendering can now draw in parallel when Multithreading is enabled.
 - Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
-- Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.
+- Change: [#15174] [Plugin] Deprecate the type ‘peep’ and add support to target a specific scripting api version.
 - Fix: [#10614] Track Designs with missing path(s) do not use alternate pathways.
 - Fix: [#12981] New vehicles do not appear in vehicle type dropdown.
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
@@ -111,7 +111,7 @@
 - Fix: [#14871] Crash when trying to place track when there are no free tile elements.
 - Fix: [#14880] Unable to close changelog window when its content fails to load.
 - Fix: [#14945] Incorrect drop height penalty on log flume ride.
-- Fix: [#14964] Unable to build in multiplayer as client with "Build while paused" cheat enabled when the host is paused.
+- Fix: [#14964] Unable to build in multiplayer as client with ‘Build while paused’ cheat enabled when the host is paused.
 
 0.3.3 (2021-03-13)
 ------------------------------------------------------------------------
@@ -218,8 +218,8 @@
 - Fix: [#13019] Simulated trains sometimes open construction window when they crash.
 - Fix: [#13021] Mowed grass and weeds don’t show up in extra zoom levels.
 - Fix: [#13024] Console cursor does not correctly render at current cursor position.
-- Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
-- Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
+- Fix: [#13029] Not all Junior Roller Coaster pieces are shown when ‘Show all track pieces’ cheat is enabled.
+- Fix: [#13044] Rides in RCT1 saves all have ‘0 customers per hour’.
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
 - Fix: [#13097] Missing direction arrow for stations
@@ -272,7 +272,7 @@
 
 0.3.0 (2020-08-15)
 ------------------------------------------------------------------------
-- Feature: [#7648] "Enable all drawable track pieces" now enables more pieces for the Twister, Vertical and Air Powered Vertical coasters.
+- Feature: [#7648] ‘Enable all drawable track pieces’ now enables more pieces for the Twister, Vertical and Air Powered Vertical coasters.
 - Feature: [#9029] Open doors with the tile inspector.
 - Feature: [#9614] Allow popping balloons and quacking ducks in the title screen.
 - Feature: [#10572] Cheat to allow building at invalid heights.
@@ -284,7 +284,7 @@
 - Feature: [#11422] Added a shortcut key for disabling/enabling clearance checks.
 - Feature: [#11788] Command to extract images from a .DAT file.
 - Feature: [#11959] Hacked go-kart tracks can now use 2x2 bends, 3x3 bends and S-bends.
-- Feature: [#12090] Boosters for the Wooden Roller Coaster (if the "Show all track pieces" cheat is enabled).
+- Feature: [#12090] Boosters for the Wooden Roller Coaster (if the ‘Show all track pieces’ cheat is enabled).
 - Feature: [#12184] .sea (RCT Classic) scenario files can now be imported.
 - Feature: [#12347] Periodically check for new releases on GitHub, and show a notification on the title screen.
 - Feature: [#12347] The ‘About OpenRCT2’ window now has a link to the OpenRCT2 Discord Server.
@@ -320,7 +320,7 @@
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.
 - Fix: [#11386] Alphabetical sorting is broken.
 - Fix: [#11405] Building a path through walls does not always remove the walls.
-- Fix: [#11450] Rides with unsuitable track can’t be opened even with "Enable all drawable track pieces" cheat.
+- Fix: [#11450] Rides with unsuitable track can’t be opened even with ‘Enable all drawable track pieces’ cheat.
 - Fix: [#11455] Object Selection window cuts off scenery names.
 - Fix: [#11623] Erratic zoom behavior when pointing outside of the map.
 - Fix: [#11640] Objects with a blank description in one language do not fall back to other languages anymore.
@@ -334,7 +334,7 @@
 - Fix: [#12071] Crash in Guest List when a guest dies.
 - Fix: [#12093] Staff window tab animation was no longer updating.
 - Fix: [#12123] Long server descriptions are not cut off properly.
-- Fix: [#12211] Map Generator shows incorrect map sizes (e.g. "150 x 0").
+- Fix: [#12211] Map Generator shows incorrect map sizes (e.g. ‘150 x 0’).
 - Fix: [#12221] Map Generation tool doesn’t place any trees.
 - Fix: [#12285] On-ride photo profit assumes every guest buys one.
 - Fix: [#12297] OpenGL renderer causing artifacts.
@@ -348,7 +348,7 @@
 - Fix: [#12611] ‘Monthly Income from ride tickets’ in Scenario Editor is removed when park is not free entry.
 - Fix: ‘j’ character has broken kerning (original bug).
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
-- Fix: Brakes keep working during "Brakes failure".
+- Fix: Brakes keep working during ‘Brakes failure’.
 - Fix: Guests maze pathfinding prefers a specific direction (original bug).
 - Removed: [#11820] Twitch support (relied on a server that has been down for a few years).
 
@@ -515,7 +515,7 @@
 - Fix: [#7829] Rotated information kiosk can cause ‘unreachable’ messages.
 - Fix: [#7878] Scroll shortcut keys ignore SHIFT/CTRL/ALT modifiers.
 - Fix: [#8064] Ride construction errors shown as (undefined string)
-- Fix: [#8219] Faulty folder recreation in "save" folder.
+- Fix: [#8219] Faulty folder recreation in ‘save’ folder.
 - Fix: [#8480, #8535] Crash when mirroring track design.
 - Fix: [#8507] Incorrect change in vehicle rolling direction.
 - Fix: [#8537] Imported RCT1 rides/shops are all numbered 1.
@@ -556,7 +556,7 @@
 - Feature: [#7980] Allow data path for RCT1 to be specified by a command line argument.
 - Feature: [#8073] Auto-upload minidumps to backtrace.io (optional, MSVC/Windows only)
 - Feature: [#8078] Add save_park command to in-game console.
-- Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
+- Feature: [#8080] New console variable ‘current_rotation’ to get or set view rotation.
 - Feature: [#8098] Glyph for Russian rouble sign.
 - Feature: [#8099] Add Powered Launch mode to Inverted RC (for RCT1 parity).
 - Feature: [#8190] Allow building footpaths on ‘corner down’ terrain.
@@ -587,7 +587,7 @@
 - Fix: [#5684] Player list can desync between clients and server and can crash.
 - Fix: [#6191] OpenRCT2 fails to run when the path has an emoji in it.
 - Fix: [#7439] Placement messages have mixed strings
-- Fix: [#7473] Disabling sound effects also disables "Disable audio on focus loss".
+- Fix: [#7473] Disabling sound effects also disables ‘Disable audio on focus loss’.
 - Fix: [#7476] Trying to Change Park Name During MP Session Instantly Crashes Host Game.
 - Fix: [#7536] Android builds fail to start.
 - Fix: [#7689] Deleting 0-tile maze gives a MONEY32_UNDEFINED (negative) refund.
@@ -606,7 +606,7 @@
 - Fix: [#8101] Title sequences window flashes after opening.
 - Fix: [#8120] Crash trying to place peep spawn outside of map.
 - Fix: [#8121] Crash Renaming park with server logging enabled.
-- Fix: [#8139] Buying land costs money when the game is in "no money" mode.
+- Fix: [#8139] Buying land costs money when the game is in ‘no money’ mode.
 - Fix: [#8141] Attempting to build entrance/exit on station 2 does not work.
 - Fix: [#8142] Reliability of mazes and crooked houses can go below 100%.
 - Fix: [#8187] Cannot set land ownership over ride entrances or exits in sandbox mode.
@@ -706,7 +706,7 @@
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an ‘off edge map’ error.
 - Improved: [#7435] Object indexing now supports multi-threading.
 - Improved: [#7510] Add horizontal clipping to cut-away view options.
-- Improved: [#7531] "Save track design" dropdown now stays open.
+- Improved: [#7531] ‘Save track design’ dropdown now stays open.
 - Improved: [#7548] Ctrl-clicking with the tile inspector open now directly selects an element and its tile.
 - Improved: [#7555] Allow setting the Twitch API URL, allowing custom API servers.
 - Improved: [#7567] Improve the performance of loading parks and the title sequence.
@@ -1004,7 +1004,7 @@
 - Fix: [#5150] --openrct-data-path sets user data path instead of OpenRCT2 data path.
 - Fix: [#5169] Parks containing packed objects fail to open.
 - Fix: [#5188] Clicking on a Magic Carpet doesn’t open the ride window.
-- Fix: [#5199] "Force a breakdown" debugging tool isn’t hidden in multiplayer.
+- Fix: [#5199] ‘Force a breakdown’ debugging tool isn’t hidden in multiplayer.
 - Fix: [#5218] Scale RCT1 park value objectives.
 - Fix: [#5219] Game crashes when opening ‘misc’ tab in options.
 - Fix: [#5238] RCT1 import: Rides are initially free when placing them.
@@ -1018,7 +1018,7 @@
 - Fix: [#5325] Game crashes if encountering an invalid ride type during research.
 - Fix: [#5345] Correct typos in descriptions for Top Spin and Splash Boats.
 - Fix: [#5350] Steel Twister RC and Giga Coaster boosters are underpowered, Junior Roller Coaster boosters overpowered compared to RCTC.
-- Fix: [#5357] "Assertion failed!" after guest with name ‘Emma Garrell’ exits/enters ride.
+- Fix: [#5357] ‘Assertion failed!’ after guest with name ‘Emma Garrell’ exits/enters ride.
 - Fix: Walls do not import from RCT1 correctly in pause mode.
 - Fix: Extraneous window tabs show up on MacOS 10.12.
 - Fix: Potential for integer overflow in ride length.
@@ -1058,7 +1058,7 @@
 This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer required.
 
 - Feature: Ability to disable rendering of weather effects and gloom.
-- Feature: New view option: "See-Through Paths".
+- Feature: New view option: ‘See-Through Paths’.
 - Feature: Add cheat to reset date.
 - Feature: Add OpenGL drawing engine.
 - Feature: Implementation of the user-defined currency.
@@ -1068,7 +1068,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Allow setting ownership of map edges.
 - Feature: Allow up to 255 cars per train.
 - Feature: Importing SV4 and SC4 files with rides.
-- Feature: Filter Object Selection Window by "Selected only" and "Non-selected only".
+- Feature: Filter Object Selection Window by ‘Selected only’ and ‘Non-selected only’.
 - Feature: Allow raising terrain to 64 in-game units.
 - Feature: Assymmetric-key-based authorisation and assignment storage.
 - Feature: Add Norwegian translation.
@@ -1167,7 +1167,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: Cheats not supported in multiplayer.
 - Fix: [#1333] Rides never become safe again after a crash.
 - Fix: [#1742] Non-ascii characters in scenario details not showing correctly.
-- Fix: [#2126] Ferris Wheels set to "backward rotation" stop working (original bug).
+- Fix: [#2126] Ferris Wheels set to ‘backward rotation’ stop working (original bug).
 - Fix: [#2449] Turning off Day/Night Circle while it is night doesn’t reset back to day.
 - Fix: [#2477] When opening the built-in load/save dialog, the list is not properly sorted.
 - Fix: [#2650] Server did not validate actions send from clients (caused error box and desynchronisation).
@@ -1255,7 +1255,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: Scenarios created with the Scenario Editor will now have the correct initial temperature for their climate (original bug).
 - Fix: Financial information can no longer be accessed from the rides/attractions menu in parks that don’t use money (original bug).
 - Fix: The path tool and tracked-ride construction tool no longer interfere with one another in certain situations (original bug).
-- Fix: Building a flat ride partially out of park boundaries will no longer trigger a misleading "too high for supports" message (original bug).
+- Fix: Building a flat ride partially out of park boundaries will no longer trigger a misleading ‘too high for supports’ message (original bug).
 - Fix: On-ride photos are now factored into the calculations of a ride’s income and profit per hour (original bug).
 - Removed: Six Flags branding and limitations.
 - Removed: Infogrames disclaimer.
@@ -1302,6 +1302,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Change research settings in-game (only available from console).
 - Feature: (Random) map generator available in scenario editor, accessible via the view menu.
 - Feature: RollerCoaster Tycoon 1 scenarios can now be opened in the scenario editor or by using the ‘edit’ command line action.
-- Feature: The "have fun" objective can now be selected in the scenario editor.
+- Feature: The ‘have fun’ objective can now be selected in the scenario editor.
 - Feature: Twitch integration.
 - Fix: Litter bins now get full and require emptying by handymen.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -347,10 +347,10 @@
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Fix: Brakes keep working during "Brakes failure".
 - Fix: Guests maze pathfinding prefers a specific direction (original bug).
+- Removed: [#11820] Twitch support (relied on a server that has been down for a few years).
 - Technical: [#8110] OpenRCT2 now uses a single directory name for title sequences instead of three.
 - Technical: [#11517] Windows Vista is supported again (libzip regression in the previous release).
 - Technical: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.
-- Removed: [#11820] Twitch support (relied on a server that has been down for a few years).
 
 0.2.6 (2020-04-17)
 ------------------------------------------------------------------------
@@ -1182,11 +1182,11 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#3063] Search exe directory for SSL bundle as well as CWD.
 - Fix: [#3120] Negative cash in finance window is not red.
 - Fix: [#4134] Can’t enable park-wide photo price for log flume and river rapids.
+- Removed: Anti-cheat code that detected money hack attempts.
 - Technical: lodepng dropped in return for libpng.
 - Technical: SDL2 upgraded from 2.0.3 to 2.0.4.
 - Technical: argparse dropped in return for bespoke command line parsing implementation.
 - Technical: Integrated breakpad for (manual) crash reporting.
-- Removed: Anti-cheat code that detected money hack attempts.
 
 0.0.3.1-beta (2015-12-04)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -154,6 +154,8 @@
 - Improved: [#14193] [Plugin] Change single quotes to double quotes in openrct2.d.ts.
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
 - Change: [#13857] Change Rotation Control Toggle to track element number 256
+- Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
+- Removed: [#14186] Network traffic window (replaced by plug-in).
 - Fix: [#4605, #11912] Water palettes are not updated properly when selected in Object Selection.
 - Fix: [#7772] Hacked vehicles may incorrectly not mark a vehicle object as in use causing accidental removal when remove_unused_objects is used.
 - Fix: [#9631, #10716] Banners drawing glitches when there are more than 32 on the screen at once.
@@ -183,8 +185,6 @@
 - Fix: [#14095] Holding down [-][+] buttons does not decrease/increase number of circuits.
 - Fix: [#14225] Desync when ‘allow early scenario completion’ is enabled.
 - Fix: [#14247] Scenarios from RCT1 allow hiring too many staff.
-- Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
-- Removed: [#14186] Network traffic window (replaced by plug-in).
 
 0.3.2 (2020-11-01)
 ------------------------------------------------------------------------
@@ -300,6 +300,7 @@
 - Change: [#11898] The ‘openrct-data-path’ command-line argument has been renamed to ‘openrct2-data-path’.
 - Change: [#11944] The ride list sort mode is now remembered for the duration of the game.
 - Change: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.
+- Removed: [#11820] Twitch support (relied on a server that has been down for a few years).
 - Fix: [#1013] Negative length displayed in Ride window.
 - Fix: [#1148] Research funding dropdown not shown in finances window.
 - Fix: [#5451] Guests scream on every descent, no matter how small.
@@ -350,7 +351,6 @@
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Fix: Brakes keep working during ‘Brakes failure’.
 - Fix: Guests maze pathfinding prefers a specific direction (original bug).
-- Removed: [#11820] Twitch support (relied on a server that has been down for a few years).
 
 0.2.6 (2020-04-17)
 ------------------------------------------------------------------------
@@ -399,6 +399,7 @@
 - Improved: [#10970] Introduced optional light effects for vehicles at night.
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Change: [#10997] Speed is automatically reset to normal upon scenario completion.
+- Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 - Fix: [#2485] Hide Vertical Faces not applied to the edges of water.
 - Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.
 - Fix: [#6766] Changelog window doesn’t open on some platforms.
@@ -434,7 +435,6 @@
 - Fix: [#11001] Rides list does not use natural sorting.
 - Fix: [objects#54] Stage Coach cars are not considered covered by the game.
 - Fix: [objects#56] Handymen cut grass incorrectly.
-- Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------
@@ -582,6 +582,7 @@
 - Improved: [#8107] Support Discord release of RCT2.
 - Improved: [#8491] Highlight entrance and exit with different colours in track design previews.
 - Improved: Almost completely new Hungarian translation.
+- Removed: [#7929] Support for scenario text objects.
 - Fix: [#3832] Changing the colour scheme of track pieces does not work in multiplayer.
 - Fix: [#4094] Coasters with long flat-to-steep pieces offer them in diagonal mode (original bug).
 - Fix: [#5684] Player list can desync between clients and server and can crash.
@@ -639,7 +640,6 @@
 - Fix: [#8804] Raising water shows money effect at the bottom rather than new height.
 - Fix: [#8811] Some fields in the sv6 save file not being copied correctly.
 - Fix: [#8824] Invalid read in footpath_chain_ride_queue.
-- Removed: [#7929] Support for scenario text objects.
 
 0.2.1 (2018-08-26)
 ------------------------------------------------------------------------
@@ -795,6 +795,7 @@
 - Improved: Major translation updates for Japanese and Polish.
 - Improved: Added 24x24, 48x48, and 96x96 icon resolutions.
 - Change: [#6384] On macOS, address ‘NSFileHandlingPanel’ deprecation by using ‘NSModalResponse’ instead.
+- Removed: [#6772] RCT2 interop removed.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#996, #2589, #2875] Viewport scrolling no longer shakes or gets stuck.
 - Fix: [#1185] Close button colour of prompt windows does not match.
@@ -881,7 +882,6 @@
 - Fix: Remove consecutive thoughts about a ride being demolished.
 - Fix: Water raft vehicles stop spinning when going up slopes.
 - Fix: Incorrect spin is applied to coasters on S-bends and other turns.
-- Removed: [#6772] RCT2 interop removed.
 
 0.1.1 (2017-08-09)
 ------------------------------------------------------------------------
@@ -992,6 +992,8 @@
 - Improved: Remove duplicate ride penalty for closed rides.
 - Improved: Make shortcut keys window larger and resizable.
 - Improved: INI configuration file now case-insensitive.
+- Removed: known_issues.txt no longer used, check issue tracker on GitHub.
+- Removed: version build from msbuild & NSIS.
 - Fix: [#1992] Felicity Anderson Cheat can crash the game, as well as blocking queues.
 - Fix: [#4493] Provide tooltip for disabled price field.
 - Fix: [#4689] Object selection tabs sometimes flicker.
@@ -1023,8 +1025,6 @@
 - Fix: Extraneous window tabs show up on MacOS 10.12.
 - Fix: Potential for integer overflow in ride length.
 - Fix: Vehicles erroneously removed when removing all guests.
-- Removed: known_issues.txt no longer used, check issue tracker on GitHub.
-- Removed: version build from msbuild & NSIS.
 
 
 0.0.6 (2017-01-29)
@@ -1089,6 +1089,8 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Change: The maximum height of Junior Roller Coasters is now 14 units, like it was in RCT1.
 - Change: Multiplayer groups are now stored in JSON format.
 - Change: MinGW builds dropped support for Windows XP.
+- Removed: BMP screenshots.
+- Removed: Intamin and Phoenix easter eggs.
 - Fix: [#933] On-ride photo price sometimes gets reset to £2 when using ‘same price in whole park’ (original bug).
 - Fix: [#1038] Guest List is out of order.
 - Fix: [#1238] Track place window does not fully adjust to custom colour scheme.
@@ -1112,8 +1114,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#3915] Restore horizontal and vertical scrollbar behaviour from RCT2 when clicking on one of the scrollbars.
 - Fix: Lay-down Roller Coasters from RCT1 saves are imported with an incorrect vehicle type (not reported).
 - Fix: High lateral G-forces penalty applied too early (not reported).
-- Removed: BMP screenshots.
-- Removed: Intamin and Phoenix easter eggs.
 
 0.0.4-beta (2016-04-15)
 ------------------------------------------------------------------------
@@ -1160,6 +1160,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Change: SDL2 upgraded from 2.0.3 to 2.0.4.
 - Change: argparse dropped in return for bespoke command line parsing implementation.
 - Change: Integrated breakpad for (manual) crash reporting.
+- Removed: Anti-cheat code that detected money hack attempts.
 - Fix: Dated autosave files are not created on OSX and Linux.
 - Fix: Title sequence directories are not deleted when title sequence is deleted on OSX and Linux.
 - Fix: Tile not highlighted when placing staff members.
@@ -1186,7 +1187,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#3063] Search exe directory for SSL bundle as well as CWD.
 - Fix: [#3120] Negative cash in finance window is not red.
 - Fix: [#4134] Can’t enable park-wide photo price for log flume and river rapids.
-- Removed: Anti-cheat code that detected money hack attempts.
 
 0.0.3.1-beta (2015-12-04)
 ------------------------------------------------------------------------
@@ -1240,6 +1240,8 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Improved: DirectDraw, DirectInput, DirectPlay and DirectSound dependencies are no longer used.
 - Change: Autosave is now measured in real-time rather than in-game date.
 - Change: Hacked rides no longer have their reliability set to 0.
+- Removed: Six Flags branding and limitations.
+- Removed: Infogrames disclaimer.
 - Fix: When placing a track, the preview will now use the same orientation as the ghost.
 - Fix: Grouping vehicles by track type no longer interferes with research.
 - Fix: Fix corrupt map elements when loading a game.
@@ -1257,8 +1259,6 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: The path tool and tracked-ride construction tool no longer interfere with one another in certain situations (original bug).
 - Fix: Building a flat ride partially out of park boundaries will no longer trigger a misleading ‘too high for supports’ message (original bug).
 - Fix: On-ride photos are now factored into the calculations of a ride’s income and profit per hour (original bug).
-- Removed: Six Flags branding and limitations.
-- Removed: Infogrames disclaimer.
 
 0.0.2-beta (2015-06-21)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,17 +9,17 @@
 - Feature: [#3868] Initial support for using TTF in OpenGL mode (still contains bugs).
 - Feature: [#7682] Follow ride/guest/staff in main window viewport.
 - Feature: [#13407] Allow building chain lifts on enclosed dinghy slide pieces when cheats are on.
-- Feature: [#15084] [Plugin] Add "vehicle.crash" hook.
+- Feature: [#15084] [Plugin] Add ‘vehicle.crash’ hook.
 - Feature: [#15143] Added a shortcut key for Giant Screenshot.
 - Feature: [#15164] Highlight elements selected by the Tile Inspector, tracks are currently not supported.
-- Feature: [#15165] [Plugin] Add the ability to create entities using "map.createEntity".
+- Feature: [#15165] [Plugin] Add the ability to create entities using ‘map.createEntity’.
 - Feature: [#15194] [Plugin] Add guest properties, ride downtime and park casualty penalty.
 - Feature: [#15195] Added a bug-report item in file dropdown menu.
 - Feature: [#15294] New vehicle animation type: flying animal.
 - Fix: [#10614] Track Designs with missing path(s) do not use alternate pathways.
 - Fix: [#12981] New vehicles do not appear in vehicle type dropdown.
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
-- Fix: [#13912] “Dome park” no longer renders dome correctly.
+- Fix: [#13912] ‘Dome park’ no longer renders dome correctly.
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#14482, #15258] Rides with invisibility hacks sometimes behave incorrectly.
 - Fix: [#14649] ImageImporter incorrectly remaps colours outside the RCT2 palette.
@@ -27,8 +27,8 @@
 - Fix: [#14741] Crash when exiting OpenRCT2 on macOS.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Fix: [#15136] Exported SV6 files cause vanilla RCT2 to hang.
-- Fix: [#15142] ToonTowner's mine roofs were moved into the pirate theme scenery group instead of the mine theme scenery group.
-- Fix: [#15148] Track Designs Manager delete confirmation window doesn't display properly.
+- Fix: [#15142] ToonTowner’s mine roofs were moved into the pirate theme scenery group instead of the mine theme scenery group.
+- Fix: [#15148] Track Designs Manager delete confirmation window doesn’t display properly.
 - Fix: [#15170] Plugin: incorrect label text alignment.
 - Fix: [#15177] Crash in lightfx_add_lights_magic_vehicle().
 - Fix: [#15184] Crash when hovering over water types in Object Selection.
@@ -38,10 +38,10 @@
 - Fix: [#15213] Freeze when hovering over Reverse Freefall Coaster in Russian.
 - Fix: [#15227] Crash on exit after hovering over water types in the Object Selection window.
 - Fix: [#15255] Tile Inspector shows banner information on walls that do not contain one.
-- Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don't disable when deactivated in options menu.
+- Fix: [#15257] Chat icon shows in scenario/track editor. Other icons don’t disable when deactivated in options menu.
 - Fix: [#15289] Unexpected behavior with duplicated banners which also caused desyncs in multiplayer.
-- Fix: [#15322] Circus music doesn't play.
-- Fix: [#15377] Entrance/exit ghost doesn't work on different stations without touching them first.
+- Fix: [#15322] Circus music doesn’t play.
+- Fix: [#15377] Entrance/exit ghost doesn’t work on different stations without touching them first.
 - Fix: [#15451] Guest list name filter remains after group selection.
 - Fix: [#15466] Crash when opening a dropdown with 0 rows.
 - Fix: [#15476] Crash when placing/clearing small scenery.
@@ -82,7 +82,7 @@
 - Feature: [#14620] [Plugin] Add properties related to guest generation.
 - Feature: [#14636] [Plugin] Add properties related to climate and weather.
 - Feature: [#14731] Opaque water (like in RCT1).
-- Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript's Object interface.
+- Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript’s Object interface.
 - Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
 - Change: [#14751] “No construction above tree height” limitation now allows placing high trees.
 - Change: [#14841] Redesign the About window, including new button to copy the current version info.
@@ -125,7 +125,7 @@
 - Feature: [#13376] Open custom window at specified tab.
 - Feature: [#13384] [Plugin] Expose all TileElement data.
 - Feature: [#13398] Add pause button to the Track Designer.
-- Feature: [#13436] macOS: use new icon that matches Big Sur's style.
+- Feature: [#13436] macOS: use new icon that matches Big Sur’s style.
 - Feature: [#13495] [Plugin] Add properties for park value, guests and company value.
 - Feature: [#13509] [Plugin] Add ability to format strings using OpenRCT2 string framework.
 - Feature: [#13512] [Plugin] Add item separators to list view.
@@ -205,7 +205,7 @@
 - Fix: [#6086] Cannot install existing track design with another name.
 - Fix: [#6614, #8623] Colours are distorted when using OpenGL with Intel integrated graphics drivers.
 - Fix: [#7443] Construction arrows pulse at irregular intervals.
-- Fix: [#7518] Water isn't cut down by view clipping tool.
+- Fix: [#7518] Water isn’t cut down by view clipping tool.
 - Fix: [#7748] Tooltips would not timeout for normal UI elements.
 - Fix: [#8015] RCT2 files are not found when put into the OpenRCT2 folder.
 - Fix: [#8957] Error title missing when building with insufficient funds
@@ -213,14 +213,14 @@
 - Fix: [#12368] Desync due to ghost station pieces affecting changing ride settings.
 - Fix: [#12940] Windows cause issues with snow drawing.
 - Fix: [#13019] Simulated trains sometimes open construction window when they crash.
-- Fix: [#13021] Mowed grass and weeds don't show up in extra zoom levels.
+- Fix: [#13021] Mowed grass and weeds don’t show up in extra zoom levels.
 - Fix: [#13024] Console cursor does not correctly render at current cursor position.
 - Fix: [#13029] Not all Junior Roller Coaster pieces are shown when "Show all track pieces" cheat is enabled.
 - Fix: [#13044] Rides in RCT1 saves all have "0 customers per hour".
 - Fix: [#13074] Entrance and exit ghosts for mazes not being removed.
 - Fix: [#13083] Dialog for renaming conflicting track design crops text out.
 - Fix: [#13097] Missing direction arrow for stations
-- Fix: [#13098] UI buttons for entrance and exit don't toggle according to them being built.
+- Fix: [#13098] UI buttons for entrance and exit don’t toggle according to them being built.
 - Fix: [#13098] Maze can still be constructed while placing entrance and exit (original bug).
 - Fix: [#13118] Closing construction window resets ride viewport.
 - Fix: [#13129] Missing error message when waiting for train to leave station on the ride measurements graph.
@@ -252,15 +252,15 @@
 - Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
 - Fix: [#12691] Ride graph tooltip incorrectly used count instead of number string.
 - Fix: [#12694] Crash when switching ride types with construction window open.
-- Fix: [#12701] Silent NSIS setup flag /S isn't silent, upgrade pop-up appears anyway.
+- Fix: [#12701] Silent NSIS setup flag /S isn’t silent, upgrade pop-up appears anyway.
 - Fix: [#12737] Space Rings draw the same vehicle 4 times.
 - Fix: [#12756] Scenario Editor crashing the game on macOS.
-- Fix: [#12764] Rides don't start aged anymore.
+- Fix: [#12764] Rides don’t start aged anymore.
 - Fix: [#12818] Ride price not ignored in free-rides parks.
 - Fix: [#12820] Title menu buttons not invalidating properly
 - Fix: [#12845] Deleting ride with active ad campaign creates incorrect notification.
 - Fix: [#12857] Incorrect Peep thoughts in imported RCT1 parks.
-- Fix: [#12881] Guests' favourite rides are not listed in the guest window.
+- Fix: [#12881] Guests’ favourite rides are not listed in the guest window.
 - Fix: [#12910] Plugin API: getRide sometimes returns null for valid ride IDs.
 - Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
 - Fix: [#12918] Cannot place vanilla TD6 tracks of the Hypercoaster, Monster Trucks, Classic Mini Roller Coaster, Spinning Wild Mouse and Hyper-Twister types.
@@ -314,7 +314,7 @@
 - Fix: [#11315] Ride that has never opened is shown as favorite ride of many guests.
 - Fix: [#11386] Alphabetical sorting is broken.
 - Fix: [#11405] Building a path through walls does not always remove the walls.
-- Fix: [#11450] Rides with unsuitable track can't be opened even with "Enable all drawable track pieces" cheat.
+- Fix: [#11450] Rides with unsuitable track can’t be opened even with "Enable all drawable track pieces" cheat.
 - Fix: [#11455] Object Selection window cuts off scenery names.
 - Fix: [#11623] Erratic zoom behavior when pointing outside of the map.
 - Fix: [#11640] Objects with a blank description in one language do not fall back to other languages anymore.
@@ -329,7 +329,7 @@
 - Fix: [#12093] Staff window tab animation was no longer updating.
 - Fix: [#12123] Long server descriptions are not cut off properly.
 - Fix: [#12211] Map Generator shows incorrect map sizes (e.g. "150 x 0").
-- Fix: [#12221] Map Generation tool doesn't place any trees.
+- Fix: [#12221] Map Generation tool doesn’t place any trees.
 - Fix: [#12285] On-ride photo profit assumes every guest buys one.
 - Fix: [#12297] OpenGL renderer causing artifacts.
 - Fix: [#12308] Cannot use cheats in editor modes.
@@ -366,7 +366,7 @@
 - Fix: [#7094] Back wall edge texture in water missing.
 - Fix: [#9719] Hacked walls in RCT1 saves are imported incorrectly.
 - Fix: [#10372, #10509, #10806] Lift base sections incorrectly exporting, causing various lift related bugs.
-- Fix: [#10928] File browser's date column is too narrow.
+- Fix: [#10928] File browser’s date column is too narrow.
 - Fix: [#10951, #11160] Attempting to place park entrances creates ghost entrances in random locations.
 - Fix: [#11005] Company value overflows.
 - Fix: [#11027] Third color on walls becomes black when saving.
@@ -397,15 +397,15 @@
 - Change: [#10997] Speed is automatically reset to normal upon scenario completion.
 - Fix: [#2485] Hide Vertical Faces not applied to the edges of water.
 - Fix: [#5249] No collision detection when building ride entrance at heights > 85.5m.
-- Fix: [#6766] Changelog window doesn't open on some platforms.
-- Fix: [#7784] Vehicle tab takes 1st car colour instead of tab_vehicle's colour.
+- Fix: [#6766] Changelog window doesn’t open on some platforms.
+- Fix: [#7784] Vehicle tab takes 1st car colour instead of tab_vehicle’s colour.
 - Fix: [#7854] Cannot build a custom spiral roller coaster design.
 - Fix: [#7854] Empty entries in spiral roller coaster designs list.
 - Fix: [#8151] Game freezes upon demolishing mazes at odd heights.
 - Fix: [#8875] RCT1 competition scenarios are classified incorrectly.
-- Fix: [#10176] Mistake in the sprite for the land tool's 6x6 grid.
+- Fix: [#10176] Mistake in the sprite for the land tool’s 6x6 grid.
 - Fix: [#10196] Doors unable to be placed at end of track corners.
-- Fix: [#10228] Can't import RCT1 Deluxe from Steam.
+- Fix: [#10228] Can’t import RCT1 Deluxe from Steam.
 - Fix: [#10313] Path furniture can be placed on level crossings.
 - Fix: [#10325] Crash when banners have no text.
 - Fix: [#10376] No ratings generated when a shop and track intersect.
@@ -423,7 +423,7 @@
 - Fix: [#10752] Mute button state not correctly set at startup.
 - Fix: [#10822] Can place too many peep spawns.
 - Fix: [#10898] Banner text has an offset in tile inspector window.
-- Fix: [#10904] RCT1/LL-scenarios with red water won't open.
+- Fix: [#10904] RCT1/LL-scenarios with red water won’t open.
 - Fix: [#10941] The Clear Scenery tool gives refunds for ghost elements.
 - Fix: [#10963] Light effects are drawn off-centre in some rotations.
 - Fix: [#10993] Bottom toolbar not refreshing when a guest leaves the park.
@@ -450,11 +450,11 @@
 - Fix: [#9179] Crash when modifying a ride occasionally.
 - Fix: [#9533] Door sounds not playing.
 - Fix: [#9574] Text overflow in scenario objective window when using CJK languages.
-- Fix: [#9603] Don't render audio when master volume is turned off.
+- Fix: [#9603] Don’t render audio when master volume is turned off.
 - Fix: [#9625] Show correct cost in scenery selection.
 - Fix: [#9669] The tile inspector shortcut key does not work with debugging tools disabled.
 - Fix: [#9675] Guest entry point limit can be bypassed in scenario editor.
-- Fix: [#9683] Cannot raise water level if part of the tool's area of effect is off of the map.
+- Fix: [#9683] Cannot raise water level if part of the tool’s area of effect is off of the map.
 - Fix: [#9684] Entering custom size for water/land tool allows confirmation with main enter key, but not numpad enter key.
 - Fix: [#9690] The keyboard shortcut for rotating the game view can be set to Enter or KP Enter, but not both.
 - Fix: [#9717] Scroll bars do not render correctly when using OpenGL renderer.
@@ -504,7 +504,7 @@
 - Fix: [#5905] Urban Park merry-go-round has entrance and exit swapped (original bug).
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
 - Fix: [#7039] Map window not rendering properly when using OpenGL.
-- Fix: [#7045] Theme window's colour pickers not drawn properly on OpenGL.
+- Fix: [#7045] Theme window’s colour pickers not drawn properly on OpenGL.
 - Fix: [#7323] Tunnel entrances not rendering in 'highlight path issues' mode if they have benches inside.
 - Fix: [#7729] Money Input Prompt breaks on certain values.
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
@@ -542,7 +542,7 @@
 - Fix: [#9411] Ad campaigns end too soon.
 - Fix: [#9476] Running `simulate` command on park yields `Completed: (null)`.
 - Fix: [#9520] Time Twister object artdec29 conversion problem.
-- Fix: Guests eating popcorn are drawn as if they're eating pizza.
+- Fix: Guests eating popcorn are drawn as if they’re eating pizza.
 - Fix: The arbitrary ride type and vehicle dropdown lists are ordered case-sensitively.
 - Improved: [#6116] Expose colour scheme for track elements in the tile inspector.
 - Improved: Allow the use of numpad enter key for console and chat.
@@ -613,7 +613,7 @@
 - Fix: [#8433] Crash if master server response is not valid JSON.
 - Fix: [#8434] Crash if curl_easy_init fails.
 - Fix: [#8443] Crash when selecting the current vehicle for ride that has none available.
-- Fix: [#8456] Junior booster track piece doesn't connect properly.
+- Fix: [#8456] Junior booster track piece doesn’t connect properly.
 - Fix: [#8464] Crash on game shutdown.
 - Fix: [#8469] Crash modifying colour on hacked rides.
 - Fix: [#8508] Underground roto-drop is not going up.
@@ -632,7 +632,7 @@
 - Fix: [#8811] Some fields in the sv6 save file not being copied correctly.
 - Fix: [#8824] Invalid read in footpath_chain_ride_queue.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
-- Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window's graph tab.
+- Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window’s graph tab.
 - Improved: [#7930] Automatically create folders for custom content.
 - Improved: [#7980] Show the full path of the scenario in the scenario select window.
 - Improved: [#7993] Allow assigning a keyboard shortcut for opening the tile inspector.
@@ -665,7 +665,7 @@
 - Fix: [#7643] No Money scenarios with funding set to zero.
 - Fix: [#7653] Finances money spinner is too narrow for big loans.
 - Fix: [#7673] Vehicle names are cut off in invention list.
-- Fix: [#7674] Rides show up as random numbers in guest's ride list.
+- Fix: [#7674] Rides show up as random numbers in guest’s ride list.
 - Fix: [#7678] Crash when loading or starting a new game while having object selection window open.
 - Fix: [#7683] 'Arbitrary ride type' dropdown state is shared between windows.
 - Fix: [#7697] Some scenery groups in RCT1 saves are never invented.
@@ -688,7 +688,7 @@
 ------------------------------------------------------------------------
 - Feature: [#1417] Allow saving track designs for flat rides.
 - Feature: [#1675] Auto-rotate shops to face footpaths.
-- Feature: [#3473] Add button in ride window's maintainance tab to refurbish the ride.
+- Feature: [#3473] Add button in ride window’s maintainance tab to refurbish the ride.
 - Feature: [#4143] New horizontal +/- spinner widgets to make adjusting values easier.
 - Feature: [#6510] Ability to select edges or a row of tiles by holding down Ctrl using the land tool.
 - Feature: [#7187] Option for early scenario completion.
@@ -700,7 +700,7 @@
 - Feature: [#7459] Allow opening and closing of parks that use no money.
 - Fix: [#2053] When clearance checks are disabled, a track piece ghost can remove non-ghost track pieces.
 - Fix: [#2611] Some objects show (undefined string) instead of a description in Korean.
-- Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don't get their extension.
+- Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don’t get their extension.
 - Fix: [#5210] Default system dialog not accessible from saving landscape window.
 - Fix: [#6134] Scenarios incorrectly categorised when using Polish version of RCT2.
 - Fix: [#6141] CSS50.dat is never loaded.
@@ -709,13 +709,13 @@
 - Fix: [#7176] Mechanics sometimes fall down from rides.
 - Fix: [#7303] Visual glitch with virtual floor near map edges.
 - Fix: [#7313] Loading an invalid path with OpenRCT2 produces results different than expected.
-- Fix: [#7327] Abstract scenery and stations don't get fully See-Through when hiding them (original bug).
+- Fix: [#7327] Abstract scenery and stations don’t get fully See-Through when hiding them (original bug).
 - Fix: [#7331] Invention list in scenario editor crashes upon removing previously-enabled ride/stall entries.
 - Fix: [#7341] Staff may auto-spawn on guests walking outside of paths.
 - Fix: [#7354] Cut-away view does not draw tile elements that have been moved down on the list.
 - Fix: [#7358] Peeps and staff entering rides still have the slope speed penalty set.
 - Fix: [#7382] Opening the mini-map reverts the size of the land tool to 1x1, regardless of what was selected before.
-- Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that's underneath a ride entrance.
+- Fix: [#7402] Edges of neigbouring footpaths stay connected after removing a path that’s underneath a ride entrance.
 - Fix: [#7405] Rides can be covered by placing scenery underneath them.
 - Fix: [#7418] Staff walk off paths with a connection but no adjacent path.
 - Fix: [#7434] Diagonal ride segments cannot be deleted if they are isolated.
@@ -728,7 +728,7 @@
 - Improved: [#2989] Multiplayer window now changes title when tab changes.
 - Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.
-- Improved: [#6221] The scenario editor's invention list is now resizeable.
+- Improved: [#6221] The scenario editor’s invention list is now resizeable.
 - Improved: [#7069] The arbitrary ride type selection dropdown is now sorted orthographically, and has its spinners removed.
 - Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
 - Improved: [#7435] Object indexing now supports multi-threading.
@@ -806,7 +806,7 @@
 - Fix: [#5609] Vehicle switching may cause '0 cars per train' to be set.
 - Fix: [#5636] Pausing the game shows mute button as active.
 - Fix: [#5741] Land rights indicators disappear when switching views.
-- Fix: [#5761] Mini coaster doesn't appear despite being selected.
+- Fix: [#5761] Mini coaster doesn’t appear despite being selected.
 - Fix: [#5788] Empty scenario names cause invisible entries in scenario list.
 - Fix: [#5809] Support Steam RCT1 file layout when loading CSG images.
 - Fix: [#5838] Crash when saving very large track designs.
@@ -819,7 +819,7 @@
 - Fix: [#6133] Construction rights not shown after selecting buy mode.
 - Fix: [#6188] Viewports not being clipped properly when zoomed out in OpenGL mode.
 - Fix: [#6193] All rings in Space Rings use the same secondary colour.
-- Fix: [#6196, #6223] Guest's energy underflows and never decreases.
+- Fix: [#6196, #6223] Guest’s energy underflows and never decreases.
 - Fix: [#6198] You cannot cancel RCT1 directory selection.
 - Fix: [#6199] Inverted Hairpin Coaster vehicle tab is not centred.
 - Fix: [#6202] Guests can break occupied benches (original bug).
@@ -839,10 +839,10 @@
 - Fix: [#6413] Maze previews only showing scenery.
 - Fix: [#6423] Importing parks containing names with Polish characters.
 - Fix: [#6423] Polish characters now correctly drawn when using the sprite font.
-- Fix: [#6445] Guests' favourite ride improperly set when importing from RCT1 or AA.
+- Fix: [#6445] Guests’ favourite ride improperly set when importing from RCT1 or AA.
 - Fix: [#6452] Scenario text cut off when switching between 32 and 64-bit builds.
 - Fix: [#6460] Crash when reading corrupt object files.
-- Fix: [#6481] Can't take screenshots of parks with colons in the name.
+- Fix: [#6481] Can’t take screenshots of parks with colons in the name.
 - Fix: [#6500] Failure to load resources when config file is missing.
 - Fix: [#6547] The server log is not logged if the server name contains CJK.
 - Fix: [#6593] Cannot hire entertainers when default scenery groups are not selected (original bug).
@@ -904,10 +904,10 @@
 - Fix: [#5880] Leaving bumper cars without building causes assertion.
 - Fix: [#5890] Fix zoomed OpenGL rendering of special sprites with primary and secondary colours.
 - Fix: [#5912] Negative queue when moving entrance in paused state.
-- Fix: [#5920] Placing guest spawn doesn't do anything every 3rd click.
+- Fix: [#5920] Placing guest spawn doesn’t do anything every 3rd click.
 - Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.
 - Fix: [#5977] Custom music files not showing up in music list.
-- Fix: [#5981] Ride list doesn't update after using quick demolish.
+- Fix: [#5981] Ride list doesn’t update after using quick demolish.
 - Fix: [#5984] Allow socket binding to same port after crash.
 - Fix: [#5998] Staff not getting paid / no loan interest.
 - Fix: [#6026] 'Select ride to advertise' dropdown does not display all items.
@@ -946,8 +946,8 @@
 - Fix: [#597] 'Finish 5 roller coasters' goal not properly checked (original bug).
 - Fix: [#667] Incorrect banner limit calculation (original bug).
 - Fix: [#739] Crocodile Ride (Log Flume) never allows more than five boats (original bug).
-- Fix: [#837] Can't move windows on title screen to where the toolbar would be (original bug).
-- Fix: [#1705] Time Twister's Medieval entrance has incorrect scrolling (original bug).
+- Fix: [#837] Can’t move windows on title screen to where the toolbar would be (original bug).
+- Fix: [#1705] Time Twister’s Medieval entrance has incorrect scrolling (original bug).
 - Fix: [#3178, #5456] Paths with non-ASCII characters not handled properly on macOS.
 - Fix: [#3346] Crash when extra long train breaks down at the back.
 - Fix: [#3479] Building in pause mode creates too many floating numbers, crashing the game.
@@ -987,7 +987,7 @@
 - Improved: [#5222] Add Catalan language.
 - Improved: [#5254] Scenario option changes are now synchronised over multiplayer.
 - Improved: [#5351] Giga Coaster and Steel Twister RC boosters now use the correct sprites.
-- Improved: Looping RC and Corkscrew RC now use booster sprites from RCT1's CSG1.DAT if available.
+- Improved: Looping RC and Corkscrew RC now use booster sprites from RCT1’s CSG1.DAT if available.
 - Improved: Scenario options are now synced in multiplayer.
 - Improved: Remove duplicate ride penalty for closed rides.
 - Improved: Make shortcut keys window larger and resizable.
@@ -1003,15 +1003,15 @@
 - Fix: [#5140] Headless server should save default users.json.
 - Fix: [#5150] --openrct-data-path sets user data path instead of OpenRCT2 data path.
 - Fix: [#5169] Parks containing packed objects fail to open.
-- Fix: [#5188] Clicking on a Magic Carpet doesn't open the ride window.
-- Fix: [#5199] "Force a breakdown" debugging tool isn't hidden in multiplayer.
+- Fix: [#5188] Clicking on a Magic Carpet doesn’t open the ride window.
+- Fix: [#5199] "Force a breakdown" debugging tool isn’t hidden in multiplayer.
 - Fix: [#5218] Scale RCT1 park value objectives.
 - Fix: [#5219] Game crashes when opening 'misc' tab in options.
 - Fix: [#5238] RCT1 import: Rides are initially free when placing them.
 - Fix: [#5252] Correct typo in Conger Eel Coaster description.
 - Fix: [#5265] Queue line TVs not detected properly.
-- Fix: [#5271] Keyboard shortcuts window isn't large enough (for some languages).
-- Fix: [#5284] Mechanic is called to fix a ride that's outside his patrol area.
+- Fix: [#5271] Keyboard shortcuts window isn’t large enough (for some languages).
+- Fix: [#5284] Mechanic is called to fix a ride that’s outside his patrol area.
 - Fix: [#5285] Intro always plays even if play_intro = false.
 - Fix: [#5299] Scenario editor crash when placing peep spawn.
 - Fix: [#5318] Using the bulldozer tool on under-construction paths results in unlimited free money.
@@ -1031,7 +1031,7 @@
 ------------------------------------------------------------------------
 - Feature: [#3355] Allow loading of parks from URLs.
 - Feature: [#4673] Add paint Z clipping.
-- Feature: [#4901] Allow entertainers' costume changes even in absence of required scenery.
+- Feature: [#4901] Allow entertainers’ costume changes even in absence of required scenery.
 - Feature: [#4916] FreeBSD support.
 - Feature: [#4963] Add boosters (from RCT1 and RCTC).
 - Feature: [#5113] Entertainers are now hired with a random costume.
@@ -1169,24 +1169,24 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#1333] Rides never become safe again after a crash.
 - Fix: [#1742] Non-ascii characters in scenario details not showing correctly.
 - Fix: [#2126] Ferris Wheels set to "backward rotation" stop working (original bug).
-- Fix: [#2449] Turning off Day/Night Circle while it is night doesn't reset back to day.
+- Fix: [#2449] Turning off Day/Night Circle while it is night doesn’t reset back to day.
 - Fix: [#2477] When opening the built-in load/save dialog, the list is not properly sorted.
 - Fix: [#2650] Server did not validate actions send from clients (caused error box and desynchronisation).
 - Fix: [#2651] Ride was not removed when multiplayer client aborted ride construction.
 - Fix: [#2654] Free transport rides can prevent guests from properly leaving the park.
-- Fix: [#2657] Don't create copies of official objects due to bugged saves (original bug).
+- Fix: [#2657] Don’t create copies of official objects due to bugged saves (original bug).
 - Fix: [#2681] When lowering/raising land/water with clearance checks off, walls still get removed.
 - Fix: [#2693] Multiplayer chat caret does not show true position.
 - Fix: [#2704] OSX Command Key not read for keyboard shortcuts.
 - Fix: [#2728] Closing a boat Hire with passengers causes empty boats to leave the platform (original bug).
-- Fix: [#2925] Screenshots don't show night filters.
+- Fix: [#2925] Screenshots don’t show night filters.
 - Fix: [#2941] Enter does not work on input box when on the title screen.
 - Fix: [#2948] New Ride window incorrectly said there were track designs available when in multiplayer mode.
 - Fix: [#2958] Unable to import RCT1 parks in the scenario editor using the load landscape dialog.
 - Fix: [#3015] Walls in SC4/SV4 files are not imported correctly.
 - Fix: [#3063] Search exe directory for SSL bundle as well as CWD.
 - Fix: [#3120] Negative cash in finance window is not red.
-- Fix: [#4134] Can't enable park-wide photo price for log flume and river rapids.
+- Fix: [#4134] Can’t enable park-wide photo price for log flume and river rapids.
 
 0.0.3.1-beta (2015-12-04)
 ------------------------------------------------------------------------
@@ -1247,7 +1247,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: Fix corrupt map elements when loading a game.
 - Fix: Fix corrupt peep counter when loading a game.
 - Fix: Parks created in the Scenario Editor now select the standard staff uniform colours by default.
-- Fix: Launched TD4 rides will now always use the RCT1 launch mode (that doesn't pass the station) (original bug).
+- Fix: Launched TD4 rides will now always use the RCT1 launch mode (that doesn’t pass the station) (original bug).
 - Fix: Guests will no longer ignore no entry signs if the tile contains more than one fence (original bug).
 - Fix: Right-clicking a piece of launched lift will no longer crash the game (original bug).
 - Fix: Fix bugs in calculation of Heartline Twister and Launched Freefall ratings (original bugs).
@@ -1255,10 +1255,10 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: TD4 River Rapids will now have the correct seat colour (original bug).
 - Fix: Message sound will no longer play in the editor modes (original bug).
 - Fix: Scenarios created with the Scenario Editor will now have the correct initial temperature for their climate (original bug).
-- Fix: Financial information can no longer be accessed from the rides/attractions menu in parks that don't use money (original bug).
+- Fix: Financial information can no longer be accessed from the rides/attractions menu in parks that don’t use money (original bug).
 - Fix: The path tool and tracked-ride construction tool no longer interfere with one another in certain situations (original bug).
 - Fix: Building a flat ride partially out of park boundaries will no longer trigger a misleading "too high for supports" message (original bug).
-- Fix: On-ride photos are now factored into the calculations of a ride's income and profit per hour (original bug).
+- Fix: On-ride photos are now factored into the calculations of a ride’s income and profit per hour (original bug).
 
 0.0.2-beta (2015-06-21)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,7 +23,7 @@
 - Fix: [#14316] Closing the Track Designs Manager window causes broken state.
 - Fix: [#14482, #15258] Rides with invisibility hacks sometimes behave incorrectly.
 - Fix: [#14649] ImageImporter incorrectly remaps colours outside the RCT2 palette.
-- Fix: [#14667] “Extreme Hawaiian Island” has unpurchaseable land tiles (original bug).
+- Fix: [#14667] ‘Extreme Hawaiian Island’ has unpurchaseable land tiles (original bug).
 - Fix: [#14741] Crash when exiting OpenRCT2 on macOS.
 - Fix: [#15096] Crash when placing entrances in the scenario editor near the map corner.
 - Fix: [#15136] Exported SV6 files cause vanilla RCT2 to hang.
@@ -49,7 +49,7 @@
 - Fix: [#15490] Tile inspector needlessly updates clearance height when changing surface slopes.
 - Fix: [#15496] Crash in paint_swinging_inverter_ship_structure().
 - Fix: [#15503] Freeze when doing specific coaster merges with block brakes.
-- Fix: [#15514] Two different “quit to menu” menu items are available in track designer and track design manager.
+- Fix: [#15514] Two different ‘quit to menu’ menu items are available in track designer and track design manager.
 - Fix: [#15560] Memory leak due to OpenGL Renderer not releasing a texture.
 - Fix: [#15567] Litter not being counted correctly during Park rating calculation (original bug).
 - Fix: [#15579] Crash in track_block_get_next().
@@ -75,7 +75,7 @@
 0.3.4 (2021-07-19)
 ------------------------------------------------------------------------
 - Feature: [#13967] Track List window now displays the path to the design when debugging tools are on.
-- Feature: [#14071] “Vandals stopped” statistic for security guards.
+- Feature: [#14071] ‘Vandals stopped’ statistic for security guards.
 - Feature: [#14169] Lighting effects for shops and stalls.
 - Feature: [#14296] Allow using early scenario completion in multiplayer.
 - Feature: [#14538] [Plugin] Add property for getting current plugin api version.
@@ -84,7 +84,7 @@
 - Feature: [#14731] Opaque water (like in RCT1).
 - Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript’s Object interface.
 - Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
-- Change: [#14751] “No construction above tree height” limitation now allows placing high trees.
+- Change: [#14751] ‘No construction above tree height’ limitation now allows placing high trees.
 - Change: [#14841] Redesign the About window, including new button to copy the current version info.
 - Fix: [#11829] Visual glitches and crashes when using RCT1 assets from mismatched or corrupt CSG1.DAT and CSG1i.DAT files.
 - Fix: [#12262] Windows can appear off screen with small screens or high scaling.
@@ -99,7 +99,7 @@
 - Fix: [#14493] [Plugin] isHidden only works for tile elements up to the first element with a base height of over 32.
 - Fix: [#14587] Confusing message when joining server with mismatched network version.
 - Fix: [#14604] American-style Steam Trains are not imported correctly from RCT1 saves.
-- Fix: [#14638] The “About OpenRCT2” window cannot be themed.
+- Fix: [#14638] The ‘About OpenRCT2’ window cannot be themed.
 - Fix: [#14682] Crash when painting Swinging Ships with invalid subtype.
 - Fix: [#14707] Crash when window is closed during text input.
 - Fix: [#14710] Ride/Track Design preview does not show if it costs more money than available.
@@ -109,7 +109,7 @@
 - Fix: [#14880] Unable to close changelog window when its content fails to load.
 - Fix: [#14945] Incorrect drop height penalty on log flume ride.
 - Fix: [#14964] Unable to build in multiplayer as client with "Build while paused" cheat enabled when the host is paused.
-- Improved: [#14511] “Unlock operating limits” cheat now also unlocks all music.
+- Improved: [#14511] ‘Unlock operating limits’ cheat now also unlocks all music.
 - Improved: [#14712, #14716] Improve startup times.
 - Improved: [#14982] Add Malgun Gothic and change Nanum Gothic filename for Korean.
 
@@ -161,10 +161,10 @@
 - Fix: [#13257] Rides that are exactly the minimum objective length are not counted.
 - Fix: [#13334] Uninitialised variables in CustomTabDesc.
 - Fix: [#13342] Rename tabChange to onTabChange in WindowDesc interface.
-- Fix: [#13427] Newly created Go-Karts show “Race won by <blank>”.
+- Fix: [#13427] Newly created Go-Karts show ‘Race won by <blank>’.
 - Fix: [#13431] [Plugin] UI disabled widgets can still be interacted with.
 - Fix: [#13454] Plug-ins do not load on Windows if the user directory contains non-ASCII characters.
-- Fix: [#13466] “Build 5 roller coasters” excitement corrupted in Park window.
+- Fix: [#13466] ‘Build 5 roller coasters’ excitement corrupted in Park window.
 - Fix: [#13469] Exception thrown from plugin in context.subscribe.
 - Fix: [#13477] Plug-in widget tooltips do not work.
 - Fix: [#13489] Mechanics continue heading to inspect broken down rides.
@@ -173,9 +173,9 @@
 - Fix: [#13832] Players last action position is invalid on opening/closing a ride in multiplayer.
 - Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Fix: [#13961] Animation for Guests sliding down Spiral Slide is missing on close zoom levels.
-- Fix: [#14012] 'Finish 5 roller coasters' goal is listed incorrectly in scenario selector.
+- Fix: [#14012] ‘Finish 5 roller coasters’ goal is listed incorrectly in scenario selector.
 - Fix: [#14095] Holding down [-][+] buttons does not decrease/increase number of circuits.
-- Fix: [#14225] Desync when “allow early scenario completion” is enabled.
+- Fix: [#14225] Desync when ‘allow early scenario completion’ is enabled.
 - Fix: [#14247] Scenarios from RCT1 allow hiring too many staff.
 - Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
 - Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
@@ -189,10 +189,10 @@
 0.3.2 (2020-11-01)
 ------------------------------------------------------------------------
 - Feature: [#12110] Add Hybrid Coaster (Rocky Mountain Construction I-Box) track type.
-- Feature: [#12999] .sea (RCT Classic) scenarios are now listed in the “New Scenario” dialog.
+- Feature: [#12999] .sea (RCT Classic) scenarios are now listed in the ‘New Scenario’ dialog.
 - Feature: [#13000] objective_options command for console.
 - Feature: [#13096] Add Esperanto translation.
-- Feature: [#13164] Add 'Objective options' to Cheats menu.
+- Feature: [#13164] Add ‘Objective options’ to Cheats menu.
 - Change: [#9568] Change lift sounds of Reverser Roller Coaster and Compact Inverted Coaster to better fitting ones.
 - Change: [#13160] The lay-out of the Park Cheats tab has been improved.
 - Fix: [#1324] Last track piece map selection still visible when placing ride entrance or exit (original bug).
@@ -267,7 +267,7 @@
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
 - Improved: [#12806] Add Esperanto diacritics to the sprite font.
 - Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.
-- Improved: [#12890] Add stroke to lowercase 'L' to differentiate from capital 'I'.
+- Improved: [#12890] Add stroke to lowercase ‘L’ to differentiate from capital ‘I’.
 - Technical: [#12749] The required version of macOS has been lowered to 10.13 (High Sierra).
 
 0.3.0 (2020-08-15)
@@ -287,7 +287,7 @@
 - Feature: [#12090] Boosters for the Wooden Roller Coaster (if the "Show all track pieces" cheat is enabled).
 - Feature: [#12184] .sea (RCT Classic) scenario files can now be imported.
 - Feature: [#12347] Periodically check for new releases on GitHub, and show a notification on the title screen.
-- Feature: [#12347] The 'About OpenRCT2' window now has a link to the OpenRCT2 Discord Server.
+- Feature: [#12347] The ‘About OpenRCT2’ window now has a link to the OpenRCT2 Discord Server.
 - Feature: [#12591] Show authors of an object on the object selection dialog.
 - Change: [#11209] Warn when user is running OpenRCT2 through Wine.
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
@@ -301,7 +301,7 @@
 - Fix: [#7006] Submarine Ride is in the wrong research group.
 - Fix: [#7324] Research window shows vehicle name instead of ride name.
 - Fix: [#7969, #8175, #12501] When loading a landscape in the Scenario Editor, the inventions list, financial settings and objective settings are reset.
-- Fix: [#10549] 'Build the best ride you can' objective missing ride name.
+- Fix: [#10549] ‘Build the best ride you can’ objective missing ride name.
 - Fix: [#10634] Guests are unable to use uphill paths out of toilets.
 - Fix: [#10751] Saved mazes are incomplete.
 - Fix: [#10876] When removing a path, its guest entry point is not removed.
@@ -339,8 +339,8 @@
 - Fix: [#12505] Stores selling multiple items can only have the first product advertised.
 - Fix: [#12506] Cannot advertise food if there are no rides in the park.
 - Fix: [#12533] Track designs list does not use natural sorting.
-- Fix: [#12611] 'Monthly Income from ride tickets' in Scenario Editor is removed when park is not free entry.
-- Fix: 'j' character has broken kerning (original bug).
+- Fix: [#12611] ‘Monthly Income from ride tickets’ in Scenario Editor is removed when park is not free entry.
+- Fix: ‘j’ character has broken kerning (original bug).
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Fix: Brakes keep working during "Brakes failure".
 - Fix: Guests maze pathfinding prefers a specific direction (original bug).
@@ -357,7 +357,7 @@
 - Feature: [#10925] Show hovered values on finance charts.
 - Feature: [#11013] Ctrl+C copies input dialog text to clipboard.
 - Feature: [#11218] load_park command for console
-- Feature: [#11272] Option for toggling notifications for 'Ride casualties' and 'Stuck or stalled vehicles'.
+- Feature: [#11272] Option for toggling notifications for ‘Ride casualties’ and ‘Stuck or stalled vehicles’.
 - Feature: [#11281] add_news_item command for console
 - Feature: [#11300] Add powered launch and reverse incline launched shuttle mode to the Stand-Up Roller Coaster (for RCT1 parity).
 - Fix: [#475] Water sides drawn incorrectly (original bug).
@@ -463,7 +463,7 @@
 - Fix: [#9926] Africa - Oasis park has wrong peep spawn (original bug).
 - Fix: [#9953] Crash when hacked rides attempt to find the closest mechanic.
 - Fix: [#9955] Resizing map in while pause mode does not work and may result in freezes.
-- Fix: [#9957] When using 'no money' cheat, guests complain of running out of cash.
+- Fix: [#9957] When using ‘no money’ cheat, guests complain of running out of cash.
 - Fix: [#9970] Wait for quarter load fails.
 - Fix: [#9994] Game action tick collision during server connect and map load.
 - Fix: [#10017] Ghost elements influencing ride excitement.
@@ -505,12 +505,12 @@
 - Fix: [#6006] Objects higher than 6 metres are considered trees (original bug).
 - Fix: [#7039] Map window not rendering properly when using OpenGL.
 - Fix: [#7045] Theme window’s colour pickers not drawn properly on OpenGL.
-- Fix: [#7323] Tunnel entrances not rendering in 'highlight path issues' mode if they have benches inside.
+- Fix: [#7323] Tunnel entrances not rendering in ‘highlight path issues’ mode if they have benches inside.
 - Fix: [#7729] Money Input Prompt breaks on certain values.
 - Fix: [#7884] Unfinished preserved rides can be demolished with quick demolish.
 - Fix: [#7913] RCT1/RCT2 title sequence timing is off.
 - Fix: [#7700, #8079, #8969] Crash when unloading buggy custom rides.
-- Fix: [#7829] Rotated information kiosk can cause 'unreachable' messages.
+- Fix: [#7829] Rotated information kiosk can cause ‘unreachable’ messages.
 - Fix: [#7878] Scroll shortcut keys ignore SHIFT/CTRL/ALT modifiers.
 - Fix: [#8064] Ride construction errors shown as (undefined string)
 - Fix: [#8219] Faulty folder recreation in "save" folder.
@@ -559,7 +559,7 @@
 - Feature: [#8080] New console variable "current_rotation" to get or set view rotation.
 - Feature: [#8098] Glyph for Russian rouble sign.
 - Feature: [#8099] Add Powered Launch mode to Inverted RC (for RCT1 parity).
-- Feature: [#8190] Allow building footpaths on 'corner down' terrain.
+- Feature: [#8190] Allow building footpaths on ‘corner down’ terrain.
 - Feature: [#8191] Allow building on-ride photos and water S-bends on the Water Coaster.
 - Feature: [#8259] Add say command to in-game console.
 - Feature: [#8374] Add replay system.
@@ -588,7 +588,7 @@
 - Fix: [#7952] Performance drop caused by code refactor.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (original bug).
-- Fix: [#7985] Giant Screenshot ignores 'Map rendering' settings.
+- Fix: [#7985] Giant Screenshot ignores ‘Map rendering’ settings.
 - Fix: [#7987] Broken track designs increase money by MONEY32_UNDEFINED.
 - Fix: [#7991] Scenery and footpaths on Construction Rights tiles can be deleted using Clear Scenery.
 - Fix: [#8034] Vanilla sprites are broken when making screenshots from command line.
@@ -667,7 +667,7 @@
 - Fix: [#7673] Vehicle names are cut off in invention list.
 - Fix: [#7674] Rides show up as random numbers in guest’s ride list.
 - Fix: [#7678] Crash when loading or starting a new game while having object selection window open.
-- Fix: [#7683] 'Arbitrary ride type' dropdown state is shared between windows.
+- Fix: [#7683] ‘Arbitrary ride type’ dropdown state is shared between windows.
 - Fix: [#7697] Some scenery groups in RCT1 saves are never invented.
 - Fix: [#7711] Inverted Hairpin Coaster allows building invisible banked pieces.
 - Fix: [#7734] Title sequence not included in macOS builds as of 0.2.0 release.
@@ -730,7 +730,7 @@
 - Improved: [#5832] Resize tile inspector automatically when selecting a tile element.
 - Improved: [#6221] The scenario editor’s invention list is now resizeable.
 - Improved: [#7069] The arbitrary ride type selection dropdown is now sorted orthographically, and has its spinners removed.
-- Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an 'off edge map' error.
+- Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an ‘off edge map’ error.
 - Improved: [#7435] Object indexing now supports multi-threading.
 - Improved: [#7510] Add horizontal clipping to cut-away view options.
 - Improved: [#7531] "Save track design" dropdown now stays open.
@@ -768,7 +768,7 @@
 - Feature: [#6353] Show custom RCT1 scenarios in New Scenario window.
 - Feature: [#6411] Add command to remove the park fence.
 - Feature: [#6414] Raise maximum launch speed of the Corkscrew RC back to 96 km/h (for RCT1 parity).
-- Feature: [#6433] Turn 'unlock all prices' into a regular (non-cheat, persistent) option.
+- Feature: [#6433] Turn ‘unlock all prices’ into a regular (non-cheat, persistent) option.
 - Feature: [#6516] Ability to search by filename in the object selection window.
 - Feature: [#6530] Land rights tool no longer blocks when a tile is not for purchase.
 - Feature: [#6568] Add smooth nearest neighbour scaling.
@@ -787,7 +787,7 @@
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#996, #2589, #2875] Viewport scrolling no longer shakes or gets stuck.
 - Fix: [#1185] Close button colour of prompt windows does not match.
-- Fix: [#1833, #4937, #6138] 'Too low!' warning when building rides and shops on the lowest land level (original bug).
+- Fix: [#1833, #4937, #6138] ‘Too low!’ warning when building rides and shops on the lowest land level (original bug).
 - Fix: [#2254] Edge scrolling horizontally now has the same speed as vertical edge scrolling.
 - Fix: [#2607] Rain rendered incorrectly in additional viewport.
 - Fix: [#3171] Guests entering from the corner of the tile in Amity Airfield (original bug).
@@ -803,7 +803,7 @@
 - Fix: [#5417] Hacked Crooked House tracked rides do not dispatch vehicles.
 - Fix: [#5445] Patrol area not imported from RCT1 saves and scenarios.
 - Fix: [#5585] Inconsistent zooming with mouse wheel.
-- Fix: [#5609] Vehicle switching may cause '0 cars per train' to be set.
+- Fix: [#5609] Vehicle switching may cause ‘0 cars per train’ to be set.
 - Fix: [#5636] Pausing the game shows mute button as active.
 - Fix: [#5741] Land rights indicators disappear when switching views.
 - Fix: [#5761] Mini coaster doesn’t appear despite being selected.
@@ -905,12 +905,12 @@
 - Fix: [#5890] Fix zoomed OpenGL rendering of special sprites with primary and secondary colours.
 - Fix: [#5912] Negative queue when moving entrance in paused state.
 - Fix: [#5920] Placing guest spawn doesn’t do anything every 3rd click.
-- Fix: [#5939] Crash when importing 'Six Flags Santa Fe'.
+- Fix: [#5939] Crash when importing ‘Six Flags Santa Fe’.
 - Fix: [#5977] Custom music files not showing up in music list.
 - Fix: [#5981] Ride list doesn’t update after using quick demolish.
 - Fix: [#5984] Allow socket binding to same port after crash.
 - Fix: [#5998] Staff not getting paid / no loan interest.
-- Fix: [#6026] 'Select ride to advertise' dropdown does not display all items.
+- Fix: [#6026] ‘Select ride to advertise’ dropdown does not display all items.
 - Fix: [#6052] Unable to place entrance/exit on certain ride types.
 - Fix: [#6071] Quick demolish can delete protected ride.
 - Fix: [#6111] Mute button always visible in editor.
@@ -933,7 +933,7 @@
 - Feature: [#5133] Add option to display guest expenditure (as seen in RCTC).
 - Feature: [#5196] Add cheat to disable ride ageing.
 - Feature: [#5504] Group vehicles into ride groups.
-- Feature: [#5576] Add a persistent 'display real names of guests' setting.
+- Feature: [#5576] Add a persistent ‘display real names of guests’ setting.
 - Feature: [#5611] Add support for Android.
 - Feature: [#5706] Add support for OpenBSD.
 - Feature: OpenRCT2 now starts up on the display it was last shown on.
@@ -943,7 +943,7 @@
 - Fix: [#259] Money making glitch involving swamps (original bug).
 - Fix: [#441] Construction rights over entrance path erased (original bug).
 - Fix: [#578] Ride ghosts show up in ride list during construction (original bug).
-- Fix: [#597] 'Finish 5 roller coasters' goal not properly checked (original bug).
+- Fix: [#597] ‘Finish 5 roller coasters’ goal not properly checked (original bug).
 - Fix: [#667] Incorrect banner limit calculation (original bug).
 - Fix: [#739] Crocodile Ride (Log Flume) never allows more than five boats (original bug).
 - Fix: [#837] Can’t move windows on title screen to where the toolbar would be (original bug).
@@ -961,7 +961,7 @@
 - Fix: [#5253] RCT1 park value conversion factor too high.
 - Fix: [#5400] New Ride window does not focus properly on newly invented ride.
 - Fix: [#5489] Sprite index crash for car view on car ride.
-- Fix: [#5730] Unable to uncheck 'No money' in the Scenario Editor.
+- Fix: [#5730] Unable to uncheck ‘No money’ in the Scenario Editor.
 - Fix: [#5750] Game freezes when ride queue linked list is corrupted.
 - Fix: [#5819] Vertical multi-dimension coaster tunnels drawn incorrectly.
 - Fix: Non-invented vehicles can be used via track designs in select-by-track-type mode.
@@ -981,7 +981,7 @@
 - Feature: [#5415] Add mute toolbar button (as seen in RCT1 and Locomotion).
 - Improved: [#3288] Added server description and greeting textboxes to the start server menu.
 - Improved: [#3502] Track previews display at higher zoom level for large layouts.
-- Improved: [#5055] Implement 'quick demolish' for rides.
+- Improved: [#5055] Implement ‘quick demolish’ for rides.
 - Improved: [#5137] Removing all guests no longer closes the rides and removes the vehicles.
 - Improved: [#5163] Minor tile inspector improvements and fixes.
 - Improved: [#5222] Add Catalan language.
@@ -1006,7 +1006,7 @@
 - Fix: [#5188] Clicking on a Magic Carpet doesn’t open the ride window.
 - Fix: [#5199] "Force a breakdown" debugging tool isn’t hidden in multiplayer.
 - Fix: [#5218] Scale RCT1 park value objectives.
-- Fix: [#5219] Game crashes when opening 'misc' tab in options.
+- Fix: [#5219] Game crashes when opening ‘misc’ tab in options.
 - Fix: [#5238] RCT1 import: Rides are initially free when placing them.
 - Fix: [#5252] Correct typo in Conger Eel Coaster description.
 - Fix: [#5265] Queue line TVs not detected properly.
@@ -1018,7 +1018,7 @@
 - Fix: [#5325] Game crashes if encountering an invalid ride type during research.
 - Fix: [#5345] Correct typos in descriptions for Top Spin and Splash Boats.
 - Fix: [#5350] Steel Twister RC and Giga Coaster boosters are underpowered, Junior Roller Coaster boosters overpowered compared to RCTC.
-- Fix: [#5357] "Assertion failed!" after guest with name 'Emma Garrell' exits/enters ride.
+- Fix: [#5357] "Assertion failed!" after guest with name ‘Emma Garrell’ exits/enters ride.
 - Fix: Walls do not import from RCT1 correctly in pause mode.
 - Fix: Extraneous window tabs show up on MacOS 10.12.
 - Fix: Potential for integer overflow in ride length.
@@ -1089,7 +1089,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Improved: Joining multiplayer will not redownload custom objects.
 - Removed: BMP screenshots.
 - Removed: Intamin and Phoenix easter eggs.
-- Fix: [#933] On-ride photo price sometimes gets reset to £2 when using 'same price in whole park' (original bug).
+- Fix: [#933] On-ride photo price sometimes gets reset to £2 when using ‘same price in whole park’ (original bug).
 - Fix: [#1038] Guest List is out of order.
 - Fix: [#1238] Track place window does not fully adjust to custom colour scheme.
 - Fix: [#2042] Guests entering queues are immediately annoyed when many entertainers are around (original bug).
@@ -1217,7 +1217,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Built-in load/save window is now used for converting saved games to scenarios.
 - Feature: Cooperative multiplayer (has some game-breaking bugs).
 - Feature: Native Linux support.
-- Feature: Console commands for fixing 'Name already in use' and banner count errors.
+- Feature: Console commands for fixing ‘Name already in use’ and banner count errors.
 - Feature: Scenario and object descriptions are now translatable.
 - Feature: UI stays responsive in pause mode.
 - Feature: Marketing campaign can now be run for up to 12 weeks.
@@ -1234,7 +1234,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Option to display all scrolling text banners as upper case (RCT1 style).
 - Feature: Option to mute audio when game is not focused.
 - Feature: Option to automatically place staff after hire.
-- Feature: Option to enable 'mow grass' by default for handymen (RCT1 style).
+- Feature: Option to enable ‘mow grass’ by default for handymen (RCT1 style).
 - Feature: Option to ignore invalid checksums on loaded parks.
 - Feature: Option to scale game display for better compatibility with high DPI screens.
 - Alteration: Autosave is now measured in real-time rather than in-game date.
@@ -1301,7 +1301,7 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Change available objects in-game (only available from console).
 - Feature: Change research settings in-game (only available from console).
 - Feature: (Random) map generator available in scenario editor, accessible via the view menu.
-- Feature: RollerCoaster Tycoon 1 scenarios can now be opened in the scenario editor or by using the 'edit' command line action.
+- Feature: RollerCoaster Tycoon 1 scenarios can now be opened in the scenario editor or by using the ‘edit’ command line action.
 - Feature: The "have fun" objective can now be selected in the scenario editor.
 - Feature: Twitch integration.
 - Fix: Litter bins now get full and require emptying by handymen.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -160,7 +160,7 @@
 - Fix: [#11438] Freeze when shrinking map size.
 - Fix: [#11484] Console output does not properly return to column 0 after line ending.
 - Fix: [#12895] Mechanics are called to repair rides that have already been fixed.
-- Fix: [#13048] Keyboard mute button interpreted as `C` key.
+- Fix: [#13048] Keyboard mute button interpreted as ‘C’ key.
 - Fix: [#13102] Underflow on height chart (Ride measurements).
 - Fix: [#13234] Incorrect vehicle mass after using Remove All Guests cheat.
 - Fix: [#13236] New ride type appears as new vehicle type in research.
@@ -175,7 +175,7 @@
 - Fix: [#13477] Plug-in widget tooltips do not work.
 - Fix: [#13489] Mechanics continue heading to inspect broken down rides.
 - Fix: [#13510] [Plugin] list view scroll resets when items is set.
-- Fix: [#13574] Crash when a JSON object does not set `originalId`.
+- Fix: [#13574] Crash when a JSON object does not set ‘originalId’.
 - Fix: [#13832] Players last action position is invalid on opening/closing a ride in multiplayer.
 - Fix: [#13937] Pathfinding gets confused when two entrances/exits from the same ride are on top of each other.
 - Fix: [#13961] Animation for Guests sliding down Spiral Slide is missing on close zoom levels.
@@ -295,7 +295,7 @@
 - Change: [#11209] Warn when user is running OpenRCT2 through Wine.
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Change: [#11449] Remove complete circuit requirement from Air Powered Vertical Coaster (for RCT1 parity).
-- Change: [#11898] The `openrct-data-path` command-line argument has been renamed to `openrct2-data-path`.
+- Change: [#11898] The ‘openrct-data-path’ command-line argument has been renamed to ‘openrct2-data-path’.
 - Change: [#11944] The ride list sort mode is now remembered for the duration of the game.
 - Fix: [#1013] Negative length displayed in Ride window.
 - Fix: [#1148] Research funding dropdown not shown in finances window.
@@ -337,7 +337,7 @@
 - Fix: [#12297] OpenGL renderer causing artifacts.
 - Fix: [#12308] Cannot use cheats in editor modes.
 - Fix: [#12312] Softlock when loading save file via command line fails.
-- Fix: [#12486] `set-rct2` has a broken g1.dat check.
+- Fix: [#12486] ‘set-rct2’ has a broken g1.dat check.
 - Fix: [#12498] Circus construction ghost does not rotate (original bug).
 - Fix: [#12505] Stores selling multiple items can only have the first product advertised.
 - Fix: [#12506] Cannot advertise food if there are no rides in the park.
@@ -542,7 +542,7 @@
 - Fix: [#9324] Crash trying to remove invalid footpath scenery.
 - Fix: [#9402] Ad campaigns disappear when you save and load the game.
 - Fix: [#9411] Ad campaigns end too soon.
-- Fix: [#9476] Running `simulate` command on park yields `Completed: (null)`.
+- Fix: [#9476] Running ‘simulate’ command on park yields ‘Completed: (null)’.
 - Fix: [#9520] Time Twister object artdec29 conversion problem.
 - Fix: Guests eating popcorn are drawn as if they’re eating pizza.
 - Fix: The arbitrary ride type and vehicle dropdown lists are ordered case-sensitively.
@@ -571,7 +571,7 @@
 - Feature: [#8670] Add ability to download missing objects when loading a park.
 - Change: [#7961] Add new object types: station, terrain surface, and terrain edge.
 - Change: [#8222] The climate setting has been moved from objective options to scenario options.
-- Change: [#8718] Allow TARMAC object to be removed when running the `remove_unused_objects` command.
+- Change: [#8718] Allow TARMAC object to be removed when running the ‘remove_unused_objects’ command.
 - Change: [#8718] No longer require the generic scenery groups and tarmac footpath to be checked when creating a scenario.
 - Change: [#8734] Disable kick button in multiplayer window when unable to use it.
 - Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
@@ -592,7 +592,7 @@
 - Fix: [#7536] Android builds fail to start.
 - Fix: [#7689] Deleting 0-tile maze gives a MONEY32_UNDEFINED (negative) refund.
 - Fix: [#7828] Copied entrances and exits stay when demolishing ride.
-- Fix: [#7945] Client IP address is logged as `(null)` in server logs.
+- Fix: [#7945] Client IP address is logged as ‘(null)’ in server logs.
 - Fix: [#7952] Performance drop caused by code refactor.
 - Fix: [#7954] Key validation fails on Windows due to non-ASCII user / player name.
 - Fix: [#7975] Inspection flag not cleared for rides which are set to never be inspected (original bug).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,11 @@
 - Feature: [#15194] [Plugin] Add guest properties, ride downtime and park casualty penalty.
 - Feature: [#15195] Added a bug-report item in file dropdown menu.
 - Feature: [#15294] New vehicle animation type: flying animal.
+- Improved: [#3417] Crash dumps are now placed in their own folder.
+- Improved: [#13524] macOS arm64 native (universal) app
+- Improved: [#15538] Software rendering can now draw in parallel when Multithreading is enabled.
+- Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
+- Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.
 - Fix: [#10614] Track Designs with missing path(s) do not use alternate pathways.
 - Fix: [#12981] New vehicles do not appear in vehicle type dropdown.
 - Fix: [#13465] Creating a scenario based on a won save game results in a scenario that’s instantly won.
@@ -58,19 +63,14 @@
 - Fix: [#15612] Crash when placing walls beside certain scenery objects.
 - Fix: [#15851] Incorrect percentage chance of jumping with Katie Smith cheat.
 - Fix: [#15858] Joanne Barton and Emma Garrell cheat incorrectly not applying effects to self.
-- Improved: [#3417] Crash dumps are now placed in their own folder.
-- Improved: [#13524] macOS arm64 native (universal) app
-- Improved: [#15538] Software rendering can now draw in parallel when Multithreading is enabled.
-- Change: [#8601] Revert ToonTower base block fix to re-enable support blocking.
-- Change: [#15174] [Plugin] Deprecate the type "peep" and add support to target a specific scripting api version.
 
 0.3.4.1 (2021-07-25)
 ------------------------------------------------------------------------
+- Improved: [#12626] Allow using RCT2 saves to mark RCT Classic (.sea) parks as finished and vice versa. 
 - Fix: [#15028] Crash when placing large scenery.
 - Fix: [#15048] Crash when removing litter with cheats.
 - Fix: [#15052] Crash when using banner window.
 - Fix: [#15063] Crash when opening large scenery signs.
-- Improved: [#12626] Allow using RCT2 saves to mark RCT Classic (.sea) parks as finished and vice versa. 
 
 0.3.4 (2021-07-19)
 ------------------------------------------------------------------------
@@ -82,6 +82,9 @@
 - Feature: [#14620] [Plugin] Add properties related to guest generation.
 - Feature: [#14636] [Plugin] Add properties related to climate and weather.
 - Feature: [#14731] Opaque water (like in RCT1).
+- Improved: [#14511] ‘Unlock operating limits’ cheat now also unlocks all music.
+- Improved: [#14712, #14716] Improve startup times.
+- Improved: [#14982] Add Malgun Gothic and change Nanum Gothic filename for Korean.
 - Change: [#14496] [Plugin] Rename Object to LoadedObject to fix conflicts with Typescript’s Object interface.
 - Change: [#14536] [Plugin] Rename ListView to ListViewWidget to make it consistent with names of other widgets.
 - Change: [#14751] ‘No construction above tree height’ limitation now allows placing high trees.
@@ -109,9 +112,6 @@
 - Fix: [#14880] Unable to close changelog window when its content fails to load.
 - Fix: [#14945] Incorrect drop height penalty on log flume ride.
 - Fix: [#14964] Unable to build in multiplayer as client with "Build while paused" cheat enabled when the host is paused.
-- Improved: [#14511] ‘Unlock operating limits’ cheat now also unlocks all music.
-- Improved: [#14712, #14716] Improve startup times.
-- Improved: [#14982] Add Malgun Gothic and change Nanum Gothic filename for Korean.
 
 0.3.3 (2021-03-13)
 ------------------------------------------------------------------------
@@ -146,6 +146,12 @@
 - Feature: [#14171] [Plugin] Add API for drawing graphics for custom widgets.
 - Feature: [#14171] [Plugin] Add click event to spinners and allow them to be held down.
 - Feature: [#14252] [Plugin] Add API for vehicle g-forces. 
+- Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
+- Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
+- Improved: [#13386] A GUI error message is now displayed if the language files are missing.
+- Improved: [#14193] [Plugin] Add TileElement union type and use it in Tile interface instead of BaseTileElement.
+- Improved: [#14193] [Plugin] Add exact type field to each TileElement, add type field to WidgetBase.
+- Improved: [#14193] [Plugin] Change single quotes to double quotes in openrct2.d.ts.
 - Change: [#13346] [Plugin] Renamed FootpathScenery to FootpathAddition, fix typos.
 - Change: [#13857] Change Rotation Control Toggle to track element number 256
 - Fix: [#4605, #11912] Water palettes are not updated properly when selected in Object Selection.
@@ -177,12 +183,6 @@
 - Fix: [#14095] Holding down [-][+] buttons does not decrease/increase number of circuits.
 - Fix: [#14225] Desync when ‘allow early scenario completion’ is enabled.
 - Fix: [#14247] Scenarios from RCT1 allow hiring too many staff.
-- Improved: [#6022] Allow up to 128 ride objects to be selected in track designer.
-- Improved: [#12917] Changed peep movement so that they stay more spread out over the full width of single tile paths.
-- Improved: [#13386] A GUI error message is now displayed if the language files are missing.
-- Improved: [#14193] [Plugin] Add TileElement union type and use it in Tile interface instead of BaseTileElement.
-- Improved: [#14193] [Plugin] Add exact type field to each TileElement, add type field to WidgetBase.
-- Improved: [#14193] [Plugin] Change single quotes to double quotes in openrct2.d.ts.
 - Removed: [#13423] Built-in explode guests cheat (replaced by plug-in).
 - Removed: [#14186] Network traffic window (replaced by plug-in).
 
@@ -193,6 +193,9 @@
 - Feature: [#13000] objective_options command for console.
 - Feature: [#13096] Add Esperanto translation.
 - Feature: [#13164] Add ‘Objective options’ to Cheats menu.
+- Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
+- Improved: [#13098] Improvements to the maze construction window user interface
+- Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
 - Change: [#9568] Change lift sounds of Reverser Roller Coaster and Compact Inverted Coaster to better fitting ones.
 - Change: [#13160] The lay-out of the Park Cheats tab has been improved.
 - Fix: [#1324] Last track piece map selection still visible when placing ride entrance or exit (original bug).
@@ -232,9 +235,6 @@
 - Fix: [#13278] Desync caused by ghost tiles changing the ride mode.
 - Fix: [#13289] Litter and vomit sometimes not loading with RCT1 saved game or scenario
 - Fix: [#13292] Impossible excitement rating requirements with finish building 5 coasters goal
-- Improved: [#13023] Made add_news_item console command last argument, assoc, optional.
-- Improved: [#13098] Improvements to the maze construction window user interface
-- Improved: [#13125] Selecting the RCT2 files now uses localised dialogs.
 
 0.3.1 (2020-09-27)
 ------------------------------------------------------------------------
@@ -247,6 +247,9 @@
 - Feature: [#12885] Add SmallSceneryElement.quadrant to the plugin API.
 - Feature: [#12886] Make all scenery placement and remove actions available to the plugin API.
 - Feature: [#2350, #12922] Add snow, heavy snow and blizzard to weather types.
+- Improved: [#12806] Add Esperanto diacritics to the sprite font.
+- Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.
+- Improved: [#12890] Add stroke to lowercase ‘L’ to differentiate from capital ‘I’.
 - Fix: [#400] Unable to place some saved tracks flush to the ground (original bug).
 - Fix: [#5753] Entertainers make themselves happy instead of the guests.
 - Fix: [#7037] Unable to save tracks starting with a sloped turn or helix.
@@ -265,9 +268,6 @@
 - Fix: [#12912] Plugin: selectedCell of CustomListView is being ignored on creation.
 - Fix: [#12918] Cannot place vanilla TD6 tracks of the Hypercoaster, Monster Trucks, Classic Mini Roller Coaster, Spinning Wild Mouse and Hyper-Twister types.
 - Fix: Incomplete loop collision box allowed overlapping track (original bug).
-- Improved: [#12806] Add Esperanto diacritics to the sprite font.
-- Improved: [#12837] Arabic text is now drawn and shaped correctly on Windows.
-- Improved: [#12890] Add stroke to lowercase ‘L’ to differentiate from capital ‘I’.
 - Technical: [#12749] The required version of macOS has been lowered to 10.13 (High Sierra).
 
 0.3.0 (2020-08-15)
@@ -289,6 +289,9 @@
 - Feature: [#12347] Periodically check for new releases on GitHub, and show a notification on the title screen.
 - Feature: [#12347] The ‘About OpenRCT2’ window now has a link to the OpenRCT2 Discord Server.
 - Feature: [#12591] Show authors of an object on the object selection dialog.
+- Improved: [#6530] Allow water and land height changes on park borders.
+- Improved: [#11390] Build hash written to screenshot metadata.
+- Improved: [#3205] Make handymen less likely to get stuck in ride queues.
 - Change: [#11209] Warn when user is running OpenRCT2 through Wine.
 - Change: [#11358] Switch copy and paste button positions in tile inspector.
 - Change: [#11449] Remove complete circuit requirement from Air Powered Vertical Coaster (for RCT1 parity).
@@ -344,9 +347,6 @@
 - Fix: RCT1 scenarios have more items in the object list than are present in the park or the research list.
 - Fix: Brakes keep working during "Brakes failure".
 - Fix: Guests maze pathfinding prefers a specific direction (original bug).
-- Improved: [#6530] Allow water and land height changes on park borders.
-- Improved: [#11390] Build hash written to screenshot metadata.
-- Improved: [#3205] Make handymen less likely to get stuck in ride queues.
 - Technical: [#8110] OpenRCT2 now uses a single directory name for title sequences instead of three.
 - Technical: [#11517] Windows Vista is supported again (libzip regression in the previous release).
 - Technical: The required version of macOS has been increased to 10.14 (Mojave) for plugin support.
@@ -360,6 +360,8 @@
 - Feature: [#11272] Option for toggling notifications for ‘Ride casualties’ and ‘Stuck or stalled vehicles’.
 - Feature: [#11281] add_news_item command for console
 - Feature: [#11300] Add powered launch and reverse incline launched shuttle mode to the Stand-Up Roller Coaster (for RCT1 parity).
+- Improved: [#6024] The close button in the object selection now advances to the next step.
+- Improved: [#11157] Slimmer virtual floor lines.
 - Fix: [#475] Water sides drawn incorrectly (original bug).
 - Fix: [#6123, #7907, #9472, #11028] Cannot build some track designs with 4 stations (original bug).
 - Fix: [#6238] Invalid tile elem iteration in Guest::UpdateUsingBin
@@ -380,8 +382,6 @@
 - Fix: [#11258] Properly remove format codes from imported strings.
 - Fix: [#11286] Fix banner tooltip colour.
 - Fix: Small red gardens in RCT1 saves are imported in the wrong colour.
-- Improved: [#6024] The close button in the object selection now advances to the next step.
-- Improved: [#11157] Slimmer virtual floor lines.
 
 0.2.5 (2020-03-24)
 ------------------------------------------------------------------------
@@ -393,6 +393,10 @@
 - Feature: [#10189] Make Track Designs work in multiplayer.
 - Feature: [#10357] Added window for scenery scatter tool, allowing for area and density selection.
 - Feature: [#10637] Console command to remove all floating objects.
+- Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
+- Improved: [#10858] Added horizontal grid lines to finance charts.
+- Improved: [#10884] Added y-axes and labels to park window charts.
+- Improved: [#10970] Introduced optional light effects for vehicles at night.
 - Change: [#1164] Use available translations for shortcut key bindings.
 - Change: [#10997] Speed is automatically reset to normal upon scenario completion.
 - Fix: [#2485] Hide Vertical Faces not applied to the edges of water.
@@ -430,16 +434,15 @@
 - Fix: [#11001] Rides list does not use natural sorting.
 - Fix: [objects#54] Stage Coach cars are not considered covered by the game.
 - Fix: [objects#56] Handymen cut grass incorrectly.
-- Improved: [#682] The staff patrol area is now drawn on the water, instead of on the surface under water.
-- Improved: [#10858] Added horizontal grid lines to finance charts.
-- Improved: [#10884] Added y-axes and labels to park window charts.
-- Improved: [#10970] Introduced optional light effects for vehicles at night.
 - Removed: [#6898] LOADMM and LOADRCT1 title sequence commands (use LOADSC instead).
 
 0.2.4 (2019-10-28)
 ------------------------------------------------------------------------
 - Feature: [#9285] Remember current group in scenario list window.
 - Feature: [#9918] Increase image list capacity by about 100k units.
+- Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
+- Improved: [#9987] Minimum load rounding.
+- Improved: [#10125] Better support for high DPI screens.
 - Change: [#1349] Increase the number of ride music played simultaneously from 2 to 32.
 - Fix: [#4927] Giant screenshot cut off at bottom and top.
 - Fix: [#7572] Queue paths connect to regular paths through fences.
@@ -472,9 +475,6 @@
 - Fix: [#10149] Desync in headless mode with rides that create smoke particles.
 - Fix: [#10249] Desync because of ride crashes and simulation mode.
 - Fix: [#10256] Desync because of advancing ahead of server ticks during map change.
-- Improved: [#9466] Add the rain weather effect to the OpenGL renderer.
-- Improved: [#9987] Minimum load rounding.
-- Improved: [#10125] Better support for high DPI screens.
 
 0.2.3 (2019-07-10)
 ------------------------------------------------------------------------
@@ -495,6 +495,8 @@
 - Change: [#8427] Ghost elements now show up as white on the mini-map.
 - Change: [#8688] Move common actions from debug menu into cheats menu.
 - Change: [#9428] Increase maximum height of the Hypercoaster to RCT1 limits.
+- Improved: [#6116] Expose colour scheme for track elements in the tile inspector.
+- Improved: Allow the use of numpad enter key for console and chat.
 - Fix: [#2294] Clients crashing the server with invalid object selection.
 - Fix: [#4568, #5896] Incorrect fences removed when building a tracked ride through
 - Fix: [#5103] OpenGL: ride track preview not rendered.
@@ -544,8 +546,6 @@
 - Fix: [#9520] Time Twister object artdec29 conversion problem.
 - Fix: Guests eating popcorn are drawn as if they’re eating pizza.
 - Fix: The arbitrary ride type and vehicle dropdown lists are ordered case-sensitively.
-- Improved: [#6116] Expose colour scheme for track elements in the tile inspector.
-- Improved: Allow the use of numpad enter key for console and chat.
 
 0.2.2 (2019-03-13)
 ------------------------------------------------------------------------
@@ -574,6 +574,14 @@
 - Change: [#8718] Allow TARMAC object to be removed when running the `remove_unused_objects` command.
 - Change: [#8718] No longer require the generic scenery groups and tarmac footpath to be checked when creating a scenario.
 - Change: [#8734] Disable kick button in multiplayer window when unable to use it.
+- Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
+- Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window’s graph tab.
+- Improved: [#7930] Automatically create folders for custom content.
+- Improved: [#7980] Show the full path of the scenario in the scenario select window.
+- Improved: [#7993] Allow assigning a keyboard shortcut for opening the tile inspector.
+- Improved: [#8107] Support Discord release of RCT2.
+- Improved: [#8491] Highlight entrance and exit with different colours in track design previews.
+- Improved: Almost completely new Hungarian translation.
 - Fix: [#3832] Changing the colour scheme of track pieces does not work in multiplayer.
 - Fix: [#4094] Coasters with long flat-to-steep pieces offer them in diagonal mode (original bug).
 - Fix: [#5684] Player list can desync between clients and server and can crash.
@@ -631,14 +639,6 @@
 - Fix: [#8804] Raising water shows money effect at the bottom rather than new height.
 - Fix: [#8811] Some fields in the sv6 save file not being copied correctly.
 - Fix: [#8824] Invalid read in footpath_chain_ride_queue.
-- Improved: [#2940] Allow mouse-dragging to set patrol area (Singleplayer only).
-- Improved: [#7730] Draw extreme vertical and lateral Gs red in the ride window’s graph tab.
-- Improved: [#7930] Automatically create folders for custom content.
-- Improved: [#7980] Show the full path of the scenario in the scenario select window.
-- Improved: [#7993] Allow assigning a keyboard shortcut for opening the tile inspector.
-- Improved: [#8107] Support Discord release of RCT2.
-- Improved: [#8491] Highlight entrance and exit with different colours in track design previews.
-- Improved: Almost completely new Hungarian translation.
 - Removed: [#7929] Support for scenario text objects.
 
 0.2.1 (2018-08-26)
@@ -654,6 +654,8 @@
 - Feature: [#7868] Placing scenery while holding shift now scales appropriately with zoom levels.
 - Feature: [#7882] Auto-detect Steam and GOG installations of RCT1.
 - Feature: [#7885] Turkish translation.
+- Improved: [#7899] Timestamps in the load/save screen are now displayed using local timezone instead of GMT.
+- Improved: [#7918] Better RCT2 detection if both disc and GOG/Steam versions are installed.
 - Fix: [#3177] Wrong keys displayed in shortcut menu.
 - Fix: [#4039] No sprite font glyph for German opening quotation mark.
 - Fix: [#5548] platform_get_locale_date_format is not implemented for Linux.
@@ -681,8 +683,6 @@
 - Fix: [#7804] Russian ride descriptions are cut off.
 - Fix: [#7872] CJK tooltips are often cut off.
 - Fix: [#7895] Import of Mega Park and the RCT1 title music do not work on some RCT1 sources.
-- Improved: [#7899] Timestamps in the load/save screen are now displayed using local timezone instead of GMT.
-- Improved: [#7918] Better RCT2 detection if both disc and GOG/Steam versions are installed.
 
 0.2.0 (2018-06-10)
 ------------------------------------------------------------------------
@@ -698,6 +698,22 @@
 - Feature: [#7332] Keyboard shortcuts for view path issues and cutaway view.
 - Feature: [#7348] Add large half loops to the Vertical Drop Roller Coaster.
 - Feature: [#7459] Allow opening and closing of parks that use no money.
+- Improved: [#2989] Multiplayer window now changes title when tab changes.
+- Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
+- Improved: [#5832] Resize tile inspector automatically when selecting a tile element.
+- Improved: [#6221] The scenario editor’s invention list is now resizeable.
+- Improved: [#7069] The arbitrary ride type selection dropdown is now sorted orthographically, and has its spinners removed.
+- Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an ‘off edge map’ error.
+- Improved: [#7435] Object indexing now supports multi-threading.
+- Improved: [#7510] Add horizontal clipping to cut-away view options.
+- Improved: [#7531] "Save track design" dropdown now stays open.
+- Improved: [#7548] Ctrl-clicking with the tile inspector open now directly selects an element and its tile.
+- Improved: [#7555] Allow setting the Twitch API URL, allowing custom API servers.
+- Improved: [#7567] Improve the performance of loading parks and the title sequence.
+- Improved: [#7577] Allow fine-tuning the virtual floor style.
+- Improved: [#7608] The vehicle selection dropdown is now sorted orthographically.
+- Improved: [#7613] Resizing the staff window now resizes the name and action columns too.
+- Improved: [#7627] Allow scrolling up and down on spinners to change their values.
 - Fix: [#2053] When clearance checks are disabled, a track piece ghost can remove non-ghost track pieces.
 - Fix: [#2611] Some objects show (undefined string) instead of a description in Korean.
 - Fix: [#3596] Saving parks, landscapes and tracks with a period in the filenames don’t get their extension.
@@ -725,22 +741,6 @@
 - Fix: [#7528] In park entrance pricing tab, switching tabs happens on mouse-down instead of mouse-up
 - Fix: [#7544] Starting a headless server with no arguments causes the game to freeze.
 - Fix: [#7571] Hovering a ride design over scenery or tracks will give tons of money.
-- Improved: [#2989] Multiplayer window now changes title when tab changes.
-- Improved: [#5339] Change eyedropper icon to actual eyedropper and change cursor to crosshair.
-- Improved: [#5832] Resize tile inspector automatically when selecting a tile element.
-- Improved: [#6221] The scenario editor’s invention list is now resizeable.
-- Improved: [#7069] The arbitrary ride type selection dropdown is now sorted orthographically, and has its spinners removed.
-- Improved: [#7302] Raising land near the map edge makes the affected area smaller instead of showing an ‘off edge map’ error.
-- Improved: [#7435] Object indexing now supports multi-threading.
-- Improved: [#7510] Add horizontal clipping to cut-away view options.
-- Improved: [#7531] "Save track design" dropdown now stays open.
-- Improved: [#7548] Ctrl-clicking with the tile inspector open now directly selects an element and its tile.
-- Improved: [#7555] Allow setting the Twitch API URL, allowing custom API servers.
-- Improved: [#7567] Improve the performance of loading parks and the title sequence.
-- Improved: [#7577] Allow fine-tuning the virtual floor style.
-- Improved: [#7608] The vehicle selection dropdown is now sorted orthographically.
-- Improved: [#7613] Resizing the staff window now resizes the name and action columns too.
-- Improved: [#7627] Allow scrolling up and down on spinners to change their values.
 
 0.1.2 (2018-03-18)
 ------------------------------------------------------------------------
@@ -784,6 +784,16 @@
 - Feature: Vehicles with matching capabilities are now always switchable.
 - Feature: Add search box to track design window.
 - Feature: Add load scenario command to title sequences.
+- Improved: [#5962] Use AVX2 instruction set where supported, resulting in a performance boost.
+- Improved: [#5964] Use SSE 4.1 instruction set where supported, resulting in a performance boost.
+- Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
+- Improved: [#6218] Speed up game start up time by saving scenario index to file.
+- Improved: [#6242] Prevent scenery aging and grass growth causing tile invalidation unless necessary - slight performance boost.
+- Improved: [#6423] Polish is now rendered using the sprite font, rather than TTF.
+- Improved: [#6746] Draw friction wheels instead of chain lift on Looping Roller Coaster stations.
+- Improved: Load/save window now refreshes list if native file dialog is closed/cancelled.
+- Improved: Major translation updates for Japanese and Polish.
+- Improved: Added 24x24, 48x48, and 96x96 icon resolutions.
 - Fix: [#816] In the map window, there are more peeps flickering than there are selected (original bug).
 - Fix: [#996, #2589, #2875] Viewport scrolling no longer shakes or gets stuck.
 - Fix: [#1185] Close button colour of prompt windows does not match.
@@ -870,16 +880,6 @@
 - Fix: Remove consecutive thoughts about a ride being demolished.
 - Fix: Water raft vehicles stop spinning when going up slopes.
 - Fix: Incorrect spin is applied to coasters on S-bends and other turns.
-- Improved: [#5962] Use AVX2 instruction set where supported, resulting in a performance boost.
-- Improved: [#5964] Use SSE 4.1 instruction set where supported, resulting in a performance boost.
-- Improved: [#6186] Transparent menu items now draw properly in OpenGL mode.
-- Improved: [#6218] Speed up game start up time by saving scenario index to file.
-- Improved: [#6242] Prevent scenery aging and grass growth causing tile invalidation unless necessary - slight performance boost.
-- Improved: [#6423] Polish is now rendered using the sprite font, rather than TTF.
-- Improved: [#6746] Draw friction wheels instead of chain lift on Looping Roller Coaster stations.
-- Improved: Load/save window now refreshes list if native file dialog is closed/cancelled.
-- Improved: Major translation updates for Japanese and Polish.
-- Improved: Added 24x24, 48x48, and 96x96 icon resolutions.
 - Technical: [#6384] On macOS, address NSFileHandlingPanel deprecation by using NSModalResponse instead.
 - Technical: [#6772] RCT2 interop removed.
 
@@ -890,6 +890,16 @@
 - Feature: [#5877] Allow up to 16 stations to be synchronised.
 - Feature: [#5970] The Bobsleigh Roller Coaster now supports on-ride photos.
 - Feature: [#5991] Allow all tracked rides that can be tested without guests to the Track Designer.
+- Improved: [#2223] Change mountain tool to ignore higher surrounding tiles.
+- Improved: [#4301] Leading and trailing whitespace in player name is now removed.
+- Improved: [#5859] OpenGL rendering performance.
+- Improved: [#5863] Switching drawing engines no longer requires the application to restart.
+- Improved: [#6003] Doors placed on tracks will now work with all vehicles.
+- Improved: [#6037] Autosaves are now stored in a subfolder.
+- Improved: The land tool buttons can now be held down to increase/decrease size.
+- Improved: Dropdowns longer than 32 items overflow into columns.
+- Improved: Ride Type option in ride window is now a dropdown.
+- Improved: "About OpenRCT2" window redesigned, now contains OpenRCT2 info and access to changelog.
 - Fix: [#2127, #2229, #5586] Mountain tool cost calculation.
 - Fix: [#3589] Crash due to invalid footpathEntry in path_paint.
 - Fix: [#3852] Constructing path not clearing scenery on server.
@@ -915,16 +925,6 @@
 - Fix: [#6071] Quick demolish can delete protected ride.
 - Fix: [#6111] Mute button always visible in editor.
 - Fix: [#6113] Track preview shows incorrect highest drop height.
-- Improved: [#2223] Change mountain tool to ignore higher surrounding tiles.
-- Improved: [#4301] Leading and trailing whitespace in player name is now removed.
-- Improved: [#5859] OpenGL rendering performance.
-- Improved: [#5863] Switching drawing engines no longer requires the application to restart.
-- Improved: [#6003] Doors placed on tracks will now work with all vehicles.
-- Improved: [#6037] Autosaves are now stored in a subfolder.
-- Improved: The land tool buttons can now be held down to increase/decrease size.
-- Improved: Dropdowns longer than 32 items overflow into columns.
-- Improved: Ride Type option in ride window is now a dropdown.
-- Improved: "About OpenRCT2" window redesigned, now contains OpenRCT2 info and access to changelog.
 
 0.1.0 (2017-07-12)
 ------------------------------------------------------------------------
@@ -991,7 +991,6 @@
 - Improved: Scenario options are now synced in multiplayer.
 - Improved: Remove duplicate ride penalty for closed rides.
 - Improved: Make shortcut keys window larger and resizable.
-- Removed: known_issues.txt no longer used, check issue tracker on GitHub.
 - Fix: [#1992] Felicity Anderson Cheat can crash the game, as well as blocking queues.
 - Fix: [#4493] Provide tooltip for disabled price field.
 - Fix: [#4689] Object selection tabs sometimes flicker.
@@ -1023,6 +1022,7 @@
 - Fix: Extraneous window tabs show up on MacOS 10.12.
 - Fix: Potential for integer overflow in ride length.
 - Fix: Vehicles erroneously removed when removing all guests.
+- Removed: known_issues.txt no longer used, check issue tracker on GitHub.
 - Technical: INI configuration file now case-insensitive.
 - Technical: Remove version build from msbuild & NSIS.
 
@@ -1080,15 +1080,13 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Objects are scanned from the user directory as well as the RCT2 directory.
 - Feature: Objects directory is scanned recursively.
 - Feature: Optionally zoom in towards the cursor rather than the screen centre.
-- Change: The maximum height of Junior Roller Coasters is now 14 units, like it was in RCT1.
 - Improved: Pathfinding algorithm.
 - Improved: Performance and reliability of loading objects.
 - Improved: Screenshots are now saved with the name of the park and the current date and time.
 - Improved: More accurate frame rate calculation.
 - Improved: In-game file dialog now shows more formats (sv6, sc6, sv4, etc.).
 - Improved: Joining multiplayer will not redownload custom objects.
-- Removed: BMP screenshots.
-- Removed: Intamin and Phoenix easter eggs.
+- Change: The maximum height of Junior Roller Coasters is now 14 units, like it was in RCT1.
 - Fix: [#933] On-ride photo price sometimes gets reset to £2 when using ‘same price in whole park’ (original bug).
 - Fix: [#1038] Guest List is out of order.
 - Fix: [#1238] Track place window does not fully adjust to custom colour scheme.
@@ -1112,6 +1110,8 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#3915] Restore horizontal and vertical scrollbar behaviour from RCT2 when clicking on one of the scrollbars.
 - Fix: Lay-down Roller Coasters from RCT1 saves are imported with an incorrect vehicle type (not reported).
 - Fix: High lateral G-forces penalty applied too early (not reported).
+- Removed: BMP screenshots.
+- Removed: Intamin and Phoenix easter eggs.
 - Technical: Multiplayer groups are now stored in JSON format.
 - Technical: MinGW builds dropped support for Windows XP.
 
@@ -1148,19 +1148,14 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Ability to disable lightning effect during a thunderstorm.
 - Feature: Ability to set ownership of map edges.
 - Feature: Display a chat hotkey when joining a server.
+- Improve: performance of rendering, particularly for highly populated parks.
+- Improve: performance of loading parks.
+- Improve: support for hacked parks.
 - Change: Server IP addresses are no longer shown in the server list.
 - Change: Theme format changed from INI to JSON (INI format no longer supported).
 - Change: Sound controls re-worked to control sound effects and ride music separately.
 - Change: Use native line endings in config.ini.
 - Change: Remove default audio device from audio device dropdown in Linux.
-- Technical: lodepng dropped in return for libpng.
-- Technical: SDL2 upgraded from 2.0.3 to 2.0.4.
-- Technical: argparse dropped in return for bespoke command line parsing implementation.
-- Technical: Integrated breakpad for (manual) crash reporting.
-- Improve: performance of rendering, particularly for highly populated parks.
-- Improve: performance of loading parks.
-- Improve: support for hacked parks.
-- Removed: Anti-cheat code that detected money hack attempts.
 - Fix: Dated autosave files are not created on OSX and Linux.
 - Fix: Title sequence directories are not deleted when title sequence is deleted on OSX and Linux.
 - Fix: Tile not highlighted when placing staff members.
@@ -1187,6 +1182,11 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: [#3063] Search exe directory for SSL bundle as well as CWD.
 - Fix: [#3120] Negative cash in finance window is not red.
 - Fix: [#4134] Can’t enable park-wide photo price for log flume and river rapids.
+- Technical: lodepng dropped in return for libpng.
+- Technical: SDL2 upgraded from 2.0.3 to 2.0.4.
+- Technical: argparse dropped in return for bespoke command line parsing implementation.
+- Technical: Integrated breakpad for (manual) crash reporting.
+- Removed: Anti-cheat code that detected money hack attempts.
 
 0.0.3.1-beta (2015-12-04)
 ------------------------------------------------------------------------
@@ -1237,11 +1237,8 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Feature: Option to enable ‘mow grass’ by default for handymen (RCT1 style).
 - Feature: Option to ignore invalid checksums on loaded parks.
 - Feature: Option to scale game display for better compatibility with high DPI screens.
-- Alteration: Autosave is now measured in real-time rather than in-game date.
-- Alteration: Hacked rides no longer have their reliability set to 0.
-- Technical: DirectDraw, DirectInput, DirectPlay and DirectSound dependencies are no longer used.
-- Removed: Six Flags branding and limitations.
-- Removed: Infogrames disclaimer.
+- Change: Autosave is now measured in real-time rather than in-game date.
+- Change: Hacked rides no longer have their reliability set to 0.
 - Fix: When placing a track, the preview will now use the same orientation as the ghost.
 - Fix: Grouping vehicles by track type no longer interferes with research.
 - Fix: Fix corrupt map elements when loading a game.
@@ -1259,6 +1256,9 @@ This is the first fully implemented version of OpenRCT2. RCT2.EXE is no longer r
 - Fix: The path tool and tracked-ride construction tool no longer interfere with one another in certain situations (original bug).
 - Fix: Building a flat ride partially out of park boundaries will no longer trigger a misleading "too high for supports" message (original bug).
 - Fix: On-ride photos are now factored into the calculations of a ride’s income and profit per hour (original bug).
+- Removed: Six Flags branding and limitations.
+- Removed: Infogrames disclaimer.
+- Technical: DirectDraw, DirectInput, DirectPlay and DirectSound dependencies are no longer used.
 
 0.0.2-beta (2015-06-21)
 ------------------------------------------------------------------------


### PR DESCRIPTION
The order is now from most to least interesting for the players: Feature - Improve - Change - Fix - Removed - Technical

This also makes the usage of the quotation marks consistent. Single quotes seem to be the way to go for British spelling:
https://grammar.yourdictionary.com/punctuation/rules-for-using-single-quotation-marks.html

- Right single-quotation mark (’) for possession (was ')
- Single quotation marks (‘...’) for names, strings, code, etc. (was '...', "...", and “...”)
