### PR TITLE
Add standalone sprite builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
           pushd src/openrct2-android/util/SpriteBuilder/build
             cmake .. -G Ninja
             cmake --build .
-            ./sb build ../../../g2.dat ../../../../../resources/g2/sprites.json
+            ./sb build ../../../../../data/g2.dat ../../../../../resources/g2/sprites.json
           popd
           pushd src/openrct2-android
             ./gradlew app:assemble

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-code-formatting
     container:
-      image: openrct2/openrct2-build:0.3.1-android
+      image: openrct2/openrct2-build:4-android
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
             ./sb build ../../../../../data/g2.dat ../../../../../resources/g2/sprites.json
           popd
           pushd src/openrct2-android
-            ./gradlew app:assemble
+            ./gradlew app:assembleRelease
           popd
           mkdir -p artifacts
           mv src/openrct2-android/app/build/outputs/apk/release/app-release.apk artifacts/openrct2-arm.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
             ./gradlew app:assemble
           popd
           mkdir -p artifacts
-          mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2-arm.apk
+          mv src/openrct2-android/app/build/outputs/apk/release/app-release.apk artifacts/openrct2-arm.apk
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
             ./sb build ../../../g2.dat ../../../../../resources/g2/sprites.json
           popd
           pushd src/openrct2-android
-            ./gradlew app:assemblePR
+            ./gradlew app:assemble
           popd
           mkdir -p artifacts
           mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2-arm.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,12 @@ jobs:
       - name: Build OpenRCT2
         run: |
           . scripts/setenv
+          mkdir src/openrct2-android/util/SpriteBuilder/build
+          pushd src/openrct2-android/util/SpriteBuilder/build
+            cmake ..
+            cmake --build .
+            ./sb build ../../../g2.dat ../../../../../resources/g2/sprites.json
+          popd
           pushd src/openrct2-android
             ./gradlew app:assemblePR
           popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,7 @@ jobs:
           . scripts/setenv
           mkdir src/openrct2-android/util/SpriteBuilder/build
           pushd src/openrct2-android/util/SpriteBuilder/build
-            cmake ..
+            cmake .. -G Ninja
             cmake --build .
             ./sb build ../../../g2.dat ../../../../../resources/g2/sprites.json
           popd

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -1,110 +1,48 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
-
+    compileSdkVersion 31
+    ndkVersion "23.1.7779620" // Latest r23b (LTS), to be synced with CI container image
     defaultConfig {
         applicationId 'io.openrct2'
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 31
 
         versionCode 2
         versionName '0.3.5.1'
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_shared'
                 targets 'openrct2', 'openrct2-ui', 'openrct2-cli'
+                // abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a'
             }
         }
     }
-
-    sourceSets {
-        main.assets.srcDirs += 'src/main/assets/'
-    }
-
-    signingConfigs {
-        debug {
-            storeFile file('external/debug.keystore')
-        }
-    }
-
     buildTypes {
-        debug {
-            applicationIdSuffix '.debug'
-            versionNameSuffix '-DEBUG'
-        }
-        pr {
-            applicationIdSuffix '.debug'
-            signingConfig signingConfigs.debug
-        }
-        develop {
-            applicationIdSuffix '.develop'
-            versionNameSuffix '-DEVELOP'
-            signingConfig signingConfigs.debug
-        }
         release {
             signingConfig signingConfigs.debug
         }
     }
 
-    flavorDimensions "version"
-    /*
-    productFlavors {
-        full {
-            dimension "version"
-        }
+    sourceSets.main {
+        jniLibs.srcDir 'libs'
     }
-    */
-
     externalNativeBuild {
         cmake {
             path 'src/main/CMakeLists.txt'
+            version "3.18.1"
         }
     }
 
