### PR TITLE
Fix BannerSetStyleAction having wrong type in constructor

### DIFF
--- a/src/openrct2/actions/BannerSetStyleAction.cpp
+++ b/src/openrct2/actions/BannerSetStyleAction.cpp
@@ -16,7 +16,7 @@
 #include "../world/Banner.h"
 #include "GameAction.h"
 
-BannerSetStyleAction::BannerSetStyleAction(BannerSetStyleType type, uint8_t bannerIndex, uint8_t parameter)
+BannerSetStyleAction::BannerSetStyleAction(BannerSetStyleType type, BannerIndex bannerIndex, uint8_t parameter)
     : _type(type)
     , _bannerIndex(bannerIndex)
     , _parameter(parameter)

--- a/src/openrct2/actions/BannerSetStyleAction.h
+++ b/src/openrct2/actions/BannerSetStyleAction.h
@@ -30,7 +30,7 @@ private:
 
 public:
     BannerSetStyleAction() = default;
-    BannerSetStyleAction(BannerSetStyleType type, uint8_t bannerIndex, uint8_t parameter);
+    BannerSetStyleAction(BannerSetStyleType type, BannerIndex bannerIndex, uint8_t parameter);
 
     void AcceptParameters(GameActionParameterVisitor& visitor) override;
 


### PR DESCRIPTION
Would bug out if the banner index is above 0xFF