### PR TITLE
Replicate vanilla RCT logic when guests heading for ride

### DIFF
--- a/src/openrct2/peep/Guest.cpp
+++ b/src/openrct2/peep/Guest.cpp
@@ -2048,59 +2048,15 @@ bool Guest::ShouldGoOnRide(Ride* ride, int32_t entranceNum, bool atQueue, bool t
                         return false;
                     }
                 }
-
-                // Peeps won't go on rides that aren't sufficiently undercover while it's raining.
-                // The threshold is fairly low and only requires about 10-15% of the ride to be undercover.
-                if (climate_is_raining() && (ride->sheltered_eighths) < 3)
+                else
                 {
-                    if (peepAtRide)
-                    {
-                        InsertNewThought(PeepThoughtType::NotWhileRaining, ride->id);
-                        if (HappinessTarget >= 64)
-                        {
-                            HappinessTarget -= 8;
-                        }
-                        ride_update_popularity(ride, 0);
-                    }
-                    ChoseNotToGoOnRide(ride, peepAtRide, true);
-                    return false;
-                }
-
-                if (!gCheatsIgnoreRideIntensity)
-                {
-                    // Intensity calculations. Even though the max intensity can go up to 15, it's capped
-                    // at 10.0 (before happiness calculations). A full happiness bar will increase the max
-                    // intensity and decrease the min intensity by about 2.5.
-                    ride_rating maxIntensity = std::min(Intensity.GetMaximum() * 100, 1000) + Happiness;
-                    ride_rating minIntensity = (Intensity.GetMinimum() * 100) - Happiness;
-                    if (ride->intensity < minIntensity)
+                    // Peeps won't go on rides that aren't sufficiently undercover while it's raining.
+                    // The threshold is fairly low and only requires about 10-15% of the ride to be undercover.
+                    if (climate_is_raining() && (ride->sheltered_eighths) < 3)
                     {
                         if (peepAtRide)
                         {
-                            InsertNewThought(PeepThoughtType::MoreThrilling, ride->id);
-                            if (HappinessTarget >= 64)
-                            {
-                                HappinessTarget -= 8;
-                            }
-                            ride_update_popularity(ride, 0);
-                        }
-                        ChoseNotToGoOnRide(ride, peepAtRide, true);
-                        return false;
-                    }
-                    if (ride->intensity > maxIntensity)
-                    {
-                        peep_ride_is_too_intense(this, ride, peepAtRide);
-                        return false;
-                    }
-
-                    // Nausea calculations.
-                    ride_rating maxNausea = NauseaMaximumThresholds[(EnumValue(NauseaTolerance) & 3)] + Happiness;
-
-                    if (ride->nausea > maxNausea)
-                    {
-                        if (peepAtRide)
-                        {
-                            InsertNewThought(PeepThoughtType::Sickening, ride->id);
+                            InsertNewThought(PeepThoughtType::NotWhileRaining, ride->id);
                             if (HappinessTarget >= 64)
                             {
                                 HappinessTarget -= 8;
@@ -2111,15 +2067,60 @@ bool Guest::ShouldGoOnRide(Ride* ride, int32_t entranceNum, bool atQueue, bool t
                         return false;
                     }
 
-                    // Very nauseous peeps will only go on very gentle rides.
-                    if (ride->nausea >= FIXED_2DP(1, 40) && Nausea > 160)
+                    if (!gCheatsIgnoreRideIntensity)
                     {
-                        ChoseNotToGoOnRide(ride, peepAtRide, false);
-                        return false;
+                        // Intensity calculations. Even though the max intensity can go up to 15, it's capped
+                        // at 10.0 (before happiness calculations). A full happiness bar will increase the max
+                        // intensity and decrease the min intensity by about 2.5.
+                        ride_rating maxIntensity = std::min(Intensity.GetMaximum() * 100, 1000) + Happiness;
+                        ride_rating minIntensity = (Intensity.GetMinimum() * 100) - Happiness;
+                        if (ride->intensity < minIntensity)
+                        {
+                            if (peepAtRide)
+                            {
+                                InsertNewThought(PeepThoughtType::MoreThrilling, ride->id);
+                                if (HappinessTarget >= 64)
+                                {
+                                    HappinessTarget -= 8;
+                                }
+                                ride_update_popularity(ride, 0);
+                            }
+                            ChoseNotToGoOnRide(ride, peepAtRide, true);
+                            return false;
+                        }
+                        if (ride->intensity > maxIntensity)
+                        {
+                            peep_ride_is_too_intense(this, ride, peepAtRide);
+                            return false;
+                        }
+
+                        // Nausea calculations.
+                        ride_rating maxNausea = NauseaMaximumThresholds[(EnumValue(NauseaTolerance) & 3)] + Happiness;
+
+                        if (ride->nausea > maxNausea)
+                        {
+                            if (peepAtRide)
+                            {
+                                InsertNewThought(PeepThoughtType::Sickening, ride->id);
+                                if (HappinessTarget >= 64)
+                                {
+                                    HappinessTarget -= 8;
+                                }
+                                ride_update_popularity(ride, 0);
+                            }
+                            ChoseNotToGoOnRide(ride, peepAtRide, true);
+                            return false;
+                        }
+
+                        // Very nauseous peeps will only go on very gentle rides.
+                        if (ride->nausea >= FIXED_2DP(1, 40) && Nausea > 160)
+                        {
+                            ChoseNotToGoOnRide(ride, peepAtRide, false);
+                            return false;
+                        }
                     }
                 }
             }
-
             // If the ride has not yet been rated and is capable of having g-forces,
             // there's a 90% chance that the peep will ignore it.
             if (!ride_has_ratings(ride) && ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_PEEP_CHECK_GFORCES))


### PR DESCRIPTION
Replacement for pr #15935, which I accidentally deleted while VS was going nuts. See discussion at #15903. Ensures guests deciding whether or not to ride a ride only perform standard weather, intensity, and nausea checks if they weren't already specifically heading for a ride.