### PR TITLE
Only add RCT1 land objects to imported SV6 if they are used

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -311,6 +311,7 @@
     <ClInclude Include="platform\Crash.h" />
     <ClInclude Include="platform\platform.h" />
     <ClInclude Include="platform\Platform2.h" />
+    <ClInclude Include="rct12\EntryList.h" />
     <ClInclude Include="rct12\Limits.h" />
     <ClInclude Include="rct12\RCT12.h" />
     <ClInclude Include="rct12\SawyerChunk.h" />

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -45,6 +45,7 @@
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"
 #include "../peep/RideUseSystem.h"
+#include "../rct12/EntryList.h"
 #include "../ride/RideData.h"
 #include "../ride/Station.h"
 #include "../ride/Track.h"
@@ -80,44 +81,6 @@ using namespace OpenRCT2;
 
 namespace RCT1
 {
-    class EntryList
-    {
-    private:
-        std::vector<std::string> _entries;
-
-    public:
-        size_t GetCount() const
-        {
-            return _entries.size();
-        }
-
-        const std::vector<std::string>& GetEntries() const
-        {
-            return _entries;
-        }
-
-        ObjectEntryIndex GetOrAddEntry(std::string_view identifier)
-        {
-            for (size_t i = 0; i < _entries.size(); i++)
-            {
-                if (_entries[i] == identifier)
-                {
-                    return static_cast<ObjectEntryIndex>(i);
-                }
-            }
-            _entries.emplace_back(identifier);
-            return static_cast<ObjectEntryIndex>(_entries.size() - 1);
-        }
-
-        void AddRange(std::initializer_list<const char*> initializerList)
-        {
-            for (auto entry : initializerList)
-            {
-                GetOrAddEntry(entry);
-            }
-        }
-    };
-
     class S4Importer final : public IParkImporter
     {
     private:
@@ -128,18 +91,18 @@ namespace RCT1
         bool _isScenario = false;
 
         // Lists of dynamic object entries
-        EntryList _rideEntries;
-        EntryList _smallSceneryEntries;
-        EntryList _largeSceneryEntries;
-        EntryList _wallEntries;
-        EntryList _pathEntries;
-        EntryList _pathAdditionEntries;
-        EntryList _sceneryGroupEntries;
-        EntryList _waterEntry;
-        EntryList _terrainSurfaceEntries;
-        EntryList _terrainEdgeEntries;
-        EntryList _footpathSurfaceEntries;
-        EntryList _footpathRailingsEntries;
+        RCT12::EntryList _rideEntries;
+        RCT12::EntryList _smallSceneryEntries;
+        RCT12::EntryList _largeSceneryEntries;
+        RCT12::EntryList _wallEntries;
+        RCT12::EntryList _pathEntries;
+        RCT12::EntryList _pathAdditionEntries;
+        RCT12::EntryList _sceneryGroupEntries;
+        RCT12::EntryList _waterEntry;
+        RCT12::EntryList _terrainSurfaceEntries;
+        RCT12::EntryList _terrainEdgeEntries;
+        RCT12::EntryList _footpathSurfaceEntries;
+        RCT12::EntryList _footpathRailingsEntries;
 
         // Lookup tables for converting from RCT1 hard coded types to the new dynamic object entries
         ObjectEntryIndex _rideTypeToRideEntryMap[EnumValue(RideType::Count)]{};
@@ -598,7 +561,7 @@ namespace RCT1
                             case ObjectType::Paths:
                             case ObjectType::PathBits:
                             {
-                                EntryList* entries = GetEntryList(objectType);
+                                RCT12::EntryList* entries = GetEntryList(objectType);
 
                                 // Check if there are spare entries available
                                 size_t maxEntries = static_cast<size_t>(object_entry_group_counts[EnumValue(objectType)]);
@@ -1484,7 +1447,7 @@ namespace RCT1
             }
         }
 
-        void AppendRequiredObjects(ObjectList& objectList, ObjectType objectType, const EntryList& entryList)
+        void AppendRequiredObjects(ObjectList& objectList, ObjectType objectType, const RCT12::EntryList& entryList)
         {
             AppendRequiredObjects(objectList, objectType, entryList.GetEntries());
         }
@@ -2456,7 +2419,7 @@ namespace RCT1
             }
         }
 
