### PR TITLE
Refactor vehicle_colour

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -178,9 +178,9 @@ enum {
     WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN,
     WIDX_VEHICLE_COLOUR_INDEX,
     WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN,
-    WIDX_VEHICLE_MAIN_COLOUR,
-    WIDX_VEHICLE_ADDITIONAL_COLOUR_1,
-    WIDX_VEHICLE_ADDITIONAL_COLOUR_2,
+    WIDX_VEHICLE_BODY_COLOR,
+    WIDX_VEHICLE_TRIM_COLOUR,
+    WIDX_VEHICLE_TERNARY_COLOUR,
 
     WIDX_PLAY_MUSIC = 14,
     WIDX_MUSIC,
@@ -463,9 +463,9 @@ static constexpr const uint64_t window_ride_page_enabled_widgets[] = {
         (1ULL << WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN) |
         (1ULL << WIDX_VEHICLE_COLOUR_INDEX) |
         (1ULL << WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN) |
-        (1ULL << WIDX_VEHICLE_MAIN_COLOUR) |
-        (1ULL << WIDX_VEHICLE_ADDITIONAL_COLOUR_1) |
-        (1ULL << WIDX_VEHICLE_ADDITIONAL_COLOUR_2),
+        (1ULL << WIDX_VEHICLE_BODY_COLOR) |
+        (1ULL << WIDX_VEHICLE_TRIM_COLOUR) |
+        (1ULL << WIDX_VEHICLE_TERNARY_COLOUR),
     MAIN_RIDE_ENABLED_WIDGETS |
         (1ULL << WIDX_PLAY_MUSIC) |
         (1ULL << WIDX_MUSIC) |
@@ -1046,7 +1046,7 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
         rct_ride_entry_vehicle* rideVehicleEntry = &rideEntry->vehicles[vehicle];
 
         auto vehicleId = ((ride->colour_scheme_type & 3) == VEHICLE_COLOUR_SCHEME_PER_VEHICLE) ? rideEntry->tab_vehicle : 0;
-        vehicle_colour vehicleColour = ride_get_vehicle_colour(ride, vehicleId);
+        VehicleColour vehicleColour = ride_get_vehicle_colour(ride, vehicleId);
         int32_t spriteIndex = 32;
         if (w->page == WINDOW_RIDE_PAGE_VEHICLE)
             spriteIndex += w->frame_no;
@@ -1054,10 +1054,10 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
         spriteIndex &= rideVehicleEntry->rotation_frame_mask;
         spriteIndex *= rideVehicleEntry->base_num_frames;
         spriteIndex += rideVehicleEntry->base_image_id;
-        spriteIndex |= (vehicleColour.additional_1 << 24) | (vehicleColour.main << 19);
+        spriteIndex |= (vehicleColour.Trim << 24) | (vehicleColour.Body << 19);
         spriteIndex |= IMAGE_TYPE_REMAP_2_PLUS;
 
-        gfx_draw_sprite(&clipDPI, ImageId::FromUInt32(spriteIndex, vehicleColour.additional_2), screenCoords);
+        gfx_draw_sprite(&clipDPI, ImageId::FromUInt32(spriteIndex, vehicleColour.Ternary), screenCoords);
     }
 }
 
@@ -3070,7 +3070,7 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
                     vehicleColourIndex = j;
                     break;
             }
-            vehicle_colour vehicleColour = ride_get_vehicle_colour(ride, vehicleColourIndex);
+            VehicleColour vehicleColour = ride_get_vehicle_colour(ride, vehicleColourIndex);
 
             int32_t spriteIndex = 16;
             if (rideVehicleEntry->flags & VEHICLE_ENTRY_FLAG_USE_16_ROTATION_FRAMES)
@@ -3079,13 +3079,13 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
             spriteIndex &= rideVehicleEntry->rotation_frame_mask;
             spriteIndex *= rideVehicleEntry->base_num_frames;
             spriteIndex += rideVehicleEntry->base_image_id;
