### PR TITLE
CMakeLists.txt: update CCache handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,19 @@ endif()
 # if it is available
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-find_package(CCache)
+option(OPENRCT2_USE_CCACHE "Use CCache to improve recompilation speed (optional)" ON)
 
-if (CCache_FOUND)
-    option(OPENRCT2_USE_CCACHE "Use CCache to improve recompilation speed (optional)" ON)
-    if (OPENRCT2_USE_CCACHE)
-        # Use e.g. "ccache clang++" instead of "clang++"
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCache_EXECUTABLE}")
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "${CCache_EXECUTABLE}")
-    endif (OPENRCT2_USE_CCACHE)
-endif (CCache_FOUND)
+if (OPENRCT2_USE_CCACHE)
+    find_package(CCache)
+
+    if (CCache_FOUND)
+         # Use e.g. "ccache clang++" instead of "clang++"
+         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCache_EXECUTABLE}")
+         set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK    "${CCache_EXECUTABLE}")
+    else()
+        message("Usage of CCache was enabled, but CCache was not found, so CCache is not being enabled.")
+    endif()
+endif (OPENRCT2_USE_CCACHE)
 
 if (APPLE)
     execute_process(COMMAND /usr/bin/uname -m OUTPUT_VARIABLE SYSTEM_MACOS_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
This PR updated slightly the handling of CCache. With the current
implementation, when CCache is not being installed, CMake will complain,
that OPENRCT2_USE_CCACHE is not set.

This logic is slightly updated, so the option OPENRCT2_USE_CCACHE is always
being available and when this option is enabled (default ON), it will
search for CCache and warn, if it's not found.

The idea behind is, as in Gentoo, we never let CCache be used by the
package itself, instead, we enabled it globally. But this the old logic,
on systems, which don't have CCache installed, it will complain about
OPENRCT2_USE_CCACHE not being used, but we have to make sure, OpenRCT2
will never use by itself CCache and this message will be gone..

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>