### PR TITLE
Fix Go Kart Random Speeds

### DIFF
--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -278,7 +278,7 @@ static void ride_race_init_vehicle_speeds(Ride* ride)
 
         rct_ride_entry* rideEntry = vehicle->GetRideEntry();
 
-        vehicle->speed = (scenario_rand() & 16) - 8 + rideEntry->vehicles[vehicle->vehicle_type].powered_max_speed;
+        vehicle->speed = (scenario_rand() & 15) - 8 + rideEntry->vehicles[vehicle->vehicle_type].powered_max_speed;
 
         if (vehicle->num_peeps != 0)
         {


### PR DESCRIPTION
Go karts in OpenRCT2 only get 2 different random speeds, very fast (around 37 kmh) and very slow (around 25 kmh)
In vanilla, Go Karts can also get a speed in between. 

The Randomvalue & 16 probably is a mistake, changing it to Randomvalue & 15 makes the behavior same as vanilla again.