### PR TITLE
[Plugin] Micro fix: nullability of TileSelection.range

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2117,7 +2117,7 @@ declare global {
     }
 
     interface TileSelection {
-        range: MapRange;
+        range: MapRange | null;
         tiles: CoordsXY[];
     }
 


### PR DESCRIPTION
Hey, in openrct2.d.ts the [TileSelection.range](https://github.com/OpenRCT2/OpenRCT2/blob/fccd298d2f189d9884f7389f23009519a4cf61b7/distribution/openrct2.d.ts#L2120) property is denoted as type `MapRange` but should actually be `MapRange | null` because both the setter and getter support `null`.

See:
- [range_get](https://github.com/OpenRCT2/OpenRCT2/blob/fccd298d2f189d9884f7389f23009519a4cf61b7/src/openrct2-ui/scripting/ScTileSelection.hpp#L49): returns `null` if nothing is selected.
- [range_set](https://github.com/OpenRCT2/OpenRCT2/blob/fccd298d2f189d9884f7389f23009519a4cf61b7/src/openrct2-ui/scripting/ScTileSelection.hpp#L71): disables the current selection if set to `null`.

A plugin increment should not be necessary as the API itself does not change.

Thanks for your time!