### PR TITLE
Fix #15981. Staff Id causing beta park file failures

### DIFF
--- a/src/openrct2/ParkFile.cpp
+++ b/src/openrct2/ParkFile.cpp
@@ -2031,7 +2031,7 @@ namespace OpenRCT2
         cs.ReadWrite(entity.AssignedStaffType);
         cs.ReadWrite(entity.MechanicTimeSinceCall);
         cs.ReadWrite(entity.HireDate);
-        if (os.GetHeader().TargetVersion <= 2)
+        if (os.GetHeader().TargetVersion <= 4)
         {
             cs.Ignore<uint8_t>();
         }


### PR DESCRIPTION
I made a mistake when rebasing thinking the staff id had been removed much earlier (version 2). When it had really been there up until version 5. Unfortunately version 5 was when I removed the field. There is possibly version 5 saves that contain the staff id with no way to accurately know which ones they are.