### PR TITLE
Refactor Land Rights window to class

### DIFF
--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/Game.h>
 #include <openrct2/Input.h>
 #include <openrct2/actions/LandBuyRightsAction.h>
+#include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/world/Park.h>
@@ -45,409 +46,361 @@ static rct_widget window_land_rights_widgets[] = {
     MakeRemapWidget({52, 53}, {24, 24}, WindowWidgetType::FlatBtn, WindowColour::Tertiary, SPR_BUY_CONSTRUCTION_RIGHTS, STR_BUY_CONSTRUCTION_RIGHTS_TIP   ), // construction rights
     WIDGETS_END,
 };
-
-static void WindowLandRightsClose(rct_window *w);
-static void WindowLandRightsMouseup(rct_window *w, rct_widgetindex widgetIndex);
-static void WindowLandRightsMousedown(rct_window *w, rct_widgetindex widgetIndex, rct_widget *widget);
-static void WindowLandRightsUpdate(rct_window *w);
-static void WindowLandRightsInvalidate(rct_window *w);
-static void WindowLandRightsPaint(rct_window *w, rct_drawpixelinfo *dpi);
-static void WindowLandRightsTextinput(rct_window *w, rct_widgetindex widgetIndex, char *text);
-static void WindowLandRightsInputsize(rct_window *w);
-static void WindowLandRightsToolupdate(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void WindowLandRightsTooldown(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void WindowLandRightsTooldrag(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void WindowLandRightsToolabort(rct_window *w, rct_widgetindex widgetIndex);
-static bool LandRightsToolIsActive();
-
-
-static rct_window_event_list window_land_rights_events([](auto& events)
-{
-    events.close = &WindowLandRightsClose;
-    events.mouse_up = &WindowLandRightsMouseup;
-    events.mouse_down = &WindowLandRightsMousedown;
-    events.update = &WindowLandRightsUpdate;
-    events.tool_update = &WindowLandRightsToolupdate;
-    events.tool_down = &WindowLandRightsTooldown;
-    events.tool_drag = &WindowLandRightsTooldrag;
-    events.tool_abort = &WindowLandRightsToolabort;
-    events.text_input = &WindowLandRightsTextinput;
-    events.invalidate = &WindowLandRightsInvalidate;
-    events.paint = &WindowLandRightsPaint;
-});
 // clang-format on
 
 constexpr uint8_t LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS = 0;
 constexpr uint8_t LAND_RIGHTS_MODE_BUY_LAND = 1;
 
-static uint8_t _landRightsMode;
-static money32 _landRightsCost;
+class LandRightsWindow final : public Window
+{
+public:
+    void OnOpen() override
+    {
+        widgets = window_land_rights_widgets;
+        enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_DECREMENT) | (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_PREVIEW)
+            | (1ULL << WIDX_BUY_LAND_RIGHTS) | (1ULL << WIDX_BUY_CONSTRUCTION_RIGHTS);
+        hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
+        WindowInitScrollWidgets(this);
+        window_push_others_below(this);
+        _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
+        pressed_widgets = (1ULL << WIDX_BUY_LAND_RIGHTS);
+
+        gLandToolSize = 1;
+
+        show_gridlines();
+        tool_set(this, WIDX_BUY_LAND_RIGHTS, Tool::UpArrow);
+        input_set_flag(INPUT_FLAG_6, true);
+
+        show_land_rights();
+
+        if (gLandRemainingConstructionSales == 0)
+        {
+            show_construction_rights();
+        }
+    }
+
+    void OnClose() override
+    {
+        if (gLandRemainingConstructionSales == 0)
+        {
+            hide_construction_rights();
+        }
+
+        // If the tool wasn't changed, turn tool off
+        if (LandRightsToolIsActive())
+            tool_cancel();
+    }
+
+    void OnMouseUp(rct_widgetindex widgetIndex) override
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_CLOSE:
+                Close();
+                break;
+            case WIDX_PREVIEW:
+                InputSize();
+                break;
+            case WIDX_BUY_LAND_RIGHTS:
+                if (_landRightsMode != LAND_RIGHTS_MODE_BUY_LAND)
+                {
+                    tool_set(this, WIDX_BUY_LAND_RIGHTS, Tool::UpArrow);
+                    _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
+                    show_land_rights();
+                    Invalidate();
+                }
+                break;
+            case WIDX_BUY_CONSTRUCTION_RIGHTS:
+                if (_landRightsMode != LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS)
+                {
+                    tool_set(this, WIDX_BUY_CONSTRUCTION_RIGHTS, Tool::UpArrow);
+                    _landRightsMode = LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS;
+                    show_construction_rights();
+                    Invalidate();
+                }
+                break;
+        }
+    }
+
+    void OnMouseDown(rct_widgetindex widgetIndex) override
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_DECREMENT:
+                // Decrement land rights tool size
+                gLandToolSize = std::max(MINIMUM_TOOL_SIZE, gLandToolSize - 1);
+
+                // Invalidate the window
+                Invalidate();
+                break;
+            case WIDX_INCREMENT:
+                // Decrement land rights tool size
+                gLandToolSize = std::min(MAXIMUM_TOOL_SIZE, gLandToolSize + 1);
+
+                // Invalidate the window
+                Invalidate();
+                break;
+        }
+    }
+
+    void OnTextInput(rct_widgetindex widgetIndex, std::string_view text) override
+    {
+        if (text.empty())
+            return;
+
+        if (widgetIndex != WIDX_PREVIEW)
+            return;
+
+        const auto res = String::Parse<int32_t>(text);
+        if (res.has_value())
+        {
+            int32_t size;
+            size = res.value();
+            size = std::max(MINIMUM_TOOL_SIZE, size);
+            size = std::min(MAXIMUM_TOOL_SIZE, size);
+            gLandToolSize = size;
+            Invalidate();
+        }
+    }
+
+    void OnUpdate() override
+    {
+        frame_no++;
+        // Close window if another tool is open
+        if (!LandRightsToolIsActive())
+            Close();
+    }
+
+    void OnPrepareDraw() override
+    {
+        SetWidgetPressed(WIDX_PREVIEW, true);
+        if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
+        {
+            SetWidgetPressed(WIDX_BUY_LAND_RIGHTS, true);
+            SetWidgetPressed(WIDX_BUY_CONSTRUCTION_RIGHTS, false);
+        }
+        else if (_landRightsMode == LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS)
+        {
+            SetWidgetPressed(WIDX_BUY_LAND_RIGHTS, false);
+            SetWidgetPressed(WIDX_BUY_CONSTRUCTION_RIGHTS, true);
+        }
+
+        window_land_rights_widgets[WIDX_PREVIEW].image = LandTool::SizeToSpriteIndex(gLandToolSize);
+
+        if (gLandRemainingOwnershipSales == 0)
+        {
+            SetWidgetDisabled(WIDX_BUY_LAND_RIGHTS, true);
+            window_land_rights_widgets[WIDX_BUY_LAND_RIGHTS].tooltip = STR_NO_LAND_RIGHTS_FOR_SALE_TIP;
+        }
+        else
+        {
+            SetWidgetDisabled(WIDX_BUY_LAND_RIGHTS, false);
+            window_land_rights_widgets[WIDX_BUY_LAND_RIGHTS].tooltip = STR_BUY_LAND_RIGHTS_TIP;
+        }
+
+        if (gLandRemainingConstructionSales == 0)
+        {
+            SetWidgetDisabled(WIDX_BUY_CONSTRUCTION_RIGHTS, true);
+            window_land_rights_widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].tooltip = STR_NO_CONSTRUCTION_RIGHTS_FOR_SALE_TIP;
+        }
+        else
+        {
+            SetWidgetDisabled(WIDX_BUY_CONSTRUCTION_RIGHTS, false);
+            window_land_rights_widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].tooltip = STR_BUY_CONSTRUCTION_RIGHTS_TIP;
+        }
+    }
+
+    void OnDraw(rct_drawpixelinfo& dpi) override
+    {
+        auto screenCoords = ScreenCoordsXY{ windowPos.x + window_land_rights_widgets[WIDX_PREVIEW].midX(),
+                                            windowPos.y + window_land_rights_widgets[WIDX_PREVIEW].midY() };
+
+        DrawWidgets(dpi);
+        // Draw number for tool sizes bigger than 7
+        if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
+        {
+            auto ft = Formatter();
+            ft.Add<uint16_t>(gLandToolSize);
+            DrawTextBasic(&dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
+        }
+
+        // Draw cost amount
+        if (_landRightsCost != MONEY32_UNDEFINED && _landRightsCost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
+        {
+            auto ft = Formatter();
+            ft.Add<money64>(_landRightsCost);
+            screenCoords = { window_land_rights_widgets[WIDX_PREVIEW].midX() + windowPos.x,
+                             window_land_rights_widgets[WIDX_PREVIEW].bottom + windowPos.y + 32 };
+            DrawTextBasic(&dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
+        }
+    }
+
+    void OnToolUpdate(rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords) override
+    {
+        map_invalidate_selection_rect();
+        gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
+
+        auto mapTile = screen_get_map_xy(screenCoords, nullptr);
+
+        if (!mapTile.has_value())
+        {
+            if (_landRightsCost != MONEY32_UNDEFINED)
+            {
+                _landRightsCost = MONEY32_UNDEFINED;
+                window_invalidate_by_class(WC_CLEAR_SCENERY);
+            }
+            return;
+        }
+
+        uint8_t state_changed = 0;
+
+        if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
+        {
+            gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
+            state_changed++;
+        }
+
+        if (gMapSelectType != MAP_SELECT_TYPE_FULL)
+        {
+            gMapSelectType = MAP_SELECT_TYPE_FULL;
+            state_changed++;
+        }
+
+        int16_t tool_size = gLandToolSize;
+        if (tool_size == 0)
+            tool_size = 1;
+
+        int16_t tool_length = (tool_size - 1) * 32;
+
+        // Move to tool bottom left
+        mapTile->x -= (tool_size - 1) * 16;
+        mapTile->y -= (tool_size - 1) * 16;
+        mapTile = mapTile->ToTileStart();
+
+        if (gMapSelectPositionA.x != mapTile->x)
+        {
+            gMapSelectPositionA.x = mapTile->x;
+            state_changed++;
+        }
+
+        if (gMapSelectPositionA.y != mapTile->y)
+        {
+            gMapSelectPositionA.y = mapTile->y;
+            state_changed++;
+        }
+
+        mapTile->x += tool_length;
+        mapTile->y += tool_length;
+
+        if (gMapSelectPositionB.x != mapTile->x)
+        {
+            gMapSelectPositionB.x = mapTile->x;
+            state_changed++;
+        }
+
+        if (gMapSelectPositionB.y != mapTile->y)
+        {
+            gMapSelectPositionB.y = mapTile->y;
+            state_changed++;
+        }
+
+        map_invalidate_selection_rect();
+        if (!state_changed)
+            return;
+
+        auto landBuyRightsAction = LandBuyRightsAction(
+            { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+            (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND) ? LandBuyRightSetting::BuyLand
+                                                           : LandBuyRightSetting::BuyConstructionRights);
+        auto res = GameActions::Query(&landBuyRightsAction);
+
+        _landRightsCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY32_UNDEFINED;
+    }
+
+    void OnToolAbort(rct_widgetindex widgetIndex) override
+    {
+        hide_gridlines();
+        if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
+        {
+            hide_land_rights();
+        }
+        else
+        {
+            hide_construction_rights();
+        }
+    }
+
+    void OnToolDown(rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords) override
+    {
+        if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
+        {
+            if (screenCoords.x != LOCATION_NULL)
+            {
+                auto landBuyRightsAction = LandBuyRightsAction(
+                    { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+                    LandBuyRightSetting::BuyLand);
+                GameActions::Execute(&landBuyRightsAction);
+            }
+        }
+        else
+        {
+            if (screenCoords.x != LOCATION_NULL)
+            {
+                auto landBuyRightsAction = LandBuyRightsAction(
+                    { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+                    LandBuyRightSetting::BuyConstructionRights);
+                GameActions::Execute(&landBuyRightsAction);
+            }
+        }
+    }
+
+    void OnToolDrag(rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords) override
+    {
+        if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
+        {
+            if (screenCoords.x != LOCATION_NULL)
+            {
+                auto landBuyRightsAction = LandBuyRightsAction(
+                    { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+                    LandBuyRightSetting::BuyLand);
+                GameActions::Execute(&landBuyRightsAction);
+            }
+        }
+        else
+        {
+            if (screenCoords.x != LOCATION_NULL)
+            {
+                auto landBuyRightsAction = LandBuyRightsAction(
+                    { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
+                    LandBuyRightSetting::BuyConstructionRights);
+                GameActions::Execute(&landBuyRightsAction);
+            }
+        }
+    }
+
+private:
+    uint8_t _landRightsMode;
+    money32 _landRightsCost;
+
+    void InputSize()
+    {
+        Formatter ft;
+        ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
+        ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
+        WindowTextInputOpen(this, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
+    }
+
+    bool LandRightsToolIsActive()
+    {
+        if (!(input_test_flag(INPUT_FLAG_TOOL_ACTIVE)))
+            return false;
+        if (gCurrentToolWidget.window_classification != WC_LAND_RIGHTS)
+            return false;
+        return true;
+    }
+};
 
 rct_window* WindowLandRightsOpen()
 {
-    rct_window* window;
-
-    // Check if window is already open
-    window = window_find_by_class(WC_LAND_RIGHTS);
-    if (window != nullptr)
-        return window;
-
-    window = WindowCreate(ScreenCoordsXY(context_get_width() - 98, 29), 98, 94, &window_land_rights_events, WC_LAND_RIGHTS, 0);
-    window->widgets = window_land_rights_widgets;
-    window->enabled_widgets = (1ULL << WIDX_CLOSE) | (1ULL << WIDX_DECREMENT) | (1ULL << WIDX_INCREMENT)
-        | (1ULL << WIDX_PREVIEW) | (1ULL << WIDX_BUY_LAND_RIGHTS) | (1ULL << WIDX_BUY_CONSTRUCTION_RIGHTS);
-    window->hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
-    WindowInitScrollWidgets(window);
-    window_push_others_below(window);
-
-    _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
-    window->pressed_widgets = (1ULL << WIDX_BUY_LAND_RIGHTS);
-
-    gLandToolSize = 1;
-
-    show_gridlines();
-    tool_set(window, WIDX_BUY_LAND_RIGHTS, Tool::UpArrow);
-    input_set_flag(INPUT_FLAG_6, true);
-
-    show_land_rights();
-
-    if (gLandRemainingConstructionSales == 0)
-    {
-        show_construction_rights();
-    }
-
-    return window;
-}
-
-static void WindowLandRightsClose(rct_window* w)
-{
-    if (gLandRemainingConstructionSales == 0)
-    {
-        hide_construction_rights();
-    }
-
-    // If the tool wasn't changed, turn tool off
-    if (LandRightsToolIsActive())
-        tool_cancel();
-}
-
-static void WindowLandRightsMouseup(rct_window* w, rct_widgetindex widgetIndex)
-{
-    switch (widgetIndex)
-    {
-        case WIDX_CLOSE:
-            window_close(w);
-            break;
-        case WIDX_PREVIEW:
-            WindowLandRightsInputsize(w);
-            break;
-        case WIDX_BUY_LAND_RIGHTS:
-            if (_landRightsMode != LAND_RIGHTS_MODE_BUY_LAND)
-            {
-                tool_set(w, WIDX_BUY_LAND_RIGHTS, Tool::UpArrow);
-                _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
-                show_land_rights();
-                w->Invalidate();
-            }
-            break;
-        case WIDX_BUY_CONSTRUCTION_RIGHTS:
-            if (_landRightsMode != LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS)
-            {
-                tool_set(w, WIDX_BUY_CONSTRUCTION_RIGHTS, Tool::UpArrow);
-                _landRightsMode = LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS;
-                show_construction_rights();
-                w->Invalidate();
-            }
-            break;
-    }
-}
-
-static void WindowLandRightsMousedown(rct_window* w, rct_widgetindex widgetIndex, rct_widget* widget)
-{
-    switch (widgetIndex)
-    {
-        case WIDX_DECREMENT:
-            // Decrement land rights tool size
-            gLandToolSize = std::max(MINIMUM_TOOL_SIZE, gLandToolSize - 1);
-
-            // Invalidate the window
-            w->Invalidate();
-            break;
-        case WIDX_INCREMENT:
-            // Decrement land rights tool size
-            gLandToolSize = std::min(MAXIMUM_TOOL_SIZE, gLandToolSize + 1);
-
-            // Invalidate the window
-            w->Invalidate();
-            break;
-    }
-}
-
-static void WindowLandRightsTextinput(rct_window* w, rct_widgetindex widgetIndex, char* text)
-{
-    int32_t size;
-    char* end;
-
-    if (widgetIndex != WIDX_PREVIEW || text == nullptr)
-        return;
-
-    size = strtol(text, &end, 10);
-    if (*end == '\0')
-    {
-        size = std::max(MINIMUM_TOOL_SIZE, size);
-        size = std::min(MAXIMUM_TOOL_SIZE, size);
-        gLandToolSize = size;
-        w->Invalidate();
-    }
-}
-
-static void WindowLandRightsInputsize(rct_window* w)
-{
-    Formatter ft;
-    ft.Add<int16_t>(MINIMUM_TOOL_SIZE);
-    ft.Add<int16_t>(MAXIMUM_TOOL_SIZE);
-    WindowTextInputOpen(w, WIDX_PREVIEW, STR_SELECTION_SIZE, STR_ENTER_SELECTION_SIZE, ft, STR_NONE, STR_NONE, 3);
-}
-
-static void WindowLandRightsUpdate(rct_window* w)
-{
-    w->frame_no++;
-    // Close window if another tool is open
-    if (!LandRightsToolIsActive())
-        window_close(w);
-}
-
-static void WindowLandRightsInvalidate(rct_window* w)
-{
-    // Set the preview image button to be pressed down
-    w->pressed_widgets |= (1ULL << WIDX_PREVIEW)
-        | (1ULL << ((_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND) ? WIDX_BUY_LAND_RIGHTS : WIDX_BUY_CONSTRUCTION_RIGHTS));
-    w->pressed_widgets &= ~(
-        1ULL
-        << ((_landRightsMode == LAND_RIGHTS_MODE_BUY_CONSTRUCTION_RIGHTS) ? WIDX_BUY_LAND_RIGHTS
-                                                                          : WIDX_BUY_CONSTRUCTION_RIGHTS));
-
-    // Update the preview image
-    window_land_rights_widgets[WIDX_PREVIEW].image = LandTool::SizeToSpriteIndex(gLandToolSize);
-
-    // Disable ownership and/or construction buying functions if there are no tiles left for sale
-    if (gLandRemainingOwnershipSales == 0)
-    {
-        w->disabled_widgets |= (1ULL << WIDX_BUY_LAND_RIGHTS);
-        window_land_rights_widgets[WIDX_BUY_LAND_RIGHTS].tooltip = STR_NO_LAND_RIGHTS_FOR_SALE_TIP;
-    }
-    else
-    {
-        w->disabled_widgets &= ~(1ULL << WIDX_BUY_LAND_RIGHTS);
-        window_land_rights_widgets[WIDX_BUY_LAND_RIGHTS].tooltip = STR_BUY_LAND_RIGHTS_TIP;
-    }
-
-    if (gLandRemainingConstructionSales == 0)
-    {
-        w->disabled_widgets |= (1ULL << WIDX_BUY_CONSTRUCTION_RIGHTS);
-        window_land_rights_widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].tooltip = STR_NO_CONSTRUCTION_RIGHTS_FOR_SALE_TIP;
-    }
-    else
-    {
-        w->disabled_widgets &= ~(1ULL << WIDX_BUY_CONSTRUCTION_RIGHTS);
-        window_land_rights_widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].tooltip = STR_BUY_CONSTRUCTION_RIGHTS_TIP;
-    }
-}
-
-static void WindowLandRightsPaint(rct_window* w, rct_drawpixelinfo* dpi)
-{
-    auto screenCoords = ScreenCoordsXY{ w->windowPos.x + window_land_rights_widgets[WIDX_PREVIEW].midX(),
-                                        w->windowPos.y + window_land_rights_widgets[WIDX_PREVIEW].midY() };
-
-    WindowDrawWidgets(w, dpi);
-    // Draw number for tool sizes bigger than 7
-    if (gLandToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
-    {
-        auto ft = Formatter();
-        ft.Add<uint16_t>(gLandToolSize);
-        DrawTextBasic(dpi, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::CENTRE });
-    }
-
-    // Draw cost amount
-    if (_landRightsCost != MONEY32_UNDEFINED && _landRightsCost != 0 && !(gParkFlags & PARK_FLAGS_NO_MONEY))
-    {
-        auto ft = Formatter();
-        ft.Add<money64>(_landRightsCost);
-        screenCoords = { window_land_rights_widgets[WIDX_PREVIEW].midX() + w->windowPos.x,
-                         window_land_rights_widgets[WIDX_PREVIEW].bottom + w->windowPos.y + 32 };
-        DrawTextBasic(dpi, screenCoords, STR_COST_AMOUNT, ft, { TextAlignment::CENTRE });
-    }
-}
-
-static void WindowLandRightsToolUpdateLandRights(const ScreenCoordsXY& screenCoords)
-{
-    map_invalidate_selection_rect();
-    gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
-
-    auto mapTile = screen_get_map_xy(screenCoords, nullptr);
-
-    if (!mapTile.has_value())
-    {
-        if (_landRightsCost != MONEY32_UNDEFINED)
-        {
-            _landRightsCost = MONEY32_UNDEFINED;
-            window_invalidate_by_class(WC_CLEAR_SCENERY);
-        }
-        return;
-    }
-
-    uint8_t state_changed = 0;
-
-    if (!(gMapSelectFlags & MAP_SELECT_FLAG_ENABLE))
-    {
-        gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
-        state_changed++;
-    }
-
-    if (gMapSelectType != MAP_SELECT_TYPE_FULL)
-    {
-        gMapSelectType = MAP_SELECT_TYPE_FULL;
-        state_changed++;
-    }
-
-    int16_t tool_size = gLandToolSize;
-    if (tool_size == 0)
-        tool_size = 1;
-
-    int16_t tool_length = (tool_size - 1) * 32;
-
-    // Move to tool bottom left
-    mapTile->x -= (tool_size - 1) * 16;
-    mapTile->y -= (tool_size - 1) * 16;
-    mapTile = mapTile->ToTileStart();
-
-    if (gMapSelectPositionA.x != mapTile->x)
-    {
-        gMapSelectPositionA.x = mapTile->x;
-        state_changed++;
-    }
-
-    if (gMapSelectPositionA.y != mapTile->y)
-    {
-        gMapSelectPositionA.y = mapTile->y;
-        state_changed++;
-    }
-
-    mapTile->x += tool_length;
-    mapTile->y += tool_length;
-
-    if (gMapSelectPositionB.x != mapTile->x)
-    {
-        gMapSelectPositionB.x = mapTile->x;
-        state_changed++;
-    }
-
-    if (gMapSelectPositionB.y != mapTile->y)
-    {
-        gMapSelectPositionB.y = mapTile->y;
-        state_changed++;
-    }
-
-    map_invalidate_selection_rect();
-    if (!state_changed)
-        return;
-
-    auto landBuyRightsAction = LandBuyRightsAction(
-        { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
-        (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND) ? LandBuyRightSetting::BuyLand
-                                                       : LandBuyRightSetting::BuyConstructionRights);
-    auto res = GameActions::Query(&landBuyRightsAction);
-
-    _landRightsCost = res.Error == GameActions::Status::Ok ? res.Cost : MONEY32_UNDEFINED;
-}
-
-/**
- *
- *  rct2: 0x0066822A
- */
-static void WindowLandRightsToolabort(rct_window* w, rct_widgetindex widgetIndex)
-{
-    hide_gridlines();
-    if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
-    {
-        hide_land_rights();
-    }
-    else
-    {
-        hide_construction_rights();
-    }
-}
-
-/**
- *
- *  rct2: 0x006681D1
- */
-static void WindowLandRightsToolupdate(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
-{
-    WindowLandRightsToolUpdateLandRights(screenCoords);
-}
-
-/**
- *
- *  rct2: 0x006681E6
- */
-static void WindowLandRightsTooldown(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
-{
-    if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
-    {
-        if (screenCoords.x != LOCATION_NULL)
-        {
-            auto landBuyRightsAction = LandBuyRightsAction(
-                { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
-                LandBuyRightSetting::BuyLand);
-            GameActions::Execute(&landBuyRightsAction);
-        }
-    }
-    else
-    {
-        if (screenCoords.x != LOCATION_NULL)
-        {
-            auto landBuyRightsAction = LandBuyRightsAction(
-                { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
-                LandBuyRightSetting::BuyConstructionRights);
-            GameActions::Execute(&landBuyRightsAction);
-        }
-    }
-}
-
-/**
- *
- *  rct2: 0x006681FB
- */
-static void WindowLandRightsTooldrag(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
-{
-    if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
-    {
-        if (screenCoords.x != LOCATION_NULL)
-        {
-            auto landBuyRightsAction = LandBuyRightsAction(
-                { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
-                LandBuyRightSetting::BuyLand);
-            GameActions::Execute(&landBuyRightsAction);
-        }
-    }
-    else
-    {
-        if (screenCoords.x != LOCATION_NULL)
-        {
-            auto landBuyRightsAction = LandBuyRightsAction(
-                { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
-                LandBuyRightSetting::BuyConstructionRights);
-            GameActions::Execute(&landBuyRightsAction);
-        }
-    }
-}
-
-static bool LandRightsToolIsActive()
-{
-    if (!(input_test_flag(INPUT_FLAG_TOOL_ACTIVE)))
-        return false;
-    if (gCurrentToolWidget.window_classification != WC_LAND_RIGHTS)
-        return false;
-    return true;
+    return WindowFocusOrCreate<LandRightsWindow>(WC_LAND_RIGHTS, ScreenCoordsXY(context_get_width() - WW, 29), WW, WH, 0);
 }


### PR DESCRIPTION
Closes #13777

I made sure the window functions the same.
I couldn't find a park that had the construction rights button enabled, and I'm not sure how to enable it, so I couldn't test that.