-        EntryList* GetEntryList(ObjectType objectType)
+        RCT12::EntryList* GetEntryList(ObjectType objectType)
         {
             switch (objectType)
             {

--- a/src/openrct2/rct12/EntryList.h
+++ b/src/openrct2/rct12/EntryList.h
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+using ObjectEntryIndex = uint16_t;
+
+namespace RCT12
+{
+    class EntryList
+    {
+    private:
+        std::vector<std::string> _entries;
+
+    public:
+        size_t GetCount() const
+        {
+            return _entries.size();
+        }
+
+        const std::vector<std::string>& GetEntries() const
+        {
+            return _entries;
+        }
+
+        ObjectEntryIndex GetOrAddEntry(std::string_view identifier)
+        {
+            for (size_t i = 0; i < _entries.size(); i++)
+            {
+                if (_entries[i] == identifier)
+                {
+                    return static_cast<ObjectEntryIndex>(i);
+                }
+            }
+            _entries.emplace_back(identifier);
+            return static_cast<ObjectEntryIndex>(_entries.size() - 1);
+        }
+
+        void AddRange(std::initializer_list<const char*> initializerList)
+        {
+            for (auto entry : initializerList)
+            {
+                GetOrAddEntry(entry);
+            }
+        }
+
+        template<uint32_t i> void AddRange(const std::string_view (&list)[i])
+        {
+            for (auto entry : list)
+            {
+                GetOrAddEntry(entry);
+            }
+        }
+    };
+} // namespace RCT12

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -889,31 +889,6 @@ std::optional<uint8_t> GetStyleFromMusicIdentifier(std::string_view identifier)
     return std::nullopt;
 }
 
-void SetDefaultRCT2TerrainObjects(ObjectList& objectList)
-{
-    // Surfaces
-    objectList.SetObject(ObjectType::TerrainSurface, 0, "rct2.terrain_surface.grass");
-    objectList.SetObject(ObjectType::TerrainSurface, 1, "rct2.terrain_surface.sand");
-    objectList.SetObject(ObjectType::TerrainSurface, 2, "rct2.terrain_surface.dirt");
-    objectList.SetObject(ObjectType::TerrainSurface, 3, "rct2.terrain_surface.rock");
-    objectList.SetObject(ObjectType::TerrainSurface, 4, "rct2.terrain_surface.martian");
-    objectList.SetObject(ObjectType::TerrainSurface, 5, "rct2.terrain_surface.chequerboard");
-    objectList.SetObject(ObjectType::TerrainSurface, 6, "rct2.terrain_surface.grass_clumps");
-    objectList.SetObject(ObjectType::TerrainSurface, 7, "rct2.terrain_surface.ice");
-    objectList.SetObject(ObjectType::TerrainSurface, 8, "rct2.terrain_surface.grid_red");
-    objectList.SetObject(ObjectType::TerrainSurface, 9, "rct2.terrain_surface.grid_yellow");
-    objectList.SetObject(ObjectType::TerrainSurface, 10, "rct2.terrain_surface.grid_purple");
-    objectList.SetObject(ObjectType::TerrainSurface, 11, "rct2.terrain_surface.grid_green");
-    objectList.SetObject(ObjectType::TerrainSurface, 12, "rct2.terrain_surface.sand_red");
-    objectList.SetObject(ObjectType::TerrainSurface, 13, "rct2.terrain_surface.sand_brown");
-
-    // Edges
-    objectList.SetObject(ObjectType::TerrainEdge, 0, "rct2.terrain_edge.rock");
-    objectList.SetObject(ObjectType::TerrainEdge, 1, "rct2.terrain_edge.wood_red");
-    objectList.SetObject(ObjectType::TerrainEdge, 2, "rct2.terrain_edge.wood_black");
-    objectList.SetObject(ObjectType::TerrainEdge, 3, "rct2.terrain_edge.ice");
-}
-
 void RCT12AddDefaultObjects(ObjectList& objectList)
 {
     // Stations

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -906,27 +906,12 @@ void SetDefaultRCT2TerrainObjects(ObjectList& objectList)
     objectList.SetObject(ObjectType::TerrainSurface, 11, "rct2.terrain_surface.grid_green");
     objectList.SetObject(ObjectType::TerrainSurface, 12, "rct2.terrain_surface.sand_red");
     objectList.SetObject(ObjectType::TerrainSurface, 13, "rct2.terrain_surface.sand_brown");
-    objectList.SetObject(ObjectType::TerrainSurface, 14, "rct1aa.terrain_surface.roof_red");
-    objectList.SetObject(ObjectType::TerrainSurface, 15, "rct1ll.terrain_surface.roof_grey");
-    objectList.SetObject(ObjectType::TerrainSurface, 16, "rct1ll.terrain_surface.rust");
-    objectList.SetObject(ObjectType::TerrainSurface, 17, "rct1ll.terrain_surface.wood");
 
     // Edges
     objectList.SetObject(ObjectType::TerrainEdge, 0, "rct2.terrain_edge.rock");
     objectList.SetObject(ObjectType::TerrainEdge, 1, "rct2.terrain_edge.wood_red");
     objectList.SetObject(ObjectType::TerrainEdge, 2, "rct2.terrain_edge.wood_black");
     objectList.SetObject(ObjectType::TerrainEdge, 3, "rct2.terrain_edge.ice");
-    objectList.SetObject(ObjectType::TerrainEdge, 4, "rct1.terrain_edge.brick");
-    objectList.SetObject(ObjectType::TerrainEdge, 5, "rct1.terrain_edge.iron");
-    objectList.SetObject(ObjectType::TerrainEdge, 6, "rct1aa.terrain_edge.grey");
-    objectList.SetObject(ObjectType::TerrainEdge, 7, "rct1aa.terrain_edge.yellow");
-    objectList.SetObject(ObjectType::TerrainEdge, 8, "rct1aa.terrain_edge.red");
-    objectList.SetObject(ObjectType::TerrainEdge, 9, "rct1ll.terrain_edge.purple");
-    objectList.SetObject(ObjectType::TerrainEdge, 10, "rct1ll.terrain_edge.green");
-    objectList.SetObject(ObjectType::TerrainEdge, 11, "rct1ll.terrain_edge.stone_brown");
-    objectList.SetObject(ObjectType::TerrainEdge, 12, "rct1ll.terrain_edge.stone_grey");
-    objectList.SetObject(ObjectType::TerrainEdge, 13, "rct1ll.terrain_edge.skyscraper_a");
-    objectList.SetObject(ObjectType::TerrainEdge, 14, "rct1ll.terrain_edge.skyscraper_b");
 }
 
 void RCT12AddDefaultObjects(ObjectList& objectList)

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -22,6 +22,7 @@
 #include "../world/Surface.h"
 #include "../world/TileElement.h"
 #include "../world/Wall.h"
+#include "EntryList.h"
 
 using namespace OpenRCT2;
 
@@ -905,6 +906,21 @@ void RCT12AddDefaultObjects(ObjectList& objectList)
             objectList.SetObject(ObjectType::Music, static_cast<ObjectEntryIndex>(i), _musicStyles[i]);
         }
     }
