### PR TITLE
Use new ImageId in most object previews

### DIFF
--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -782,3 +782,8 @@ rct_drawpixelinfo rct_drawpixelinfo::Crop(const ScreenCoordsXY& pos, const Scree
     result.pitch = static_cast<int16_t>(width + pitch - size.width);
     return result;
 }
+
+FilterPaletteID GetGlassPaletteId(colour_t c)
+{
+    return GlassPaletteIds[c];
+}

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -77,9 +77,11 @@ void BannerObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t he
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
-    uint32_t imageId = 0x20D00000 | _legacyType.image;
-    gfx_draw_sprite(dpi, imageId + 0, screenCoords + ScreenCoordsXY{ -12, 8 }, 0);
-    gfx_draw_sprite(dpi, imageId + 1, screenCoords + ScreenCoordsXY{ -12, 8 }, 0);
+    auto image0 = ImageId(_legacyType.image, COLOUR_BORDEAUX_RED);
+    auto image1 = ImageId(_legacyType.image + 1, COLOUR_BORDEAUX_RED);
+
+    gfx_draw_sprite(dpi, image0, screenCoords + ScreenCoordsXY{ -12, 8 });
+    gfx_draw_sprite(dpi, image1, screenCoords + ScreenCoordsXY{ -12, 8 });
 }
 
 void BannerObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -45,10 +45,9 @@ void EntranceObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t 
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
-    uint32_t imageId = _legacyType.image_id;
-    gfx_draw_sprite(dpi, imageId + 1, screenCoords + ScreenCoordsXY{ -32, 14 }, 0);
-    gfx_draw_sprite(dpi, imageId + 0, screenCoords + ScreenCoordsXY{ 0, 28 }, 0);
-    gfx_draw_sprite(dpi, imageId + 2, screenCoords + ScreenCoordsXY{ 32, 44 }, 0);
+    gfx_draw_sprite(dpi, ImageId(_legacyType.image_id + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
+    gfx_draw_sprite(dpi, ImageId(_legacyType.image_id + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+    gfx_draw_sprite(dpi, ImageId(_legacyType.image_id + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
 }
 
 void EntranceObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -82,7 +82,7 @@ void FootpathItemObject::Unload()
 void FootpathItemObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    gfx_draw_sprite(dpi, _legacyType.image, screenCoords - ScreenCoordsXY{ 22, 24 }, 0);
+    gfx_draw_sprite(dpi, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });
 }
 
 static PathBitDrawType ParseDrawType(const std::string& s)

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -71,8 +71,8 @@ void FootpathObject::Unload()
 void FootpathObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    gfx_draw_sprite(dpi, _pathSurfaceDescriptor.PreviewImage, screenCoords - ScreenCoordsXY{ 49, 17 }, 0);
-    gfx_draw_sprite(dpi, _queueSurfaceDescriptor.PreviewImage, screenCoords + ScreenCoordsXY{ 4, -17 }, 0);
+    gfx_draw_sprite(dpi, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });
+    gfx_draw_sprite(dpi, ImageId(_queueSurfaceDescriptor.PreviewImage), screenCoords + ScreenCoordsXY{ 4, -17 });
 }
 
 void FootpathObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -50,9 +50,13 @@ void FootpathRailingsObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, 
 {
     auto x = width / 2;
     auto y = height / 2;
+    auto helper = ImageId(ImageIndexUndefined);
+    if (Colour != COLOUR_NULL)
+        helper = helper.WithPrimary(Colour);
+
     if (SupportType == RailingEntrySupportType::Pole)
     {
-        auto img = ImageId(BridgeImageId + 20 + 15, Colour);
+        auto img = helper.WithIndex(BridgeImageId + 20 + 15);
         for (int i = 0; i < 2; i++)
         {
             auto h = i * 16;
@@ -60,16 +64,16 @@ void FootpathRailingsObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, 
             gfx_draw_sprite(dpi, img, { x + 8, y + 16 + h });
         }
 
-        gfx_draw_sprite(dpi, BridgeImageId + 5, { x, y - 17 }, 0);
-        gfx_draw_sprite(dpi, RailingsImageId + 1, { x + 4, y - 14 }, 0);
-        gfx_draw_sprite(dpi, RailingsImageId + 1, { x + 27, y - 2 }, 0);
+        gfx_draw_sprite(dpi, helper.WithIndex(BridgeImageId + 5), { x, y - 17 });
+        gfx_draw_sprite(dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
+        gfx_draw_sprite(dpi, ImageId(RailingsImageId + 1), { x + 27, y - 2 });
     }
     else
     {
-        gfx_draw_sprite(dpi, BridgeImageId + 22, { x + 0, y + 16 }, 0);
-        gfx_draw_sprite(dpi, BridgeImageId + 49, { x, y - 17 }, 0);
-        gfx_draw_sprite(dpi, RailingsImageId + 1, { x + 4, y - 14 }, 0);
-        gfx_draw_sprite(dpi, RailingsImageId + 1, { x + 27, y - 3 }, 0);
+        gfx_draw_sprite(dpi, helper.WithIndex(BridgeImageId + 22), { x + 0, y + 16 });
+        gfx_draw_sprite(dpi, helper.WithIndex(BridgeImageId + 49), { x, y - 17 });
+        gfx_draw_sprite(dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
+        gfx_draw_sprite(dpi, ImageId(RailingsImageId + 1), { x + 27, y - 3 });
     }
 }
 

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -44,9 +44,9 @@ void FootpathSurfaceObject::Unload()
 void FootpathSurfaceObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2 - 16, height / 2 };
-    gfx_draw_sprite(dpi, BaseImageId + 3, screenCoords, 0);
-    gfx_draw_sprite(dpi, BaseImageId + 16, { screenCoords.x + 32, screenCoords.y - 16 }, 0);
-    gfx_draw_sprite(dpi, BaseImageId + 8, { screenCoords.x + 32, screenCoords.y + 16 }, 0);
+    gfx_draw_sprite(dpi, ImageId(BaseImageId + 3), screenCoords);
+    gfx_draw_sprite(dpi, ImageId(BaseImageId + 16), { screenCoords.x + 32, screenCoords.y - 16 });
+    gfx_draw_sprite(dpi, ImageId(BaseImageId + 8), { screenCoords.x + 32, screenCoords.y + 16 });
 }
 
 void FootpathSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -105,8 +105,8 @@ void LargeSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) - 39 };
 