-    productFlavors {
-        /*
-        arm7 {
-            ndk {
-                abiFilters 'armeabi-v7a'
-            }
-        }
-        */
-        arm {
-            ndk {
-                abiFilters 'armeabi-v7a', 'arm64-v8a'
-            }
-        }
-        /*
-        x86 {
-            ndk {
-                abiFilters 'x86', 'x86_64'
-            }
-        }
-        */
+    lintOptions {
+        abortOnError false
     }
-}
-
-delete {
-    delete 'src/main/assets/openrct2'
-}
-
-copy {
-    from '../../../bin/data'
-    into 'src/main/assets/openrct2'
 }
 
 dependencies {
     implementation 'commons-io:commons-io:2.6'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
 }
 
-allprojects {
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:deprecation"
-        }
-    }
-}

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -4,6 +4,27 @@ plugins {
 
 apply plugin: 'com.android.application'
 
+project.ext.ASSET_DIR = projectDir.toString() + '/openrct2-data'
+
+task myCopy(type: Copy) {
+    from "${projectDir.toString()}/../../../data/"
+    into project.ext.ASSET_DIR
+}
+
+//assemble.dependsOn myCopy
+tasks.whenTaskAdded { task ->
+    switch (task.name) {
+       case 'assembleDebug':
+       case 'assembleRelease':
+       case 'mergeDebugAssets':
+       case 'mergeReleaseAssets':
+       case 'lintVitalAnalyzeRelease':
+           task.dependsOn 'myCopy'
+    }
+}
+
+apply from: 'download_openrct2_data.gradle'
+
 android {
     compileSdkVersion 31
     ndkVersion "23.1.7779620" // Latest r23b (LTS), to be synced with CI container image
@@ -31,6 +52,7 @@ android {
 
     sourceSets.main {
         jniLibs.srcDir 'libs'
+        assets.srcDirs = [project.ext.ASSET_DIR]
     }
     externalNativeBuild {
         cmake {
@@ -43,17 +65,6 @@ android {
         abortOnError false
     }
 }
-
-project.ext.ASSET_DIR = projectDir.toString() + '/openrct2-data'
-
-task myCopy(type: Copy) {
-    from "${projectDir.toString()}/../../../data/"
-    into project.ext.ASSET_DIR
-}
-
-assemble.dependsOn myCopy
-
-apply from: 'download_openrct2_data.gradle'
 
 dependencies {
     implementation 'commons-io:commons-io:2.6'

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "de.undercouch.download" version "4.1.2"
+}
+
 apply plugin: 'com.android.application'
 
 android {
@@ -39,6 +43,17 @@ android {
         abortOnError false
     }
 }
+
+project.ext.ASSET_DIR = projectDir.toString() + '/openrct2-data'
+
+task myCopy(type: Copy) {
+    from "${projectDir.toString()}/../../../data/"
+    into project.ext.ASSET_DIR
+}
+
+assemble.dependsOn myCopy
+
+apply from: 'download_openrct2_data.gradle'
 
 dependencies {
     implementation 'commons-io:commons-io:2.6'

--- a/src/openrct2-android/app/download_openrct2_data.gradle
+++ b/src/openrct2-android/app/download_openrct2_data.gradle
@@ -23,10 +23,12 @@ task extractOpenRCT2data(type: Copy) {
 }
 
 tasks.whenTaskAdded { task ->
-    if (task.name == 'assembleDebug') {
-        task.dependsOn 'extractOpenRCT2data'
-    }
-    if (task.name == 'assembleRelease') {
-        task.dependsOn 'extractOpenRCT2data'
+    switch (task.name) {
+       case 'assembleDebug':
+       case 'assembleRelease':
+       case 'mergeDebugAssets':
+       case 'mergeReleaseAssets':
+       case 'lintVitalAnalyzeRelease':
+           task.dependsOn 'extractOpenRCT2data'
     }
 }

--- a/src/openrct2-android/app/download_openrct2_data.gradle
+++ b/src/openrct2-android/app/download_openrct2_data.gradle
@@ -1,0 +1,32 @@
+task downloadObjectsFile(type: Download) {
+    src ([
+        'https://github.com/OpenRCT2/objects/releases/download/v1.2.4/objects.zip',
+        'https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip'
+    ])
+    dest buildDir
+    onlyIfModified true
+}
+
+task downloadAndUnzipObjects(dependsOn: downloadObjectsFile, type: Copy) {
+    from zipTree(file("${downloadObjectsFile.dest}/objects.zip"))
+    into "${project.ext.ASSET_DIR}/object"
+}
+
+task downloadAndUnzipTitle(dependsOn: downloadObjectsFile, type: Copy) {
+    from zipTree(file("${downloadObjectsFile.dest}/title-sequences.zip"))
+    into "${project.ext.ASSET_DIR}/sequence"
+}
+
+task extractOpenRCT2data(type: Copy) {
+    dependsOn downloadAndUnzipObjects
+    dependsOn downloadAndUnzipTitle
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name == 'assembleDebug') {
+        task.dependsOn 'extractOpenRCT2data'
+    }
+    if (task.name == 'assembleRelease') {
+        task.dependsOn 'extractOpenRCT2data'
+    }
+}

--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:theme="@style/AppTheme.Splash">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/AppTheme.Splash">
+            android:theme="@style/AppTheme.Splash"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.8.0)
 
 project(openrct2-android CXX)
 
@@ -131,8 +131,6 @@ include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/freetype2")
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/SDL2")
 
 # now build app's shared lib
-include_directories(./ndk_helper
-                    ${ANDROID_NDK}/sources/android/cpufeatures)
 add_definitions(-DDISABLE_HTTP -DDISABLE_DISCORD_RPC -DDISABLE_HTTP -DDISABLE_NETWORK -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
 
 # Fix SpeexDSP compilation
@@ -182,7 +180,7 @@ file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${ORCT2_ROOT}/src/openrct2-cli/*.hpp")
 
 add_library(openrct2 SHARED ${LIBOPENRCT2_SOURCES})
-target_link_libraries(openrct2 android stdc++ log dl z SDL2 png icu icuuc icudata ssl crypto)
+target_link_libraries(openrct2 android stdc++ log dl z SDL2 png icu icuuc icudata)# ssl crypto)
 
 add_library(openrct2-ui SHARED ${OPENRCT2_GUI_SOURCES})
 target_link_libraries(openrct2-ui openrct2 android stdc++ GLESv1_CM GLESv2 SDL2main speexdsp)

--- a/src/openrct2-android/build.gradle
+++ b/src/openrct2-android/build.gradle
@@ -2,14 +2,12 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:7.0.3'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -17,7 +15,11 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip

--- a/src/openrct2-android/util/SpriteBuilder/CMakeLists.txt
+++ b/src/openrct2-android/util/SpriteBuilder/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.6.0)
+project(SpriteBuilder CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(ROOT_DIR "${CMAKE_SOURCE_DIR}/../../../../")
+include_directories("${ROOT_DIR}/src")
+include_directories("${ROOT_DIR}/src/thirdparty")
+# Directory installed in OpenRCT2's Android Docker images
+include_directories("/nlohmann/../")
+
+# Some most common files required in tests
+set(SB_SOURCES
+    "${ROOT_DIR}/src/openrct2/cmdline/SpriteCommands.cpp"
+    "${ROOT_DIR}/src/openrct2/CmdlineSprite.cpp"
+    "${ROOT_DIR}/src/openrct2/core/Console.cpp"
+    "${ROOT_DIR}/src/openrct2/core/Diagnostics.cpp"
+    "${ROOT_DIR}/src/openrct2/core/File.cpp"
+    "${ROOT_DIR}/src/openrct2/core/FileStream.cpp"
+    "${ROOT_DIR}/src/openrct2/core/Guard.cpp"
+    "${ROOT_DIR}/src/openrct2/core/Imaging.cpp"
+    "${ROOT_DIR}/src/openrct2/core/Json.cpp"
+    "${ROOT_DIR}/src/openrct2/core/Path.cpp"
+    "${ROOT_DIR}/src/openrct2/core/String.cpp"
+    "${ROOT_DIR}/src/openrct2/Diagnostic.cpp"
+    "${ROOT_DIR}/src/openrct2/drawing/Drawing.cpp"
+    "${ROOT_DIR}/src/openrct2/drawing/ImageImporter.cpp"
+    "${ROOT_DIR}/src/openrct2/drawing/NewDrawing.cpp"
+    "${ROOT_DIR}/src/openrct2/interface/ZoomLevel.cpp"
+    "${ROOT_DIR}/src/openrct2/localisation/ConversionTables.cpp"
+    "${ROOT_DIR}/src/openrct2/localisation/FormatCodes.cpp"
+    "${ROOT_DIR}/src/openrct2/localisation/UTF8.cpp"
+    "${ROOT_DIR}/src/openrct2/platform/Platform.Posix.cpp"
+    "${ROOT_DIR}/src/openrct2/platform/Posix.cpp"
+    "${ROOT_DIR}/src/openrct2/platform/Shared.cpp"
+    "${ROOT_DIR}/src/openrct2/util/Util.cpp"
+    "${ROOT_DIR}/src/openrct2/Version.cpp"
+    "sb.cpp"
+    )
+
+add_executable(sb ${SB_SOURCES})
+set_target_properties(sb PROPERTIES COMPILE_DEFINITIONS "DISABLE_HTTP;SPRITE_BUILDER")
+find_package(PNG REQUIRED)
+target_link_libraries(sb ${PNG_LIBRARIES})

--- a/src/openrct2-android/util/SpriteBuilder/sb.cpp
+++ b/src/openrct2-android/util/SpriteBuilder/sb.cpp
@@ -1,0 +1,87 @@
+#include "openrct2/CmdlineSprite.h"
+#include "openrct2/Context.h"
+#include "openrct2/drawing/Drawing.h"
+#include "openrct2/object/Object.h"
+
+bool gOpenRCT2Headless = true;
+bool gOpenRCT2NoGraphics = false;
+float gDayNightCycle = 0;
+uint16_t gClimateLightningFlash = 0;
+
+void mask_avx2(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    mask_scalar(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
+}
+void mask_sse4_1(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    mask_scalar(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
+}
+
+void* object_entry_get_chunk(ObjectType objectType, ObjectEntryIndex index)
+{
+    throw std::runtime_error("invalid call");
+    return nullptr;
+}
+int32_t context_get_width()
+{
+    throw std::runtime_error("invalid call");
+    return 0;
+}
+int32_t context_get_height()
+{
+    throw std::runtime_error("invalid call");
+    return 0;
+}
+void platform_get_openrct2_data_path(utf8* outPath, size_t outSize)
+{
+    throw std::runtime_error("invalid call");
+}
+void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+{
+    throw std::runtime_error("invalid call");
+}
+const rct_g1_element* gfx_get_g1_element(ImageId image_id)
+{
+    throw std::runtime_error("invalid call");
+    return nullptr;
+}
+const rct_g1_element* gfx_get_g1_element(ImageIndex image_idx)
+{
+    throw std::runtime_error("invalid call");
+    return nullptr;
+}
+void context_set_fullscreen_mode(int32_t mode)
+{
+    throw std::runtime_error("invalid_call");
+}
+void context_recreate_window()
+{
+    throw std::runtime_error("invalid_call");
+}
+namespace OpenRCT2
+{
+    [[nodiscard]] IContext* GetContext()
+    {
+        throw std::runtime_error("invalid_call");
+        return nullptr;
+    }
+} // namespace OpenRCT2
+
+int main(int argc, const char** argv)
+{
+    if (argc < 2)
+    {
+        fprintf(stderr, "Need at least one argument\n");
+    }
+    auto result = cmdline_for_sprite(&argv[1], argc - 1);
+    if (result != 1)
+    {
+        fprintf(stderr, "Command failed\n");
+        return 1;
+    }
+    return 0;
+}

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -412,6 +412,7 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         return 1;
     }
 
+#ifndef SPRITE_BUILDER
     if (_strcmpi(argv[0], "exportalldat") == 0)
     {
         if (argc < 3)
@@ -501,6 +502,7 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         }
         return 1;
     }
+#endif // SPRITE_BUILDER
 
     if (_strcmpi(argv[0], "create") == 0)
     {
@@ -657,6 +659,6 @@ int32_t cmdline_for_sprite(const char** argv, int32_t argc)
         return 1;
     }
 
-    fprintf(stderr, "Unknown sprite command.\n");
+    fprintf(stderr, "Unknown sprite command '%s'.\n", argv[0]);
     return 1;
 }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(SPRITE_BUILDER)
 #    include <unicode/ucnv.h>
 #    include <unicode/unistr.h>
 #    include <unicode/utypes.h>

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -155,30 +155,6 @@ static void read_and_convert_gxdat(IStream* stream, size_t count, bool is_rctc, 
     }
 }
 
-void mask_scalar(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
-{
-    for (int32_t yy = 0; yy < height; yy++)
-    {
-        for (int32_t xx = 0; xx < width; xx++)
-        {
-            uint8_t colour = (*colourSrc) & (*maskSrc);
-            if (colour != 0)
-            {
-                *dst = colour;
-            }
-
-            maskSrc++;
-            colourSrc++;
-            dst++;
-        }
-        maskSrc += maskWrap;
-        colourSrc += colourWrap;
-        dst += dstWrap;
-    }
-}
-
 static rct_gx _g1 = {};
 static rct_gx _g2 = {};
 static rct_gx _csg = {};
@@ -303,6 +279,7 @@ bool gfx_load_g2()
     return false;
 }
 
+#ifndef SPRITE_BUILDER
 bool gfx_load_csg()
 {
     log_verbose("gfx_load_csg()");
@@ -360,6 +337,7 @@ bool gfx_load_csg()
         return false;
     }
 }
+#endif // SPRITE_BUILDER
 
 static std::optional<PaletteMap> FASTCALL gfx_draw_sprite_get_palette(ImageId imageId)
 {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -553,6 +553,30 @@ ImageCatalogue ImageId::GetCatalogue() const
     return ImageCatalogue::UNKNOWN;
 }
 
+void mask_scalar(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    for (int32_t yy = 0; yy < height; yy++)
+    {
+        for (int32_t xx = 0; xx < width; xx++)
+        {
+            uint8_t colour = (*colourSrc) & (*maskSrc);
+            if (colour != 0)
+            {
+                *dst = colour;
+            }
+
+            maskSrc++;
+            colourSrc++;
+            dst++;
+        }
+        maskSrc += maskWrap;
+        colourSrc += colourWrap;
+        dst += dstWrap;
+    }
+}
+
 void (*mask_fn)(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
     int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
@@ -859,8 +883,10 @@ void RefreshVideo(bool recreateWindow)
 
 void ToggleWindowedMode()
 {
+#ifndef SPRITE_BUILDER
     int32_t targetMode = gConfigGeneral.fullscreen_mode == 0 ? 2 : 0;
     context_set_fullscreen_mode(targetMode);
     gConfigGeneral.fullscreen_mode = targetMode;
     config_save_default();
+#endif // SPRITE_BUILDER
 }

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -47,6 +47,7 @@ namespace Platform
 
     CurrencyType GetCurrencyValue(const char* currCode)
     {
+#ifndef SPRITE_BUILDER
         if (currCode == nullptr || strlen(currCode) < 3)
         {
             return CurrencyType::Pounds;
@@ -59,6 +60,7 @@ namespace Platform
                 return static_cast<CurrencyType>(currency);
             }
         }
+#endif // SPRITE_BUILDER
 
         return CurrencyType::Pounds;
     }


### PR DESCRIPTION
This is towards addressing https://github.com/OpenRCT2/OpenRCT2/issues/15191 given recent influx of Android users.

This only requires libpng (and transitively zlib) on host and nlohmann-json, which is a header only library which we ship in Android docker images already.

Next step is to update cmake to find libpng, verify it is installed in relevant docker, modify build steps for android to compile g2, embed the resulting g2 (and probably `data/`) somewhere in the apk.