### PR TITLE
Fix: Track designs of some ride types incorrectly exported to TD6

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#15878] Crash when opening a ride window for a corrupted vehicle.
 - Fix: [#15908] Crash when track elements have no ride assigned.
 - Fix: [#15919] Research status incorrectly considered for scenery when in editor modes.
+- Fix: Track designs of some coaster types are incorrectly exported to TD6.
 
 0.3.5 (2021-11-06)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,7 +9,7 @@
 - Fix: [#15878] Crash when opening a ride window for a corrupted vehicle.
 - Fix: [#15908] Crash when track elements have no ride assigned.
 - Fix: [#15919] Research status incorrectly considered for scenery when in editor modes.
-- Fix: Track designs of some coaster types are incorrectly exported to TD6.
+- Fix: [#15938] Track designs of some ride types are incorrectly exported to TD6.
 
 0.3.5 (2021-11-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -48,7 +48,7 @@ bool T6Exporter::SaveTrack(const utf8* path)
 bool T6Exporter::SaveTrack(OpenRCT2::IStream* stream)
 {
     OpenRCT2::MemoryStream tempStream;
-    tempStream.WriteValue<uint8_t>(_trackDesign->type);
+    tempStream.WriteValue<uint8_t>(OpenRCT2RideTypeToRCT2RideType(_trackDesign->type));
     tempStream.WriteValue<uint8_t>(_trackDesign->vehicle_type);
     tempStream.WriteValue<uint32_t>(_trackDesign->flags);
     tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign->ride_mode));


### PR DESCRIPTION
This bug caused the following ride types not to export correctly:

- RIDE_TYPE_HYPERCOASTER
- RIDE_TYPE_CLASSIC_MINI_ROLLER_COASTER
- RIDE_TYPE_MONSTER_TRUCKS
- RIDE_TYPE_HYPER_TWISTER
- RIDE_TYPE_SPINNING_WILD_MOUSE