### PR TITLE
Remove support for vendored gtest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           - platform: x86_64
             distro: bionic
             image: openrct2/openrct2-build:4-bionic
-            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz" -DWITH_TESTS=off
           - platform: x86_64
             distro: focal
             image: openrct2/openrct2-build:5-focal
@@ -260,7 +260,7 @@ jobs:
           - platform: i686
             distro: bionic
             image: openrct2/openrct2-build:4-bionic32
-            build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g -gz"
+            build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g -gz" -DWITH_TESTS=off
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
         include:
           - platform: x86_64
             distro: bionic
-            image: openrct2/openrct2-build:0.3.1-bionic
+            image: openrct2/openrct2-build:4-bionic
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
           - platform: x86_64
             distro: focal
@@ -259,7 +259,7 @@ jobs:
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
           - platform: i686
             distro: bionic
-            image: openrct2/openrct2-build:0.3.1-bionic32
+            image: openrct2/openrct2-build:4-bionic32
             build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g -gz"
     steps:
       - name: Checkout

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -1,68 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 
-option(SYSTEM_GTEST "Use the googletest library provided by the system.")
+find_package(GTest REQUIRED)
 
-if (SYSTEM_GTEST)
-    find_package(GTest REQUIRED)
-
-    set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
-
-    message(WARNING "Gtest strongly advices against using a system installation, see https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#why-is-it-not-recommended-to-install-a-pre-compiled-copy-of-google-test-for-example-into-usrlocal for detailed information. If errors occur please double-check without the SYSTEM_GTEST flag.")
-else (SYSTEM_GTEST)
-
-        # Bootstrap GoogleTest
-        INCLUDE(ExternalProject)
-
-        ExternalProject_Add(
-                googletest-distribution
-                URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.tar.gz # v1.11.0 release
-                URL_HASH SHA1=b0399e38211cc4fedd612f71bad7984ed4cbe8fe
-                TIMEOUT 10
-                CONFIGURE_COMMAND ""
-                BUILD_COMMAND ""
-                INSTALL_COMMAND ""
-        )
-
-        # Specify include dir
-        ExternalProject_Get_Property(googletest-distribution SOURCE_DIR)
-        set(GOOGLETEST_DISTRIB_SOURCE_DIR "${SOURCE_DIR}")
-
-        ExternalProject_Add(
-                googletest
-                DEPENDS googletest-distribution
-                DOWNLOAD_COMMAND ""
-                SOURCE_DIR "${GOOGLETEST_DISTRIB_SOURCE_DIR}"
-                CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${TARGET_M} -DBUILD_GMOCK=off"
-                BUILD_BYPRODUCTS "googletest-prefix/src/googletest-build/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-                BUILD_BYPRODUCTS "googletest-prefix/src/googletest-build/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-                # Disable install step
-                INSTALL_COMMAND ""
-                # Wrap download, configure and build steps in a script to log output
-                LOG_DOWNLOAD ON
-                LOG_CONFIGURE ON
-                LOG_BUILD ON)
-
-
-        # Specify include dir
-        set(GTEST_INCLUDE_DIRS ${GOOGLETEST_DISTRIB_SOURCE_DIR}/googletest/include)
-
-        # Library
-        ExternalProject_Get_Property(googletest BINARY_DIR)
-        set(GOOGLETEST_BINARY_DIR "${BINARY_DIR}/lib")
-        set(GTEST_LIBRARY_PATH ${GOOGLETEST_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})
-        set(GTEST_MAIN_LIBRARY_PATH ${GOOGLETEST_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX})
-        set(GTEST_LIBRARY gtest)
-        set(GTEST_MAIN_LIBRARY gtest_main)
-        add_library(${GTEST_LIBRARY} STATIC IMPORTED)
-        add_library(${GTEST_MAIN_LIBRARY} STATIC IMPORTED)
-        set_property(TARGET ${GTEST_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_LIBRARY_PATH})
-        set_property(TARGET ${GTEST_MAIN_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_MAIN_LIBRARY_PATH})
-        add_dependencies(${GTEST_LIBRARY} googletest)
-        add_dependencies(${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
-
-        set(GTEST_LIBRARIES gtest gtest_main pthread)
-
-endif (SYSTEM_GTEST)
+set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
 
 include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 include_directories("${ROOT_DIR}/src")


### PR DESCRIPTION
Originally implemented only to satisfy the (somewhat dubious) claim of
gtest about the necessity to provide your own copy. The original claim
got removed here:
https://github.com/google/googletest/commit/5437926b2213b1c45c2f34bd858734de90e5fffd