+}
+
+static void AppendRequiredObjects(ObjectList& objectList, ObjectType objectType, const std::vector<std::string>& objectNames)
+{
+    for (const auto& objectName : objectNames)
+    {
+        auto descriptor = ObjectEntryDescriptor(objectName);
+        descriptor.Type = objectType;
+        objectList.Add(descriptor);
+    }
+}
+
+void AppendRequiredObjects(ObjectList& objectList, ObjectType objectType, const RCT12::EntryList& entryList)
+{
+    AppendRequiredObjects(objectList, objectType, entryList.GetEntries());
 }
 
 money64 RCT12CompletedCompanyValueToOpenRCT2(money32 origValue)

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -24,6 +24,10 @@ class ObjectList;
 
 using track_type_t = uint16_t;
 using RCT12TrackType = uint8_t;
+namespace RCT12
+{
+    class EntryList;
+}
 
 constexpr uint8_t RCT2_STRING_FORMAT_ARG_START = 123;
 constexpr uint8_t RCT2_STRING_FORMAT_ARG_END = 141;
@@ -833,6 +837,7 @@ RCT12TrackType OpenRCT2FlatTrackTypeToRCT12(track_type_t origTrackType);
 std::string_view GetStationIdentifierFromStyle(uint8_t style);
 std::optional<uint8_t> GetStyleFromMusicIdentifier(std::string_view identifier);
 void RCT12AddDefaultObjects(ObjectList& objectList);
