### PR TITLE
Part of #15485: Use normalised tile element type enum for setting type

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2446,7 +2446,7 @@ static void Sub6CbcE2(
         map_set_tile_element(southTileCoords, &_tempSideTrackTileElement);
 
         // Set the temporary track element
-        _tempTrackTileElement.SetType(TILE_ELEMENT_TYPE_TRACK);
+        _tempTrackTileElement.SetTypeN(TileElementTypeN::Track);
         _tempTrackTileElement.SetDirection(trackDirection);
         _tempTrackTileElement.AsTrack()->SetHasChain((liftHillAndInvertedState & CONSTRUCTION_LIFT_HILL_SELECTED) != 0);
         _tempTrackTileElement.SetOccupiedQuadrants(quarterTile.GetBaseQuarterOccupied());

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1815,7 +1815,7 @@ namespace RCT1
                             clearanceZ += LAND_HEIGHT_STEP;
                         }
 
-                        dst->SetType(TILE_ELEMENT_TYPE_WALL);
+                        dst->SetTypeN(TileElementTypeN::Wall);
                         dst->SetDirection(edge);
                         dst->SetBaseZ(baseZ);
                         dst->SetClearanceZ(clearanceZ);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -7360,7 +7360,7 @@ void Vehicle::UpdateLandscapeDoor() const
 
     auto coords = CoordsXYZ{ x, y, TrackLocation.z }.ToTileStart();
     auto* tileElement = map_get_track_element_at_from_ride(coords, ride);
-    if (tileElement != nullptr && tileElement->GetType() == static_cast<uint8_t>(TileElementType::Track))
+    if (tileElement != nullptr && tileElement->GetTypeN() == TileElementTypeN::Track)
     {
         AnimateLandscapeDoor<false>(tileElement->AsTrack(), next_vehicle_on_train == SPRITE_INDEX_NULL);
     }
@@ -7434,7 +7434,7 @@ void Vehicle::UpdateLandscapeDoorBackwards() const
 
     auto coords = CoordsXYZ{ TrackLocation, TrackLocation.z };
     auto* tileElement = map_get_track_element_at_from_ride(coords, ride);
-    if (tileElement != nullptr && tileElement->GetType() == static_cast<uint8_t>(TileElementType::Track))
+    if (tileElement != nullptr && tileElement->GetTypeN() == TileElementTypeN::Track)
     {
         AnimateLandscapeDoor<true>(tileElement->AsTrack(), next_vehicle_on_train == SPRITE_INDEX_NULL);
     }

--- a/src/openrct2/scripting/bindings/world/ScTile.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTile.cpp
@@ -105,7 +105,7 @@ namespace OpenRCT2::Scripting
                     auto numToInsert = numElements - currentNumElements;
                     for (size_t i = 0; i < numToInsert; i++)
                     {
-                        tile_element_insert(pos, 0, TileElementType::Surface);
+                        tile_element_insert(pos, 0, TileElementTypeN::Surface);
                     }
 
                     // Copy data to element span
@@ -150,7 +150,7 @@ namespace OpenRCT2::Scripting
             std::vector<TileElement> data(first, first + origNumElements);
 
             auto pos = TileCoordsXYZ(TileCoordsXY(_coords), 0).ToCoordsXYZ();
-            auto newElement = tile_element_insert(pos, 0, TileElementType::Surface);
+            auto newElement = tile_element_insert(pos, 0, TileElementTypeN::Surface);
             if (newElement == nullptr)
             {
                 auto ctx = GetDukContext();

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1234,7 +1234,7 @@ static TileElement* AllocateTileElements(size_t numElementsOnTile, size_t numNew
  *
  *  rct2: 0x0068B1F6
  */
-TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type)
+TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementTypeN type)
 {
     const auto& tileLoc = TileCoordsXYZ(loc);
 
@@ -1278,7 +1278,7 @@ TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants
     // Insert new map element
     auto* insertedElement = newTileElement;
     newTileElement->type = 0;
-    newTileElement->SetType(static_cast<uint8_t>(type));
+    newTileElement->SetTypeN(type);
     newTileElement->SetBaseZ(loc.z);
     newTileElement->Flags = 0;
     newTileElement->SetLastForTile(isLastForTile);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -189,7 +189,7 @@ void map_remove_all_rides();
 void map_invalidate_map_selection_tiles();
 void map_invalidate_selection_rect();
 bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements = 1);
-TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type);
+TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementTypeN type);
 
 template<typename T> T* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants)
 {

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -60,6 +60,18 @@ enum class TileElementType : uint8_t
     Banner = (7 << 2),
 };
 
+enum class TileElementTypeN : uint8_t
+{
+    Surface = 0,
+    Path = 1,
+    Track = 2,
+    SmallScenery = 3,
+    Entrance = 4,
+    Wall = 5,
+    LargeScenery = 6,
+    Banner = 7,
+};
+
 struct TileElement;
 struct SurfaceElement;
 struct PathElement;
@@ -82,6 +94,9 @@ struct TileElementBase
 
     uint8_t GetType() const;
     void SetType(uint8_t newType);
+
+    TileElementTypeN GetTypeN() const;
+    void SetTypeN(TileElementTypeN newType);
 
     Direction GetDirection() const;
     void SetDirection(Direction direction);

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -48,18 +48,6 @@ enum
     TILE_ELEMENT_TYPE_BANNER = (7 << 2),
 };
 
-enum class TileElementType : uint8_t
-{
-    Surface = (0 << 2),
-    Path = (1 << 2),
-    Track = (2 << 2),
-    SmallScenery = (3 << 2),
-    Entrance = (4 << 2),
-    Wall = (5 << 2),
-    LargeScenery = (6 << 2),
-    Banner = (7 << 2),
-};
-
 enum class TileElementTypeN : uint8_t
 {
     Surface = 0,
@@ -93,7 +81,6 @@ struct TileElementBase
     void Remove();
 
     uint8_t GetType() const;
-    void SetType(uint8_t newType);
 
     TileElementTypeN GetTypeN() const;
     void SetTypeN(TileElementTypeN newType);
@@ -126,8 +113,7 @@ struct TileElementBase
         if constexpr (std::is_same_v<TType, TileElement>)
             return reinterpret_cast<const TileElement*>(this);
         else
-            return static_cast<TileElementType>(GetType()) == TType::ElementType ? reinterpret_cast<const TType*>(this)
-                                                                                 : nullptr;
+            return GetTypeN() == TType::ElementType ? reinterpret_cast<const TType*>(this) : nullptr;
     }
 
     template<typename TType> TType* as()
@@ -135,7 +121,7 @@ struct TileElementBase
         if constexpr (std::is_same_v<TType, TileElement>)
             return reinterpret_cast<TileElement*>(this);
         else
-            return static_cast<TileElementType>(GetType()) == TType::ElementType ? reinterpret_cast<TType*>(this) : nullptr;
+            return GetTypeN() == TType::ElementType ? reinterpret_cast<TType*>(this) : nullptr;
     }
 
     const SurfaceElement* AsSurface() const
@@ -225,7 +211,7 @@ assert_struct_size(TileElement, 16);
 
 struct SurfaceElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::Surface;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::Surface;
 
 private:
     uint8_t Slope;
@@ -272,7 +258,7 @@ assert_struct_size(SurfaceElement, 16);
 
 struct PathElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::Path;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::Path;
 
 private:
     ObjectEntryIndex SurfaceIndex;  // 5
@@ -362,7 +348,7 @@ assert_struct_size(PathElement, 16);
 
 struct TrackElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::Track;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::Track;
 
 private:
     track_type_t TrackType;
@@ -463,7 +449,7 @@ assert_struct_size(TrackElement, 16);
 
 struct SmallSceneryElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::SmallScenery;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::SmallScenery;
 
 private:
     ObjectEntryIndex entryIndex; // 5
