### PR TITLE
Add function to get all entities on a tile to plugin api

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -93,7 +93,7 @@ The following people are not part of the development team, but have been contrib
 * Keith Stellyes (keithstellyes) - Misc.
 * Bas Cantrijn (Basssiiie) - Various plugin additions, misc.
 * Adrian Zdanowicz (CookiePLMonster) - Misc.
-* Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes
+* Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes, api function to get entities on a tile
 
 ## Bug fixes
 * (KirilAngelov)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Feature: [#13858] Flatride bases can be made invisible.
 - Feature: [#14676] [Plugin] Allow plugins to store data in .park files.
 - Feature: [#15367] Individual track elements can now be drawn as another ride type.
+- Feature: [#15901] [Plugin] Add map.getAllEntitiesOnTile to API.
 - Feature: [#16029] [Plugin] Add TrackElement.rideType to API.
 - Feature: [#16097] The Looping Roller Coaster can now draw all elements from the LIM Launched Roller Coaster.
 - Feature: [#16132, #16389] The Corkscrew, Twister and Vertical Drop Roller Coasters can now draw inline twists.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -604,6 +604,15 @@ declare global {
         getAllEntities(type: "staff"): Staff[];
         getAllEntities(type: "car"): Car[];
         getAllEntities(type: "litter"): Litter[];
+        getAllEntitiesOnTile(type: EntityType, x: number, y: number): Entity[];
+        /**
+         * @deprecated since version 34, use guest or staff instead.
+         */
+        getAllEntitiesOnTile(type: "peep", x: number, y: number): Peep[];
+        getAllEntitiesOnTile(type: "guest", x: number, y: number): Guest[];
+        getAllEntitiesOnTile(type: "staff", x: number, y: number): Staff[];
+        getAllEntitiesOnTile(type: "car", x: number, y: number): Car[];
+        getAllEntitiesOnTile(type: "litter", x: number, y: number): Litter[];
         createEntity(type: EntityType, initializer: object): Entity;
     }
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -604,15 +604,11 @@ declare global {
         getAllEntities(type: "staff"): Staff[];
         getAllEntities(type: "car"): Car[];
         getAllEntities(type: "litter"): Litter[];
-        getAllEntitiesOnTile(type: EntityType, x: number, y: number): Entity[];
-        /**
-         * @deprecated since version 34, use guest or staff instead.
-         */
-        getAllEntitiesOnTile(type: "peep", x: number, y: number): Peep[];
-        getAllEntitiesOnTile(type: "guest", x: number, y: number): Guest[];
-        getAllEntitiesOnTile(type: "staff", x: number, y: number): Staff[];
-        getAllEntitiesOnTile(type: "car", x: number, y: number): Car[];
-        getAllEntitiesOnTile(type: "litter", x: number, y: number): Litter[];
+        getAllEntitiesOnTile(type: EntityType, tile: Tile): Entity[];
+        getAllEntitiesOnTile(type: "guest", tile: Tile): Guest[];
+        getAllEntitiesOnTile(type: "staff", tile: Tile): Staff[];
+        getAllEntitiesOnTile(type: "car", tile: Tile): Car[];
+        getAllEntitiesOnTile(type: "litter", tile: Tile): Litter[];
         createEntity(type: EntityType, initializer: object): Entity;
     }
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -604,11 +604,11 @@ declare global {
         getAllEntities(type: "staff"): Staff[];
         getAllEntities(type: "car"): Car[];
         getAllEntities(type: "litter"): Litter[];
-        getAllEntitiesOnTile(type: EntityType, tile: Tile): Entity[];
-        getAllEntitiesOnTile(type: "guest", tile: Tile): Guest[];
-        getAllEntitiesOnTile(type: "staff", tile: Tile): Staff[];
-        getAllEntitiesOnTile(type: "car", tile: Tile): Car[];
-        getAllEntitiesOnTile(type: "litter", tile: Tile): Litter[];
+        getAllEntitiesOnTile(type: EntityType, tilePos: CoordsXY): Entity[];
+        getAllEntitiesOnTile(type: "guest", tilePos: CoordsXY): Guest[];
+        getAllEntitiesOnTile(type: "staff", tilePos: CoordsXY): Staff[];
+        getAllEntitiesOnTile(type: "car", tilePos: CoordsXY): Car[];
+        getAllEntitiesOnTile(type: "litter", tilePos: CoordsXY): Litter[];
         createEntity(type: EntityType, initializer: object): Entity;
     }
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 48;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 49;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -167,12 +167,13 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(const std::string& type, const DukValue& tile) const
+    std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(
+        const std::string& type, const DukValue& tilePos) const
     {
         try
         {
             // Get the tile position
-            const auto pos = CoordsXY(tile["x"].as_int(), tile["y"].as_int());
+            const auto pos = CoordsXY(tilePos["x"].as_int(), tilePos["y"].as_int());
 
             // Declare a vector that will hold the result to return
             std::vector<DukValue> result;
@@ -230,8 +231,8 @@ namespace OpenRCT2::Scripting
         }
         catch (const DukException&)
         {
-            // Throw an error if an invalid Tile argument was passed
-            duk_error(_context, DUK_ERR_ERROR, "Invalid tile argument.");
+            // Throw an error if an invalid tilePos argument was passed
+            duk_error(_context, DUK_ERR_ERROR, "Invalid tilePos argument.");
         }
     }
 

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -170,70 +170,62 @@ namespace OpenRCT2::Scripting
     std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(
         const std::string& type, const DukValue& tilePos) const
     {
-        try
+        // Get the tile position
+        const auto pos = FromDuk<CoordsXY>(tilePos);
+
+        // Declare a vector that will hold the result to return
+        std::vector<DukValue> result;
+
+        // Use EntityTileList to iterate all entities of the given type on the tile, and push them to result
+        if (type == "balloon")
         {
-            // Get the tile position
-            const auto pos = CoordsXY(tilePos["x"].as_int(), tilePos["y"].as_int());
-
-            // Declare a vector that will hold the result to return
-            std::vector<DukValue> result;
-
-            // Use EntityTileList to iterate all entities of the given type on the tile, and push them to result
-            if (type == "balloon")
+            for (auto sprite : EntityTileList<Balloon>(pos))
             {
-                for (auto sprite : EntityTileList<Balloon>(pos))
-                {
-                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
-                }
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
             }
-            else if (type == "car")
-            {
-                for (auto sprite : EntityTileList<Vehicle>(pos))
-                {
-                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(sprite->sprite_index)));
-                }
-            }
-            else if (type == "litter")
-            {
-                for (auto sprite : EntityTileList<Litter>(pos))
-                {
-                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScLitter>(sprite->sprite_index)));
-                }
-            }
-            else if (type == "duck")
-            {
-                for (auto sprite : EntityTileList<Duck>(pos))
-                {
-                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
-                }
-            }
-            else if (type == "guest")
-            {
-                for (auto sprite : EntityTileList<Guest>(pos))
-                {
-                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
-                }
-            }
-            else if (type == "staff")
-            {
-                for (auto sprite : EntityTileList<Staff>(pos))
-                {
-                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
-                }
-            }
-            else
-            {
-                // If the given type isn't valid, throw an error
-                duk_error(_context, DUK_ERR_ERROR, "Invalid entity type: %s", type.c_str());
-            }
-
-            return result;
         }
-        catch (const DukException&)
+        else if (type == "car")
         {
-            // Throw an error if an invalid tilePos argument was passed
-            duk_error(_context, DUK_ERR_ERROR, "Invalid tilePos argument.");
+            for (auto sprite : EntityTileList<Vehicle>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(sprite->sprite_index)));
+            }
         }
+        else if (type == "litter")
+        {
+            for (auto sprite : EntityTileList<Litter>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScLitter>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "duck")
+        {
+            for (auto sprite : EntityTileList<Duck>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "guest")
+        {
+            for (auto sprite : EntityTileList<Guest>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "staff")
+        {
+            for (auto sprite : EntityTileList<Staff>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
+            }
+        }
+        else
+        {
+            // If the given type isn't valid, throw an error
+            duk_error(_context, DUK_ERR_ERROR, "Invalid entity type: %s", type.c_str());
+        }
+
+        return result;
     }
 
     template<typename TEntityType, typename TScriptType>

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -185,7 +185,6 @@ namespace OpenRCT2::Scripting
             {
                 result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(sprite->sprite_index)));
             }
-            
         }
         else if (type == "litter")
         {

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -167,6 +167,73 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
+    std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(const std::string& type, int32_t x, int32_t y) const
+    {
+        const auto pos = CoordsXY(x, y);
+
+        std::vector<DukValue> result;
+        if (type == "balloon")
+        {
+            for (auto sprite : EntityTileList<Balloon>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "car")
+        {
+            for (auto sprite : EntityTileList<Vehicle>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(sprite->sprite_index)));
+            }
+            
+        }
+        else if (type == "litter")
+        {
+            for (auto sprite : EntityTileList<Litter>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScLitter>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "duck")
+        {
+            for (auto sprite : EntityTileList<Duck>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "peep")
+        {
+            for (auto sprite : EntityTileList<Guest>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
+            }
+            for (auto sprite : EntityTileList<Staff>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "guest")
+        {
+            for (auto sprite : EntityTileList<Guest>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
+            }
+        }
+        else if (type == "staff")
+        {
+            for (auto sprite : EntityTileList<Staff>(pos))
+            {
+                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
+            }
+        }
+        else
+        {
+            duk_error(_context, DUK_ERR_ERROR, "Invalid entity type.");
+        }
+
+        return result;
+    }
+
     template<typename TEntityType, typename TScriptType>
     DukValue createEntityType(duk_context* ctx, const DukValue& initializer)
     {
@@ -252,6 +319,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_method(ctx, &ScMap::getTile, "getTile");
         dukglue_register_method(ctx, &ScMap::getEntity, "getEntity");
         dukglue_register_method(ctx, &ScMap::getAllEntities, "getAllEntities");
+        dukglue_register_method(ctx, &ScMap::getAllEntitiesOnTile, "getAllEntitiesOnTile");
         dukglue_register_method(ctx, &ScMap::createEntity, "createEntity");
     }
 

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -167,70 +167,72 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(const std::string& type, int32_t x, int32_t y) const
+    std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(const std::string& type, const DukValue& tile) const
     {
-        const auto pos = CoordsXY(x, y);
+        try
+        {
+            // Get the tile position
+            const auto pos = CoordsXY(tile["x"].as_int(), tile["y"].as_int());
 
-        std::vector<DukValue> result;
-        if (type == "balloon")
-        {
-            for (auto sprite : EntityTileList<Balloon>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
-            }
-        }
-        else if (type == "car")
-        {
-            for (auto sprite : EntityTileList<Vehicle>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(sprite->sprite_index)));
-            }
-        }
-        else if (type == "litter")
-        {
-            for (auto sprite : EntityTileList<Litter>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScLitter>(sprite->sprite_index)));
-            }
-        }
-        else if (type == "duck")
-        {
-            for (auto sprite : EntityTileList<Duck>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
-            }
-        }
-        else if (type == "peep")
-        {
-            for (auto sprite : EntityTileList<Guest>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
-            }
-            for (auto sprite : EntityTileList<Staff>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
-            }
-        }
-        else if (type == "guest")
-        {
-            for (auto sprite : EntityTileList<Guest>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
-            }
-        }
-        else if (type == "staff")
-        {
-            for (auto sprite : EntityTileList<Staff>(pos))
-            {
-                result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
-            }
-        }
-        else
-        {
-            duk_error(_context, DUK_ERR_ERROR, "Invalid entity type.");
-        }
+            // Declare a vector that will hold the result to return
+            std::vector<DukValue> result;
 
-        return result;
+            // Use EntityTileList to iterate all entities of the given type on the tile, and push them to result
+            if (type == "balloon")
+            {
+                for (auto sprite : EntityTileList<Balloon>(pos))
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
+                }
+            }
+            else if (type == "car")
+            {
+                for (auto sprite : EntityTileList<Vehicle>(pos))
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScVehicle>(sprite->sprite_index)));
+                }
+            }
+            else if (type == "litter")
+            {
+                for (auto sprite : EntityTileList<Litter>(pos))
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScLitter>(sprite->sprite_index)));
+                }
+            }
+            else if (type == "duck")
+            {
+                for (auto sprite : EntityTileList<Duck>(pos))
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScEntity>(sprite->sprite_index)));
+                }
+            }
+            else if (type == "guest")
+            {
+                for (auto sprite : EntityTileList<Guest>(pos))
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScGuest>(sprite->sprite_index)));
+                }
+            }
+            else if (type == "staff")
+            {
+                for (auto sprite : EntityTileList<Staff>(pos))
+                {
+                    result.push_back(GetObjectAsDukValue(_context, std::make_shared<ScStaff>(sprite->sprite_index)));
+                }
+            }
+            else
+            {
+                // If the given type isn't valid, throw an error
+                duk_error(_context, DUK_ERR_ERROR, "Invalid entity type: %s", type.c_str());
+            }
+
+            return result;
+        }
+        catch (const DukException&)
+        {
+            // Throw an error if an invalid Tile argument was passed
+            duk_error(_context, DUK_ERR_ERROR, "Invalid tile argument.");
+        }
     }
 
     template<typename TEntityType, typename TScriptType>

