### PR TITLE
Fix #15974 Cannot download object from server

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -40,7 +40,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;
@@ -2505,13 +2505,6 @@ void NetworkBase::Server_Handle_MAPREQUEST(NetworkConnection& connection, Networ
     auto& repo = GetContext().GetObjectRepository();
     for (uint32_t i = 0; i < size; i++)
     {
-        const char* name = reinterpret_cast<const char*>(packet.Read(8));
-        if (name == nullptr)
-        {
-            log_error("Client sent malformed object request data %s", connection.Socket->GetHostName());
-            return;
-        }
-
         uint8_t generation{};
         packet >> generation;
 


### PR DESCRIPTION
Due to some leftover code from NSF rebase, server will parse MAPREQUEST incorrectly. so client will fail to download objects.