@@ -496,7 +482,7 @@ assert_struct_size(SmallSceneryElement, 16);
 
 struct LargeSceneryElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::LargeScenery;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::LargeScenery;
 
 private:
     ObjectEntryIndex EntryIndex;
@@ -534,7 +520,7 @@ assert_struct_size(LargeSceneryElement, 16);
 
 struct WallElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::Wall;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::Wall;
 
 private:
     ObjectEntryIndex entryIndex; // 05
@@ -579,7 +565,7 @@ assert_struct_size(WallElement, 16);
 
 struct EntranceElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::Entrance;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::Entrance;
 
 private:
     uint8_t entranceType;      // 5
@@ -624,7 +610,7 @@ assert_struct_size(EntranceElement, 16);
 
 struct BannerElement : TileElementBase
 {
-    static constexpr TileElementType ElementType = TileElementType::Banner;
+    static constexpr TileElementTypeN ElementType = TileElementTypeN::Banner;
 
 private:
     BannerIndex index;    // 5

--- a/src/openrct2/world/TileElementBase.cpp
+++ b/src/openrct2/world/TileElementBase.cpp
@@ -15,12 +15,6 @@ uint8_t TileElementBase::GetType() const
     return this->type & TILE_ELEMENT_TYPE_MASK;
 }
 
-void TileElementBase::SetType(uint8_t newType)
-{
-    this->type &= ~TILE_ELEMENT_TYPE_MASK;
-    this->type |= (newType & TILE_ELEMENT_TYPE_MASK);
-}
-
 TileElementTypeN TileElementBase::GetTypeN() const
 {
     return static_cast<TileElementTypeN>((this->type & TILE_ELEMENT_TYPE_MASK) >> 2);

--- a/src/openrct2/world/TileElementBase.cpp
+++ b/src/openrct2/world/TileElementBase.cpp
@@ -21,6 +21,17 @@ void TileElementBase::SetType(uint8_t newType)
     this->type |= (newType & TILE_ELEMENT_TYPE_MASK);
 }
 
+TileElementTypeN TileElementBase::GetTypeN() const
+{
+    return static_cast<TileElementTypeN>((this->type & TILE_ELEMENT_TYPE_MASK) >> 2);
+}
+
+void TileElementBase::SetTypeN(TileElementTypeN newType)
+{
+    this->type &= ~TILE_ELEMENT_TYPE_MASK;
+    this->type |= ((EnumValue(newType) << 2) & TILE_ELEMENT_TYPE_MASK);
+}
+
 Direction TileElementBase::GetDirection() const
 {
     return this->type & TILE_ELEMENT_DIRECTION_MASK;

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -347,7 +347,7 @@ namespace OpenRCT2::TileInspector
             // The occupiedQuadrants will be automatically set when the element is copied over, so it's not necessary to set
             // them correctly _here_.
             TileElement* const pastedElement = tile_element_insert(
-                { loc, element.GetBaseZ() }, 0b0000, TileElementType::Surface);
+                { loc, element.GetBaseZ() }, 0b0000, TileElementTypeN::Surface);
 
             bool lastForTile = pastedElement->IsLastForTile();
             *pastedElement = element;

--- a/test/testpaint/generate.cpp
+++ b/test/testpaint/generate.cpp
@@ -437,7 +437,7 @@ private:
         for (int direction = 0; direction < 4; direction++)
         {
             TileElement tileElement = {};
-            tileElement.SetType(TILE_ELEMENT_TYPE_TRACK);
+            tileElement.SetTypeN(TileElementTypeN::Track);
             tileElement.SetLastForTile(true);
             tileElement.AsTrack()->SetTrackType(trackType);
             tileElement.base_height = 3;


### PR DESCRIPTION
This introduces the enum with normalised values and modifies all the setters to use it. More details as to the why can be found #15485.

Follow-up PRs will also modify the getters and drop the `N` postfix.