--- a/src/openrct2/scripting/bindings/world/ScMap.hpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.hpp
@@ -42,6 +42,8 @@ namespace OpenRCT2::Scripting
 
         std::vector<DukValue> getAllEntities(const std::string& type) const;
 
+        std::vector<DukValue> getAllEntitiesOnTile(const std::string& type, int32_t x, int32_t y) const;
+
         DukValue createEntity(const std::string& type, const DukValue& initializer);
 
         static void Register(duk_context* ctx);

--- a/src/openrct2/scripting/bindings/world/ScMap.hpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.hpp
@@ -42,7 +42,7 @@ namespace OpenRCT2::Scripting
 
         std::vector<DukValue> getAllEntities(const std::string& type) const;
 
-        std::vector<DukValue> getAllEntitiesOnTile(const std::string& type, int32_t x, int32_t y) const;
+        std::vector<DukValue> getAllEntitiesOnTile(const std::string& type, const DukValue& tile) const;
 
         DukValue createEntity(const std::string& type, const DukValue& initializer);
 

--- a/src/openrct2/scripting/bindings/world/ScMap.hpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.hpp
@@ -42,7 +42,7 @@ namespace OpenRCT2::Scripting
 
         std::vector<DukValue> getAllEntities(const std::string& type) const;
 
-        std::vector<DukValue> getAllEntitiesOnTile(const std::string& type, const DukValue& tile) const;
+        std::vector<DukValue> getAllEntitiesOnTile(const std::string& type, const DukValue& tilePos) const;
 
         DukValue createEntity(const std::string& type, const DukValue& initializer);
 


### PR DESCRIPTION
Add function map.getAllEntitiesOnTile() to api

- This was made to allow getting entities on a tile without the need to manually iterate over all entities of a given type, such as the value returned by getAllEntities()
- getAllEntitiesOnTile() was made to closely resemble the already existing getAllEntities()
- In general tems, getAllEntitiesOnTile() is to EntityTileList<T> as getAllEntities() is to EntityList<T>
- Currently, the tile position is taken in as two integer parameters that are then used to construct a CoordsXY object. This could be changed to take a single CoordsXY parameter instead, if that would be better
- I appended `, api function to get entities on a tile` to my name in contributors.md, I can change how it's worded or remove that change entirely if it's not necessary