+void AppendRequiredObjects(ObjectList& objectList, ObjectType objectType, const RCT12::EntryList& entryList);
 
 static constexpr money32 RCT12_COMPANY_VALUE_ON_FAILED_OBJECTIVE = 0x80000001;
 

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -832,7 +832,6 @@ track_type_t RCT12FlatTrackTypeToOpenRCT2(RCT12TrackType origTrackType);
 RCT12TrackType OpenRCT2FlatTrackTypeToRCT12(track_type_t origTrackType);
 std::string_view GetStationIdentifierFromStyle(uint8_t style);
 std::optional<uint8_t> GetStyleFromMusicIdentifier(std::string_view identifier);
-void SetDefaultRCT2TerrainObjects(ObjectList& objectList);
 void RCT12AddDefaultObjects(ObjectList& objectList);
 
 static constexpr money32 RCT12_COMPANY_VALUE_ON_FAILED_OBJECTIVE = 0x80000001;

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -311,7 +311,7 @@ namespace RCT2
         }
         else if (terrainEdge - std::size(DefaultTerrainEdges) < std::size(OpenRCT2HybridTerrainEdges))
         {
-            return OpenRCT2HybridTerrainSurfaces[terrainEdge - std::size(DefaultTerrainEdges)];
+            return OpenRCT2HybridTerrainEdges[terrainEdge - std::size(DefaultTerrainEdges)];
         }
         return DefaultTerrainEdges[0];
     }

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -274,35 +274,45 @@ namespace RCT2
         return {};
     }
 
