### PR TITLE
Make Parkfile Pathfinding Deterministic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,9 @@ set(OBJECTS_VERSION "1.2.4")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c82605035f120188b7334a781a786ced9588e9af")
 
-set(REPLAYS_VERSION "0.0.60")
+set(REPLAYS_VERSION "0.0.61")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "1EB460BB3C71BD21CCBE778BEF1E8CD593241A18")
+set(REPLAYS_SHA1 "18BFAD02A453CE0D5926C13A856546ED825AD0F1")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.2.4/objects.zip</ObjectsUrl>
     <ObjectsSha1>c82605035f120188b7334a781a786ced9588e9af</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.60/replays.zip</ReplaysUrl>
-    <ReplaysSha1>1EB460BB3C71BD21CCBE778BEF1E8CD593241A18</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.61/replays.zip</ReplaysUrl>
+    <ReplaysSha1>18BFAD02A453CE0D5926C13A856546ED825AD0F1</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -331,11 +331,7 @@ struct Peep : EntityBase
     uint8_t EnergyTarget;
     uint8_t Mass;
     uint8_t WindowInvalidateFlags;
-    union
-    {
-        ride_id_t CurrentRide;
-        ParkEntranceIndex ChosenParkEntrance;
-    };
+    ride_id_t CurrentRide;
     StationIndex CurrentRideStation;
     uint8_t CurrentTrain;
     union

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -40,7 +40,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1735,11 +1735,16 @@ static int32_t GuestPathFindPeepSpawn(Peep* peep, uint8_t edges)
  */
 static int32_t GuestPathFindParkEntranceLeaving(Peep* peep, uint8_t edges)
 {
-    // If entrance no longer exists, choose a new one
-    if ((peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN) && peep->ChosenParkEntrance.ToUnderlying() >= gParkEntrances.size())
+    TileCoordsXYZ entranceGoal{};
+    if (peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN)
     {
-        peep->ChosenParkEntrance = ParkEntranceIndex::GetNull();
-        peep->PeepFlags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
+        entranceGoal = peep->PathfindGoal;
+        auto* entranceElement = map_get_park_entrance_element_at(entranceGoal.ToCoordsXYZ(), false);
+        // If entrance no longer exists, choose a new one
+        if (entranceElement == nullptr)
+        {
+            peep->PeepFlags &= ~(PEEP_FLAGS_PARK_ENTRANCE_CHOSEN);
+        }
     }
 
     if (!(peep->PeepFlags & PEEP_FLAGS_PARK_ENTRANCE_CHOSEN))
@@ -1749,13 +1754,11 @@ static int32_t GuestPathFindParkEntranceLeaving(Peep* peep, uint8_t edges)
         if (chosenEntrance.IsNull())
             return guest_path_find_aimless(peep, edges);
 
-        peep->ChosenParkEntrance = chosenEntrance;
         peep->PeepFlags |= PEEP_FLAGS_PARK_ENTRANCE_CHOSEN;
+        entranceGoal = TileCoordsXYZ(gParkEntrances[chosenEntrance.ToUnderlying()]);
     }
 
-    const auto& entrance = gParkEntrances[peep->ChosenParkEntrance.ToUnderlying()];
-
-    gPeepPathFindGoalPosition = TileCoordsXYZ(entrance);
+    gPeepPathFindGoalPosition = entranceGoal;
     gPeepPathFindIgnoreForeignQueues = true;
     gPeepPathFindQueueRideIndex = RIDE_ID_NULL;
 


### PR DESCRIPTION
Currently the parkfile pathfinding is undeterministic when leaving the park. This fixes that issue by removing the park entrance index from being recorded (the index is not guaranteed to be the same in multiplayer).