-            spriteIndex |= (vehicleColour.additional_1 << 24) | (vehicleColour.main << 19);
+            spriteIndex |= (vehicleColour.Trim << 24) | (vehicleColour.Body << 19);
             spriteIndex |= IMAGE_TYPE_REMAP_2_PLUS;
 
             nextSpriteToDraw->x = x;
             nextSpriteToDraw->y = y;
             nextSpriteToDraw->sprite_index = spriteIndex;
-            nextSpriteToDraw->tertiary_colour = vehicleColour.additional_2;
+            nextSpriteToDraw->tertiary_colour = vehicleColour.Ternary;
             nextSpriteToDraw++;
 
             x += rideVehicleEntry->spacing / 17432;
@@ -4312,7 +4312,7 @@ static void WindowRideColourResize(rct_window* w)
  */
 static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex, rct_widget* widget)
 {
-    vehicle_colour vehicleColour;
+    VehicleColour vehicleColour;
     int32_t i, numItems;
     rct_string_id stringId;
 
@@ -4425,17 +4425,17 @@ static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex
 
             Dropdown::SetChecked(w->vehicleIndex, true);
             break;
-        case WIDX_VEHICLE_MAIN_COLOUR:
+        case WIDX_VEHICLE_BODY_COLOR:
             vehicleColour = ride_get_vehicle_colour(ride, w->vehicleIndex);
-            WindowDropdownShowColour(w, widget, w->colours[1], vehicleColour.main);
+            WindowDropdownShowColour(w, widget, w->colours[1], vehicleColour.Body);
             break;
-        case WIDX_VEHICLE_ADDITIONAL_COLOUR_1:
+        case WIDX_VEHICLE_TRIM_COLOUR:
             vehicleColour = ride_get_vehicle_colour(ride, w->vehicleIndex);
-            WindowDropdownShowColour(w, widget, w->colours[1], vehicleColour.additional_1);
+            WindowDropdownShowColour(w, widget, w->colours[1], vehicleColour.Trim);
             break;
-        case WIDX_VEHICLE_ADDITIONAL_COLOUR_2:
+        case WIDX_VEHICLE_TERNARY_COLOUR:
             vehicleColour = ride_get_vehicle_colour(ride, w->vehicleIndex);
-            WindowDropdownShowColour(w, widget, w->colours[1], vehicleColour.additional_2);
+            WindowDropdownShowColour(w, widget, w->colours[1], vehicleColour.Ternary);
             break;
     }
 }
