### PR TITLE
Fix clang-tidy renaming mistake from #15956

### DIFF
--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -589,7 +589,7 @@ static void WindowMapScrollmousedown(rct_window* w, int32_t scrollIndex, const S
         window_scroll_to_location(mainWindow, { mapCoords, mapZ });
     }
 
-    if (scenery_tool_is_active())
+    if (LandToolIsActive())
     {
         // Set land terrain
         int32_t landToolSize = std::max<int32_t>(1, gLandToolSize);


### PR DESCRIPTION
I'm confident that this is the only remaining mistake. I went through these steps to find all cases.

- Copy full diff to one file. Make it all lowercase and remove underscores, since then the function identifiers look the same.
- Remove all:
	• `^[^+-].*\r\n` (all lines not starting with `-` or `+`)
	• `^(---|\+\+\+).*$\r\n` (lines starting with `---` or `+++`)
- Duplicate result to new file (so we have one file for removed lines and one for added lines), then run either regexes on one of them:
	• `^-.*\r\n` (all lines starting with `-`)
	• `^\+.*\r\n` (all lines starting with `+`)
- Remove the starting `-` or `+` on each line (use multi-line select), then compare the two files to find irregularities.

Since this removes all underscores and make everything lowercase, it may fail to find cases where different functions result in the same name. I don't think there were any such cases, or they would've caused collisions already.

The only other irregularity was a newline.