-    static constexpr std::string_view _terrainSurfaces[] = {
-        "rct2.terrain_surface.grass",        "rct2.terrain_surface.sand",        "rct2.terrain_surface.dirt",
-        "rct2.terrain_surface.rock",         "rct2.terrain_surface.martian",     "rct2.terrain_surface.chequerboard",
-        "rct2.terrain_surface.grass_clumps", "rct2.terrain_surface.ice",         "rct2.terrain_surface.grid_red",
-        "rct2.terrain_surface.grid_yellow",  "rct2.terrain_surface.grid_purple", "rct2.terrain_surface.grid_green",
-        "rct2.terrain_surface.sand_red",     "rct2.terrain_surface.sand_brown",
+    // Additional surface styles added to OpenRCT2 as a feature if RCT1 linked
+    static constexpr std::string_view OpenRCT2HybridTerrainSurfaces[] = {
+        "rct1aa.terrain_surface.roof_red",
+        "rct1ll.terrain_surface.roof_grey",
+        "rct1ll.terrain_surface.rust",
+        "rct1ll.terrain_surface.wood",
     };
 
-    static constexpr std::string_view _terrainEdges[] = {
-        "rct2.terrain_edge.rock",
-        "rct2.terrain_edge.wood_red",
-        "rct2.terrain_edge.wood_black",
-        "rct2.terrain_edge.ice",
-    };
-
-    void AddDefaultObjects(ObjectList& objectList)
+    std::string_view GetTerrainSurfaceObject(uint8_t terrainSurface)
     {
-        RCT12AddDefaultObjects(objectList);
-
-        // Surfaces
-        for (size_t i = 0; i < std::size(_terrainSurfaces); i++)
+        if (terrainSurface < std::size(DefaultTerrainSurfaces))
         {
-            objectList.SetObject(ObjectType::TerrainSurface, static_cast<ObjectEntryIndex>(i), _terrainSurfaces[i]);
+            return DefaultTerrainSurfaces[terrainSurface];
         }
-
-        // Edges
-        for (size_t i = 0; i < std::size(_terrainEdges); i++)
+        else if (terrainSurface - std::size(DefaultTerrainSurfaces) < std::size(OpenRCT2HybridTerrainSurfaces))
         {
-            objectList.SetObject(ObjectType::TerrainEdge, static_cast<ObjectEntryIndex>(i), _terrainEdges[i]);
+            return OpenRCT2HybridTerrainSurfaces[terrainSurface - std::size(DefaultTerrainSurfaces)];
         }
+        return DefaultTerrainSurfaces[0];
+    }
+
+    // Additional surface edges added to OpenRCT2 as a feature if RCT1 was linked
+    static constexpr std::string_view OpenRCT2HybridTerrainEdges[] = {
+        "rct1.terrain_edge.brick",          "rct1.terrain_edge.iron",           "rct1aa.terrain_edge.grey",
+        "rct1aa.terrain_edge.yellow",       "rct1aa.terrain_edge.red",          "rct1ll.terrain_edge.purple",
+        "rct1ll.terrain_edge.green",        "rct1ll.terrain_edge.stone_brown",  "rct1ll.terrain_edge.stone_grey",
+        "rct1ll.terrain_edge.skyscraper_a", "rct1ll.terrain_edge.skyscraper_b",
+    };
+
+    std::string_view GetTerrainEdgeObject(uint8_t terrainEdge)
+    {
+        if (terrainEdge < std::size(DefaultTerrainEdges))
+        {
+            return DefaultTerrainEdges[terrainEdge];
+        }
+        else if (terrainEdge - std::size(DefaultTerrainEdges) < std::size(OpenRCT2HybridTerrainEdges))
+        {
+            return OpenRCT2HybridTerrainSurfaces[terrainEdge - std::size(DefaultTerrainEdges)];
+        }
+        return DefaultTerrainEdges[0];
     }
 } // namespace RCT2

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../object/Object.h"
+#include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
@@ -271,5 +272,37 @@ namespace RCT2
         if (foundMapping)
             return result;
         return {};
+    }
+
+    static constexpr std::string_view _terrainSurfaces[] = {
+        "rct2.terrain_surface.grass",        "rct2.terrain_surface.sand",        "rct2.terrain_surface.dirt",
+        "rct2.terrain_surface.rock",         "rct2.terrain_surface.martian",     "rct2.terrain_surface.chequerboard",
+        "rct2.terrain_surface.grass_clumps", "rct2.terrain_surface.ice",         "rct2.terrain_surface.grid_red",
+        "rct2.terrain_surface.grid_yellow",  "rct2.terrain_surface.grid_purple", "rct2.terrain_surface.grid_green",
+        "rct2.terrain_surface.sand_red",     "rct2.terrain_surface.sand_brown",
+    };
+
+    static constexpr std::string_view _terrainEdges[] = {
+        "rct2.terrain_edge.rock",
+        "rct2.terrain_edge.wood_red",
+        "rct2.terrain_edge.wood_black",
+        "rct2.terrain_edge.ice",
+    };
+
+    void AddDefaultObjects(ObjectList& objectList)
+    {
+        RCT12AddDefaultObjects(objectList);
+
+        // Surfaces
+        for (size_t i = 0; i < std::size(_terrainSurfaces); i++)
+        {
+            objectList.SetObject(ObjectType::TerrainSurface, static_cast<ObjectEntryIndex>(i), _terrainSurfaces[i]);
+        }
+
+        // Edges
+        for (size_t i = 0; i < std::size(_terrainEdges); i++)
+        {
+            objectList.SetObject(ObjectType::TerrainEdge, static_cast<ObjectEntryIndex>(i), _terrainEdges[i]);
+        }
     }
 } // namespace RCT2

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -273,46 +273,4 @@ namespace RCT2
             return result;
         return {};
     }