@@ -4517,21 +4517,21 @@ static void WindowRideColourDropdown(rct_window* w, rct_widgetindex widgetIndex,
             w->vehicleIndex = dropdownIndex;
             w->Invalidate();
             break;
-        case WIDX_VEHICLE_MAIN_COLOUR:
+        case WIDX_VEHICLE_BODY_COLOR:
         {
             auto rideSetAppearanceAction = RideSetAppearanceAction(
                 rideId, RideSetAppearanceType::VehicleColourBody, dropdownIndex, w->vehicleIndex);
             GameActions::Execute(&rideSetAppearanceAction);
         }
         break;
-        case WIDX_VEHICLE_ADDITIONAL_COLOUR_1:
+        case WIDX_VEHICLE_TRIM_COLOUR:
         {
             auto rideSetAppearanceAction = RideSetAppearanceAction(
                 rideId, RideSetAppearanceType::VehicleColourTrim, dropdownIndex, w->vehicleIndex);
             GameActions::Execute(&rideSetAppearanceAction);
         }
         break;
-        case WIDX_VEHICLE_ADDITIONAL_COLOUR_2:
+        case WIDX_VEHICLE_TERNARY_COLOUR:
         {
             auto rideSetAppearanceAction = RideSetAppearanceAction(
                 rideId, RideSetAppearanceType::VehicleColourTernary, dropdownIndex, w->vehicleIndex);
@@ -4580,7 +4580,7 @@ static void WindowRideColourTooldrag(rct_window* w, rct_widgetindex widgetIndex,
 static void WindowRideColourInvalidate(rct_window* w)
 {
     TrackColour trackColour;
-    vehicle_colour vehicleColour;
+    VehicleColour vehicleColour;
 
     auto widgets = window_ride_page_widgets[w->page];
     if (w->widgets != widgets)
@@ -4709,47 +4709,46 @@ static void WindowRideColourInvalidate(rct_window* w)
         vehicleColour = ride_get_vehicle_colour(ride, w->vehicleIndex);
 
         window_ride_colour_widgets[WIDX_VEHICLE_PREVIEW].type = WindowWidgetType::Scroll;
-        window_ride_colour_widgets[WIDX_VEHICLE_MAIN_COLOUR].type = WindowWidgetType::ColourBtn;
-        window_ride_colour_widgets[WIDX_VEHICLE_MAIN_COLOUR].image = WindowRideGetColourButtonImage(vehicleColour.main);
+        window_ride_colour_widgets[WIDX_VEHICLE_BODY_COLOR].type = WindowWidgetType::ColourBtn;
+        window_ride_colour_widgets[WIDX_VEHICLE_BODY_COLOR].image = WindowRideGetColourButtonImage(vehicleColour.Body);
 
-        bool allowChangingAdditionalColour1 = false;
-        bool allowChangingAdditionalColour2 = false;
+        bool allowChangingTrimColour = false;
+        bool allowChangingTernaryColour = false;
 
         for (int32_t i = 0; i < ride->num_cars_per_train; i++)
         {
             uint8_t vehicleTypeIndex = ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, i);
 
-            if (rideEntry->vehicles[vehicleTypeIndex].flags & VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1)
+            if (rideEntry->vehicles[vehicleTypeIndex].flags & VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR)
             {
-                allowChangingAdditionalColour1 = true;
+                allowChangingTrimColour = true;
             }
-            if (rideEntry->vehicles[vehicleTypeIndex].flags & VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2)
+            if (rideEntry->vehicles[vehicleTypeIndex].flags & VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR)
             {
-                allowChangingAdditionalColour2 = true;
+                allowChangingTernaryColour = true;
             }
         }
 
         // Additional colours
-        if (allowChangingAdditionalColour1)
+        if (allowChangingTrimColour)
         {
-            window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_1].type = WindowWidgetType::ColourBtn;
-            window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_1].image = WindowRideGetColourButtonImage(
-                vehicleColour.additional_1);
-            if (allowChangingAdditionalColour2)
+            window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::ColourBtn;
+            window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].image = WindowRideGetColourButtonImage(vehicleColour.Trim);
+            if (allowChangingTernaryColour)
             {
-                window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_2].type = WindowWidgetType::ColourBtn;
-                window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_2].image = WindowRideGetColourButtonImage(
-                    vehicleColour.additional_2);
+                window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].type = WindowWidgetType::ColourBtn;
+                window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].image = WindowRideGetColourButtonImage(
+                    vehicleColour.Ternary);
             }
             else
             {
-                window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_2].type = WindowWidgetType::Empty;
+                window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].type = WindowWidgetType::Empty;
             }
         }
         else
         {
-            window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_1].type = WindowWidgetType::Empty;
-            window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_2].type = WindowWidgetType::Empty;
+            window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::Empty;
+            window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].type = WindowWidgetType::Empty;
         }
 
         // Vehicle colour scheme type
@@ -4793,9 +4792,9 @@ static void WindowRideColourInvalidate(rct_window* w)
         window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WindowWidgetType::Empty;
         window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_INDEX].type = WindowWidgetType::Empty;
         window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].type = WindowWidgetType::Empty;
-        window_ride_colour_widgets[WIDX_VEHICLE_MAIN_COLOUR].type = WindowWidgetType::Empty;
-        window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_1].type = WindowWidgetType::Empty;
-        window_ride_colour_widgets[WIDX_VEHICLE_ADDITIONAL_COLOUR_2].type = WindowWidgetType::Empty;
+        window_ride_colour_widgets[WIDX_VEHICLE_BODY_COLOR].type = WindowWidgetType::Empty;
+        window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::Empty;
+        window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].type = WindowWidgetType::Empty;
     }
 
     ft.Rewind();
@@ -4949,9 +4948,9 @@ static void WindowRideColourScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
     spriteIndex &= rideVehicleEntry->rotation_frame_mask;
     spriteIndex *= rideVehicleEntry->base_num_frames;
     spriteIndex += rideVehicleEntry->base_image_id;
