### PR TITLE
Fix #16063: broken Object Selection preview for glass

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Improved: [#10664] Invisibility status is now shown in the Tile Inspector.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#16008] Tile Inspector can select elements from last tile without reselecting it.
+- Fix: [#16063] Object Selection preview for objects with glass is broken.
 
 0.3.5.1 (2021-11-21)
 ------------------------------------------------------------------------

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -119,11 +119,7 @@ void SmallSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
     {
-        imageId = _legacyType.image + 0x44500004;
-        if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_SECONDARY_COLOUR))
-        {
-            imageId |= 0x92000000;
-        }
+        imageId = (_legacyType.image + 4) | IMAGE_TYPE_TRANSPARENT | (EnumValue(GlassPaletteIds[COLOUR_BORDEAUX_RED]) << 19);
         gfx_draw_sprite(dpi, imageId, screenCoords, 0);
     }
 


### PR DESCRIPTION
Looked at the Scenery window code for the fix.