-
-    // Additional surface styles added to OpenRCT2 as a feature if RCT1 linked
-    static constexpr std::string_view OpenRCT2HybridTerrainSurfaces[] = {
-        "rct1aa.terrain_surface.roof_red",
-        "rct1ll.terrain_surface.roof_grey",
-        "rct1ll.terrain_surface.rust",
-        "rct1ll.terrain_surface.wood",
-    };
-
-    std::string_view GetTerrainSurfaceObject(uint8_t terrainSurface)
-    {
-        if (terrainSurface < std::size(DefaultTerrainSurfaces))
-        {
-            return DefaultTerrainSurfaces[terrainSurface];
-        }
-        else if (terrainSurface - std::size(DefaultTerrainSurfaces) < std::size(OpenRCT2HybridTerrainSurfaces))
-        {
-            return OpenRCT2HybridTerrainSurfaces[terrainSurface - std::size(DefaultTerrainSurfaces)];
-        }
-        return DefaultTerrainSurfaces[0];
-    }
-
-    // Additional surface edges added to OpenRCT2 as a feature if RCT1 was linked
-    static constexpr std::string_view OpenRCT2HybridTerrainEdges[] = {
-        "rct1.terrain_edge.brick",          "rct1.terrain_edge.iron",           "rct1aa.terrain_edge.grey",
-        "rct1aa.terrain_edge.yellow",       "rct1aa.terrain_edge.red",          "rct1ll.terrain_edge.purple",
-        "rct1ll.terrain_edge.green",        "rct1ll.terrain_edge.stone_brown",  "rct1ll.terrain_edge.stone_grey",
-        "rct1ll.terrain_edge.skyscraper_a", "rct1ll.terrain_edge.skyscraper_b",
-    };
-
-    std::string_view GetTerrainEdgeObject(uint8_t terrainEdge)
-    {
-        if (terrainEdge < std::size(DefaultTerrainEdges))
-        {
-            return DefaultTerrainEdges[terrainEdge];
-        }
-        else if (terrainEdge - std::size(DefaultTerrainEdges) < std::size(OpenRCT2HybridTerrainEdges))
-        {
-            return OpenRCT2HybridTerrainEdges[terrainEdge - std::size(DefaultTerrainEdges)];
-        }
-        return DefaultTerrainEdges[0];
-    }
 } // namespace RCT2

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 struct rct_ride_entry;
+class ObjectList;
 enum class EditorStep : uint8_t;
 
 namespace RCT2
@@ -1063,6 +1064,7 @@ namespace RCT2
     const FootpathMapping* GetFootpathSurfaceId(
         const ObjectEntryDescriptor& desc, bool ideallyLoaded = false, bool isQueue = false);
     std::optional<rct_object_entry> GetBestObjectEntryForSurface(std::string_view surface, std::string_view railings);
+    void AddDefaultObjects(ObjectList& objectList);
 } // namespace RCT2
 
 std::vector<uint8_t> DecryptSea(const fs::path& path);

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1073,6 +1073,14 @@ namespace RCT2
         "rct2.terrain_surface.sand_red",     "rct2.terrain_surface.sand_brown",
     };
 
+    // Additional surface styles added to OpenRCT2 as a feature if RCT1 linked
+    static constexpr std::string_view OpenRCT2HybridTerrainSurfaces[] = {
+        "rct1aa.terrain_surface.roof_red",
+        "rct1ll.terrain_surface.roof_grey",
+        "rct1ll.terrain_surface.rust",
+        "rct1ll.terrain_surface.wood",
+    };
+
     static constexpr std::string_view DefaultTerrainEdges[] = {
         "rct2.terrain_edge.rock",
         "rct2.terrain_edge.wood_red",
@@ -1080,8 +1088,13 @@ namespace RCT2
         "rct2.terrain_edge.ice",
     };
 