-    spriteIndex |= (vehicleColour.additional_1 << 24) | (vehicleColour.main << 19);
+    spriteIndex |= (vehicleColour.Trim << 24) | (vehicleColour.Body << 19);
     spriteIndex |= IMAGE_TYPE_REMAP_2_PLUS;
-    gfx_draw_sprite(dpi, ImageId::FromUInt32(spriteIndex, vehicleColour.additional_2), screenCoords);
+    gfx_draw_sprite(dpi, ImageId::FromUInt32(spriteIndex, vehicleColour.Ternary), screenCoords);
 }
 
 #pragma endregion

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -107,7 +107,7 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
 
     for (uint8_t i = 0; i < coloursCount; i++)
     {
-        _presetColours.list[i] = stream->ReadValue<vehicle_colour>();
+        _presetColours.list[i] = stream->ReadValue<VehicleColour>();
     }
 
     if (IsRideTypeShopOrFacility(_legacyType.ride_type[0]))
@@ -824,14 +824,14 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(json_t& jCar)
             { "isReverserPassengerCar", VEHICLE_ENTRY_FLAG_REVERSER_PASSENGER_CAR },
             { "hasInvertedSpriteSet", VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET },
             { "hasDodgemInUseLights", VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS },
-            { "hasAdditionalColour2", VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2 },
+            { "hasAdditionalColour2", VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR },
             { "recalculateSpriteBounds", VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS },
             { "VEHICLE_ENTRY_FLAG_11", VEHICLE_ENTRY_FLAG_USE_16_ROTATION_FRAMES },
             { "overrideNumberOfVerticalFrames", VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES },
             { "spriteBoundsIncludeInvertedSet", VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET },
             { "hasAdditionalSpinningFrames", VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES },
             { "isLift", VEHICLE_ENTRY_FLAG_LIFT },
-            { "hasAdditionalColour1", VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1 },
+            { "hasAdditionalColour1", VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR },
             { "hasSwinging", VEHICLE_ENTRY_FLAG_SWINGING },
             { "hasSpinning", VEHICLE_ENTRY_FLAG_SPINNING },
             { "isPowered", VEHICLE_ENTRY_FLAG_POWERED },
@@ -857,13 +857,13 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar(json_t& jCar)
             { "VEHICLE_ENTRY_FLAG_5", VEHICLE_ENTRY_FLAG_REVERSER_PASSENGER_CAR },
             { "VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET", VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET },
             { "VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS", VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS },
-            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2", VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2 },
+            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2", VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR },
             { "VEHICLE_ENTRY_FLAG_10", VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS },
             { "VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES", VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES },
             { "VEHICLE_ENTRY_FLAG_13", VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET },
             { "VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES", VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES },
             { "VEHICLE_ENTRY_FLAG_LIFT", VEHICLE_ENTRY_FLAG_LIFT },
-            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1", VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1 },
+            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1", VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR },
             { "VEHICLE_ENTRY_FLAG_SWINGING", VEHICLE_ENTRY_FLAG_SWINGING },
             { "VEHICLE_ENTRY_FLAG_SPINNING", VEHICLE_ENTRY_FLAG_SPINNING },
             { "VEHICLE_ENTRY_FLAG_POWERED", VEHICLE_ENTRY_FLAG_POWERED },
@@ -925,27 +925,27 @@ vehicle_colour_preset_list RideObject::ReadJsonCarColours(json_t& jCarColours)
     return list;
 }
 
