### PR TITLE
Use vector for entity lists

### DIFF
--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -45,7 +45,7 @@ union Entity
 };
 
 static Entity _entities[MAX_ENTITIES]{};
-static std::array<std::list<uint16_t>, EnumValue(EntityType::Count)> gEntityLists;
+static std::array<std::vector<uint16_t>, EnumValue(EntityType::Count)> gEntityLists;
 static std::vector<uint16_t> _freeIdList;
 
 static bool _entityFlashingList[MAX_ENTITIES];
@@ -153,7 +153,7 @@ static void ResetFreeIds()
     std::iota(std::rbegin(_freeIdList), std::rend(_freeIdList), 0);
 }
 
-const std::list<uint16_t>& GetEntityList(const EntityType id)
+const std::vector<uint16_t>& GetEntityList(const EntityType id)
 {
     return gEntityLists[EnumValue(id)];
 }

--- a/src/openrct2/ride/TrainManager.cpp
+++ b/src/openrct2/ride/TrainManager.cpp
@@ -19,9 +19,14 @@ namespace TrainManager
     {
         Entity = nullptr;
 
-        while (iter != end && Entity == nullptr)
+        while (index >= 0 && Entity == nullptr)
         {
-            Entity = GetEntity<Vehicle>(*iter++);
+            if (index >= vec->size())
+            {
+                // This can happen if multiple entities were removed at once.
+                continue;
+            }
+            Entity = GetEntity<Vehicle>((*vec)[index--]);
             if (Entity != nullptr && !Entity->IsHead())
             {
                 Entity = nullptr;

--- a/src/openrct2/ride/TrainManager.h
+++ b/src/openrct2/ride/TrainManager.h
@@ -8,7 +8,7 @@
  *****************************************************************************/
 #pragma once
 #include <cstdint>
-#include <list>
+#include <vector>
 
 struct Vehicle;
 
@@ -18,19 +18,20 @@ namespace TrainManager
     class View
     {
     private:
-        const std::list<uint16_t>* vec;
+        const std::vector<uint16_t>* vec;
 
         class Iterator
         {
         private:
-            std::list<uint16_t>::const_iterator iter;
-            std::list<uint16_t>::const_iterator end;
+            const std::vector<uint16_t>* vec{};
+            int32_t index{};
             Vehicle* Entity = nullptr;
 
         public:
-            Iterator(std::list<uint16_t>::const_iterator _iter, std::list<uint16_t>::const_iterator _end)
-                : iter(_iter)
-                , end(_end)
+            Iterator() = default;
+            Iterator(const std::vector<uint16_t>* v, int32_t startIndex)
+                : vec(v)
+                , index{ startIndex }
             {
                 ++(*this);
             }
@@ -67,11 +68,14 @@ namespace TrainManager
 
         Iterator begin()
         {
-            return Iterator(std::cbegin(*vec), std::cend(*vec));
+            if (vec->empty())
+                return end();
+
+            return Iterator(vec, static_cast<int32_t>(vec->size()) - 1);
         }
         Iterator end()
         {
-            return Iterator(std::cend(*vec), std::cend(*vec));
+            return Iterator();
         }
     };
 } // namespace TrainManager


### PR DESCRIPTION
develop:
```openrct2 benchsimulate parks/bpb.sv6
11/27/21 18:15:56
Run on (12 X 3696 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 262K (x6)
  L3 Unified 12582K (x1)
------------------------------------------------------------------------
Benchmark              Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------
baseline            4342 ns         4395 ns       160000 ClimateAcc_ms=0 DateAcc_ms=0 GameActionsAcc_ms=0 MapAnimationAcc_ms=0 MapPathWideFlagsAcc_ms=0 MapRestoreProvisionalElementsAcc_ms=0 MapStashProvisionalElementsAcc_ms=0 MapTilesAcc_ms=0 MiscAcc_ms=0 NetworkFlushAcc_ms=0 NetworkUpdateAcc_ms=0 NewsAcc_ms=0 ParkAcc_ms=0 PeepAcc_ms=0 ResearchAcc_ms=0 RideAcc_ms=0 RideMeasurmentsAcc_ms=0 RideRatingsAcc_ms=0 ScenarioAcc_ms=0 ScriptsAcc_ms=0 SoundsAcc_ms=0 VehicleAcc_ms=0 items_per_second=227.556k/s
parks/bpb.sv6     654494 ns       655692 ns         1120 ClimateAcc_ms=0 DateAcc_ms=0 GameActionsAcc_ms=64 MapAnimationAcc_ms=64 MapPathWideFlagsAcc_ms=0 MapRestoreProvisionalElementsAcc_ms=49 MapStashProvisionalElementsAcc_ms=0 MapTilesAcc_ms=0 MiscAcc_ms=60 NetworkFlushAcc_ms=64 NetworkUpdateAcc_ms=0 NewsAcc_ms=64 ParkAcc_ms=64 PeepAcc_ms=49 ResearchAcc_ms=64 RideAcc_ms=64 RideMeasurmentsAcc_ms=64 RideRatingsAcc_ms=64 ScenarioAcc_ms=0 ScriptsAcc_ms=64 SoundsAcc_ms=64 VehicleAcc_ms=60 items_per_second=1.52511k/s
```

PR:
```
openrct2 benchsimulate parks/bpb.sv6
11/27/21 22:18:49
Run on (12 X 3696 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 262K (x6)
  L3 Unified 12582K (x1)
------------------------------------------------------------------------
Benchmark              Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------
baseline            4463 ns         4450 ns       154483 ClimateAcc_ms=0 DateAcc_ms=0 GameActionsAcc_ms=0 MapAnimationAcc_ms=0 MapPathWideFlagsAcc_ms=0 MapRestoreProvisionalElementsAcc_ms=0 MapStashProvisionalElementsAcc_ms=0 MapTilesAcc_ms=0 MiscAcc_ms=0 NetworkFlushAcc_ms=0 NetworkUpdateAcc_ms=0 NewsAcc_ms=0 ParkAcc_ms=0 PeepAcc_ms=0 ResearchAcc_ms=0 RideAcc_ms=0 RideMeasurmentsAcc_ms=0 RideRatingsAcc_ms=0 ScenarioAcc_ms=0 ScriptsAcc_ms=0 SoundsAcc_ms=0 VehicleAcc_ms=0 items_per_second=224.703k/s
parks/bpb.sv6     391848 ns       392369 ns         1792 ClimateAcc_ms=0 DateAcc_ms=0 GameActionsAcc_ms=2 MapAnimationAcc_ms=2 MapPathWideFlagsAcc_ms=0 MapRestoreProvisionalElementsAcc_ms=1 MapStashProvisionalElementsAcc_ms=0 MapTilesAcc_ms=0 MiscAcc_ms=2 NetworkFlushAcc_ms=2 NetworkUpdateAcc_ms=0 NewsAcc_ms=2 ParkAcc_ms=2 PeepAcc_ms=1 ResearchAcc_ms=2 RideAcc_ms=2 RideMeasurmentsAcc_ms=2 RideRatingsAcc_ms=2 ScenarioAcc_ms=0 ScriptsAcc_ms=2 SoundsAcc_ms=2 VehicleAcc_ms=2 items_per_second=2.54862k/s
```

40% gain.