### PR TITLE
Fix #15138: Sometimes small scenery stays when building through it

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#12869] The Tile Inspector window’s layout has been tweaked slightly.
 - Change: [#15899] Weird bonus for path 0 - likely intended as a queue bonus (original bug).
+- Fix: [#15138] Sometimes small scenery stays when building through it.
 - Fix: [#15620] Placing track designs at locations blocked by anything results in wrong error message.
 - Fix: [#15843] Tile Inspector can be resized too small.
 - Fix: [#15844] Tile Inspector has inconsistent text colours.

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -71,18 +71,19 @@ int32_t map_place_non_scenery_clear_func(TileElement** tile_element, const Coord
 }
 
 static bool MapLoc68BABCShouldContinue(
-    TileElement* tileElement, const CoordsXYRangedZ& pos, CLEAR_FUNC clearFunc, uint8_t flags, money32& price,
+    TileElement** tileElementPtr, const CoordsXYRangedZ& pos, CLEAR_FUNC clearFunc, uint8_t flags, money32& price,
     uint8_t crossingMode, bool canBuildCrossing)
 {
     if (clearFunc != nullptr)
     {
-        if (!clearFunc(&tileElement, pos, flags, &price))
+        if (!clearFunc(tileElementPtr, pos, flags, &price))
         {
             return true;
         }
     }
 
     // Crossing mode 1: building track over path
+    auto tileElement = *tileElementPtr;
     if (crossingMode == 1 && canBuildCrossing && tileElement->GetType() == TILE_ELEMENT_TYPE_PATH
         && tileElement->GetBaseZ() == pos.baseZ && !tileElement->AsPath()->IsQueue() && !tileElement->AsPath()->IsSloped())
     {
@@ -153,7 +154,7 @@ GameActions::Result::Ptr MapCanConstructWithClearAt(
                 if (tileElement->GetOccupiedQuadrants() & (quarterTile.GetBaseQuarterOccupied()))
                 {
                     if (MapLoc68BABCShouldContinue(
-                            tileElement, pos, clearFunc, flags, res->Cost, crossingMode, canBuildCrossing))
+                            &tileElement, pos, clearFunc, flags, res->Cost, crossingMode, canBuildCrossing))
                     {
                         continue;
                     }
@@ -250,7 +251,7 @@ GameActions::Result::Ptr MapCanConstructWithClearAt(
                     continue;
                 }
 
-                if (MapLoc68BABCShouldContinue(tileElement, pos, clearFunc, flags, res->Cost, crossingMode, canBuildCrossing))
+                if (MapLoc68BABCShouldContinue(&tileElement, pos, clearFunc, flags, res->Cost, crossingMode, canBuildCrossing))
                 {
                     continue;
                 }


### PR DESCRIPTION
This happened because the tile element pointer that was passed to the `map_place_clear_func` function was a copy. The function decreases the pointer after deletion, however, since the pointer was passed as a copy, the iterating loop skipped over the next element on the tile.

This can be tested by stacking small blocks or building quarter-tile scenery pieces on the same tile, then building a path through it.