-std::vector<vehicle_colour> RideObject::ReadJsonColourConfiguration(json_t& jColourConfig)
+std::vector<VehicleColour> RideObject::ReadJsonColourConfiguration(json_t& jColourConfig)
 {
-    std::vector<vehicle_colour> config;
+    std::vector<VehicleColour> config;
 
     for (auto& jColours : jColourConfig)
     {
-        vehicle_colour carColour = {};
+        VehicleColour carColour = {};
 
         auto colours = Json::AsArray(jColours);
         if (colours.size() >= 1)
         {
-            carColour.main = Colour::FromString(Json::GetString(colours[0]));
-            carColour.additional_1 = carColour.main;
-            carColour.additional_2 = carColour.main;
+            carColour.Body = Colour::FromString(Json::GetString(colours[0]));
+            carColour.Trim = carColour.Body;
+            carColour.Ternary = carColour.Body;
             if (colours.size() >= 2)
             {
-                carColour.additional_1 = Colour::FromString(Json::GetString(colours[1]));
+                carColour.Trim = Colour::FromString(Json::GetString(colours[1]));
             }
             if (colours.size() >= 3)
             {
-                carColour.additional_2 = Colour::FromString(Json::GetString(colours[2]));
+                carColour.Ternary = Colour::FromString(Json::GetString(colours[2]));
             }
         }
         config.push_back(carColour);

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -54,7 +54,7 @@ private:
     std::vector<rct_ride_entry_vehicle> ReadJsonCars(json_t& jCars);
     rct_ride_entry_vehicle ReadJsonCar(json_t& jCar);
     vehicle_colour_preset_list ReadJsonCarColours(json_t& jCarColours);
-    std::vector<vehicle_colour> ReadJsonColourConfiguration(json_t& jColourConfig);
+    std::vector<VehicleColour> ReadJsonColourConfiguration(json_t& jColourConfig);
 
     static uint8_t CalculateNumVerticalFrames(const rct_ride_entry_vehicle* vehicleEntry);
     static uint8_t CalculateNumHorizontalFrames(const rct_ride_entry_vehicle* vehicleEntry);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2092,26 +2092,20 @@ TrackColour ride_get_track_colour(Ride* ride, int32_t colourScheme)
     return result;
 }
 
-vehicle_colour ride_get_vehicle_colour(Ride* ride, int32_t vehicleIndex)
+VehicleColour ride_get_vehicle_colour(Ride* ride, int32_t vehicleIndex)
 {
-    vehicle_colour result;
-
     // Prevent indexing array out of bounds
     vehicleIndex = std::min<int32_t>(vehicleIndex, MAX_CARS_PER_TRAIN);
-
-    result.main = ride->vehicle_colours[vehicleIndex].Body;
-    result.additional_1 = ride->vehicle_colours[vehicleIndex].Trim;
-    result.additional_2 = ride->vehicle_colours[vehicleIndex].Ternary;
-    return result;
+    return ride->vehicle_colours[vehicleIndex];
 }
 
-static bool ride_does_vehicle_colour_exist(ObjectEntryIndex subType, vehicle_colour* vehicleColour)
+static bool ride_does_vehicle_colour_exist(ObjectEntryIndex subType, VehicleColour* vehicleColour)
 {
     for (auto& ride : GetRideManager())
     {
         if (ride.subtype != subType)
             continue;
-        if (ride.vehicle_colours[0].Body != vehicleColour->main)
+        if (ride.vehicle_colours[0].Body != vehicleColour->Body)
             continue;
         return false;
     }
@@ -2139,7 +2133,7 @@ int32_t ride_get_unused_preset_vehicle_colour(ObjectEntryIndex subType)
     {
         uint8_t numColourConfigurations = presetList->count;
         int32_t randomConfigIndex = util_rand() % numColourConfigurations;
-        vehicle_colour* preset = &presetList->list[randomConfigIndex];
+        VehicleColour* preset = &presetList->list[randomConfigIndex];
 
         if (ride_does_vehicle_colour_exist(subType, preset))
         {
@@ -2163,10 +2157,8 @@ void ride_set_vehicle_colours_to_random_preset(Ride* ride, uint8_t preset_index)
         assert(preset_index < presetList->count);
 
         ride->colour_scheme_type = RIDE_COLOUR_SCHEME_ALL_SAME;
-        vehicle_colour* preset = &presetList->list[preset_index];
-        ride->vehicle_colours[0].Body = preset->main;
-        ride->vehicle_colours[0].Trim = preset->additional_1;
-        ride->vehicle_colours[0].Ternary = preset->additional_2;
+        VehicleColour* preset = &presetList->list[preset_index];
+        ride->vehicle_colours[0] = *preset;
     }
     else
     {
@@ -2174,10 +2166,8 @@ void ride_set_vehicle_colours_to_random_preset(Ride* ride, uint8_t preset_index)
         uint32_t count = std::min(presetList->count, static_cast<uint8_t>(32));
         for (uint32_t i = 0; i < count; i++)
         {
-            vehicle_colour* preset = &presetList->list[i];
-            ride->vehicle_colours[i].Body = preset->main;
-            ride->vehicle_colours[i].Trim = preset->additional_1;
-            ride->vehicle_colours[i].Ternary = preset->additional_2;
+            VehicleColour* preset = &presetList->list[i];
+            ride->vehicle_colours[i] = *preset;
         }
     }
 }
@@ -4263,7 +4253,7 @@ void Ride::SetColourPreset(uint8_t index)
         if (rideEntry != nullptr && rideEntry->vehicle_preset_list->count > 0)
         {
             auto list = rideEntry->vehicle_preset_list->list[0];
-            colours = { list.main, list.additional_1, list.additional_2 };
+            colours = { list.Body, list.Trim, list.Ternary };
         }
     }
     else if (index < colourPresets->count)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1037,7 +1037,7 @@ Staff* ride_get_assigned_mechanic(Ride* ride);
 int32_t ride_get_total_length(const Ride* ride);
 int32_t ride_get_total_time(Ride* ride);
 TrackColour ride_get_track_colour(Ride* ride, int32_t colourScheme);
-vehicle_colour ride_get_vehicle_colour(Ride* ride, int32_t vehicleIndex);
+VehicleColour ride_get_vehicle_colour(Ride* ride, int32_t vehicleIndex);
 int32_t ride_get_unused_preset_vehicle_colour(ObjectEntryIndex subType);
 void ride_set_vehicle_colours_to_random_preset(Ride* ride, uint8_t preset_index);
 void ride_measurements_update();

--- a/src/openrct2/ride/RideColour.h
+++ b/src/openrct2/ride/RideColour.h
@@ -17,10 +17,3 @@ struct TrackColour
     uint8_t additional;
     uint8_t supports;
 };
