### PR TITLE
Refactor ride-specific bounding boxes into uniform BoundBox structs

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -315,6 +315,7 @@
     <ClInclude Include="object\WallObject.h" />
     <ClInclude Include="object\WaterObject.h" />
     <ClInclude Include="OpenRCT2.h" />
+    <ClInclude Include="paint\Boundbox.h" />
     <ClInclude Include="paint\Paint.Entity.h" />
     <ClInclude Include="paint\Paint.h" />
     <ClInclude Include="paint\Painter.h" />

--- a/src/openrct2/paint/Boundbox.h
+++ b/src/openrct2/paint/Boundbox.h
@@ -1,0 +1,40 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2022 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../world/Location.hpp"
+
+#include <cstdint>
+
+struct BoundBoxXY
+{
+    CoordsXY length{};
+    CoordsXY offset{};
+
+    constexpr BoundBoxXY() = default;
+    constexpr BoundBoxXY(CoordsXY _length, CoordsXY _offset)
+        : length(_length)
+        , offset(_offset)
+    {
+    }
+};
+
+struct BoundBoxXYZ
+{
+    CoordsXYZ length{};
+    CoordsXYZ offset{};
+
+    constexpr BoundBoxXYZ() = default;
+    constexpr BoundBoxXYZ(CoordsXYZ _length, CoordsXYZ _offset)
+        : length(_length)
+        , offset(_offset)
+    {
+    }
+};

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -306,13 +306,9 @@ static constexpr const uint16_t* WoodenCurveSupportImageIds[12] = {
     nullptr,
 };
 
-struct unk_supports_desc_bound_box {
-    CoordsXYZ offset;
-    CoordsXYZ length;
-};
 
 struct unk_supports_desc {
-    unk_supports_desc_bound_box bounding_box;
+    BoundBoxXYZ bounding_box;
     uint8_t var_6;
     uint8_t var_7;
 };