-    uint32_t imageId = 0xB2D00000 | _legacyType.image;
-    gfx_draw_sprite(dpi, imageId, screenCoords, 0);
+    const auto image = ImageId(_legacyType.image, COLOUR_BORDEAUX_RED, COLOUR_YELLOW);
+    gfx_draw_sprite(dpi, image, screenCoords);
 }
 
 std::vector<rct_large_scenery_tile> LargeSceneryObject::ReadTiles(OpenRCT2::IStream* stream)

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -392,7 +392,7 @@ void RideObject::DrawPreview(rct_drawpixelinfo* dpi, [[maybe_unused]] int32_t wi
         imageId++;
     }
 
-    gfx_draw_sprite(dpi, imageId, { 0, 0 }, 0);
+    gfx_draw_sprite(dpi, ImageId(imageId), { 0, 0 });
 }
 
 std::string RideObject::GetDescription() const

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -62,8 +62,8 @@ void SceneryGroupObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
-    uint32_t imageId = _legacyType.image + 0x20600001;
-    gfx_draw_sprite(dpi, imageId, screenCoords - ScreenCoordsXY{ 15, 14 }, 0);
+    const auto imageId = ImageId(_legacyType.image + 1, COLOUR_DARK_GREEN);
+    gfx_draw_sprite(dpi, imageId, screenCoords - ScreenCoordsXY{ 15, 14 });
 }
 
 static std::optional<uint8_t> GetSceneryType(const ObjectType type)

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -97,13 +97,13 @@ void SmallSceneryObject::Unload()
 
 void SmallSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
 {
-    uint32_t imageId = _legacyType.image;
+    auto imageId = ImageId(_legacyType.image);
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR))
     {
-        imageId |= 0x20D00000;
+        imageId = imageId.WithPrimary(COLOUR_BORDEAUX_RED);
         if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_SECONDARY_COLOUR))
         {
-            imageId |= 0x92000000;
+            imageId = imageId.WithSecondary(COLOUR_YELLOW);
         }
     }
 
@@ -115,22 +115,22 @@ void SmallSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
         screenCoords.y -= 12;
     }
 
-    gfx_draw_sprite(dpi, imageId, screenCoords, 0);
+    gfx_draw_sprite(dpi, imageId, screenCoords);
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
     {
-        imageId = (_legacyType.image + 4) | IMAGE_TYPE_TRANSPARENT | (EnumValue(GlassPaletteIds[COLOUR_BORDEAUX_RED]) << 19);
-        gfx_draw_sprite(dpi, imageId, screenCoords, 0);
+        imageId = ImageId(_legacyType.image + 4, EnumValue(GlassPaletteIds[COLOUR_BORDEAUX_RED])).WithBlended(true);
+        gfx_draw_sprite(dpi, imageId, screenCoords);
     }
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_ANIMATED_FG))
     {
-        imageId = _legacyType.image + 4;
+        imageId = ImageId(_legacyType.image + 4);
         if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_SECONDARY_COLOUR))
         {
-            imageId |= 0x92000000;
+            imageId = imageId.WithSecondary(COLOUR_YELLOW);
         }
-        gfx_draw_sprite(dpi, imageId, screenCoords, 0);
+        gfx_draw_sprite(dpi, imageId, screenCoords);
     }
 }
 

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -119,7 +119,7 @@ void SmallSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int3
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
     {
-        imageId = ImageId(_legacyType.image + 4, EnumValue(GlassPaletteIds[COLOUR_BORDEAUX_RED])).WithBlended(true);
+        imageId = ImageId(_legacyType.image + 4).WithTransparancy(COLOUR_BORDEAUX_RED);
         gfx_draw_sprite(dpi, imageId, screenCoords);
     }
 


### PR DESCRIPTION
~~There is one problem with this - it crashes when you try to get a preview of a small scenery object with glass. I have no clue why.~~ Now fixed, thanks Ted!