### PR TITLE
Load placeholder empty images if CSG not linked

### DIFF
--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -89,16 +89,26 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     }
     else if (String::StartsWith(s, "$CSG"))
     {
-        if (is_csg_loaded())
+        auto range = ParseRange(s.substr(4));
+        if (!range.empty())
         {
-            auto range = ParseRange(s.substr(4));
-            if (!range.empty())
+            if (is_csg_loaded())
             {
                 for (auto i : range)
                 {
                     result.push_back(std::make_unique<RequiredImage>(
                         static_cast<uint32_t>(SPR_CSG_BEGIN + i),
                         [](uint32_t idx) -> const rct_g1_element* { return gfx_get_g1_element(idx); }));
+                }
+            }
+            else
+            {
+                std::string id(context->GetObjectIdentifier());
+                log_warning("CSG not loaded inserting placeholder images for %s", id.c_str());
+                result.resize(range.size());
+                for (auto& res : result)
+                {
+                    res = std::make_unique<RequiredImage>();
                 }
             }
         }


### PR DESCRIPTION
This should reduce some of the more bizare graphical issues when loading rct1 parks without rct1 linked. This is more of a placeholder until we have fallback images in the objects.
![unknown](https://user-images.githubusercontent.com/1277401/143954722-523530e3-0c20-4c6d-b6d0-d21302a8d9e5.png)