-
-struct vehicle_colour
-{
-    uint8_t main;
-    uint8_t additional_1;
-    uint8_t additional_2;
-};

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -12,6 +12,7 @@
 #include "../rct2/Limits.h"
 #include "RideColour.h"
 #include "ShopItem.h"
+#include "VehicleColour.h"
 #include "VehicleEntry.h"
 
 #include <cstdint>
@@ -38,7 +39,7 @@ struct track_colour_preset_list
 struct vehicle_colour_preset_list
 {
     uint8_t count;
-    vehicle_colour list[256];
+    VehicleColour list[256];
 };
 
 /**

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -428,7 +428,7 @@ enum : uint32_t
     VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS = 1
         << 7, // When set the vehicle has an additional frame for when in use. Used only by dodgems.
     VEHICLE_ENTRY_FLAG_ALLOW_DOORS_DEPRECATED = 1 << 8, // Not used any more - every vehicle will now work with doors.
-    VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2 = 1 << 9,
+    VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR = 1 << 9,
     VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS = 1 << 10, // Only used during loading of the objects.
     VEHICLE_ENTRY_FLAG_USE_16_ROTATION_FRAMES = 1
         << 11, // Instead of the default 32 rotation frames. Only used for boat hire and works only for non sloped sprites.
@@ -442,7 +442,7 @@ enum : uint32_t
         << 14, // 16x additional frames for vehicle. A spinning item with additional frames must always face forward to
                // load/unload. Spinning without can load/unload at 4 rotations.
     VEHICLE_ENTRY_FLAG_LIFT = 1 << 15,
-    VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1 = 1 << 16,
+    VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR = 1 << 16,
     VEHICLE_ENTRY_FLAG_SWINGING = 1 << 17,
     VEHICLE_ENTRY_FLAG_SPINNING = 1 << 18,
     VEHICLE_ENTRY_FLAG_POWERED = 1 << 19,


### PR DESCRIPTION
Closes #16028 
I removed vehicle_colour and replaced all of its references to VehicleColour.
I also changed an enum and some local variables to conform to VehicleColour members.
I ran the game and loaded up the "Six Flags over Texas" scenario to make sure nothing crashes.

This is my first contribution to this project and only the second open source project I have ever contributed code to, so let me know if there's anything I missed or should do.
Thank you!