### PR TITLE
Make track designs NSF map size safe

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -716,9 +716,7 @@ template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignSceneryElement& val)
     {
-        stream->Write(&val.x);
-        stream->Write(&val.y);
-        stream->Write(&val.z);
+        stream->Write(&val.loc);
         stream->Write(&val.flags);
         stream->Write(&val.primary_colour);
         stream->Write(&val.secondary_colour);
@@ -727,9 +725,7 @@ template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
     }
     static void decode(OpenRCT2::IStream* stream, TrackDesignSceneryElement& val)
     {
-        stream->Read(&val.x);
-        stream->Read(&val.y);
-        stream->Read(&val.z);
+        stream->Read(&val.loc);
         stream->Read(&val.flags);
         stream->Read(&val.primary_colour);
         stream->Read(&val.secondary_colour);
@@ -741,7 +737,7 @@ template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
         char msg[128] = {};
         snprintf(
             msg, sizeof(msg), "TrackDesignSceneryElement(x = %d, y = %d, z = %d, flags = %d, colour1 = %d, colour2 = %d)",
-            val.x, val.y, val.z, val.flags, val.primary_colour, val.secondary_colour);
+            val.loc.x, val.loc.y, val.loc.z, val.flags, val.primary_colour, val.secondary_colour);
         stream->Write(msg, strlen(msg));
 
         auto identifier = val.scenery_object.GetName();

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -40,7 +40,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -127,9 +127,9 @@ namespace RCT2
         for (const auto& sceneryElement : _trackDesign->scenery_elements)
         {
             tempStream.Write(&sceneryElement.scenery_object.Entry, sizeof(rct_object_entry));
-            tempStream.WriteValue<int8_t>(sceneryElement.x);
-            tempStream.WriteValue<int8_t>(sceneryElement.y);
-            tempStream.WriteValue<int8_t>(sceneryElement.z);
+            tempStream.WriteValue<int8_t>(sceneryElement.loc.x / COORDS_XY_STEP);
+            tempStream.WriteValue<int8_t>(sceneryElement.loc.y / COORDS_XY_STEP);
+            tempStream.WriteValue<int8_t>(sceneryElement.loc.z / COORDS_Z_STEP);
             tempStream.WriteValue<uint8_t>(sceneryElement.flags);
             tempStream.WriteValue<uint8_t>(sceneryElement.primary_colour);
             tempStream.WriteValue<uint8_t>(sceneryElement.secondary_colour);

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -203,9 +203,9 @@ namespace RCT2
                 _stream.Read(&t6SceneryElement, sizeof(TD6SceneryElement));
                 TrackDesignSceneryElement sceneryElement{};
                 sceneryElement.scenery_object = ObjectEntryDescriptor(t6SceneryElement.scenery_object);
-                sceneryElement.x = t6SceneryElement.x;
-                sceneryElement.y = t6SceneryElement.y;
-                sceneryElement.z = t6SceneryElement.z;
+                sceneryElement.loc.x = t6SceneryElement.x * COORDS_XY_STEP;
+                sceneryElement.loc.y = t6SceneryElement.y * COORDS_XY_STEP;
+                sceneryElement.loc.z = t6SceneryElement.z * COORDS_Z_STEP;
                 sceneryElement.flags = t6SceneryElement.flags;
                 sceneryElement.primary_colour = t6SceneryElement.primary_colour;
                 sceneryElement.secondary_colour = t6SceneryElement.secondary_colour;

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -47,9 +47,7 @@ struct TrackDesignEntranceElement
 struct TrackDesignSceneryElement
 {
     ObjectEntryDescriptor scenery_object;
-    int8_t x;
-    int8_t y;
-    int8_t z;
+    CoordsXYZ loc;
     uint8_t flags;
     uint8_t primary_colour;
     uint8_t secondary_colour;

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -217,12 +217,9 @@ static bool track_design_is_supported_object(const Object* obj)
 static void track_design_save_push_tile_element_desc(
     const rct_object_entry& entry, const CoordsXYZ& loc, uint8_t flags, uint8_t primaryColour, uint8_t secondaryColour)
 {
-    auto tileLoc = TileCoordsXYZ(loc);
     TrackDesignSceneryElement item{};
     item.scenery_object = ObjectEntryDescriptor(entry);
-    item.x = tileLoc.x;
-    item.y = tileLoc.y;
-    item.z = tileLoc.z;
+    item.loc = loc;
     item.flags = flags;
     item.primary_colour = primaryColour;
     item.secondary_colour = secondaryColour;
@@ -442,15 +439,10 @@ static void track_design_save_pop_tile_element(const CoordsXY& loc, TileElement*
 static void track_design_save_pop_tile_element_desc(const ObjectEntryDescriptor& entry, const CoordsXYZ& loc, uint8_t flags)
 {
     size_t removeIndex = SIZE_MAX;
-    auto tileLoc = TileCoordsXYZ(loc);
     for (size_t i = 0; i < _trackSavedTileElementsDesc.size(); i++)
     {
         TrackDesignSceneryElement* item = &_trackSavedTileElementsDesc[i];
-        if (item->x != tileLoc.x)
-            continue;
-        if (item->y != tileLoc.y)
-            continue;
-        if (item->z != tileLoc.z)
+        if (item->loc != loc)
             continue;
         if (item->flags != flags)
             continue;


### PR DESCRIPTION
This really needs #16091 before it can be tested properly.
After this should do the same for entrances. Entrances are NSF map size safe I think but they could do with using the standard CoordsXYZ type instead of yet another xyz type.