### PR TITLE
Make check for localisation changes more robust

### DIFF
--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Commit and push
         working-directory: OpenRCT2
         run: |
-          if [[ $(git status -s) ]]; then
+          if [[ $(git status --porcelain) ]]; then
               echo "Committing and pushing..."
               git add .
               git config --global user.name "OpenRCT2 git bot"


### PR DESCRIPTION
Use `--porcelain` instead of `--short` in `git status`. From the git manual:

> **-s**
> **--short**
> Give the output in the short-format.

> **--porcelain[=\<version>]**
> Give the output in an easy-to-parse format for scripts. This is similar to the short output, __but will remain stable across Git versions and regardless of user configuration__. See below for details.
> 
> The version parameter is used to specify the format version. This is optional and defaults to the original version v1 format.
