### PR TITLE
Fix #16075: Track designs save scenery in wrong location

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#16007] Scenario Editor "Entry Price" appears to the right of the value field.
 - Fix: [#16008] Tile Inspector can select elements from last tile without reselecting it.
 - Fix: [#16063] Object Selection preview for objects with glass is broken.
+- Fix: [#16075] Exporting track designs saves scenery in incorrect locations.
 - Fix: [#16087] The Looping Roller Coaster booster is now always drawn correctly.
 
 0.3.5.1 (2021-11-21)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5318,8 +5318,10 @@ static void TrackDesignCallback(int32_t result, [[maybe_unused]] const utf8* pat
  */
 static void WindowRideMeasurementsDesignSave(rct_window* w)
 {
+    TrackDesignState tds{};
+
     Ride* ride = get_ride(w->rideId);
-    _trackDesign = ride->SaveToTrackDesign();
+    _trackDesign = ride->SaveToTrackDesign(tds);
     if (!_trackDesign)
     {
         return;
@@ -5327,7 +5329,6 @@ static void WindowRideMeasurementsDesignSave(rct_window* w)
 
     if (gTrackDesignSaveMode)
     {
-        TrackDesignState tds{};
         auto errMessage = _trackDesign->CreateTrackDesignScenery(tds);
         if (errMessage != STR_NONE)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -953,7 +953,7 @@ void Ride::UpdateAll()
     OpenRCT2::RideAudio::UpdateMusicChannels();
 }
 
-std::unique_ptr<TrackDesign> Ride::SaveToTrackDesign() const
+std::unique_ptr<TrackDesign> Ride::SaveToTrackDesign(TrackDesignState& tds) const
 {
     if (!(lifecycle_flags & RIDE_LIFECYCLE_TESTED))
     {
@@ -967,7 +967,6 @@ std::unique_ptr<TrackDesign> Ride::SaveToTrackDesign() const
         return nullptr;
     }
 
-    auto tds = TrackDesignState{};
     auto td = std::make_unique<TrackDesign>();
     auto errMessage = td->CreateTrackDesign(tds, *this);
     if (errMessage != STR_NONE)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -105,6 +105,7 @@ namespace ShelteredSectionsBits
 }; // namespace ShelteredSectionsBits
 
 struct TrackDesign;
+struct TrackDesignState;
 enum class RideMode : uint8_t;
 enum class RideStatus : uint8_t;
 
@@ -356,7 +357,7 @@ public:
     static void UpdateAll();
     static bool NameExists(std::string_view name, ride_id_t excludeRideId = RIDE_ID_NULL);
 
-    [[nodiscard]] std::unique_ptr<TrackDesign> SaveToTrackDesign() const;
+    [[nodiscard]] std::unique_ptr<TrackDesign> SaveToTrackDesign(TrackDesignState& tds) const;
 
     uint64_t GetAvailableModes() const;
     const RideTypeDescriptor& GetRideTypeDescriptor() const;


### PR DESCRIPTION
Should have used the state from the ride instead of creating a new one.