-    std::string_view GetTerrainSurfaceObject(uint8_t terrainSurface);
-    std::string_view GetTerrainEdgeObject(uint8_t terrainEdge);
+    // Additional surface edges added to OpenRCT2 as a feature if RCT1 was linked
+    static constexpr std::string_view OpenRCT2HybridTerrainEdges[] = {
+        "rct1.terrain_edge.brick",          "rct1.terrain_edge.iron",           "rct1aa.terrain_edge.grey",
+        "rct1aa.terrain_edge.yellow",       "rct1aa.terrain_edge.red",          "rct1ll.terrain_edge.purple",
+        "rct1ll.terrain_edge.green",        "rct1ll.terrain_edge.stone_brown",  "rct1ll.terrain_edge.stone_grey",
+        "rct1ll.terrain_edge.skyscraper_a", "rct1ll.terrain_edge.skyscraper_b",
+    };
 } // namespace RCT2
 
 std::vector<uint8_t> DecryptSea(const fs::path& path);

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1064,7 +1064,24 @@ namespace RCT2
     const FootpathMapping* GetFootpathSurfaceId(
         const ObjectEntryDescriptor& desc, bool ideallyLoaded = false, bool isQueue = false);
     std::optional<rct_object_entry> GetBestObjectEntryForSurface(std::string_view surface, std::string_view railings);
-    void AddDefaultObjects(ObjectList& objectList);
+
+    static constexpr std::string_view DefaultTerrainSurfaces[] = {
+        "rct2.terrain_surface.grass",        "rct2.terrain_surface.sand",        "rct2.terrain_surface.dirt",
+        "rct2.terrain_surface.rock",         "rct2.terrain_surface.martian",     "rct2.terrain_surface.chequerboard",
+        "rct2.terrain_surface.grass_clumps", "rct2.terrain_surface.ice",         "rct2.terrain_surface.grid_red",
+        "rct2.terrain_surface.grid_yellow",  "rct2.terrain_surface.grid_purple", "rct2.terrain_surface.grid_green",
+        "rct2.terrain_surface.sand_red",     "rct2.terrain_surface.sand_brown",
+    };
+
+    static constexpr std::string_view DefaultTerrainEdges[] = {
+        "rct2.terrain_edge.rock",
+        "rct2.terrain_edge.wood_red",
+        "rct2.terrain_edge.wood_black",
+        "rct2.terrain_edge.ice",
+    };
+
+    std::string_view GetTerrainSurfaceObject(uint8_t terrainSurface);
+    std::string_view GetTerrainEdgeObject(uint8_t terrainEdge);
 } // namespace RCT2
 
 std::vector<uint8_t> DecryptSea(const fs::path& path);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1749,7 +1749,7 @@ namespace RCT2
             // Add default rct2 terrain surfaces and edges
             AddDefaultEntries();
 
-            // Find and if any rct1 terrain surfaces or edges have been used
+            // Find if any rct1 terrain surfaces or edges have been used
             const bool hasRCT1Terrain = std::any_of(
                 std::begin(_s6.tile_elements), std::end(_s6.tile_elements), [](RCT12TileElement& tile) {
                     auto* surface = tile.AsSurface();
@@ -1772,7 +1772,7 @@ namespace RCT2
             if (hasRCT1Terrain)
             {
                 _terrainSurfaceEntries.AddRange(OpenRCT2HybridTerrainSurfaces);
-                _terrainSurfaceEntries.AddRange(OpenRCT2HybridTerrainEdges);
+                _terrainEdgeEntries.AddRange(OpenRCT2HybridTerrainEdges);
             }
 
             AppendRequiredObjects(objectList, ObjectType::TerrainSurface, _terrainSurfaceEntries);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1732,8 +1732,7 @@ namespace RCT2
                 }
             }
 
-            SetDefaultRCT2TerrainObjects(objectList);
-            RCT12AddDefaultObjects(objectList);
+            AddDefaultObjects(objectList);
             return objectList;
         }
     };

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1749,7 +1749,10 @@ namespace RCT2
                 }
             }
 
+            // Add default rct2 terrain surfaces and edges
             AddDefaultEntries();
+
+            // Find and add all in use additional (rct1) terrain surfaces and edges
             for (auto tile : _s6.tile_elements)
             {
                 auto* surface = tile.AsSurface();


### PR DESCRIPTION
We were mistakenly loading rct1 surfaces and sides when loading rct2 parks leading to a confusing ui.