### PR TITLE
Modify unreliability factors: 3D Cinema, Flying Saucers

### DIFF
--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -2871,7 +2871,7 @@ void ride_ratings_calculate_3d_cinema(Ride* ride, RideRatingUpdateState& state)
 {
     ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
     ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
-    ride->unreliability_factor = 21;
+    ride->unreliability_factor = 12;
     set_unreliability_factor(ride);
 
     // Base ratings
@@ -3832,7 +3832,7 @@ void ride_ratings_calculate_flying_saucers(Ride* ride, RideRatingUpdateState& st
 {
     ride->lifecycle_flags |= RIDE_LIFECYCLE_TESTED;
     ride->lifecycle_flags |= RIDE_LIFECYCLE_NO_RAW_STATS;
-    ride->unreliability_factor = 32;
+    ride->unreliability_factor = 17;
     set_unreliability_factor(ride);
 
     RatingTuple ratings = {


### PR DESCRIPTION
The initial unreliability factors for a couple rides seem inappropriate. The 3D Cinema's unreliability_factor is set at 21; it's tied with the Motion Simulator, and only the Enterprise (22), Roto-Drop (24), Reverse Freefall Coaster (25), LIM-launched coaster (25), and Air-powered vertical coaster (28) are higher. Based on the stats, it seems like it shouldn't really be the same as the motion simulator - it's probably just meant to be a movie theater where you wear 3D glasses. IDK if anybody tinkered with these values over time, but perhaps if so, the digits got swapped? I think 12 makes sense, if not even still too high. The Miniature Railroad is 11, the Car Ride, Mini Helicopters, River Rafts, and Ghost Train are 12, and the Junior Coaster and Dinghy Slide are 13.

There is still actually one ride with a much higher value - the Flying Saucers, at *32*. I think this is probably based on the history of the Flying Saucers ride at Disneyland in California, which opened in the 60s and was apparently notoriously hard to maintain - see https://en.wikipedia.org/wiki/Flying_Saucers_(attraction). Still, regular Dodgems comes at half of that, 16, and it's rainproof to boot, which already makes Flying Saucers feel like a somewhat pointless alternative. I proposed 17 just to make it a tad more unreliable than Dodgems because it's rain-exposed.