@@ -595,7 +591,7 @@ bool wooden_a_supports_paint_setup(
         {
             auto imageId = imageTemplate.WithIndex(WoodenCurveSupportImageIds[supportType][special]);
 
-            unk_supports_desc_bound_box bBox = byte_97B23C[special].bounding_box;
+            BoundBoxXYZ bBox = byte_97B23C[special].bounding_box;
 
             if (byte_97B23C[special].var_6 == 0 || session.WoodenSupportsPrependTo == nullptr)
             {
@@ -768,7 +764,7 @@ bool wooden_b_supports_paint_setup(
         { // byte_97B23C[special].var_7 is never 0
             auto imageId = imageTemplate.WithIndex(WoodenCurveSupportImageIds[supportType][specialIndex]);
 
-            const unk_supports_desc_bound_box& boundBox = supportsDesc.bounding_box;
+            const BoundBoxXYZ& boundBox = supportsDesc.bounding_box;
 
             if (supportsDesc.var_6 == 0 || session.WoodenSupportsPrependTo == nullptr)
             {
@@ -1303,7 +1299,7 @@ bool path_a_supports_paint_setup(
         ImageIndex imageIndex = pathPaintInfo.BridgeImageId + 55 + specialIndex;
 
         const unk_supports_desc& supportsDesc = byte_98D8D4[specialIndex];
-        const unk_supports_desc_bound_box& boundBox = supportsDesc.bounding_box;
+        const BoundBoxXYZ& boundBox = supportsDesc.bounding_box;
 
         if (supportsDesc.var_6 == 0 || session.WoodenSupportsPrependTo == nullptr)
         {

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -14,6 +14,7 @@
 #include "../sprites.h"
 #include "../util/Math.hpp"
 #include "../world/Surface.h"
+#include "Boundbox.h"
 #include "Paint.h"
 #include "tile_element/Paint.TileElement.h"
 

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -592,7 +592,7 @@ bool wooden_a_supports_paint_setup(
         {
             auto imageId = imageTemplate.WithIndex(WoodenCurveSupportImageIds[supportType][special]);
 
-            BoundBoxXYZ bBox = byte_97B23C[special].bounding_box;
+            const BoundBoxXYZ& bBox = byte_97B23C[special].bounding_box;
 
             if (byte_97B23C[special].var_6 == 0 || session.WoodenSupportsPrependTo == nullptr)
             {

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -9,6 +9,7 @@
 
 #include "../../entity/EntityRegistry.h"
 #include "../../interface/Viewport.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../../ride/Vehicle.h"

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -17,7 +17,7 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-static constexpr const BoundBoxXY crooked_house_data[] = {
+static constexpr const BoundBoxXY CrookedHouseData[] = {
     {
         { 6, 0 },
         { 42, 24 },
@@ -69,7 +69,7 @@ static void PaintCrookedHouseStructure(
         }
     }
 
-    const auto& boundBox = crooked_house_data[segment];
+    const auto& boundBox = CrookedHouseData[segment];
     auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_MISC]);
     auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsParent(

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -17,13 +17,7 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-struct rct_crooked_house_bound_box
-{
-    CoordsXY offset;
-    CoordsXY length;
-};
-
-static constexpr const rct_crooked_house_bound_box crooked_house_data[] = {
+static constexpr const BoundBoxXY crooked_house_data[] = {
     {
         { 6, 0 },
         { 42, 24 },

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -34,10 +34,10 @@ static constexpr const uint8_t edges_1x4_nw_se[] = {
 
 /** rct2: 0x008A8CA8 */
 static constexpr BoundBoxXY FerrisWheelData[] = {
-    { { 1, 8 }, { 31, 16 }  },
-    { { 8, 1 }, { 16, 31 }  },
-    { { 1, 8 }, { 31, 16 }  },
-    { { 8, 1 }, { 16, 31 }  },
+    { { 1, 8 }, { 31, 16 } },
+    { { 8, 1 }, { 16, 31 } },
+    { { 1, 8 }, { 31, 16 } },
+    { { 8, 1 }, { 16, 31 } },
 };
 
 static void PaintFerrisWheelRiders(

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -32,18 +32,12 @@ static constexpr const uint8_t edges_1x4_nw_se[] = {
     EDGE_NE | EDGE_SW | EDGE_SE,
 };
 
-struct ferris_wheel_bound_box
-{
-    CoordsXY length;
-    CoordsXY offset;
-};
-
 /** rct2: 0x008A8CA8 */
-static constexpr ferris_wheel_bound_box FerrisWheelData[] = {
-    { { 31, 16 }, { 1, 8 } },
-    { { 16, 31 }, { 8, 1 } },
-    { { 31, 16 }, { 1, 8 } },
-    { { 16, 31 }, { 8, 1 } },
+static constexpr BoundBoxXY FerrisWheelData[] = {
+    { { 1, 8 }, { 31, 16 }  },
+    { { 8, 1 }, { 16, 31 }  },
+    { { 1, 8 }, { 31, 16 }  },
+    { { 8, 1 }, { 16, 31 }  },
 };
 
 static void PaintFerrisWheelRiders(

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -10,6 +10,7 @@
 #include "../../entity/EntityRegistry.h"
 #include "../../entity/Guest.h"
 #include "../../interface/Viewport.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../Ride.h"

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -17,7 +17,7 @@
 #include "../TrackPaint.h"
 #include "../Vehicle.h"
 
-static constexpr BoundBoxXY haunted_house_data[] = {
+static constexpr BoundBoxXY HauntedHouseData[] = {
     { { 6, 0 }, { 42, 24 } }, { { 0, 0 }, { 0, 0 } },   { { -16, -16 }, { 32, 32 } },
     { { 0, 0 }, { 0, 0 } },   { { 0, 6 }, { 24, 42 } }, { { 0, 0 }, { 0, 0 } },
 };
@@ -39,7 +39,7 @@ static void PaintHauntedHouseStructure(
         frameNum = vehicle->Pitch;
     }
 
-    const auto& boundBox = haunted_house_data[part];
+    const auto& boundBox = HauntedHouseData[part];
     auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_MISC]);
     auto baseImageIndex = rideEntry->Cars[0].base_image_id;
     auto imageIndex = baseImageIndex + direction;

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -9,6 +9,7 @@
 
 #include "../../entity/EntityRegistry.h"
 #include "../../interface/Viewport.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../Ride.h"

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -17,13 +17,7 @@
 #include "../TrackPaint.h"
 #include "../Vehicle.h"
 
-struct haunted_house_bound_box
-{
-    CoordsXY offset;
-    CoordsXY length;
-};
-
-static constexpr haunted_house_bound_box haunted_house_data[] = {
+static constexpr BoundBoxXY haunted_house_data[] = {
     { { 6, 0 }, { 42, 24 } }, { { 0, 0 }, { 0, 0 } },   { { -16, -16 }, { 32, 32 } },
     { { 0, 0 }, { 0, 0 } },   { { 0, 6 }, { 24, 42 } }, { { 0, 0 }, { 0, 0 } },
 };

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -36,14 +36,6 @@ enum
     SPR_MAGIC_CARPET_PENDULUM_SW = 22102,
 };
 
-struct bound_box
-{
-    int16_t x;
-    int16_t y;
-    int16_t width;
-    int16_t height;
-};
-
 static constexpr const int16_t MagicCarpetOscillationZ[] = {
     -2, -1, 1, 5, 10, 16, 23, 30, 37, 45, 52, 59, 65, 70, 74, 76, 77, 76, 74, 70, 65, 59, 52, 45, 37, 30, 23, 16, 10, 5, 1, -1,
 };
@@ -53,7 +45,7 @@ static constexpr const int8_t MagicCarpetOscillationXY[] = {
     0, -5, -11, -17, -22, -26, -29, -30, -31, -30, -29, -26, -22, -17, -11, -5,
 };
 
-static constexpr const bound_box MagicCarpetBounds[] = {
+static constexpr const BoundBoxXY MagicCarpetBounds[] = {
     { 0, 8, 32, 16 },
     { 8, 0, 16, 32 },
     { 0, 8, 32, 16 },
@@ -202,16 +194,16 @@ static void PaintMagicCarpetStructure(
         session.CurrentlyDrawnEntity = vehicle;
     }
 
-    bound_box bb = MagicCarpetBounds[direction];
+    BoundBoxXY bb = MagicCarpetBounds[direction];
     CoordsXYZ offset, bbOffset, bbSize;
     offset.x = (direction & 1) ? 0 : axisOffset;
     offset.y = (direction & 1) ? axisOffset : 0;
     offset.z = height + 7;
-    bbOffset.x = bb.x;
-    bbOffset.y = bb.y;
+    bbOffset.x = bb.offset.x;
+    bbOffset.y = bb.offset.y;
     bbOffset.z = height + 7;
-    bbSize.x = bb.width;
-    bbSize.y = bb.height;
+    bbSize.x = bb.length.x;
+    bbSize.y = bb.offset.y;
     bbSize.z = 127;
 
     PaintMagicCarpetFrame(session, Plane::Back, direction, offset, bbOffset, bbSize);

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -10,6 +10,7 @@
 #include "../../entity/EntityRegistry.h"
 #include "../../interface/Viewport.h"
 #include "../../object/StationObject.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../Ride.h"
@@ -46,10 +47,10 @@ static constexpr const int8_t MagicCarpetOscillationXY[] = {
 };
 
 static constexpr const BoundBoxXY MagicCarpetBounds[] = {
-    { 0, 8, 32, 16 },
-    { 8, 0, 16, 32 },
-    { 0, 8, 32, 16 },
-    { 8, 0, 16, 32 },
+    { { 0, 8 }, { 32, 16 } },
+    { { 8, 0 }, { 16, 32 } },
+    { { 0, 8 }, { 32, 16 } },
+    { { 8, 0 }, { 16, 32 } },
 };
 
 static ImageIndex GetMagicCarpetFrameImage(Plane plane, Direction direction)

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -203,7 +203,7 @@ static void PaintMagicCarpetStructure(
     bbOffset.y = bb.offset.y;
     bbOffset.z = height + 7;
     bbSize.x = bb.length.x;
-    bbSize.y = bb.offset.y;
+    bbSize.y = bb.length.y;
     bbSize.z = 127;
 
     PaintMagicCarpetFrame(session, Plane::Back, direction, offset, bbOffset, bbSize);

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -35,7 +35,7 @@ static constexpr const uint32_t SwingingInverterShipAnimatingBaseSpriteOffset[] 
 };
 
 /** rct2: 0x01428020 */
-static constexpr const BoundBoxXY swinging_inverter_ship_bounds[] = {
+static constexpr const BoundBoxXY SwingingInverterShipBounds[] = {
     { 0, 8, 32, 16 },
     { 8, 0, 16, 32 },
     { 0, 8, 32, 16 },
@@ -64,7 +64,7 @@ static void PaintSwingingInverterShipStructure(
     if (rideEntry == nullptr)
         return;
 
-    const auto& boundBox = swinging_inverter_ship_bounds[direction];
+    const auto& boundBox = SwingingInverterShipBounds[direction];
     CoordsXYZ offset((direction & 1) ? 0 : axisOffset, (direction & 1) ? axisOffset : 0, height);
     CoordsXYZ bbLength(boundBox.length.x, boundBox.length.y, 127);
     CoordsXYZ bbOffset(boundBox.offset.x, boundBox.offset.y, height);

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -34,20 +34,12 @@ static constexpr const uint32_t SwingingInverterShipAnimatingBaseSpriteOffset[] 
     33,
 };
 
-struct swinging_inverter_ship_bound_box
-{
-    int16_t length_x;
-    int16_t length_y;
-    int16_t offset_x;
-    int16_t offset_y;
-};
-
 /** rct2: 0x01428020 */
-static constexpr const swinging_inverter_ship_bound_box swinging_inverter_ship_bounds[] = {
-    { 32, 16, 0, 8 },
-    { 16, 32, 8, 0 },
-    { 32, 16, 0, 8 },
-    { 16, 32, 8, 0 },
+static constexpr const BoundBoxXY swinging_inverter_ship_bounds[] = {
+    { 0, 8, 32, 16 },
+    { 8, 0, 16, 32 },
+    { 0, 8, 32, 16 },
+    { 8, 0, 16, 32 },
 };
 
 enum
@@ -74,8 +66,8 @@ static void PaintSwingingInverterShipStructure(
 
     const auto& boundBox = swinging_inverter_ship_bounds[direction];
     CoordsXYZ offset((direction & 1) ? 0 : axisOffset, (direction & 1) ? axisOffset : 0, height);
-    CoordsXYZ bbLength(boundBox.length_x, boundBox.length_y, 127);
-    CoordsXYZ bbOffset(boundBox.offset_x, boundBox.offset_y, height);
+    CoordsXYZ bbLength(boundBox.length.x, boundBox.length.y, 127);
+    CoordsXYZ bbOffset(boundBox.offset.x, boundBox.offset.y, height);
 
     Vehicle* vehicle = nullptr;
     if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -10,6 +10,7 @@
 #include "../../entity/EntityRegistry.h"
 #include "../../interface/Viewport.h"
 #include "../../object/StationObject.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../Ride.h"
@@ -36,10 +37,10 @@ static constexpr const uint32_t SwingingInverterShipAnimatingBaseSpriteOffset[] 
 
 /** rct2: 0x01428020 */
 static constexpr const BoundBoxXY SwingingInverterShipBounds[] = {
-    { 0, 8, 32, 16 },
-    { 8, 0, 16, 32 },
-    { 0, 8, 32, 16 },
-    { 8, 0, 16, 32 },
+    { { 0, 8 }, { 32, 16 } },
+    { { 8, 0 }, { 16, 32 } },
+    { { 0, 8 }, { 32, 16 } },
+    { { 8, 0 }, { 16, 32 } },
 };
 
 enum

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -102,7 +102,7 @@ static void PaintSwingingShipStructure(
     CoordsXYZ offset((direction & 1) ? 0 : axisOffset, (direction & 1) ? axisOffset : 0, height + 7);
     CoordsXYZ bbLength(bounds.length.x, bounds.length.y, 80);
     CoordsXYZ bbOffset(bounds.offset.x, bounds.offset.y, height + 7);
-    
+
     auto baseImageId = rideEntry->Cars[0].base_image_id + SwingingShipBaseSpriteOffset[direction];
     if (vehicle != nullptr)
     {

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -25,15 +25,6 @@ static constexpr const uint8_t track_map_1x5[][5] = {
     { 0, 4, 3, 2, 1 },
     { 0, 1, 2, 3, 4 },
 };
-
-struct swinging_ship_bound_box
-{
-    int16_t length_x;
-    int16_t length_y;
-    int16_t offset_x;
-    int16_t offset_y;
-};
-
 /** rct2: 0x008A83B0 */
 static constexpr const uint32_t SwingingShipBaseSpriteOffset[] = {
     0,
@@ -43,11 +34,11 @@ static constexpr const uint32_t SwingingShipBaseSpriteOffset[] = {
 };
 
 /** rct2: 0x008A83C0 */
-static constexpr const swinging_ship_bound_box SwingingShipData[] = {
-    { 31, 16, 1, 8 },
-    { 16, 31, 8, 1 },
-    { 31, 16, 1, 8 },
-    { 16, 31, 8, 1 },
+static constexpr const BoundBoxXY SwingingShipData[] = {
+    {  1, 8, 31, 16 },
+    {  8, 1, 16, 31 },
+    {  1, 8, 31, 16 },
+    {  8, 1, 16, 31 },
 };
 
 enum
@@ -108,9 +99,9 @@ static void PaintSwingingShipStructure(
 
     const auto& bounds = SwingingShipData[direction];
     CoordsXYZ offset((direction & 1) ? 0 : axisOffset, (direction & 1) ? axisOffset : 0, height + 7);
-    CoordsXYZ bbLength(bounds.length_x, bounds.length_y, 80);
-    CoordsXYZ bbOffset(bounds.offset_x, bounds.offset_y, height + 7);
-
+    CoordsXYZ bbLength(bounds.length.x, bounds.length.y, 80);
+    CoordsXYZ bbOffset(bounds.offset.x, bounds.offset.y, height + 7);
+    
     auto baseImageId = rideEntry->Cars[0].base_image_id + SwingingShipBaseSpriteOffset[direction];
     if (vehicle != nullptr)
     {

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -35,10 +35,10 @@ static constexpr const uint32_t SwingingShipBaseSpriteOffset[] = {
 
 /** rct2: 0x008A83C0 */
 static constexpr const BoundBoxXY SwingingShipData[] = {
-    {  1, 8, 31, 16 },
-    {  8, 1, 16, 31 },
-    {  1, 8, 31, 16 },
-    {  8, 1, 16, 31 },
+    { 1, 8, 31, 16 },
+    { 8, 1, 16, 31 },
+    { 1, 8, 31, 16 },
+    { 8, 1, 16, 31 },
 };
 
 enum

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -10,6 +10,7 @@
 #include "../../entity/EntityRegistry.h"
 #include "../../interface/Viewport.h"
 #include "../../object/StationObject.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../Ride.h"
@@ -35,10 +36,10 @@ static constexpr const uint32_t SwingingShipBaseSpriteOffset[] = {
 
 /** rct2: 0x008A83C0 */
 static constexpr const BoundBoxXY SwingingShipData[] = {
-    { 1, 8, 31, 16 },
-    { 8, 1, 16, 31 },
-    { 1, 8, 31, 16 },
-    { 8, 1, 16, 31 },
+    { { 1, 8 }, { 31, 16 } },
+    { { 8, 1 }, { 16, 31 } },
+    { { 1, 8 }, { 31, 16 } },
+    { { 8, 1 }, { 16, 31 } },
 };
 
 enum

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -10,6 +10,7 @@
 #include "../../common.h"
 #include "../../interface/Viewport.h"
 #include "../../object/StationObject.h"
+#include "../../paint/Boundbox.h"
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../../world/Map.h"

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -271,7 +271,7 @@ static constexpr const uint32_t ghost_train_track_pieces_right_eight_to_diag[4][
     },
 };
 
-static constexpr const BoundBoxXY ghost_train_track_pieces_right_eight_to_diag_boxes[4][4] = {
+static constexpr const BoundBoxXY GhostTrainTrackPiecesRightEightToDiagBoxes[4][4] = {
     {
         { { 0, 6 }, { 32, 20 } },
         { { 0, 16 }, { 32, 16 } },
@@ -327,7 +327,7 @@ static constexpr const uint32_t ghost_train_track_pieces_left_eight_to_diag[4][4
     },
 };
 
-static constexpr const BoundBoxXY ghost_train_track_pieces_left_eight_to_diag_boxes[4][4] = {
+static constexpr const BoundBoxXY GhostTrainTrackPiecesLeftEightToDiagBoxes[4][4] = {
     {
         { { 0, 6 }, { 32, 20 } },
         { { 0, 0 }, { 32, 16 } },
@@ -949,8 +949,8 @@ static void paint_monorail_track_left_eighth_to_diag(
     if (index >= 0)
     {
         uint32_t imageId = ghost_train_track_pieces_left_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
-        const CoordsXY offset = ghost_train_track_pieces_left_eight_to_diag_boxes[direction][index].offset;
-        const CoordsXY bounds = ghost_train_track_pieces_left_eight_to_diag_boxes[direction][index].length;
+        const CoordsXY offset = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].offset;
+        const CoordsXY bounds = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
     }
 
@@ -1017,8 +1017,8 @@ static void paint_monorail_track_right_eighth_to_diag(
     if (index >= 0)
     {
         uint32_t imageId = ghost_train_track_pieces_right_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
-        const CoordsXY offset = ghost_train_track_pieces_right_eight_to_diag_boxes[direction][index].offset;
-        const CoordsXY bounds = ghost_train_track_pieces_right_eight_to_diag_boxes[direction][index].length;
+        const CoordsXY offset = GhostTrainTrackPiecesRightEightToDiagBoxes[direction][index].offset;
+        const CoordsXY bounds = GhostTrainTrackPiecesRightEightToDiagBoxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
     }
 

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -718,8 +718,8 @@ static void paint_monorail_track_s_bend_left(
     };
 
     uint32_t imageId = monorail_track_pieces_s_bend_left[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
-    CoordsXY offset = boxList[trackSequence].offset;
-    CoordsXY bounds = boxList[trackSequence].length;
+    const CoordsXY& offset = boxList[trackSequence].offset;
+    const CoordsXY& bounds = boxList[trackSequence].length;
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 3 });
@@ -812,8 +812,8 @@ static void paint_monorail_track_s_bend_right(
     };
 
     uint32_t imageId = monorail_track_pieces_s_bend_right[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
-    CoordsXY offset = boxList[trackSequence].offset;
-    CoordsXY bounds = boxList[trackSequence].length;
+    const CoordsXY& offset = boxList[trackSequence].offset;
+    const CoordsXY& bounds = boxList[trackSequence].length;
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 3 });
@@ -950,8 +950,8 @@ static void paint_monorail_track_left_eighth_to_diag(
     if (index >= 0)
     {
         uint32_t imageId = ghost_train_track_pieces_left_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
-        const CoordsXY offset = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].offset;
-        const CoordsXY bounds = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].length;
+        const CoordsXY& offset = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].offset;
+        const CoordsXY& bounds = GhostTrainTrackPiecesLeftEightToDiagBoxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
     }
 

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -271,57 +271,32 @@ static constexpr const uint32_t ghost_train_track_pieces_right_eight_to_diag[4][
     },
 };
 
-static constexpr const CoordsXY ghost_train_track_pieces_right_eight_to_diag_bounds[4][4] = {
+static constexpr const BoundBoxXY ghost_train_track_pieces_right_eight_to_diag_boxes[4][4] = {
     {
-        { 32, 20 },
-        { 32, 16 },
-        { 16, 16 },
-        { 16, 16 },
+        { { 0, 6 }, { 32, 20 } },
+        { { 0, 16 }, { 32, 16 } },
+        { { 0, 0 }, { 16, 16 } },
+        { { 16, 0 }, { 16, 16 } },
     },
     {
-        { 20, 32 },
-        { 16, 32 },
-        { 16, 16 },
-        { 16, 16 },
+        { { 6, 0 }, { 20, 32 } },
+        { { 16, 0 }, { 16, 32 } },
+        { { 0, 16 }, { 16, 16 } },
+        { { 0, 0 }, { 16, 16 } },
     },
     {
-        { 32, 20 },
-        { 34, 16 },
-        { 28, 28 },
-        { 16, 18 },
-    },
-    {
-        { 20, 32 },
-        { 16, 32 },
-        { 16, 16 },
-        { 16, 16 },
-    },
-};
 
-static constexpr const CoordsXY ghost_train_track_pieces_right_eight_to_diag_offset[4][4] = {
-    {
-        { 0, 6 },
-        { 0, 16 },
-        { 0, 0 },
-        { 16, 0 },
+        { { 0, 6 }, { 32, 20 } },
+        { { 0, 0 }, { 34, 16 } },
+        { { 4, 4 }, { 28, 28 } },
+        { { 0, 16 }, { 16, 18 } },
     },
     {
-        { 6, 0 },
-        { 16, 0 },
-        { 0, 16 },
-        { 0, 0 },
-    },
-    {
-        { 0, 6 },
-        { 0, 0 },
-        { 4, 4 },
-        { 0, 16 },
-    },
-    {
-        { 6, 0 },
-        { 0, 0 },
-        { 16, 0 },
-        { 16, 16 },
+
+        { { 6, 0 }, { 20, 32 } },
+        { { 0, 0 }, { 16, 32 } },
+        { { 16, 0 }, { 16, 16 } },
+        { { 16, 16 }, { 16, 16 } },
     },
 };
 
@@ -352,57 +327,30 @@ static constexpr const uint32_t ghost_train_track_pieces_left_eight_to_diag[4][4
     },
 };
 
-static constexpr const CoordsXY ghost_train_track_pieces_left_eight_to_diag_bounds[4][4] = {
+static constexpr const BoundBoxXY ghost_train_track_pieces_left_eight_to_diag_boxes[4][4] = {
     {
-        { 32, 20 },
-        { 32, 16 },
-        { 16, 16 },
-        { 16, 16 },
+        { { 0, 6 }, { 32, 20 } },
+        { { 0, 0 }, { 32, 16 } },
+        { { 0, 16 }, { 16, 16 } },
+        { { 16, 16 }, { 16, 16 } },
     },
     {
-        { 20, 32 },
-        { 16, 34 },
-        { 16, 16 },
-        { 18, 16 },
+        { { 6, 0 }, { 20, 32 } },
+        { { 0, 0 }, { 16, 34 } },
+        { { 16, 16 }, { 16, 16 } },
+        { { 16, 0 }, { 18, 16 } },
     },
     {
-        { 32, 20 },
-        { 32, 16 },
-        { 16, 16 },
-        { 16, 16 },
+        { { 0, 6 }, { 32, 20 } },
+        { { 0, 16 }, { 32, 16 } },
+        { { 16, 0 }, { 16, 16 } },
+        { { 0, 0 }, { 16, 16 } },
     },
     {
-        { 20, 32 },
-        { 16, 32 },
-        { 16, 16 },
-        { 16, 16 },
-    },
-};
-
-static constexpr const CoordsXY ghost_train_track_pieces_left_eight_to_diag_offset[4][4] = {
-    {
-        { 0, 6 },
-        { 0, 0 },
-        { 0, 16 },
-        { 16, 16 },
-    },
-    {
-        { 6, 0 },
-        { 0, 0 },
-        { 16, 16 },
-        { 16, 0 },
-    },
-    {
-        { 0, 6 },
-        { 0, 16 },
-        { 16, 0 },
-        { 0, 0 },
-    },
-    {
-        { 6, 0 },
-        { 16, 0 },
-        { 0, 0 },
-        { 0, 16 },
+        { { 6, 0 }, { 20, 32 } },
+        { { 16, 0 }, { 16, 32 } },
+        { { 0, 0 }, { 16, 16 } },
+        { { 0, 16 }, { 16, 16 } },
     },
 };
 
@@ -761,23 +709,16 @@ static void paint_monorail_track_s_bend_left(
         trackSequence = 3 - trackSequence;
     }
 
-    static constexpr CoordsXY offsetList[] = {
-        { 0, 6 },
-        { 0, 0 },
-        { 0, 6 },
-        { 0, 6 },
-    };
-
-    static constexpr CoordsXY boundsList[] = {
-        { 32, 20 },
-        { 32, 26 },
-        { 32, 26 },
-        { 32, 20 },
+    static constexpr BoundBoxXY boxList[] = {
+        { { 0, 6 }, { 32, 20 } },
+        { { 0, 0 }, { 32, 26 } },
+        { { 0, 6 }, { 32, 26 } },
+        { { 0, 6 }, { 32, 20 } },
     };
 
     uint32_t imageId = monorail_track_pieces_s_bend_left[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
-    CoordsXY offset = offsetList[trackSequence];
-    CoordsXY bounds = boundsList[trackSequence];
+    CoordsXY offset = boxList[trackSequence].offset;
+    CoordsXY bounds = boxList[trackSequence].length;
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 3 });
@@ -865,23 +806,13 @@ static void paint_monorail_track_s_bend_right(
         trackSequence = 3 - trackSequence;
     }
 
-    static constexpr CoordsXY offsetList[] = {
-        { 0, 6 },
-        { 0, 6 },
-        { 0, 0 },
-        { 0, 6 },
-    };
-
-    static constexpr CoordsXY boundsList[] = {
-        { 32, 20 },
-        { 32, 26 },
-        { 32, 26 },
-        { 32, 20 },
+    static constexpr BoundBoxXY boxList[] = {
+        { { 0, 6 }, { 32, 20 } }, { { 0, 6 }, { 32, 26 } }, { { 0, 0 }, { 32, 26 } }, { { 0, 6 }, { 32, 20 } }
     };
 
     uint32_t imageId = monorail_track_pieces_s_bend_right[direction & 1][trackSequence] | session.TrackColours[SCHEME_TRACK];
-    CoordsXY offset = offsetList[trackSequence];
-    CoordsXY bounds = boundsList[trackSequence];
+    CoordsXY offset = boxList[trackSequence].offset;
+    CoordsXY bounds = boxList[trackSequence].length;
     if (direction == 0 || direction == 2)
     {
         PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 3 });
@@ -1018,8 +949,8 @@ static void paint_monorail_track_left_eighth_to_diag(
     if (index >= 0)
     {
         uint32_t imageId = ghost_train_track_pieces_left_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
-        const CoordsXY offset = ghost_train_track_pieces_left_eight_to_diag_offset[direction][index];
-        const CoordsXY bounds = ghost_train_track_pieces_left_eight_to_diag_bounds[direction][index];
+        const CoordsXY offset = ghost_train_track_pieces_left_eight_to_diag_boxes[direction][index].offset;
+        const CoordsXY bounds = ghost_train_track_pieces_left_eight_to_diag_boxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
     }
 
@@ -1086,8 +1017,8 @@ static void paint_monorail_track_right_eighth_to_diag(
     if (index >= 0)
     {
         uint32_t imageId = ghost_train_track_pieces_right_eight_to_diag[direction][index] | session.TrackColours[SCHEME_TRACK];
-        const CoordsXY offset = ghost_train_track_pieces_right_eight_to_diag_offset[direction][index];
-        const CoordsXY bounds = ghost_train_track_pieces_right_eight_to_diag_bounds[direction][index];
+        const CoordsXY offset = ghost_train_track_pieces_right_eight_to_diag_boxes[direction][index].offset;
+        const CoordsXY bounds = ghost_train_track_pieces_right_eight_to_diag_boxes[direction][index].length;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { bounds.x, bounds.y, 2 }, { offset.x, offset.y, height });
     }
 

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -702,44 +702,6 @@ struct TileCoordsXYZD : public TileCoordsXYZ
     }
 };
 
-struct BoundBoxXY
-{
-    CoordsXY offset{};
-    CoordsXY length{};
-
-    constexpr BoundBoxXY() = default;
-    constexpr BoundBoxXY(CoordsXY _offset, CoordsXY _length)
-        : offset(_offset)
-        , length(_length)
-    {
-    }
-
-    constexpr BoundBoxXY(int32_t _offX, int32_t _offY, int32_t _lenX, int32_t _lenY)
-        : offset({ _offX, _offY })
-        , length({ _lenX, _lenY })
-    {
-    }
-};
-
-struct BoundBoxXYZ
-{
-    CoordsXYZ offset{};
-    CoordsXYZ length{};
-
-    constexpr BoundBoxXYZ() = default;
-    constexpr BoundBoxXYZ(CoordsXYZ _offset, CoordsXYZ _length)
-        : offset(_offset)
-        , length(_length)
-    {
-    }
-
-    constexpr BoundBoxXYZ(int32_t _offX, int32_t _offY, int32_t _offZ, int32_t _lenX, int32_t _lenY, int32_t _lenZ)
-        : offset({ _offX, _offY, _offZ })
-        , length({ _lenX, _lenY, _lenZ })
-    {
-    }
-};
-
 /**
  * Represents a range of the map using regular coordinates.
  */

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -721,6 +721,25 @@ struct BoundBoxXY
     }
 };
 
+struct BoundBoxXYZ
+{
+    CoordsXYZ offset{};
+    CoordsXYZ length{};
+
+    constexpr BoundBoxXYZ() = default;
+    constexpr BoundBoxXYZ(CoordsXYZ _offset, CoordsXYZ _length)
+        : offset(_offset)
+        , length(_length)
+    {
+    }
+
+    constexpr BoundBoxXYZ(int32_t _offX, int32_t _offY, int32_t _offZ, int32_t _lenX, int32_t _lenY, int32_t _lenZ)
+        : offset({_offX, _offY, _offZ})
+        , length({_lenX, _lenY, _lenZ})
+    {
+    }
+};
+
 /**
  * Represents a range of the map using regular coordinates.
  */

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -702,6 +702,25 @@ struct TileCoordsXYZD : public TileCoordsXYZ
     }
 };
 
+struct BoundBoxXY
+{
+    CoordsXY offset{};
+    CoordsXY length{};
+
+    constexpr BoundBoxXY() = default;
+    constexpr BoundBoxXY(CoordsXY _offset, CoordsXY _length)
+        : offset(_offset)
+        , length(_length)
+    {
+    }
+
+    constexpr BoundBoxXY(int32_t _offX, int32_t _offY, int32_t _lenX, int32_t _lenY)
+        : offset({_offX, _offY})
+        , length({_lenX, _lenY})
+    {
+    }
+};
+
 /**
  * Represents a range of the map using regular coordinates.
  */

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -715,8 +715,8 @@ struct BoundBoxXY
     }
 
     constexpr BoundBoxXY(int32_t _offX, int32_t _offY, int32_t _lenX, int32_t _lenY)
-        : offset({_offX, _offY})
-        , length({_lenX, _lenY})
+        : offset({ _offX, _offY })
+        , length({ _lenX, _lenY })
     {
     }
 };
@@ -734,8 +734,8 @@ struct BoundBoxXYZ
     }
 
     constexpr BoundBoxXYZ(int32_t _offX, int32_t _offY, int32_t _offZ, int32_t _lenX, int32_t _lenY, int32_t _lenZ)
-        : offset({_offX, _offY, _offZ})
-        , length({_lenX, _lenY, _lenZ})
+        : offset({ _offX, _offY, _offZ })
+        , length({ _lenX, _lenY, _lenZ })
     {
     }
 };


### PR DESCRIPTION
This PR attempts to find all the possible usages of ride-specific bounding boxes and replace them with a uniform struct.

Closes #16146.

This is being submitted as a draft because I've already half started on #16152  as well by adding the `BoundBoxXYZ` struct - it just needs to be added into the places where the original issue mentions.