### PR TITLE
Fix: Old file extension is used for save_park and autosave

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -180,6 +180,7 @@ The following people are not part of the development team, but have been contrib
 * Soham Roy (sohamroy19)
 * Gaven Rendell (Rendello)
 * Christian Haase (chrhaase)
+* Cory Sanin (CorySanin)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -619,7 +619,7 @@ void save_game_cmd(const utf8* name /* = nullptr */)
         char savePath[MAX_PATH];
         platform_get_user_directory(savePath, "save", sizeof(savePath));
         safe_strcat_path(savePath, name, sizeof(savePath));
-        path_append_extension(savePath, ".sv6", sizeof(savePath));
+        path_append_extension(savePath, ".park", sizeof(savePath));
         save_game_with_name(savePath);
     }
 }
@@ -662,7 +662,7 @@ static void limit_autosave_count(const size_t numberOfFilesToKeep, bool processL
 
     auto environment = GetContext()->GetPlatformEnvironment();
     auto folderDirectory = environment->GetDirectoryPath(DIRBASE::USER, DIRID::SAVE);
-    char const* fileFilter = "autosave_*.sv6";
+    char const* fileFilter = "autosave_*.park";
     if (processLandscapeFolder)
     {
         folderDirectory = environment->GetDirectoryPath(DIRBASE::USER, DIRID::LANDSCAPE);
@@ -723,7 +723,7 @@ static void limit_autosave_count(const size_t numberOfFilesToKeep, bool processL
 void game_autosave()
 {
     const char* subDirectory = "save";
-    const char* fileExtension = ".sv6";
+    const char* fileExtension = ".park";
     uint32_t saveFlags = 0x80000000;
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -134,7 +134,7 @@ void scenario_begin()
     char savePath[MAX_PATH];
     platform_get_user_directory(savePath, "save", sizeof(savePath));
     safe_strcat_path(savePath, park.Name.c_str(), sizeof(savePath));
-    path_append_extension(savePath, ".sv6", sizeof(savePath));
+    path_append_extension(savePath, ".park", sizeof(savePath));
     gScenarioSavePath = savePath;
 
     gCurrentExpenditure = 0;


### PR DESCRIPTION
Use correct file extension when saving from the console or when performing an autosave. Otherwise PARK files are generated with the old sv6 extension. I don't believe a changelog entry is necessary since the "headline feature" pretty much covers it for the next release.