### PR TITLE
Fix: #16162 Go Kart speeds not correctly randomised

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,9 @@ set(OBJECTS_VERSION "1.2.4")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "c82605035f120188b7334a781a786ced9588e9af")
 
-set(REPLAYS_VERSION "0.0.61")
+set(REPLAYS_VERSION "0.0.62")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "18BFAD02A453CE0D5926C13A856546ED825AD0F1")
+set(REPLAYS_SHA1 "0B234FA152AFA49F5204ADA97CBAAE39A538961B")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#16063] Object Selection preview for objects with glass is broken.
 - Fix: [#16075] Exporting track designs saves scenery in incorrect locations.
 - Fix: [#16087] The Looping Roller Coaster booster is now always drawn correctly.
+- Fix: [#16162] Go Karts speeds are not correctly randomised, they only go very fast or very slow.
 
 0.3.5.1 (2021-11-21)
 ------------------------------------------------------------------------

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -48,8 +48,8 @@
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.2.4/objects.zip</ObjectsUrl>
     <ObjectsSha1>c82605035f120188b7334a781a786ced9588e9af</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.61/replays.zip</ReplaysUrl>
-    <ReplaysSha1>18BFAD02A453CE0D5926C13A856546ED825AD0F1</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.62/replays.zip</ReplaysUrl>
+    <ReplaysSha1>0B234FA152AFA49F5204ADA97CBAAE39A538961B</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -40,7 +40,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -278,7 +278,7 @@ static void ride_race_init_vehicle_speeds(Ride* ride)
 
         rct_ride_entry* rideEntry = vehicle->GetRideEntry();
 
-        vehicle->speed = (scenario_rand() & 16) - 8 + rideEntry->vehicles[vehicle->vehicle_type].powered_max_speed;
+        vehicle->speed = (scenario_rand() & 15) - 8 + rideEntry->vehicles[vehicle->vehicle_type].powered_max_speed;
 
         if (vehicle->num_peeps != 0)
         {


### PR DESCRIPTION
In OpenRCT2, at the start of a race Go karts will only get the maximum possible speed or the minimum possible speed. In vanilla, Go karts could also get a speed in between. 
This PR will make the behavior same as in vanilla again.
Issue: #16162