### PR TITLE
Part of #15485: normalise all OpenRCT2 tile element types

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -291,7 +291,7 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
                 info.SpriteType = ViewportInteractionItem::None;
                 return info;
             }
-            if (tileElement->GetTypeN() == TileElementTypeN::Path)
+            if (tileElement->GetType() == TileElementType::Path)
             {
                 info.SpriteType = ViewportInteractionItem::None;
                 return info;
@@ -310,7 +310,7 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
             auto ft = Formatter();
             ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_MODIFY);
 
-            if (tileElement->GetTypeN() == TileElementTypeN::Entrance)
+            if (tileElement->GetType() == TileElementType::Entrance)
             {
                 rct_string_id stringId;
                 if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
@@ -368,7 +368,7 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
             const auto& rtd = ride->GetRideTypeDescriptor();
             ft.Add<rct_string_id>(GetRideComponentName(rtd.NameConvention.station).capitalised);
 
-            if (tileElement->GetTypeN() == TileElementTypeN::Entrance)
+            if (tileElement->GetType() == TileElementType::Entrance)
                 stationIndex = tileElement->AsEntrance()->GetStationIndex();
             else
                 stationIndex = tileElement->AsTrack()->GetStationIndex();
@@ -485,7 +485,7 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
             if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
                 break;
 
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 break;
 
             ft.Add<rct_string_id>(STR_MAP_TOOLTIP_STRINGID_CLICK_TO_REMOVE);
@@ -622,7 +622,7 @@ static void ViewportInteractionRemoveFootpath(TileElement* tileElement, const Co
         return;
     do
     {
-        if (tileElement2->GetTypeN() == TileElementTypeN::Path && tileElement2->GetBaseZ() == z)
+        if (tileElement2->GetType() == TileElementType::Path && tileElement2->GetBaseZ() == z)
         {
             footpath_remove({ mapCoords, z }, GAME_COMMAND_FLAG_APPLY);
             break;

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -935,7 +935,7 @@ static void WindowFootpathSetSelectionStartBridgeAtPoint(const ScreenCoordsXY& s
 
     int32_t z = tileElement->GetBaseZ();
 
-    if (tileElement->GetTypeN() == TileElementTypeN::Surface)
+    if (tileElement->GetType() == TileElementType::Surface)
     {
         uint8_t slope = tileElement->AsSurface()->GetSlope();
         if (slope & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP)
@@ -1036,7 +1036,7 @@ static void WindowFootpathStartBridgeAtPoint(const ScreenCoordsXY& screenCoords)
         return;
     }
 
-    if (tileElement->GetTypeN() == TileElementTypeN::Surface)
+    if (tileElement->GetType() == TileElementType::Surface)
     {
         // If we start the path on a slope, the arrow is slightly raised, so we
         // expect the path to be slightly raised as well.
@@ -1056,7 +1056,7 @@ static void WindowFootpathStartBridgeAtPoint(const ScreenCoordsXY& screenCoords)
     else
     {
         z = tileElement->GetBaseZ();
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             if (tileElement->AsPath()->IsSloped())
             {
@@ -1201,7 +1201,7 @@ static TileElement* FootpathGetTileElementToRemove()
     {
         if (tileElement == nullptr)
             break;
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             if (tileElement->GetBaseZ() == z)
             {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1296,7 +1296,7 @@ static void WindowMapSetPeepSpawnToolUpdate(const ScreenCoordsXY& screenCoords)
         return;
 
     mapZ = tileElement->GetBaseZ();
-    if (tileElement->GetTypeN() == TileElementTypeN::Surface)
+    if (tileElement->GetType() == TileElementType::Surface)
     {
         if ((tileElement->AsSurface()->GetSlope() & TILE_ELEMENT_SLOPE_ALL_CORNERS_UP) != 0)
             mapZ += 16;
@@ -1440,10 +1440,10 @@ static uint16_t MapWindowGetPixelColourPeep(const CoordsXY& c)
             break;
         }
 
-        auto tileElementType = tileElement->GetTypeN();
+        auto tileElementType = tileElement->GetType();
         if (EnumValue(tileElementType) >= maxSupportedTileElementType)
         {
-            tileElementType = TileElementTypeN::Surface;
+            tileElementType = TileElementType::Surface;
         }
         colour &= ElementTypeMaskColour[EnumValue(tileElementType)];
         colour |= ElementTypeAddColour[EnumValue(tileElementType)];
@@ -1471,19 +1471,19 @@ static uint16_t MapWindowGetPixelColourRide(const CoordsXY& c)
             break;
         }
 
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 if (tileElement->AsSurface()->GetWaterHeight() > 0)
                     // Why is this a different water colour as above (195)?
                     colourB = MapColour(PALETTE_INDEX_194);
                 if (!(tileElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED))
                     colourB = MapColourUnowned(colourB);
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 colourA = MapColour(PALETTE_INDEX_14); // lighter grey
                 break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                     break;
                 ride = get_ride(tileElement->AsEntrance()->GetRideIndex());
@@ -1493,7 +1493,7 @@ static uint16_t MapWindowGetPixelColourRide(const CoordsXY& c)
                     colourA = RideKeyColours[static_cast<size_t>(colourKey)];
                 }
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 ride = get_ride(tileElement->AsTrack()->GetRideIndex());
                 if (ride != nullptr)
                 {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -1471,19 +1471,19 @@ static uint16_t MapWindowGetPixelColourRide(const CoordsXY& c)
             break;
         }
 
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 if (tileElement->AsSurface()->GetWaterHeight() > 0)
                     // Why is this a different water colour as above (195)?
                     colourB = MapColour(PALETTE_INDEX_194);
                 if (!(tileElement->AsSurface()->GetOwnership() & OWNERSHIP_OWNED))
                     colourB = MapColourUnowned(colourB);
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 colourA = MapColour(PALETTE_INDEX_14); // lighter grey
                 break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                     break;
                 ride = get_ride(tileElement->AsEntrance()->GetRideIndex());
@@ -1493,7 +1493,7 @@ static uint16_t MapWindowGetPixelColourRide(const CoordsXY& c)
                     colourA = RideKeyColours[static_cast<size_t>(colourKey)];
                 }
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 ride = get_ride(tileElement->AsTrack()->GetRideIndex());
                 if (ride != nullptr)
                 {
@@ -1501,6 +1501,8 @@ static uint16_t MapWindowGetPixelColourRide(const CoordsXY& c)
                     colourA = RideKeyColours[static_cast<size_t>(colourKey)];
                 }
 
+                break;
+            default:
                 break;
         }
     } while (!(tileElement++)->IsLastForTile());

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1175,7 +1175,7 @@ static void WindowRideUpdateOverallView(Ride* ride)
 
     while (tile_element_iterator_next(&it))
     {
-        if (it.element->GetTypeN() != TileElementTypeN::Track)
+        if (it.element->GetType() != TileElementType::Track)
             continue;
 
         if (it.element->AsTrack()->GetRideIndex() != ride->id)
@@ -1357,15 +1357,15 @@ rct_window* WindowRideOpenTrack(TileElement* tileElement)
         auto ride = get_ride(rideIndex);
         if (ride != nullptr)
         {
-            const auto type = tileElement->GetTypeN();
-            if (type == TileElementTypeN::Entrance)
+            const auto type = tileElement->GetType();
+            if (type == TileElementType::Entrance)
             {
                 // Open ride window in station view
                 auto entranceElement = tileElement->AsEntrance();
                 auto stationIndex = entranceElement->GetStationIndex();
                 return WindowRideOpenStation(ride, stationIndex);
             }
-            else if (type == TileElementTypeN::Track)
+            else if (type == TileElementType::Track)
             {
                 // Open ride window in station view
                 auto trackElement = tileElement->AsTrack();
@@ -4235,7 +4235,7 @@ static void WindowRideSetTrackColourScheme(rct_window* w, const ScreenCoordsXY& 
 
     if (info.SpriteType != ViewportInteractionItem::Ride)
         return;
-    if (info.Element->GetTypeN() != TileElementTypeN::Track)
+    if (info.Element->GetType() != TileElementType::Track)
         return;
     if (info.Element->AsTrack()->GetRideIndex() != w->rideId)
         return;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1357,26 +1357,24 @@ rct_window* WindowRideOpenTrack(TileElement* tileElement)
         auto ride = get_ride(rideIndex);
         if (ride != nullptr)
         {
-            switch (tileElement->GetType())
+            const auto type = tileElement->GetTypeN();
+            if (type == TileElementTypeN::Entrance)
             {
-                case TILE_ELEMENT_TYPE_ENTRANCE:
+                // Open ride window in station view
+                auto entranceElement = tileElement->AsEntrance();
+                auto stationIndex = entranceElement->GetStationIndex();
+                return WindowRideOpenStation(ride, stationIndex);
+            }
+            else if (type == TileElementTypeN::Track)
+            {
+                // Open ride window in station view
+                auto trackElement = tileElement->AsTrack();
+                auto trackType = trackElement->GetTrackType();
+                const auto& ted = GetTrackElementDescriptor(trackType);
+                if (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
                 {
-                    // Open ride window in station view
-                    auto entranceElement = tileElement->AsEntrance();
-                    auto stationIndex = entranceElement->GetStationIndex();
+                    auto stationIndex = trackElement->GetStationIndex();
                     return WindowRideOpenStation(ride, stationIndex);
-                }
-                case TILE_ELEMENT_TYPE_TRACK:
-                {
-                    // Open ride window in station view
-                    auto trackElement = tileElement->AsTrack();
-                    auto trackType = trackElement->GetTrackType();
-                    const auto& ted = GetTrackElementDescriptor(trackType);
-                    if (ted.SequenceProperties[0] & TRACK_SEQUENCE_FLAG_ORIGIN)
-                    {
-                        auto stationIndex = trackElement->GetStationIndex();
-                        return WindowRideOpenStation(ride, stationIndex);
-                    }
                 }
             }
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2446,7 +2446,7 @@ static void Sub6CbcE2(
         map_set_tile_element(southTileCoords, &_tempSideTrackTileElement);
 
         // Set the temporary track element
-        _tempTrackTileElement.SetTypeN(TileElementTypeN::Track);
+        _tempTrackTileElement.SetType(TileElementType::Track);
         _tempTrackTileElement.SetDirection(trackDirection);
         _tempTrackTileElement.AsTrack()->SetHasChain((liftHillAndInvertedState & CONSTRUCTION_LIFT_HILL_SELECTED) != 0);
         _tempTrackTileElement.SetOccupiedQuadrants(quarterTile.GetBaseQuarterOccupied());

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -836,9 +836,9 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
         return;
 
     // Page widgets
-    switch (tileElement->GetTypeN())
+    switch (tileElement->GetType())
     {
-        case TileElementTypeN::Surface:
+        case TileElementType::Surface:
             switch (widgetIndex)
             {
                 case WIDX_SURFACE_BUTTON_REMOVE_FENCES:
@@ -860,7 +860,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widgetindex
             break;
 
-        case TileElementTypeN::Path:
+        case TileElementType::Path:
             switch (widgetIndex)
             {
                 case WIDX_PATH_CHECK_SLOPED:
@@ -898,7 +898,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TileElementTypeN::Track:
+        case TileElementType::Track:
             switch (widgetIndex)
             {
                 case WIDX_TRACK_CHECK_APPLY_TO_ALL:
@@ -923,7 +923,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TileElementTypeN::SmallScenery:
+        case TileElementType::SmallScenery:
             switch (widgetIndex)
             {
                 case WIDX_SCENERY_CHECK_QUARTER_N:
@@ -943,7 +943,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
             switch (widgetIndex)
             {
                 case WIDX_ENTRANCE_BUTTON_MAKE_USABLE:
@@ -952,7 +952,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
             switch (widgetIndex)
             {
                 case WIDX_BANNER_CHECK_BLOCK_NE:
@@ -965,8 +965,8 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TileElementTypeN::LargeScenery:
-        case TileElementTypeN::Wall:
+        case TileElementType::LargeScenery:
+        case TileElementType::Wall:
         default:
             break;
     }
@@ -1022,9 +1022,9 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
     if (tileElement == nullptr)
         return;
 
-    switch (tileElement->GetTypeN())
+    switch (tileElement->GetType())
     {
-        case TileElementTypeN::Surface:
+        case TileElementType::Surface:
             switch (widgetIndex)
             {
                 case WIDX_SURFACE_SPINNER_HEIGHT_INCREASE:
@@ -1036,7 +1036,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::Path:
+        case TileElementType::Path:
             switch (widgetIndex)
             {
                 case WIDX_PATH_SPINNER_HEIGHT_INCREASE:
@@ -1048,7 +1048,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::Track:
+        case TileElementType::Track:
             switch (widgetIndex)
             {
                 case WIDX_TRACK_SPINNER_HEIGHT_INCREASE:
@@ -1074,7 +1074,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::SmallScenery:
+        case TileElementType::SmallScenery:
             switch (widgetIndex)
             {
                 case WIDX_SCENERY_SPINNER_HEIGHT_INCREASE:
@@ -1086,7 +1086,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
             switch (widgetIndex)
             {
                 case WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE:
@@ -1101,7 +1101,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::Wall:
+        case TileElementType::Wall:
             switch (widgetIndex)
             {
                 case WIDX_WALL_SPINNER_HEIGHT_INCREASE:
@@ -1139,7 +1139,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
             switch (widgetIndex)
             {
                 case WIDX_LARGE_SCENERY_SPINNER_HEIGHT_INCREASE:
@@ -1151,7 +1151,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
             switch (widgetIndex)
             {
                 case WIDX_BANNER_SPINNER_HEIGHT_INCREASE:
@@ -1193,7 +1193,7 @@ static void WindowTileInspectorDropdown(rct_window* w, rct_widgetindex widgetInd
 
     if (w->tileInspectorPage == TileInspectorPage::Wall)
     {
-        openrct2_assert(tileElement->GetTypeN() == TileElementTypeN::Wall, "Element is not a wall");
+        openrct2_assert(tileElement->GetType() == TileElementType::Wall, "Element is not a wall");
 
         if (widgetIndex == WIDX_WALL_DROPDOWN_SLOPE_BUTTON)
         {
@@ -1378,31 +1378,31 @@ static void WindowTileInspectorInvalidate(rct_window* w)
     if (windowTileInspectorSelectedIndex != -1)
     {
         const auto element = WindowTileInspectorGetSelectedElement(w);
-        switch (element->GetTypeN())
+        switch (element->GetType())
         {
             default:
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 page = TileInspectorPage::Surface;
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 page = TileInspectorPage::Path;
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 page = TileInspectorPage::Track;
                 break;
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
                 page = TileInspectorPage::Scenery;
                 break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 page = TileInspectorPage::Entrance;
                 break;
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
                 page = TileInspectorPage::Wall;
                 break;
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
                 page = TileInspectorPage::LargeScenery;
                 break;
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
                 page = TileInspectorPage::Banner;
                 break;
         }
@@ -1481,9 +1481,9 @@ static void WindowTileInspectorInvalidate(rct_window* w)
     if (tileElement == nullptr)
         return;
 
-    switch (tileElement->GetTypeN())
+    switch (tileElement->GetType())
     {
-        case TileElementTypeN::Surface:
+        case TileElementType::Surface:
             w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_SURFACE_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1519,7 +1519,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(
                 w, WIDX_SURFACE_CHECK_DIAGONAL, tileElement->AsSurface()->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT);
             break;
-        case TileElementTypeN::Path:
+        case TileElementType::Path:
             w->widgets[WIDX_PATH_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_PATH_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_PATH_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1565,7 +1565,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(
                 w, WIDX_PATH_CHECK_EDGE_N, tileElement->AsPath()->GetCorners() & (1 << ((3 - get_current_rotation()) & 3)));
             break;
-        case TileElementTypeN::Track:
+        case TileElementType::Track:
             w->widgets[WIDX_TRACK_CHECK_APPLY_TO_ALL].top = GBBT(propertiesAnchor, 0);
             w->widgets[WIDX_TRACK_CHECK_APPLY_TO_ALL].bottom = GBBB(propertiesAnchor, 0);
             w->widgets[WIDX_TRACK_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 1) + 3;
@@ -1585,7 +1585,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_BLOCK_BRAKE_CLOSED, tileElement->AsTrack()->BlockBrakeClosed());
             WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE, tileElement->AsTrack()->IsIndestructible());
             break;
-        case TileElementTypeN::SmallScenery:
+        case TileElementType::SmallScenery:
         {
             // Raise / Lower
             w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
@@ -1634,7 +1634,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_COLLISION_W, W);
             break;
         }
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
             w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1647,7 +1647,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
                 w, WIDX_ENTRANCE_BUTTON_MAKE_USABLE,
                 tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE);
             break;
-        case TileElementTypeN::Wall:
+        case TileElementType::Wall:
         {
             bool canBeSloped = false;
             bool hasAnimation = false;
@@ -1687,7 +1687,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetEnabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME_DECREASE, hasAnimation);
             break;
         }
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1695,7 +1695,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT_DECREASE].top = GBBT(propertiesAnchor, 0) + 4;
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT_DECREASE].bottom = GBBB(propertiesAnchor, 0) - 4;
             break;
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
             w->widgets[WIDX_BANNER_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_BANNER_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_BANNER_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1766,9 +1766,9 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
         if (tileElement == nullptr)
             return;
 
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
             {
                 // Details
                 // Terrain texture name
@@ -1836,7 +1836,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 // Details
                 auto pathEl = tileElement->AsPath();
@@ -1912,7 +1912,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto trackElement = tileElement->AsTrack();
                 ride_id_t rideId = trackElement->GetRideIndex();
@@ -1986,7 +1986,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 // Details
                 // Age
@@ -2041,7 +2041,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 // Details
                 // Entrance type
@@ -2116,7 +2116,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 // Details
                 // Type
@@ -2174,7 +2174,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 // Details
                 // Type
@@ -2225,7 +2225,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
             {
                 // Details
                 // Banner info
@@ -2316,20 +2316,20 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
             DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 2, 0 }, stringFormat, checkboxFormatter);
         }
 
-        const auto type = tileElement->GetTypeN();
+        const auto type = tileElement->GetType();
         switch (type)
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 typeName = language_get_string(STR_TILE_INSPECTOR_SURFACE);
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 typeName = tileElement->AsPath()->IsQueue() ? language_get_string(STR_QUEUE_LINE_MAP_TIP)
                                                             : language_get_string(STR_FOOTPATH_MAP_TIP);
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 typeName = language_get_string(STR_RIDE_COMPONENT_TRACK_CAPITALISED);
                 break;
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 const auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
                 snprintf(
@@ -2338,10 +2338,10 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
                 typeName = buffer;
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 typeName = language_get_string(STR_RIDE_CONSTRUCTION_ENTRANCE);
                 break;
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 const auto* entry = tileElement->AsWall()->GetEntry();
                 snprintf(
@@ -2350,10 +2350,10 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
                 typeName = buffer;
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
                 typeName = language_get_string(STR_OBJECT_SELECTION_LARGE_SCENERY);
                 break;
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
                 snprintf(
                     buffer, sizeof(buffer), "%s (%d)", language_get_string(STR_BANNER_WINDOW_TITLE),
                     tileElement->AsBanner()->GetIndex());

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -836,9 +836,9 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
         return;
 
     // Page widgets
-    switch (tileElement->GetType())
+    switch (tileElement->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_SURFACE:
+        case TileElementTypeN::Surface:
             switch (widgetIndex)
             {
                 case WIDX_SURFACE_BUTTON_REMOVE_FENCES:
@@ -860,7 +860,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widgetindex
             break;
 
-        case TILE_ELEMENT_TYPE_PATH:
+        case TileElementTypeN::Path:
             switch (widgetIndex)
             {
                 case WIDX_PATH_CHECK_SLOPED:
@@ -898,7 +898,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_TRACK:
+        case TileElementTypeN::Track:
             switch (widgetIndex)
             {
                 case WIDX_TRACK_CHECK_APPLY_TO_ALL:
@@ -923,7 +923,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+        case TileElementTypeN::SmallScenery:
             switch (widgetIndex)
             {
                 case WIDX_SCENERY_CHECK_QUARTER_N:
@@ -943,7 +943,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
             switch (widgetIndex)
             {
                 case WIDX_ENTRANCE_BUTTON_MAKE_USABLE:
@@ -952,7 +952,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_BANNER:
+        case TileElementTypeN::Banner:
             switch (widgetIndex)
             {
                 case WIDX_BANNER_CHECK_BLOCK_NE:
@@ -965,8 +965,8 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::LargeScenery:
+        case TileElementTypeN::Wall:
         default:
             break;
     }
@@ -1022,9 +1022,9 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
     if (tileElement == nullptr)
         return;
 
-    switch (tileElement->GetType())
+    switch (tileElement->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_SURFACE:
+        case TileElementTypeN::Surface:
             switch (widgetIndex)
             {
                 case WIDX_SURFACE_SPINNER_HEIGHT_INCREASE:
@@ -1036,7 +1036,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_PATH:
+        case TileElementTypeN::Path:
             switch (widgetIndex)
             {
                 case WIDX_PATH_SPINNER_HEIGHT_INCREASE:
@@ -1048,7 +1048,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_TRACK:
+        case TileElementTypeN::Track:
             switch (widgetIndex)
             {
                 case WIDX_TRACK_SPINNER_HEIGHT_INCREASE:
@@ -1074,7 +1074,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+        case TileElementTypeN::SmallScenery:
             switch (widgetIndex)
             {
                 case WIDX_SCENERY_SPINNER_HEIGHT_INCREASE:
@@ -1086,7 +1086,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
             switch (widgetIndex)
             {
                 case WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE:
@@ -1101,7 +1101,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Wall:
             switch (widgetIndex)
             {
                 case WIDX_WALL_SPINNER_HEIGHT_INCREASE:
@@ -1139,7 +1139,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
             switch (widgetIndex)
             {
                 case WIDX_LARGE_SCENERY_SPINNER_HEIGHT_INCREASE:
@@ -1151,7 +1151,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             } // switch widget index
             break;
 
-        case TILE_ELEMENT_TYPE_BANNER:
+        case TileElementTypeN::Banner:
             switch (widgetIndex)
             {
                 case WIDX_BANNER_SPINNER_HEIGHT_INCREASE:
@@ -1378,32 +1378,31 @@ static void WindowTileInspectorInvalidate(rct_window* w)
     if (windowTileInspectorSelectedIndex != -1)
     {
         const auto element = WindowTileInspectorGetSelectedElement(w);
-        auto type = element->GetType();
-        switch (type)
+        switch (element->GetTypeN())
         {
             default:
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 page = TileInspectorPage::Surface;
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 page = TileInspectorPage::Path;
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 page = TileInspectorPage::Track;
                 break;
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
                 page = TileInspectorPage::Scenery;
                 break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 page = TileInspectorPage::Entrance;
                 break;
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
                 page = TileInspectorPage::Wall;
                 break;
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
                 page = TileInspectorPage::LargeScenery;
                 break;
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
                 page = TileInspectorPage::Banner;
                 break;
         }
@@ -1482,9 +1481,9 @@ static void WindowTileInspectorInvalidate(rct_window* w)
     if (tileElement == nullptr)
         return;
 
-    switch (tileElement->GetType())
+    switch (tileElement->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_SURFACE:
+        case TileElementTypeN::Surface:
             w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_SURFACE_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_SURFACE_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1520,7 +1519,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(
                 w, WIDX_SURFACE_CHECK_DIAGONAL, tileElement->AsSurface()->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT);
             break;
-        case TILE_ELEMENT_TYPE_PATH:
+        case TileElementTypeN::Path:
             w->widgets[WIDX_PATH_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_PATH_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_PATH_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1566,7 +1565,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(
                 w, WIDX_PATH_CHECK_EDGE_N, tileElement->AsPath()->GetCorners() & (1 << ((3 - get_current_rotation()) & 3)));
             break;
-        case TILE_ELEMENT_TYPE_TRACK:
+        case TileElementTypeN::Track:
             w->widgets[WIDX_TRACK_CHECK_APPLY_TO_ALL].top = GBBT(propertiesAnchor, 0);
             w->widgets[WIDX_TRACK_CHECK_APPLY_TO_ALL].bottom = GBBB(propertiesAnchor, 0);
             w->widgets[WIDX_TRACK_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 1) + 3;
@@ -1586,7 +1585,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_BLOCK_BRAKE_CLOSED, tileElement->AsTrack()->BlockBrakeClosed());
             WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE, tileElement->AsTrack()->IsIndestructible());
             break;
-        case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+        case TileElementTypeN::SmallScenery:
         {
             // Raise / Lower
             w->widgets[WIDX_SCENERY_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
@@ -1635,7 +1634,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_COLLISION_W, W);
             break;
         }
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
             w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_ENTRANCE_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1648,7 +1647,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
                 w, WIDX_ENTRANCE_BUTTON_MAKE_USABLE,
                 tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE);
             break;
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Wall:
         {
             bool canBeSloped = false;
             bool hasAnimation = false;
@@ -1688,7 +1687,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             WidgetSetEnabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME_DECREASE, hasAnimation);
             break;
         }
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1696,7 +1695,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT_DECREASE].top = GBBT(propertiesAnchor, 0) + 4;
             w->widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT_DECREASE].bottom = GBBB(propertiesAnchor, 0) - 4;
             break;
-        case TILE_ELEMENT_TYPE_BANNER:
+        case TileElementTypeN::Banner:
             w->widgets[WIDX_BANNER_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
             w->widgets[WIDX_BANNER_SPINNER_HEIGHT].bottom = GBBB(propertiesAnchor, 0) - 3;
             w->widgets[WIDX_BANNER_SPINNER_HEIGHT_INCREASE].top = GBBT(propertiesAnchor, 0) + 4;
@@ -1767,9 +1766,9 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
         if (tileElement == nullptr)
             return;
 
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
             {
                 // Details
                 // Terrain texture name
@@ -1837,7 +1836,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 // Details
                 auto pathEl = tileElement->AsPath();
@@ -1913,7 +1912,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto trackElement = tileElement->AsTrack();
                 ride_id_t rideId = trackElement->GetRideIndex();
@@ -1987,7 +1986,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 // Details
                 // Age
@@ -2042,7 +2041,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 // Details
                 // Entrance type
@@ -2117,7 +2116,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 // Details
                 // Type
@@ -2175,7 +2174,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 // Details
                 // Type
@@ -2226,7 +2225,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 break;
             }
 
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
             {
                 // Details
                 // Banner info
@@ -2287,7 +2286,6 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
 
         const bool selectedRow = i == windowTileInspectorSelectedIndex;
         const bool hoveredRow = i == windowTileInspectorHighlightedIndex;
-        int32_t type = tileElement->GetType();
         const char* typeName = "";
 
         // Draw row background colour
@@ -2318,19 +2316,20 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
             DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 2, 0 }, stringFormat, checkboxFormatter);
         }
 
+        const auto type = tileElement->GetTypeN();
         switch (type)
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 typeName = language_get_string(STR_TILE_INSPECTOR_SURFACE);
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 typeName = tileElement->AsPath()->IsQueue() ? language_get_string(STR_QUEUE_LINE_MAP_TIP)
                                                             : language_get_string(STR_FOOTPATH_MAP_TIP);
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 typeName = language_get_string(STR_RIDE_COMPONENT_TRACK_CAPITALISED);
                 break;
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 const auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
                 snprintf(
@@ -2339,10 +2338,10 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
                 typeName = buffer;
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 typeName = language_get_string(STR_RIDE_CONSTRUCTION_ENTRANCE);
                 break;
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 const auto* entry = tileElement->AsWall()->GetEntry();
                 snprintf(
@@ -2351,17 +2350,17 @@ static void WindowTileInspectorScrollpaint(rct_window* w, rct_drawpixelinfo* dpi
                 typeName = buffer;
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
                 typeName = language_get_string(STR_OBJECT_SELECTION_LARGE_SCENERY);
                 break;
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
                 snprintf(
                     buffer, sizeof(buffer), "%s (%d)", language_get_string(STR_BANNER_WINDOW_TITLE),
                     tileElement->AsBanner()->GetIndex());
                 typeName = buffer;
                 break;
             default:
-                snprintf(buffer, sizeof(buffer), "%s (%d)", language_get_string(STR_UNKNOWN_OBJECT_TYPE), type);
+                snprintf(buffer, sizeof(buffer), "%s (%d)", language_get_string(STR_UNKNOWN_OBJECT_TYPE), EnumValue(type));
                 typeName = buffer;
         }
 

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -132,10 +132,10 @@ void setup_in_use_selection_flags()
     {
         ObjectEntryIndex type;
 
-        switch (iter.element->GetTypeN())
+        switch (iter.element->GetType())
         {
             default:
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
             {
                 auto surfaceEl = iter.element->AsSurface();
                 auto surfaceIndex = surfaceEl->GetSurfaceStyle();
@@ -145,9 +145,9 @@ void setup_in_use_selection_flags()
                 Editor::SetSelectedObject(ObjectType::TerrainEdge, edgeIndex, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto footpathEl = iter.element->AsPath();
                 auto legacyPathEntryIndex = footpathEl->GetLegacyPathEntryIndex();
@@ -169,11 +169,11 @@ void setup_in_use_selection_flags()
                 }
                 break;
             }
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
                 type = iter.element->AsSmallScenery()->GetEntryIndex();
                 Editor::SetSelectedObject(ObjectType::SmallScenery, type, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto parkEntranceEl = iter.element->AsEntrance();
                 if (parkEntranceEl->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
@@ -197,15 +197,15 @@ void setup_in_use_selection_flags()
                 }
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
                 type = iter.element->AsWall()->GetEntryIndex();
                 Editor::SetSelectedObject(ObjectType::Walls, type, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
                 type = iter.element->AsLargeScenery()->GetEntryIndex();
                 Editor::SetSelectedObject(ObjectType::LargeScenery, type, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
             {
                 auto banner = iter.element->AsBanner()->GetBanner();
                 if (banner != nullptr)

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -132,10 +132,10 @@ void setup_in_use_selection_flags()
     {
         ObjectEntryIndex type;
 
-        switch (iter.element->GetType())
+        switch (iter.element->GetTypeN())
         {
             default:
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
             {
                 auto surfaceEl = iter.element->AsSurface();
                 auto surfaceIndex = surfaceEl->GetSurfaceStyle();
@@ -145,9 +145,9 @@ void setup_in_use_selection_flags()
                 Editor::SetSelectedObject(ObjectType::TerrainEdge, edgeIndex, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto footpathEl = iter.element->AsPath();
                 auto legacyPathEntryIndex = footpathEl->GetLegacyPathEntryIndex();
@@ -169,11 +169,11 @@ void setup_in_use_selection_flags()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
                 type = iter.element->AsSmallScenery()->GetEntryIndex();
                 Editor::SetSelectedObject(ObjectType::SmallScenery, type, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto parkEntranceEl = iter.element->AsEntrance();
                 if (parkEntranceEl->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
@@ -197,15 +197,15 @@ void setup_in_use_selection_flags()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
                 type = iter.element->AsWall()->GetEntryIndex();
                 Editor::SetSelectedObject(ObjectType::Walls, type, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
                 type = iter.element->AsLargeScenery()->GetEntryIndex();
                 Editor::SetSelectedObject(ObjectType::LargeScenery, type, OBJECT_SELECTION_FLAG_SELECTED);
                 break;
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
             {
                 auto banner = iter.element->AsBanner()->GetBanner();
                 if (banner != nullptr)

--- a/src/openrct2/ParkFile.cpp
+++ b/src/openrct2/ParkFile.cpp
@@ -902,7 +902,7 @@ namespace OpenRCT2
                             tile_element_iterator_begin(&it);
                             while (tile_element_iterator_next(&it))
                             {
-                                if (it.element->GetTypeN() == TileElementTypeN::Path)
+                                if (it.element->GetType() == TileElementType::Path)
                                 {
                                     auto* pathElement = it.element->AsPath();
                                     if (pathElement->HasLegacyPathEntry())
@@ -947,7 +947,7 @@ namespace OpenRCT2
                         continue;
                     do
                     {
-                        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+                        if (tileElement->GetType() != TileElementType::Track)
                             continue;
 
                         auto* trackElement = tileElement->AsTrack();

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -128,10 +128,9 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
             if (tileElement->IsGhost())
                 continue;
 
-            auto type = tileElement->GetType();
-            switch (type)
+            switch (tileElement->GetTypeN())
             {
-                case TILE_ELEMENT_TYPE_PATH:
+                case TileElementTypeN::Path:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_FOOTPATH)
                     {
                         auto footpathRemoveAction = FootpathRemoveAction({ tilePos, tileElement->GetBaseZ() });
@@ -147,7 +146,7 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                         }
                     }
                     break;
-                case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+                case TileElementTypeN::SmallScenery:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_SMALL)
                     {
                         auto removeSceneryAction = SmallSceneryRemoveAction(
@@ -165,7 +164,7 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                         }
                     }
                     break;
-                case TILE_ELEMENT_TYPE_WALL:
+                case TileElementTypeN::Wall:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_SMALL)
                     {
                         CoordsXYZD wallLocation = { tilePos, tileElement->GetBaseZ(), tileElement->GetDirection() };
@@ -182,7 +181,7 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                         }
                     }
                     break;
-                case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+                case TileElementTypeN::LargeScenery:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_LARGE)
                     {
                         auto removeSceneryAction = LargeSceneryRemoveAction(
@@ -199,6 +198,8 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                             tileEdited = executing;
                         }
                     }
+                    break;
+                default:
                     break;
             }
         } while (!tileEdited && !(tileElement++)->IsLastForTile());

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -128,9 +128,9 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
             if (tileElement->IsGhost())
                 continue;
 
-            switch (tileElement->GetTypeN())
+            switch (tileElement->GetType())
             {
-                case TileElementTypeN::Path:
+                case TileElementType::Path:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_FOOTPATH)
                     {
                         auto footpathRemoveAction = FootpathRemoveAction({ tilePos, tileElement->GetBaseZ() });
@@ -146,7 +146,7 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                         }
                     }
                     break;
-                case TileElementTypeN::SmallScenery:
+                case TileElementType::SmallScenery:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_SMALL)
                     {
                         auto removeSceneryAction = SmallSceneryRemoveAction(
@@ -164,7 +164,7 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                         }
                     }
                     break;
-                case TileElementTypeN::Wall:
+                case TileElementType::Wall:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_SMALL)
                     {
                         CoordsXYZD wallLocation = { tilePos, tileElement->GetBaseZ(), tileElement->GetDirection() };
@@ -181,7 +181,7 @@ money32 ClearAction::ClearSceneryFromTile(const CoordsXY& tilePos, bool executin
                         }
                     }
                     break;
-                case TileElementTypeN::LargeScenery:
+                case TileElementType::LargeScenery:
                     if (_itemsToClear & CLEARABLE_ITEMS::SCENERY_LARGE)
                     {
                         auto removeSceneryAction = LargeSceneryRemoveAction(
@@ -220,7 +220,7 @@ void ClearAction::ResetClearLargeSceneryFlag()
             {
                 if (tileElement == nullptr)
                     break;
-                if (tileElement->GetTypeN() == TileElementTypeN::LargeScenery)
+                if (tileElement->GetType() == TileElementType::LargeScenery)
                 {
                     tileElement->AsLargeScenery()->SetIsAccounted(false);
                 }

--- a/src/openrct2/actions/FootpathRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathRemoveAction.cpp
@@ -133,7 +133,7 @@ TileElement* FootpathRemoveAction::GetFootpathElement() const
         {
             while (!(tileElement++)->IsLastForTile())
             {
-                if (tileElement->GetTypeN() != TileElementTypeN::Path && !tileElement->IsGhost())
+                if (tileElement->GetType() != TileElementType::Path && !tileElement->IsGhost())
                 {
                     continue;
                 }
@@ -165,10 +165,10 @@ GameActions::Result FootpathRemoveAction::RemoveBannersAtElement(const CoordsXY&
     auto result = GameActions::Result();
     while (!(tileElement++)->IsLastForTile())
     {
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
             return result;
 
-        if (tileElement->GetTypeN() != TileElementTypeN::Banner)
+        if (tileElement->GetType() != TileElementType::Banner)
             continue;
 
         auto bannerRemoveAction = BannerRemoveAction({ loc, tileElement->GetBaseZ(), tileElement->AsBanner()->GetPosition() });

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -258,7 +258,7 @@ void LandSetHeightAction::SmallSceneryRemoval() const
     {
         if (tileElement == nullptr)
             break;
-        if (tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+        if (tileElement->GetType() != TileElementType::SmallScenery)
             continue;
         if (_height > tileElement->clearance_height)
             continue;
@@ -325,12 +325,12 @@ TileElement* LandSetHeightAction::CheckUnremovableObstructions(TileElement* surf
 {
     for (auto* tileElement : TileElementsView(_coords))
     {
-        const auto elementType = tileElement->GetTypeN();
+        const auto elementType = tileElement->GetType();
 
         // Wall's and Small Scenery are removed and therefore do not need checked
-        if (elementType == TileElementTypeN::Wall)
+        if (elementType == TileElementType::Wall)
             continue;
-        if (elementType == TileElementTypeN::SmallScenery)
+        if (elementType == TileElementType::SmallScenery)
             continue;
         if (tileElement->IsGhost())
             continue;
@@ -382,10 +382,10 @@ int32_t LandSetHeightAction::map_set_land_height_clear_func(
     TileElement** tile_element, [[maybe_unused]] const CoordsXY& coords, [[maybe_unused]] uint8_t flags,
     [[maybe_unused]] money32* price)
 {
-    if ((*tile_element)->GetTypeN() == TileElementTypeN::Surface)
+    if ((*tile_element)->GetType() == TileElementType::Surface)
         return 0;
 
-    if ((*tile_element)->GetTypeN() == TileElementTypeN::SmallScenery)
+    if ((*tile_element)->GetType() == TileElementType::SmallScenery)
         return 0;
 
     return 1;

--- a/src/openrct2/actions/SetCheatAction.cpp
+++ b/src/openrct2/actions/SetCheatAction.cpp
@@ -383,7 +383,7 @@ void SetCheatAction::WaterPlants() const
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() == TileElementTypeN::SmallScenery)
+        if (it.element->GetType() == TileElementType::SmallScenery)
         {
             it.element->AsSmallScenery()->SetAge(0);
         }
@@ -399,7 +399,7 @@ void SetCheatAction::FixVandalism() const
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() != TileElementTypeN::Path)
+        if (it.element->GetType() != TileElementType::Path)
             continue;
 
         if (!(it.element)->AsPath()->HasAddition())
@@ -422,7 +422,7 @@ void SetCheatAction::RemoveLitter() const
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() != TileElementTypeN::Path)
+        if (it.element->GetType() != TileElementType::Path)
             continue;
 
         auto* path = it.element->AsPath();

--- a/src/openrct2/actions/SignSetStyleAction.cpp
+++ b/src/openrct2/actions/SignSetStyleAction.cpp
@@ -54,7 +54,7 @@ GameActions::Result SignSetStyleAction::Query() const
             log_warning("Invalid game command for setting sign style, banner id '%d' not found", _bannerIndex);
             return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_NONE);
         }
-        if (tileElement->GetTypeN() != TileElementTypeN::LargeScenery)
+        if (tileElement->GetType() != TileElementType::LargeScenery)
         {
             log_warning("Invalid game command for setting sign style, banner id '%d' is not large", _bannerIndex);
             return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_NONE);

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -78,7 +78,7 @@ GameActions::Result TrackRemoveAction::Query() const
         if (tileElement->GetBaseZ() != _origin.z)
             continue;
 
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if ((tileElement->GetDirection()) != _origin.direction)
@@ -176,7 +176,7 @@ GameActions::Result TrackRemoveAction::Query() const
             if (tileElement->GetBaseZ() != mapLoc.z)
                 continue;
 
-            if (tileElement->GetTypeN() != TileElementTypeN::Track)
+            if (tileElement->GetType() != TileElementType::Track)
                 continue;
 
             if (tileElement->GetDirection() != _origin.direction)
@@ -272,7 +272,7 @@ GameActions::Result TrackRemoveAction::Execute() const
         if (tileElement->GetBaseZ() != _origin.z)
             continue;
 
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if ((tileElement->GetDirection()) != _origin.direction)
@@ -352,7 +352,7 @@ GameActions::Result TrackRemoveAction::Execute() const
             if (tileElement->GetBaseZ() != mapLoc.z)
                 continue;
 
-            if (tileElement->GetTypeN() != TileElementTypeN::Track)
+            if (tileElement->GetType() != TileElementType::Track)
                 continue;
 
             if (tileElement->GetDirection() != _origin.direction)

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -505,8 +505,8 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
     {
         if (tileElement == nullptr)
             break;
-        auto elementType = tileElement->GetTypeN();
-        if (elementType == TileElementTypeN::Surface)
+        auto elementType = tileElement->GetType();
+        if (elementType == TileElementType::Surface)
             continue;
         if (tileElement->IsGhost())
             continue;
@@ -514,7 +514,7 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
             continue;
         if (z1 <= tileElement->base_height)
             continue;
-        if (elementType == TileElementTypeN::Wall)
+        if (elementType == TileElementType::Wall)
         {
             int32_t direction = tileElement->GetDirection();
             if (_edge == direction)
@@ -530,17 +530,17 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
         auto res = GameActions::Result(GameActions::Status::NoClearance, STR_CANT_BUILD_THIS_HERE, STR_NONE);
         switch (elementType)
         {
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 map_obstruction_set_error_text(tileElement, res);
                 return res;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 if (tileElement->AsPath()->GetEdges() & (1 << _edge))
                 {
                     map_obstruction_set_error_text(tileElement, res);
                     return res;
                 }
                 break;
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 const auto* largeSceneryElement = tileElement->AsLargeScenery();
                 const auto* sceneryEntry = largeSceneryElement->GetEntry();
@@ -560,7 +560,7 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
                 }
                 break;
             }
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
                 if (sceneryEntry != nullptr && sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_NO_WALLS))
@@ -570,7 +570,7 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
                 }
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 if (!WallCheckObstructionWithTrack(wall, z0, tileElement->AsTrack(), wallAcrossTrack))
                 {
                     return res;

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -505,8 +505,8 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
     {
         if (tileElement == nullptr)
             break;
-        int32_t elementType = tileElement->GetType();
-        if (elementType == TILE_ELEMENT_TYPE_SURFACE)
+        auto elementType = tileElement->GetTypeN();
+        if (elementType == TileElementTypeN::Surface)
             continue;
         if (tileElement->IsGhost())
             continue;
@@ -514,7 +514,7 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
             continue;
         if (z1 <= tileElement->base_height)
             continue;
-        if (elementType == TILE_ELEMENT_TYPE_WALL)
+        if (elementType == TileElementTypeN::Wall)
         {
             int32_t direction = tileElement->GetDirection();
             if (_edge == direction)
@@ -530,17 +530,17 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
         auto res = GameActions::Result(GameActions::Status::NoClearance, STR_CANT_BUILD_THIS_HERE, STR_NONE);
         switch (elementType)
         {
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 map_obstruction_set_error_text(tileElement, res);
                 return res;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 if (tileElement->AsPath()->GetEdges() & (1 << _edge))
                 {
                     map_obstruction_set_error_text(tileElement, res);
                     return res;
                 }
                 break;
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 const auto* largeSceneryElement = tileElement->AsLargeScenery();
                 const auto* sceneryEntry = largeSceneryElement->GetEntry();
@@ -560,7 +560,7 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
                 if (sceneryEntry != nullptr && sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_NO_WALLS))
@@ -570,11 +570,13 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 if (!WallCheckObstructionWithTrack(wall, z0, tileElement->AsTrack(), wallAcrossTrack))
                 {
                     return res;
                 }
+                break;
+            default:
                 break;
         }
     } while (!(tileElement++)->IsLastForTile());

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -254,7 +254,7 @@ bool JumpingFountain::IsJumpingFountain(const JumpingFountainType newType, const
         return false;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
         if (tileElement->GetBaseZ() != newLoc.z)
             continue;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2904,9 +2904,9 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
             {
                 Ride* ride;
 
-                switch (tileElement->GetTypeN())
+                switch (tileElement->GetType())
                 {
-                    case TileElementTypeN::Path:
+                    case TileElementType::Path:
                     {
                         if (!tileElement->AsPath()->HasAddition())
                             break;
@@ -2930,11 +2930,11 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
                         }
                         break;
                     }
-                    case TileElementTypeN::LargeScenery:
-                    case TileElementTypeN::SmallScenery:
+                    case TileElementType::LargeScenery:
+                    case TileElementType::SmallScenery:
                         num_scenery++;
                         break;
-                    case TileElementTypeN::Track:
+                    case TileElementType::Track:
                         ride = get_ride(tileElement->AsTrack()->GetRideIndex());
                         if (ride != nullptr)
                         {
@@ -4860,13 +4860,13 @@ void Guest::UpdateRideMazePathfinding()
         if (stationBaseZ != tileElement->GetBaseZ())
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Track)
         {
             mazeType = maze_type::hedge;
             break;
         }
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Entrance
+        if (tileElement->GetType() == TileElementType::Entrance
             && tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT)
         {
             mazeType = maze_type::entrance_or_exit;
@@ -5356,7 +5356,7 @@ void Guest::UpdateWalking()
 
     for (;; tileElement++)
     {
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             if (NextLoc.z == tileElement->GetBaseZ())
                 break;
@@ -6264,7 +6264,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             if (tileElement->IsGhost())
                 continue;
         }
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
         if (tileElement->GetDirection() != edge)
             continue;
@@ -6303,7 +6303,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             if (tileElement->IsGhost())
                 continue;
         }
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
         if (direction_reverse(tileElement->GetDirection()) != edge)
             continue;
@@ -6336,7 +6336,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (peep->NextLoc.z + (6 * COORDS_Z_STEP) < tileElement->GetBaseZ())
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Track)
         {
             if (peep_should_watch_ride(tileElement))
             {
@@ -6344,7 +6344,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             }
         }
 
-        if (tileElement->GetTypeN() == TileElementTypeN::LargeScenery)
+        if (tileElement->GetType() == TileElementType::LargeScenery)
         {
             const auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             if (sceneryEntry == nullptr || !(sceneryEntry->flags & LARGE_SCENERY_FLAG_PHOTOGENIC))
@@ -6379,12 +6379,12 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             continue;
         if (peep->NextLoc.z + (6 * COORDS_Z_STEP) < tileElement->GetBaseZ())
             continue;
-        if (tileElement->GetTypeN() == TileElementTypeN::Surface)
+        if (tileElement->GetType() == TileElementType::Surface)
             continue;
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Wall)
+        if (tileElement->GetType() == TileElementType::Wall)
         {
             auto wallEntry = tileElement->AsWall()->GetEntry();
             if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
@@ -6422,7 +6422,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             if (tileElement->IsGhost())
                 continue;
         }
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
         if (direction_reverse(tileElement->GetDirection()) != edge)
             continue;
@@ -6453,7 +6453,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (peep->NextLoc.z + (8 * COORDS_Z_STEP) < tileElement->GetBaseZ())
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Track)
         {
             if (peep_should_watch_ride(tileElement))
             {
@@ -6461,7 +6461,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             }
         }
 
-        if (tileElement->GetTypeN() == TileElementTypeN::LargeScenery)
+        if (tileElement->GetType() == TileElementType::LargeScenery)
         {
             auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             if (!(sceneryEntry == nullptr || sceneryEntry->flags & LARGE_SCENERY_FLAG_PHOTOGENIC))
@@ -6496,12 +6496,12 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             continue;
         if (peep->NextLoc.z + (8 * COORDS_Z_STEP) < tileElement->GetBaseZ())
             continue;
-        if (tileElement->GetTypeN() == TileElementTypeN::Surface)
+        if (tileElement->GetType() == TileElementType::Surface)
             continue;
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Wall)
+        if (tileElement->GetType() == TileElementType::Wall)
         {
             auto wallEntry = tileElement->AsWall()->GetEntry();
             if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
@@ -6538,7 +6538,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             if (tileElement->IsGhost())
                 continue;
         }
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
         if (direction_reverse(tileElement->GetDirection()) != edge)
             continue;
@@ -6569,7 +6569,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
         if (peep->NextLoc.z + (10 * COORDS_Z_STEP) < tileElement->GetBaseZ())
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Track)
         {
             if (peep_should_watch_ride(tileElement))
             {
@@ -6577,7 +6577,7 @@ static bool peep_find_ride_to_look_at(Peep* peep, uint8_t edge, ride_id_t* rideT
             }
         }
 
-        if (tileElement->GetTypeN() == TileElementTypeN::LargeScenery)
+        if (tileElement->GetType() == TileElementType::LargeScenery)
         {
             const auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             if (sceneryEntry == nullptr || !(sceneryEntry->flags & LARGE_SCENERY_FLAG_PHOTOGENIC))

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2904,9 +2904,9 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
             {
                 Ride* ride;
 
-                switch (tileElement->GetType())
+                switch (tileElement->GetTypeN())
                 {
-                    case TILE_ELEMENT_TYPE_PATH:
+                    case TileElementTypeN::Path:
                     {
                         if (!tileElement->AsPath()->HasAddition())
                             break;
@@ -2930,11 +2930,11 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
                         }
                         break;
                     }
-                    case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-                    case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+                    case TileElementTypeN::LargeScenery:
+                    case TileElementTypeN::SmallScenery:
                         num_scenery++;
                         break;
-                    case TILE_ELEMENT_TYPE_TRACK:
+                    case TileElementTypeN::Track:
                         ride = get_ride(tileElement->AsTrack()->GetRideIndex());
                         if (ride != nullptr)
                         {
@@ -2960,6 +2960,8 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
                                 }
                             }
                         }
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -27,7 +27,7 @@ static bool isLocationLitterable(const CoordsXYZ& mapPos)
         return false;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
 
         int32_t pathZ = tileElement->GetBaseZ();

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -279,17 +279,17 @@ bool Peep::CheckForPath()
 
     TileElement* tile_element = map_get_first_element_at(NextLoc);
 
-    auto mapType = TileElementTypeN::Path;
+    auto mapType = TileElementType::Path;
     if (GetNextIsSurface())
     {
-        mapType = TileElementTypeN::Surface;
+        mapType = TileElementType::Surface;
     }
 
     do
     {
         if (tile_element == nullptr)
             break;
-        if (tile_element->GetTypeN() == mapType)
+        if (tile_element->GetType() == mapType)
         {
             if (NextLoc.z == tile_element->GetBaseZ())
             {
@@ -724,7 +724,7 @@ void Peep::UpdateFalling()
         do
         {
             // If a path check if we are on it
-            if (tile_element->GetTypeN() == TileElementTypeN::Path)
+            if (tile_element->GetType() == TileElementType::Path)
             {
                 int32_t height = map_height_from_slope(
                                      { x, y }, tile_element->AsPath()->GetSlopeDirection(), tile_element->AsPath()->IsSloped())
@@ -737,7 +737,7 @@ void Peep::UpdateFalling()
                 saved_map = tile_element;
                 break;
             } // If a surface get the height and see if we are on it
-            else if (tile_element->GetTypeN() == TileElementTypeN::Surface)
+            else if (tile_element->GetType() == TileElementType::Surface)
             {
                 // If the surface is water check to see if we could be drowning
                 if (tile_element->AsSurface()->GetWaterHeight() > 0)
@@ -794,7 +794,7 @@ void Peep::UpdateFalling()
 
     NextLoc = { CoordsXY{ x, y }.ToTileStart(), saved_map->GetBaseZ() };
 
-    if (saved_map->GetTypeN() != TileElementTypeN::Path)
+    if (saved_map->GetType() != TileElementType::Path)
     {
         SetNextFlags(0, false, true);
     }
@@ -1808,7 +1808,7 @@ static bool peep_interact_with_entrance(Peep* peep, const CoordsXYE& coords, uin
             {
                 if (nextTileElement == nullptr)
                     break;
-                if (nextTileElement->GetTypeN() != TileElementTypeN::Path)
+                if (nextTileElement->GetType() != TileElementType::Path)
                     continue;
 
                 if (nextTileElement->AsPath()->IsQueue())
@@ -2352,14 +2352,14 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
         if (tileElement->IsGhost())
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             peep_interact_with_path(this, { newLoc, tileElement });
             tile_result = tileElement;
             return;
         }
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Track)
         {
             if (peep_interact_with_shop(this, { newLoc, tileElement }))
             {
@@ -2367,7 +2367,7 @@ void Peep::PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result)
                 return;
             }
         }
-        else if (tileElement->GetTypeN() == TileElementTypeN::Entrance)
+        else if (tileElement->GetType() == TileElementType::Entrance)
         {
             if (peep_interact_with_entrance(this, { newLoc, tileElement }, pathing_result))
             {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -223,7 +223,7 @@ bool Staff::CanIgnoreWideFlag(const CoordsXYZ& staffPos, TileElement* path) cons
         bool widefound = false;
         do
         {
-            if (test_element->GetTypeN() != TileElementTypeN::Path)
+            if (test_element->GetType() != TileElementType::Path)
             {
                 continue;
             }
@@ -434,7 +434,7 @@ Direction Staff::HandymanDirectionToNearestLitter() const
     {
         if (tileElement->base_height != nextZ)
             continue;
-        if (tileElement->GetTypeN() == TileElementTypeN::Entrance || tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Entrance || tileElement->GetType() == TileElementType::Track)
         {
             return INVALID_DIRECTION;
         }
@@ -450,7 +450,7 @@ Direction Staff::HandymanDirectionToNearestLitter() const
     {
         if (tileElement->base_height != nextZ)
             continue;
-        if (tileElement->GetTypeN() == TileElementTypeN::Entrance || tileElement->GetTypeN() == TileElementTypeN::Track)
+        if (tileElement->GetType() == TileElementType::Entrance || tileElement->GetType() == TileElementType::Track)
         {
             return INVALID_DIRECTION;
         }
@@ -1203,7 +1203,7 @@ void Staff::UpdateWatering()
 
         do
         {
-            if (tile_element->GetTypeN() != TileElementTypeN::SmallScenery)
+            if (tile_element->GetType() != TileElementType::SmallScenery)
                 continue;
 
             if (abs(NextLoc.z - tile_element->GetBaseZ()) > 4 * COORDS_Z_STEP)
@@ -1270,7 +1270,7 @@ void Staff::UpdateEmptyingBin()
 
         for (;; tile_element++)
         {
-            if (tile_element->GetTypeN() == TileElementTypeN::Path)
+            if (tile_element->GetType() == TileElementType::Path)
             {
                 if (NextLoc.z == tile_element->GetBaseZ())
                     break;
@@ -1584,7 +1584,7 @@ bool Staff::UpdatePatrollingFindWatering()
 
         do
         {
-            if (tile_element->GetTypeN() != TileElementTypeN::SmallScenery)
+            if (tile_element->GetType() != TileElementType::SmallScenery)
             {
                 continue;
             }
@@ -1647,7 +1647,7 @@ bool Staff::UpdatePatrollingFindBin()
 
     for (;; tileElement++)
     {
-        if (tileElement->GetTypeN() == TileElementTypeN::Path && (tileElement->GetBaseZ() == NextLoc.z))
+        if (tileElement->GetType() == TileElementType::Path && (tileElement->GetBaseZ() == NextLoc.z))
             break;
 
         if (tileElement->IsLastForTile())

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1254,7 +1254,7 @@ static int32_t cc_remove_park_fences(InteractiveConsole& console, [[maybe_unused
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() == TileElementTypeN::Surface)
+        if (it.element->GetType() == TileElementType::Surface)
         {
             // Remove all park fence flags
             it.element->AsSurface()->SetParkFences(0);

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -247,9 +247,9 @@ static void virtual_floor_get_tile_properties(
     //  * Ghost objects, which are displayed as lit squares
     for (auto* tileElement : TileElementsView(loc))
     {
-        const auto elementType = tileElement->GetTypeN();
+        const auto elementType = tileElement->GetType();
 
-        if (elementType == TileElementTypeN::Surface)
+        if (elementType == TileElementType::Surface)
         {
             if (height < tileElement->GetClearanceZ())
             {
@@ -272,7 +272,7 @@ static void virtual_floor_get_tile_properties(
             continue;
         }
 
-        if (elementType == TileElementTypeN::Wall || elementType == TileElementTypeN::Banner)
+        if (elementType == TileElementType::Wall || elementType == TileElementType::Banner)
         {
             int32_t direction = tileElement->GetDirection();
             *outOccupiedEdges |= 1 << direction;

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -247,45 +247,41 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
                 {
                     break;
                 }
-                switch (tile_element_sub_iterator->GetType())
-                {
-                    case TILE_ELEMENT_TYPE_PATH:
-                        session->PathElementOnSameHeight = tile_element_sub_iterator;
-                        break;
-                    case TILE_ELEMENT_TYPE_TRACK:
-                        session->TrackElementOnSameHeight = tile_element_sub_iterator;
-                        break;
-                }
+                auto type = tile_element_sub_iterator->GetTypeN();
+                if (type == TileElementTypeN::Path)
+                    session->PathElementOnSameHeight = tile_element_sub_iterator;
+                else if (type == TileElementTypeN::Track)
+                    session->TrackElementOnSameHeight = tile_element_sub_iterator;
             }
         }
 
         CoordsXY mapPosition = session->MapPosition;
         session->CurrentlyDrawnItem = tile_element;
         // Setup the painting of for example: the underground, signs, rides, scenery, etc.
-        switch (tile_element->GetType())
+        switch (tile_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 PaintSurface(session, direction, baseZ, *(tile_element->AsSurface()));
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 PaintPath(session, baseZ, *(tile_element->AsPath()));
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 PaintTrack(session, direction, baseZ, *(tile_element->AsTrack()));
                 break;
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
                 PaintSmallScenery(session, direction, baseZ, *(tile_element->AsSmallScenery()));
                 break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 PaintEntrance(session, direction, baseZ, *(tile_element->AsEntrance()));
                 break;
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
                 PaintWall(session, direction, baseZ, *(tile_element->AsWall()));
                 break;
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
                 PaintLargeScenery(session, direction, baseZ, *(tile_element->AsLargeScenery()));
                 break;
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
                 PaintBanner(session, direction, baseZ, *(tile_element->AsBanner()));
                 break;
         }

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -194,7 +194,7 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
 
     element--;
 
-    if (element->GetTypeN() == TileElementTypeN::Surface && (element->AsSurface()->GetWaterHeight() > 0))
+    if (element->GetType() == TileElementType::Surface && (element->AsSurface()->GetWaterHeight() > 0))
     {
         max_height = element->AsSurface()->GetWaterHeight();
     }
@@ -247,10 +247,10 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
                 {
                     break;
                 }
-                auto type = tile_element_sub_iterator->GetTypeN();
-                if (type == TileElementTypeN::Path)
+                auto type = tile_element_sub_iterator->GetType();
+                if (type == TileElementType::Path)
                     session->PathElementOnSameHeight = tile_element_sub_iterator;
-                else if (type == TileElementTypeN::Track)
+                else if (type == TileElementType::Track)
                     session->TrackElementOnSameHeight = tile_element_sub_iterator;
             }
         }
@@ -258,30 +258,30 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
         CoordsXY mapPosition = session->MapPosition;
         session->CurrentlyDrawnItem = tile_element;
         // Setup the painting of for example: the underground, signs, rides, scenery, etc.
-        switch (tile_element->GetTypeN())
+        switch (tile_element->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 PaintSurface(session, direction, baseZ, *(tile_element->AsSurface()));
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 PaintPath(session, baseZ, *(tile_element->AsPath()));
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 PaintTrack(session, direction, baseZ, *(tile_element->AsTrack()));
                 break;
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
                 PaintSmallScenery(session, direction, baseZ, *(tile_element->AsSmallScenery()));
                 break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 PaintEntrance(session, direction, baseZ, *(tile_element->AsEntrance()));
                 break;
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
                 PaintWall(session, direction, baseZ, *(tile_element->AsWall()));
                 break;
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
                 PaintLargeScenery(session, direction, baseZ, *(tile_element->AsLargeScenery()));
                 break;
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
                 PaintBanner(session, direction, baseZ, *(tile_element->AsBanner()));
                 break;
         }
@@ -300,7 +300,7 @@ static void sub_68B3FB(paint_session* session, int32_t x, int32_t y)
         return;
     }
 
-    if ((tile_element - 1)->GetTypeN() == TileElementTypeN::Surface)
+    if ((tile_element - 1)->GetType() == TileElementType::Surface)
     {
         return;
     }

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -80,10 +80,10 @@ static TileElement* get_banner_on_path(TileElement* path_element)
     do
     {
         // Path on top, so no banners
-        if (bannerElement->GetTypeN() == TileElementTypeN::Path)
+        if (bannerElement->GetType() == TileElementType::Path)
             return nullptr;
         // Found a banner
-        if (bannerElement->GetTypeN() == TileElementTypeN::Banner)
+        if (bannerElement->GetType() == TileElementType::Banner)
             return bannerElement;
         // Last element so there can't be any other banners
         if (bannerElement->IsLastForTile())
@@ -284,7 +284,7 @@ static uint8_t footpath_element_next_in_direction(TileCoordsXYZ loc, PathElement
             break;
         if (nextTileElement->IsGhost())
             continue;
-        if (nextTileElement->GetTypeN() != TileElementTypeN::Path)
+        if (nextTileElement->GetType() != TileElementType::Path)
             continue;
         if (!IsValidPathZAndDirection(nextTileElement, loc.z, chosenDirection))
             continue;
@@ -338,9 +338,9 @@ static uint8_t footpath_element_dest_in_dir(
         if (tileElement->IsGhost())
             continue;
 
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 if (loc.z != tileElement->base_height)
                     continue;
@@ -353,7 +353,7 @@ static uint8_t footpath_element_dest_in_dir(
                 }
             }
             break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 if (loc.z != tileElement->base_height)
                     continue;
                 switch (tileElement->AsEntrance()->GetEntranceType())
@@ -378,7 +378,7 @@ static uint8_t footpath_element_dest_in_dir(
                         return PATH_SEARCH_PARK_EXIT;
                 }
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 if (!IsValidPathZAndDirection(tileElement, loc.z, chosenDirection))
                     continue;
@@ -752,9 +752,9 @@ static void peep_pathfind_heuristic_search(
             continue;
 
         ride_id_t rideIndex = RIDE_ID_NULL;
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 if (loc.z != tileElement->base_height)
                     continue;
@@ -769,7 +769,7 @@ static void peep_pathfind_heuristic_search(
                 searchResult = PATH_SEARCH_SHOP_ENTRANCE;
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 if (loc.z != tileElement->base_height)
                     continue;
                 Direction direction;
@@ -814,7 +814,7 @@ static void peep_pathfind_heuristic_search(
                         continue;
                 }
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 /* For peeps heading for a ride with a queue, the goal is the last
                  * queue path.
@@ -1307,7 +1307,7 @@ Direction peep_pathfind_choose_direction(const TileCoordsXYZ& loc, Peep* peep)
             break;
         if (dest_tile_element->base_height != loc.z)
             continue;
-        if (dest_tile_element->GetTypeN() != TileElementTypeN::Path)
+        if (dest_tile_element->GetType() != TileElementType::Path)
             continue;
         found = true;
         if (first_tile_element == nullptr)
@@ -1812,7 +1812,7 @@ static void get_ride_queue_end(TileCoordsXYZ& loc)
     bool found = false;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+        if (tileElement->GetType() != TileElementType::Entrance)
             continue;
 
         if (loc.z != tileElement->base_height)
@@ -1834,7 +1834,7 @@ static void get_ride_queue_end(TileCoordsXYZ& loc)
 
     while (true)
     {
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             lastPathElement = tileElement;
             // Update the current queue end
@@ -1859,7 +1859,7 @@ static void get_ride_queue_end(TileCoordsXYZ& loc)
             if (tileElement == firstPathElement)
                 continue;
 
-            if (tileElement->GetTypeN() != TileElementTypeN::Path)
+            if (tileElement->GetType() != TileElementType::Path)
                 continue;
 
             if (baseZ == tileElement->base_height)

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -338,9 +338,9 @@ static uint8_t footpath_element_dest_in_dir(
         if (tileElement->IsGhost())
             continue;
 
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 if (loc.z != tileElement->base_height)
                     continue;
@@ -353,7 +353,7 @@ static uint8_t footpath_element_dest_in_dir(
                 }
             }
             break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 if (loc.z != tileElement->base_height)
                     continue;
                 switch (tileElement->AsEntrance()->GetEntranceType())
@@ -378,7 +378,8 @@ static uint8_t footpath_element_dest_in_dir(
                         return PATH_SEARCH_PARK_EXIT;
                 }
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
+            {
                 if (!IsValidPathZAndDirection(tileElement, loc.z, chosenDirection))
                     continue;
                 if (tileElement->AsPath()->IsWide())
@@ -407,6 +408,9 @@ static uint8_t footpath_element_dest_in_dir(
                     return footpath_element_dest_in_dir(loc, dir, outRideIndex, level + 1);
                 }
                 return PATH_SEARCH_DEAD_END;
+            }
+            default:
+                break;
         }
     } while (!(tileElement++)->IsLastForTile());
 
@@ -748,9 +752,9 @@ static void peep_pathfind_heuristic_search(
             continue;
 
         ride_id_t rideIndex = RIDE_ID_NULL;
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 if (loc.z != tileElement->base_height)
                     continue;
@@ -765,7 +769,7 @@ static void peep_pathfind_heuristic_search(
                 searchResult = PATH_SEARCH_SHOP_ENTRANCE;
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 if (loc.z != tileElement->base_height)
                     continue;
                 Direction direction;
@@ -810,7 +814,7 @@ static void peep_pathfind_heuristic_search(
                         continue;
                 }
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 /* For peeps heading for a ride with a queue, the goal is the last
                  * queue path.

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -469,9 +469,9 @@ namespace RCT1
 
             while (tileIndex < maxTiles)
             {
-                switch (tileElement->GetType())
+                switch (static_cast<RCT12TileElementType>(tileElement->GetType()))
                 {
-                    case TILE_ELEMENT_TYPE_SURFACE:
+                    case RCT12TileElementType::Surface:
                     {
                         auto surfaceEl = tileElement->AsSurface();
                         auto surfaceStyle = surfaceEl->GetSurfaceStyle();
@@ -480,7 +480,7 @@ namespace RCT1
                         AddEntryForTerrainEdge(edgeStyle);
                         break;
                     }
-                    case TILE_ELEMENT_TYPE_PATH:
+                    case RCT12TileElementType::Path:
                     {
                         uint8_t pathType = tileElement->AsPath()->GetRCT1PathType();
                         uint8_t pathAdditionsType = tileElement->AsPath()->GetAddition();
@@ -495,13 +495,13 @@ namespace RCT1
                         AddEntryForFootpathRailings(footpathRailingsType);
                         break;
                     }
-                    case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+                    case RCT12TileElementType::SmallScenery:
                         AddEntryForSmallScenery(tileElement->AsSmallScenery()->GetEntryIndex());
                         break;
-                    case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+                    case RCT12TileElementType::LargeScenery:
                         AddEntryForLargeScenery(tileElement->AsLargeScenery()->GetEntryIndex());
                         break;
-                    case TILE_ELEMENT_TYPE_WALL:
+                    case RCT12TileElementType::Wall:
                     {
                         for (int32_t edge = 0; edge < 4; edge++)
                         {
@@ -514,6 +514,8 @@ namespace RCT1
                         }
                         break;
                     }
+                    default:
+                        break;
                 }
 
                 if ((tileElement++)->IsLastForTile())
@@ -1552,8 +1554,8 @@ namespace RCT1
         size_t ImportTileElement(TileElement* dst, const RCT12TileElement* src)
         {
             // Todo: allow for changing definition of OpenRCT2 tile element types - replace with a map
-            uint8_t tileElementType = src->GetType();
-            dst->ClearAs(static_cast<TileElementTypeN>(tileElementType >> 2));
+            auto tileElementType = static_cast<TileElementTypeN>(src->GetType() >> 2);
+            dst->ClearAs(tileElementType);
             dst->SetDirection(src->GetDirection());
 
             // All saved in "flags"
@@ -1567,7 +1569,7 @@ namespace RCT1
 
             switch (tileElementType)
             {
-                case TILE_ELEMENT_TYPE_SURFACE:
+                case TileElementTypeN::Surface:
                 {
                     auto dst2 = dst->AsSurface();
                     auto src2 = src->AsSurface();
@@ -1586,7 +1588,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TILE_ELEMENT_TYPE_PATH:
+                case TileElementTypeN::Path:
                 {
                     auto dst2 = dst->AsPath();
                     auto src2 = src->AsPath();
@@ -1641,7 +1643,7 @@ namespace RCT1
                     }
                     return 1;
                 }
-                case TILE_ELEMENT_TYPE_TRACK:
+                case TileElementTypeN::Track:
                 {
                     auto dst2 = dst->AsTrack();
                     auto src2 = src->AsTrack();
@@ -1688,7 +1690,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+                case TileElementTypeN::SmallScenery:
                 {
                     auto dst2 = dst->AsSmallScenery();
                     auto src2 = src->AsSmallScenery();
@@ -1723,7 +1725,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TILE_ELEMENT_TYPE_ENTRANCE:
+                case TileElementTypeN::Entrance:
                 {
                     auto dst2 = dst->AsEntrance();
                     auto src2 = src->AsEntrance();
@@ -1746,7 +1748,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TILE_ELEMENT_TYPE_WALL:
+                case TileElementTypeN::Wall:
                 {
                     auto src2 = src->AsWall();
                     auto slope = src2->GetRCT1Slope();
@@ -1801,7 +1803,7 @@ namespace RCT1
 
                     return numAddedElements;
                 }
-                case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+                case TileElementTypeN::LargeScenery:
                 {
                     auto dst2 = dst->AsLargeScenery();
                     auto src2 = src->AsLargeScenery();
@@ -1814,7 +1816,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TILE_ELEMENT_TYPE_BANNER:
+                case TileElementTypeN::Banner:
                 {
                     auto dst2 = dst->AsBanner();
                     auto src2 = src->AsBanner();

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1535,7 +1535,7 @@ namespace RCT1
                     {
                         // Add a default surface element, we always need at least one element per tile
                         auto& dstElement = tileElements.emplace_back();
-                        dstElement.ClearAs(TileElementTypeN::Surface);
+                        dstElement.ClearAs(TileElementType::Surface);
                         dstElement.SetLastForTile(true);
                     }
 
@@ -1554,7 +1554,7 @@ namespace RCT1
         size_t ImportTileElement(TileElement* dst, const RCT12TileElement* src)
         {
             // Todo: allow for changing definition of OpenRCT2 tile element types - replace with a map
-            auto tileElementType = static_cast<TileElementTypeN>(src->GetType() >> 2);
+            auto tileElementType = static_cast<TileElementType>(src->GetType() >> 2);
             dst->ClearAs(tileElementType);
             dst->SetDirection(src->GetDirection());
 
@@ -1569,7 +1569,7 @@ namespace RCT1
 
             switch (tileElementType)
             {
-                case TileElementTypeN::Surface:
+                case TileElementType::Surface:
                 {
                     auto dst2 = dst->AsSurface();
                     auto src2 = src->AsSurface();
@@ -1588,7 +1588,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TileElementTypeN::Path:
+                case TileElementType::Path:
                 {
                     auto dst2 = dst->AsPath();
                     auto src2 = src->AsPath();
@@ -1643,7 +1643,7 @@ namespace RCT1
                     }
                     return 1;
                 }
-                case TileElementTypeN::Track:
+                case TileElementType::Track:
                 {
                     auto dst2 = dst->AsTrack();
                     auto src2 = src->AsTrack();
@@ -1690,7 +1690,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TileElementTypeN::SmallScenery:
+                case TileElementType::SmallScenery:
                 {
                     auto dst2 = dst->AsSmallScenery();
                     auto src2 = src->AsSmallScenery();
@@ -1725,7 +1725,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TileElementTypeN::Entrance:
+                case TileElementType::Entrance:
                 {
                     auto dst2 = dst->AsEntrance();
                     auto src2 = src->AsEntrance();
@@ -1748,7 +1748,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TileElementTypeN::Wall:
+                case TileElementType::Wall:
                 {
                     auto src2 = src->AsWall();
                     auto slope = src2->GetRCT1Slope();
@@ -1780,7 +1780,7 @@ namespace RCT1
                             clearanceZ += LAND_HEIGHT_STEP;
                         }
 
-                        dst->SetTypeN(TileElementTypeN::Wall);
+                        dst->SetType(TileElementType::Wall);
                         dst->SetDirection(edge);
                         dst->SetBaseZ(baseZ);
                         dst->SetClearanceZ(clearanceZ);
@@ -1803,7 +1803,7 @@ namespace RCT1
 
                     return numAddedElements;
                 }
-                case TileElementTypeN::LargeScenery:
+                case TileElementType::LargeScenery:
                 {
                     auto dst2 = dst->AsLargeScenery();
                     auto src2 = src->AsLargeScenery();
@@ -1816,7 +1816,7 @@ namespace RCT1
 
                     return 1;
                 }
-                case TileElementTypeN::Banner:
+                case TileElementType::Banner:
                 {
                     auto dst2 = dst->AsBanner();
                     auto src2 = src->AsBanner();
@@ -2409,7 +2409,7 @@ namespace RCT1
             {
                 TileElement* element = it.element;
 
-                if (element->GetTypeN() != TileElementTypeN::Entrance)
+                if (element->GetType() != TileElementType::Entrance)
                     continue;
                 if (element->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
                     continue;
@@ -2563,7 +2563,7 @@ namespace RCT1
                         continue;
                     do
                     {
-                        if (tileElement->GetTypeN() == TileElementTypeN::Track)
+                        if (tileElement->GetType() == TileElementType::Track)
                         {
                             // Lift hill tops are the only pieces present in RCT1 that can count as a block brake.
                             if (!tileElement->AsTrack()->HasChain())

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1533,7 +1533,7 @@ namespace RCT1
                     {
                         // Add a default surface element, we always need at least one element per tile
                         auto& dstElement = tileElements.emplace_back();
-                        dstElement.ClearAs(TILE_ELEMENT_TYPE_SURFACE);
+                        dstElement.ClearAs(TileElementTypeN::Surface);
                         dstElement.SetLastForTile(true);
                     }
 
@@ -1553,7 +1553,7 @@ namespace RCT1
         {
             // Todo: allow for changing definition of OpenRCT2 tile element types - replace with a map
             uint8_t tileElementType = src->GetType();
-            dst->ClearAs(tileElementType);
+            dst->ClearAs(static_cast<TileElementTypeN>(tileElementType >> 2));
             dst->SetDirection(src->GetDirection());
 
             // All saved in "flags"

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -447,33 +447,6 @@ bool is_user_string_id(rct_string_id stringId)
     return stringId >= 0x8000 && stringId < 0x9000;
 }
 
-uint8_t RCT12TileElement::GetBannerIndex()
-{
-    switch (GetType())
-    {
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-        {
-            auto* sceneryEntry = get_large_scenery_entry(AsLargeScenery()->GetEntryIndex());
-            if (sceneryEntry->scrolling_mode == SCROLLING_MODE_NONE)
-                return RCT12_BANNER_INDEX_NULL;
-
-            return AsLargeScenery()->GetBannerIndex();
-        }
-        case TILE_ELEMENT_TYPE_WALL:
-        {
-            auto* wallEntry = get_wall_entry(AsWall()->GetEntryIndex());
-            if (wallEntry == nullptr || wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
-                return RCT12_BANNER_INDEX_NULL;
-
-            return AsWall()->GetBannerIndex();
-        }
-        case TILE_ELEMENT_TYPE_BANNER:
-            return AsBanner()->GetIndex();
-        default:
-            return RCT12_BANNER_INDEX_NULL;
-    }
-}
-
 bool RCT12PathElement::IsBroken() const
 {
     return (flags & RCT12_TILE_ELEMENT_FLAG_BROKEN) != 0;

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -378,7 +378,6 @@ struct RCT12TileElement : public RCT12TileElementBase
     {
         return as<RCT12BannerElement, RCT12TileElementType::Banner>();
     }
-    uint8_t GetBannerIndex();
 };
 assert_struct_size(RCT12TileElement, 8);
 struct RCT12SurfaceElement : RCT12TileElementBase

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1167,7 +1167,7 @@ namespace RCT2
                     {
                         // Add a default surface element, we always need at least one element per tile
                         auto& dstElement = tileElements.emplace_back();
-                        dstElement.ClearAs(TILE_ELEMENT_TYPE_SURFACE);
+                        dstElement.ClearAs(TileElementTypeN::Surface);
                         dstElement.SetLastForTile(true);
                     }
 
@@ -1185,7 +1185,7 @@ namespace RCT2
         {
             // Todo: allow for changing definition of OpenRCT2 tile element types - replace with a map
             uint8_t tileElementType = src->GetType();
-            dst->ClearAs(tileElementType);
+            dst->ClearAs(static_cast<TileElementTypeN>(tileElementType >> 2));
             dst->SetDirection(src->GetDirection());
             dst->SetBaseZ(src->base_height * COORDS_Z_STEP);
             dst->SetClearanceZ(src->clearance_height * COORDS_Z_STEP);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1167,7 +1167,7 @@ namespace RCT2
                     {
                         // Add a default surface element, we always need at least one element per tile
                         auto& dstElement = tileElements.emplace_back();
-                        dstElement.ClearAs(TileElementTypeN::Surface);
+                        dstElement.ClearAs(TileElementType::Surface);
                         dstElement.SetLastForTile(true);
                     }
 
@@ -1185,7 +1185,7 @@ namespace RCT2
         {
             // Todo: allow for changing definition of OpenRCT2 tile element types - replace with a map
             uint8_t tileElementType = src->GetType();
-            dst->ClearAs(static_cast<TileElementTypeN>(tileElementType >> 2));
+            dst->ClearAs(static_cast<TileElementType>(tileElementType >> 2));
             dst->SetDirection(src->GetDirection());
             dst->SetBaseZ(src->base_height * COORDS_Z_STEP);
             dst->SetClearanceZ(src->clearance_height * COORDS_Z_STEP);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1196,9 +1196,9 @@ namespace RCT2
             dst->SetLastForTile(src->IsLastForTile());
             dst->SetInvisible(invisible);
 
-            switch (tileElementType)
+            switch (static_cast<RCT12TileElementType>(tileElementType))
             {
-                case TILE_ELEMENT_TYPE_SURFACE:
+                case RCT12TileElementType::Surface:
                 {
                     auto dst2 = dst->AsSurface();
                     auto src2 = src->AsSurface();
@@ -1216,7 +1216,7 @@ namespace RCT2
 
                     break;
                 }
-                case TILE_ELEMENT_TYPE_PATH:
+                case RCT12TileElementType::Path:
                 {
                     auto dst2 = dst->AsPath();
                     auto src2 = src->AsPath();
@@ -1254,7 +1254,7 @@ namespace RCT2
 
                     break;
                 }
-                case TILE_ELEMENT_TYPE_TRACK:
+                case RCT12TileElementType::Track:
                 {
                     auto dst2 = dst->AsTrack();
                     auto src2 = src->AsTrack();
@@ -1302,7 +1302,7 @@ namespace RCT2
 
                     break;
                 }
-                case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+                case RCT12TileElementType::SmallScenery:
                 {
                     auto dst2 = dst->AsSmallScenery();
                     auto src2 = src->AsSmallScenery();
@@ -1317,7 +1317,7 @@ namespace RCT2
 
                     break;
                 }
-                case TILE_ELEMENT_TYPE_ENTRANCE:
+                case RCT12TileElementType::Entrance:
                 {
                     auto dst2 = dst->AsEntrance();
                     auto src2 = src->AsEntrance();
@@ -1348,7 +1348,7 @@ namespace RCT2
                     }
                     break;
                 }
-                case TILE_ELEMENT_TYPE_WALL:
+                case RCT12TileElementType::Wall:
                 {
                     auto dst2 = dst->AsWall();
                     auto src2 = src->AsWall();
@@ -1385,7 +1385,7 @@ namespace RCT2
                     }
                     break;
                 }
-                case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+                case RCT12TileElementType::LargeScenery:
                 {
                     auto dst2 = dst->AsLargeScenery();
                     auto src2 = src->AsLargeScenery();
@@ -1418,7 +1418,7 @@ namespace RCT2
                     }
                     break;
                 }
-                case TILE_ELEMENT_TYPE_BANNER:
+                case RCT12TileElementType::Banner:
                 {
                     auto dst2 = dst->AsBanner();
                     auto src2 = src->AsBanner();

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -409,7 +409,7 @@ bool ride_try_get_origin_element(const Ride* ride, CoordsXYE* output)
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() != TileElementTypeN::Track)
+        if (it.element->GetType() != TileElementType::Track)
             continue;
         if (it.element->AsTrack()->GetRideIndex() != ride->id)
             continue;
@@ -718,8 +718,7 @@ bool track_block_get_previous(const CoordsXYE& trackPos, track_begin_end* outTra
  */
 int32_t ride_find_track_gap(const Ride* ride, CoordsXYE* input, CoordsXYE* output)
 {
-    if (ride == nullptr || input == nullptr || input->element == nullptr
-        || input->element->GetTypeN() != TileElementTypeN::Track)
+    if (ride == nullptr || input == nullptr || input->element == nullptr || input->element->GetType() != TileElementType::Track)
         return 0;
 
     if (ride->type == RIDE_TYPE_MAZE)
@@ -2260,7 +2259,7 @@ static void ride_shop_connected(Ride* ride)
     {
         if (tileElement == nullptr)
             break;
-        if (tileElement->GetTypeN() == TileElementTypeN::Track && tileElement->AsTrack()->GetRideIndex() == ride->id)
+        if (tileElement->GetType() == TileElementType::Track && tileElement->AsTrack()->GetRideIndex() == ride->id)
         {
             trackElement = tileElement->AsTrack();
             break;
@@ -2446,11 +2445,11 @@ static void ride_entrance_set_map_tooltip(TileElement* tileElement)
 
 void ride_set_map_tooltip(TileElement* tileElement)
 {
-    if (tileElement->GetTypeN() == TileElementTypeN::Entrance)
+    if (tileElement->GetType() == TileElementType::Entrance)
     {
         ride_entrance_set_map_tooltip(tileElement);
     }
-    else if (tileElement->GetTypeN() == TileElementTypeN::Track)
+    else if (tileElement->GetType() == TileElementType::Track)
     {
         if (tileElement->AsTrack()->IsStation())
         {
@@ -2461,7 +2460,7 @@ void ride_set_map_tooltip(TileElement* tileElement)
             ride_track_set_map_tooltip(tileElement);
         }
     }
-    else if (tileElement->GetTypeN() == TileElementTypeN::Path)
+    else if (tileElement->GetType() == TileElementType::Path)
     {
         ride_queue_banner_set_map_tooltip(tileElement);
     }
@@ -2616,7 +2615,7 @@ void Ride::ChainQueues() const
         {
             do
             {
-                if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+                if (tileElement->GetType() != TileElementType::Entrance)
                     continue;
                 if (tileElement->GetBaseZ() != mapLocation.z)
                     continue;
@@ -2961,7 +2960,7 @@ static void ride_set_maze_entrance_exit_points(Ride* ride)
         {
             if (tileElement == nullptr)
                 break;
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 continue;
             if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE
                 && tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_EXIT)
@@ -3595,7 +3594,7 @@ static bool ride_initialise_cable_lift_track(Ride* ride, bool isApplying)
         return success;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->GetBaseZ() != location.z)
             continue;
@@ -3829,7 +3828,7 @@ TrackElement* Ride::GetOriginElement(StationIndex stationIndex) const
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         auto* trackElement = tileElement->AsTrack();
@@ -4559,7 +4558,7 @@ bool ride_has_any_track_elements(const Ride* ride)
     tile_element_iterator_begin(&it);
     while (tile_element_iterator_next(&it))
     {
-        if (it.element->GetTypeN() != TileElementTypeN::Track)
+        if (it.element->GetType() != TileElementType::Track)
             continue;
         if (it.element->AsTrack()->GetRideIndex() != ride->id)
             continue;
@@ -4934,7 +4933,7 @@ static int32_t ride_get_track_length(Ride* ride)
             continue;
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Track)
+            if (tileElement->GetType() != TileElementType::Track)
                 continue;
 
             trackType = tileElement->AsTrack()->GetTrackType();
@@ -5323,7 +5322,7 @@ TileElement* get_station_platform(const CoordsXYRangedZ& coords)
     {
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Track)
+            if (tileElement->GetType() != TileElementType::Track)
                 continue;
             /* Check if tileElement is a station platform. */
             if (!tileElement->AsTrack()->IsStation())
@@ -5604,7 +5603,7 @@ void determine_ride_entrance_and_exit_locations()
                     {
                         do
                         {
-                            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+                            if (tileElement->GetType() != TileElementType::Entrance)
                             {
                                 continue;
                             }
@@ -5775,7 +5774,7 @@ void Ride::UpdateRideTypeForAllPieces()
 
             do
             {
-                if (tileElement->GetTypeN() != TileElementTypeN::Track)
+                if (tileElement->GetType() != TileElementType::Track)
                     continue;
 
                 auto* trackElement = tileElement->AsTrack();

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -1008,7 +1008,7 @@ bool ride_modify(CoordsXYE* input)
     }
 
     // Check if element is a station entrance or exit
-    if (tileElement.element->GetTypeN() == TileElementTypeN::Entrance)
+    if (tileElement.element->GetType() == TileElementType::Entrance)
         return ride_modify_entrance_or_exit(tileElement);
 
     ride_create_or_find_construction_window(rideIndex);
@@ -1025,7 +1025,7 @@ bool ride_modify(CoordsXYE* input)
             tileElement = endOfTrackElement;
     }
 
-    if (tileElement.element == nullptr || tileElement.element->GetTypeN() != TileElementTypeN::Track)
+    if (tileElement.element == nullptr || tileElement.element->GetType() != TileElementType::Track)
         return false;
 
     auto tileCoords = CoordsXYZ{ tileElement, tileElement.element->GetBaseZ() };
@@ -1209,7 +1209,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
     auto info = get_map_coordinates_from_pos(screenCoords, EnumsToFlags(ViewportInteractionItem::Ride));
     if (info.SpriteType != ViewportInteractionItem::None)
     {
-        if (info.Element->GetTypeN() == TileElementTypeN::Track)
+        if (info.Element->GetType() == TileElementType::Track)
         {
             const auto* trackElement = info.Element->AsTrack();
             if (trackElement->GetRideIndex() == gRideEntranceExitPlaceRideIndex)
@@ -1288,7 +1288,7 @@ CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenC
                 continue;
             do
             {
-                if (tileElement->GetTypeN() != TileElementTypeN::Track)
+                if (tileElement->GetType() != TileElementType::Track)
                     continue;
                 if (tileElement->GetBaseZ() != stationBaseZ)
                     continue;
@@ -1363,7 +1363,7 @@ void Ride::ValidateStations()
                 {
                     if (tileElement->GetBaseZ() != location.z)
                         continue;
-                    if (tileElement->GetTypeN() != TileElementTypeN::Track)
+                    if (tileElement->GetType() != TileElementType::Track)
                         continue;
                     if (tileElement->AsTrack()->GetRideIndex() != id)
                         continue;
@@ -1418,7 +1418,7 @@ void Ride::ValidateStations()
                 {
                     if (blockLocation.z != tileElement->GetBaseZ())
                         continue;
-                    if (tileElement->GetTypeN() != TileElementTypeN::Track)
+                    if (tileElement->GetType() != TileElementType::Track)
                         continue;
 
                     ted = &GetTrackElementDescriptor(tileElement->AsTrack()->GetTrackType());
@@ -1489,7 +1489,7 @@ void Ride::ValidateStations()
             continue;
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 continue;
             if (tileElement->base_height != locationCoords.z)
                 continue;
@@ -1511,7 +1511,7 @@ void Ride::ValidateStations()
                 continue;
             do
             {
-                if (trackElement->GetTypeN() != TileElementTypeN::Track)
+                if (trackElement->GetType() != TileElementType::Track)
                     continue;
                 if (trackElement->AsTrack()->GetRideIndex() != id)
                     continue;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -429,9 +429,9 @@ static void ride_ratings_score_close_proximity_in_direction(
         if (tileElement->IsGhost())
             continue;
 
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 if (state.ProximityBaseHeight <= inputTileElement->base_height)
                 {
                     if (inputTileElement->clearance_height <= tileElement->base_height)
@@ -440,13 +440,13 @@ static void ride_ratings_score_close_proximity_in_direction(
                     }
                 }
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 if (abs(inputTileElement->GetBaseZ() - tileElement->GetBaseZ()) <= 2 * COORDS_Z_STEP)
                 {
                     proximity_score_increment(state, PROXIMITY_PATH_SIDE_CLOSE);
                 }
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 if (inputTileElement->AsTrack()->GetRideIndex() != tileElement->AsTrack()->GetRideIndex())
                 {
                     if (abs(inputTileElement->GetBaseZ() - tileElement->GetBaseZ()) <= 2 * COORDS_Z_STEP)
@@ -455,8 +455,8 @@ static void ride_ratings_score_close_proximity_in_direction(
                     }
                 }
                 break;
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::SmallScenery:
+            case TileElementTypeN::LargeScenery:
                 if (tileElement->GetBaseZ() < inputTileElement->GetClearanceZ())
                 {
                     if (inputTileElement->GetBaseZ() > tileElement->GetClearanceZ())
@@ -468,6 +468,8 @@ static void ride_ratings_score_close_proximity_in_direction(
                         proximity_score_increment(state, PROXIMITY_SCENERY_SIDE_BELOW);
                     }
                 }
+                break;
+            default:
                 break;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -483,38 +485,33 @@ static void ride_ratings_score_close_proximity_loops_helper(RideRatingUpdateStat
         if (tileElement->IsGhost())
             continue;
 
-        switch (tileElement->GetType())
+        auto type = tileElement->GetTypeN();
+        if (type == TileElementTypeN::Path)
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            int32_t zDiff = static_cast<int32_t>(tileElement->base_height)
+                - static_cast<int32_t>(coordsElement.element->base_height);
+            if (zDiff >= 0 && zDiff <= 16)
+            {
+                proximity_score_increment(state, PROXIMITY_PATH_TROUGH_VERTICAL_LOOP);
+            }
+        }
+        else if (type == TileElementTypeN::Track)
+        {
+            bool elementsAreAt90DegAngle = ((tileElement->GetDirection() ^ coordsElement.element->GetDirection()) & 1) != 0;
+            if (elementsAreAt90DegAngle)
             {
                 int32_t zDiff = static_cast<int32_t>(tileElement->base_height)
                     - static_cast<int32_t>(coordsElement.element->base_height);
                 if (zDiff >= 0 && zDiff <= 16)
                 {
-                    proximity_score_increment(state, PROXIMITY_PATH_TROUGH_VERTICAL_LOOP);
-                }
-            }
-            break;
-
-            case TILE_ELEMENT_TYPE_TRACK:
-            {
-                bool elementsAreAt90DegAngle = ((tileElement->GetDirection() ^ coordsElement.element->GetDirection()) & 1) != 0;
-                if (elementsAreAt90DegAngle)
-                {
-                    int32_t zDiff = static_cast<int32_t>(tileElement->base_height)
-                        - static_cast<int32_t>(coordsElement.element->base_height);
-                    if (zDiff >= 0 && zDiff <= 16)
+                    proximity_score_increment(state, PROXIMITY_TRACK_THROUGH_VERTICAL_LOOP);
+                    if (tileElement->AsTrack()->GetTrackType() == TrackElemType::LeftVerticalLoop
+                        || tileElement->AsTrack()->GetTrackType() == TrackElemType::RightVerticalLoop)
                     {
-                        proximity_score_increment(state, PROXIMITY_TRACK_THROUGH_VERTICAL_LOOP);
-                        if (tileElement->AsTrack()->GetTrackType() == TrackElemType::LeftVerticalLoop
-                            || tileElement->AsTrack()->GetTrackType() == TrackElemType::RightVerticalLoop)
-                        {
-                            proximity_score_increment(state, PROXIMITY_INTERSECTING_VERTICAL_LOOP);
-                        }
+                        proximity_score_increment(state, PROXIMITY_INTERSECTING_VERTICAL_LOOP);
                     }
                 }
             }
-            break;
         }
     } while (!(tileElement++)->IsLastForTile());
 }
@@ -557,9 +554,9 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
             continue;
 
         int32_t waterHeight;
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 state.ProximityBaseHeight = tileElement->base_height;
                 if (tileElement->GetBaseZ() == state.Proximity.z)
                 {
@@ -589,7 +586,7 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
                     }
                 }
                 break;
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 if (!tileElement->AsPath()->IsQueue())
                 {
                     if (tileElement->GetClearanceZ() == inputTileElement->GetBaseZ())
@@ -617,7 +614,7 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
                     }
                 }
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto trackType = tileElement->AsTrack()->GetTrackType();
                 if (trackType == TrackElemType::LeftVerticalLoop || trackType == TrackElemType::RightVerticalLoop)
@@ -700,8 +697,10 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
                         }
                     }
                 }
+                break;
             }
-            break;
+            default:
+                break;
         } // switch tileElement->GetType
     } while (!(tileElement++)->IsLastForTile());
 

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -218,7 +218,7 @@ static void ride_ratings_update_state_2(RideRatingUpdateState& state)
     {
         if (tileElement->IsGhost())
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->GetBaseZ() != loc.z)
             continue;
@@ -325,7 +325,7 @@ static void ride_ratings_update_state_5(RideRatingUpdateState& state)
     {
         if (tileElement->IsGhost())
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->GetBaseZ() != loc.z)
             continue;
@@ -429,9 +429,9 @@ static void ride_ratings_score_close_proximity_in_direction(
         if (tileElement->IsGhost())
             continue;
 
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 if (state.ProximityBaseHeight <= inputTileElement->base_height)
                 {
                     if (inputTileElement->clearance_height <= tileElement->base_height)
@@ -440,13 +440,13 @@ static void ride_ratings_score_close_proximity_in_direction(
                     }
                 }
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 if (abs(inputTileElement->GetBaseZ() - tileElement->GetBaseZ()) <= 2 * COORDS_Z_STEP)
                 {
                     proximity_score_increment(state, PROXIMITY_PATH_SIDE_CLOSE);
                 }
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 if (inputTileElement->AsTrack()->GetRideIndex() != tileElement->AsTrack()->GetRideIndex())
                 {
                     if (abs(inputTileElement->GetBaseZ() - tileElement->GetBaseZ()) <= 2 * COORDS_Z_STEP)
@@ -455,8 +455,8 @@ static void ride_ratings_score_close_proximity_in_direction(
                     }
                 }
                 break;
-            case TileElementTypeN::SmallScenery:
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::SmallScenery:
+            case TileElementType::LargeScenery:
                 if (tileElement->GetBaseZ() < inputTileElement->GetClearanceZ())
                 {
                     if (inputTileElement->GetBaseZ() > tileElement->GetClearanceZ())
@@ -485,8 +485,8 @@ static void ride_ratings_score_close_proximity_loops_helper(RideRatingUpdateStat
         if (tileElement->IsGhost())
             continue;
 
-        auto type = tileElement->GetTypeN();
-        if (type == TileElementTypeN::Path)
+        auto type = tileElement->GetType();
+        if (type == TileElementType::Path)
         {
             int32_t zDiff = static_cast<int32_t>(tileElement->base_height)
                 - static_cast<int32_t>(coordsElement.element->base_height);
@@ -495,7 +495,7 @@ static void ride_ratings_score_close_proximity_loops_helper(RideRatingUpdateStat
                 proximity_score_increment(state, PROXIMITY_PATH_TROUGH_VERTICAL_LOOP);
             }
         }
-        else if (type == TileElementTypeN::Track)
+        else if (type == TileElementType::Track)
         {
             bool elementsAreAt90DegAngle = ((tileElement->GetDirection() ^ coordsElement.element->GetDirection()) & 1) != 0;
             if (elementsAreAt90DegAngle)
@@ -554,9 +554,9 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
             continue;
 
         int32_t waterHeight;
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 state.ProximityBaseHeight = tileElement->base_height;
                 if (tileElement->GetBaseZ() == state.Proximity.z)
                 {
@@ -586,7 +586,7 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
                     }
                 }
                 break;
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 if (!tileElement->AsPath()->IsQueue())
                 {
                     if (tileElement->GetClearanceZ() == inputTileElement->GetBaseZ())
@@ -614,7 +614,7 @@ static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, Til
                     }
                 }
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto trackType = tileElement->AsTrack()->GetTrackType();
                 if (trackType == TrackElemType::LeftVerticalLoop || trackType == TrackElemType::RightVerticalLoop)
@@ -1468,8 +1468,8 @@ static int32_t ride_ratings_get_scenery_score(Ride* ride)
                 if (tileElement->IsGhost())
                     continue;
 
-                const auto type = tileElement->GetTypeN();
-                if (type == TileElementTypeN::SmallScenery || type == TileElementTypeN::LargeScenery)
+                const auto type = tileElement->GetType();
+                if (type == TileElementType::SmallScenery || type == TileElementType::LargeScenery)
                     numSceneryItems++;
             } while (!(tileElement++)->IsLastForTile());
         }

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -339,7 +339,7 @@ TileElement* ride_get_station_start_track_element(const Ride* ride, StationIndex
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() == TileElementTypeN::Track && stationStart.z == tileElement->GetBaseZ())
+        if (tileElement->GetType() == TileElementType::Track && stationStart.z == tileElement->GetBaseZ())
             return tileElement;
 
     } while (!(tileElement++)->IsLastForTile());
@@ -357,7 +357,7 @@ TileElement* ride_get_station_exit_element(const CoordsXYZ& elementPos)
     {
         if (tileElement == nullptr)
             break;
-        if (tileElement->GetTypeN() == TileElementTypeN::Entrance && elementPos.z == tileElement->GetBaseZ())
+        if (tileElement->GetType() == TileElementType::Entrance && elementPos.z == tileElement->GetBaseZ())
             return tileElement;
     } while (!(tileElement++)->IsLastForTile());
 

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -79,7 +79,7 @@ static TileElement* find_station_element(const CoordsXYZD& loc, ride_id_t rideIn
     {
         if (loc.z != tileElement->GetBaseZ())
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->GetDirection() != loc.direction)
             continue;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2160,7 +2160,7 @@ static void TrackDesignPreviewClearMap()
     for (int32_t i = 0; i < numTiles; i++)
     {
         auto* element = &tileElements.emplace_back();
-        element->ClearAs(TILE_ELEMENT_TYPE_SURFACE);
+        element->ClearAs(TileElementTypeN::Surface);
         element->SetLastForTile(true);
         element->AsSurface()->SetSlope(TILE_ELEMENT_SLOPE_FLAT);
         element->AsSurface()->SetWaterHeight(0);

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -274,7 +274,7 @@ rct_string_id TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, const R
 
             do
             {
-                if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+                if (tileElement->GetType() != TileElementType::Entrance)
                     continue;
                 if (tileElement->GetBaseZ() == z)
                     break;
@@ -352,7 +352,7 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, const Ri
             {
                 if (tileElement == nullptr)
                     break;
-                if (tileElement->GetTypeN() != TileElementTypeN::Track)
+                if (tileElement->GetType() != TileElementType::Track)
                     continue;
                 if (tileElement->AsTrack()->GetRideIndex() != ride.id)
                     continue;
@@ -386,7 +386,7 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, const Ri
     {
         if (tileElement == nullptr)
             return STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
-        if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+        if (tileElement->GetType() != TileElementType::Entrance)
             continue;
         if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
             continue;
@@ -415,7 +415,7 @@ rct_string_id TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, const Ri
         return STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+        if (tileElement->GetType() != TileElementType::Entrance)
             continue;
         if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_EXIT)
             continue;
@@ -459,7 +459,7 @@ CoordsXYE TrackDesign::MazeGetFirstElement(const Ride& ride)
                 if (tile.element == nullptr)
                     break;
 
-                if (tile.element->GetTypeN() != TileElementTypeN::Track)
+                if (tile.element->GetType() != TileElementType::Track)
                     continue;
                 if (tile.element->AsTrack()->GetRideIndex() == ride.id)
                 {
@@ -1726,7 +1726,7 @@ static GameActions::Result TrackDesignPlaceRide(TrackDesignState& tds, TrackDesi
 
                     do
                     {
-                        if (tile_element->GetTypeN() != TileElementTypeN::Track)
+                        if (tile_element->GetType() != TileElementType::Track)
                         {
                             continue;
                         }
@@ -2160,7 +2160,7 @@ static void TrackDesignPreviewClearMap()
     for (int32_t i = 0; i < numTiles; i++)
     {
         auto* element = &tileElements.emplace_back();
-        element->ClearAs(TileElementTypeN::Surface);
+        element->ClearAs(TileElementType::Surface);
         element->SetLastForTile(true);
         element->AsSurface()->SetSlope(TILE_ELEMENT_SLOPE_FLAT);
         element->AsSurface()->SetWaterHeight(0);

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -148,14 +148,14 @@ static int32_t tile_element_get_total_element_count(TileElement* tileElement)
     int32_t elementCount;
     rct_large_scenery_tile* tile;
 
-    switch (tileElement->GetTypeN())
+    switch (tileElement->GetType())
     {
-        case TileElementTypeN::Path:
-        case TileElementTypeN::SmallScenery:
-        case TileElementTypeN::Wall:
+        case TileElementType::Path:
+        case TileElementType::SmallScenery:
+        case TileElementType::Wall:
             return 1;
 
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
         {
             auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             tile = sceneryEntry->tiles;
@@ -585,17 +585,17 @@ static void track_design_save_remove_tile_element(
 
 static bool track_design_save_should_select_scenery_around(ride_id_t rideIndex, TileElement* tileElement)
 {
-    switch (tileElement->GetTypeN())
+    switch (tileElement->GetType())
     {
-        case TileElementTypeN::Path:
+        case TileElementType::Path:
             if (tileElement->AsPath()->IsQueue() && tileElement->AsPath()->GetRideIndex() == rideIndex)
                 return true;
             break;
-        case TileElementTypeN::Track:
+        case TileElementType::Track:
             if (tileElement->AsTrack()->GetRideIndex() == rideIndex)
                 return true;
             break;
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
             // FIXME: This will always break and return false!
             if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
                 break;
@@ -624,21 +624,21 @@ static void track_design_save_select_nearby_scenery_for_tile(ride_id_t rideIndex
             do
             {
                 ViewportInteractionItem interactionType = ViewportInteractionItem::None;
-                switch (tileElement->GetTypeN())
+                switch (tileElement->GetType())
                 {
-                    case TileElementTypeN::Path:
+                    case TileElementType::Path:
                         if (!tileElement->AsPath()->IsQueue())
                             interactionType = ViewportInteractionItem::Footpath;
                         else if (tileElement->AsPath()->GetRideIndex() == rideIndex)
                             interactionType = ViewportInteractionItem::Footpath;
                         break;
-                    case TileElementTypeN::SmallScenery:
+                    case TileElementType::SmallScenery:
                         interactionType = ViewportInteractionItem::Scenery;
                         break;
-                    case TileElementTypeN::Wall:
+                    case TileElementType::Wall:
                         interactionType = ViewportInteractionItem::Wall;
                         break;
-                    case TileElementTypeN::LargeScenery:
+                    case TileElementType::LargeScenery:
                         interactionType = ViewportInteractionItem::LargeScenery;
                         break;
                     default:

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -148,14 +148,14 @@ static int32_t tile_element_get_total_element_count(TileElement* tileElement)
     int32_t elementCount;
     rct_large_scenery_tile* tile;
 
-    switch (tileElement->GetType())
+    switch (tileElement->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_PATH:
-        case TILE_ELEMENT_TYPE_SMALL_SCENERY:
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Path:
+        case TileElementTypeN::SmallScenery:
+        case TileElementTypeN::Wall:
             return 1;
 
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
         {
             auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             tile = sceneryEntry->tiles;
@@ -585,17 +585,17 @@ static void track_design_save_remove_tile_element(
 
 static bool track_design_save_should_select_scenery_around(ride_id_t rideIndex, TileElement* tileElement)
 {
-    switch (tileElement->GetType())
+    switch (tileElement->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_PATH:
+        case TileElementTypeN::Path:
             if (tileElement->AsPath()->IsQueue() && tileElement->AsPath()->GetRideIndex() == rideIndex)
                 return true;
             break;
-        case TILE_ELEMENT_TYPE_TRACK:
+        case TileElementTypeN::Track:
             if (tileElement->AsTrack()->GetRideIndex() == rideIndex)
                 return true;
             break;
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
             // FIXME: This will always break and return false!
             if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
                 break;
@@ -603,6 +603,8 @@ static bool track_design_save_should_select_scenery_around(ride_id_t rideIndex, 
                 break;
             if (tileElement->AsEntrance()->GetRideIndex() == rideIndex)
                 return true;
+            break;
+        default:
             break;
     }
     return false;
@@ -622,22 +624,24 @@ static void track_design_save_select_nearby_scenery_for_tile(ride_id_t rideIndex
             do
             {
                 ViewportInteractionItem interactionType = ViewportInteractionItem::None;
-                switch (tileElement->GetType())
+                switch (tileElement->GetTypeN())
                 {
-                    case TILE_ELEMENT_TYPE_PATH:
+                    case TileElementTypeN::Path:
                         if (!tileElement->AsPath()->IsQueue())
                             interactionType = ViewportInteractionItem::Footpath;
                         else if (tileElement->AsPath()->GetRideIndex() == rideIndex)
                             interactionType = ViewportInteractionItem::Footpath;
                         break;
-                    case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+                    case TileElementTypeN::SmallScenery:
                         interactionType = ViewportInteractionItem::Scenery;
                         break;
-                    case TILE_ELEMENT_TYPE_WALL:
+                    case TileElementTypeN::Wall:
                         interactionType = ViewportInteractionItem::Wall;
                         break;
-                    case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+                    case TileElementTypeN::LargeScenery:
                         interactionType = ViewportInteractionItem::LargeScenery;
+                        break;
+                    default:
                         break;
                 }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1729,19 +1729,19 @@ void Vehicle::UpdateMeasurements()
             if (tileElement->GetBaseZ() <= z)
                 continue;
 
-            if (tileElement->GetTypeN() == TileElementTypeN::LargeScenery)
+            if (tileElement->GetType() == TileElementType::LargeScenery)
             {
                 coverFound = true;
                 break;
             }
 
-            if (tileElement->GetTypeN() == TileElementTypeN::Path)
+            if (tileElement->GetType() == TileElementType::Path)
             {
                 coverFound = true;
                 break;
             }
 
-            if (tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+            if (tileElement->GetType() != TileElementType::SmallScenery)
                 continue;
 
             auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
@@ -3001,7 +3001,7 @@ bool Vehicle::CurrentTowerElementIsTop()
         while (!tileElement->IsLastForTile())
         {
             tileElement++;
-            if (tileElement->GetTypeN() == TileElementTypeN::Track
+            if (tileElement->GetType() == TileElementType::Track
                 && tileElement->AsTrack()->GetTrackType() == TrackElemType::TowerSection)
             {
                 return false;
@@ -4583,7 +4583,7 @@ static bool vehicle_boat_is_location_accessible(const CoordsXYZ& location)
         if (tileElement->IsGhost())
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Surface)
+        if (tileElement->GetType() == TileElementType::Surface)
         {
             int32_t waterZ = tileElement->AsSurface()->GetWaterHeight();
             if (location.z != waterZ)
@@ -6671,7 +6671,7 @@ static void block_brakes_open_previous_section(Ride& ride, const CoordsXYZ& vehi
             slowLocation.y = slowTrackBeginEnd.end_y;
             slowTileElement = *(slowTrackBeginEnd.begin_element);
             if (slowLocation == location && slowTileElement.GetBaseZ() == tileElement->GetBaseZ()
-                && slowTileElement.GetTypeN() == tileElement->GetTypeN()
+                && slowTileElement.GetType() == tileElement->GetType()
                 && slowTileElement.GetDirection() == tileElement->GetDirection())
             {
                 return;
@@ -7360,7 +7360,7 @@ void Vehicle::UpdateLandscapeDoor() const
 
     auto coords = CoordsXYZ{ x, y, TrackLocation.z }.ToTileStart();
     auto* tileElement = map_get_track_element_at_from_ride(coords, ride);
-    if (tileElement != nullptr && tileElement->GetTypeN() == TileElementTypeN::Track)
+    if (tileElement != nullptr && tileElement->GetType() == TileElementType::Track)
     {
         AnimateLandscapeDoor<false>(tileElement->AsTrack(), next_vehicle_on_train == SPRITE_INDEX_NULL);
     }
@@ -7434,7 +7434,7 @@ void Vehicle::UpdateLandscapeDoorBackwards() const
 
     auto coords = CoordsXYZ{ TrackLocation, TrackLocation.z };
     auto* tileElement = map_get_track_element_at_from_ride(coords, ride);
-    if (tileElement != nullptr && tileElement->GetTypeN() == TileElementTypeN::Track)
+    if (tileElement != nullptr && tileElement->GetType() == TileElementType::Track)
     {
         AnimateLandscapeDoor<true>(tileElement->AsTrack(), next_vehicle_on_train == SPRITE_INDEX_NULL);
     }

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -122,7 +122,7 @@ static const TrackElement* chairlift_paint_util_map_get_track_element_at_from_ri
 
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->GetRideIndex() != ride->id)
             continue;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -564,7 +564,7 @@ static bool scenario_prepare_rides_for_save()
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() == TileElementTypeN::Track)
+        if (it.element->GetType() == TileElementType::Track)
         {
             markTrackAsIndestructible = false;
 

--- a/src/openrct2/scripting/bindings/world/ScTile.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTile.cpp
@@ -105,7 +105,7 @@ namespace OpenRCT2::Scripting
                     auto numToInsert = numElements - currentNumElements;
                     for (size_t i = 0; i < numToInsert; i++)
                     {
-                        tile_element_insert(pos, 0, TileElementTypeN::Surface);
+                        tile_element_insert(pos, 0, TileElementType::Surface);
                     }
 
                     // Copy data to element span
@@ -150,7 +150,7 @@ namespace OpenRCT2::Scripting
             std::vector<TileElement> data(first, first + origNumElements);
 
             auto pos = TileCoordsXYZ(TileCoordsXY(_coords), 0).ToCoordsXYZ();
-            auto newElement = tile_element_insert(pos, 0, TileElementTypeN::Surface);
+            auto newElement = tile_element_insert(pos, 0, TileElementType::Surface);
             if (newElement == nullptr)
             {
                 auto ctx = GetDukContext();

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -63,21 +63,21 @@ namespace OpenRCT2::Scripting
     void ScTileElement::type_set(std::string value)
     {
         if (value == "surface")
-            _element->type = TILE_ELEMENT_TYPE_SURFACE;
+            _element->SetTypeN(TileElementTypeN::Surface);
         else if (value == "footpath")
-            _element->type = TILE_ELEMENT_TYPE_PATH;
+            _element->SetTypeN(TileElementTypeN::Path);
         else if (value == "track")
-            _element->type = TILE_ELEMENT_TYPE_TRACK;
+            _element->SetTypeN(TileElementTypeN::Track);
         else if (value == "small_scenery")
-            _element->type = TILE_ELEMENT_TYPE_SMALL_SCENERY;
+            _element->SetTypeN(TileElementTypeN::SmallScenery);
         else if (value == "entrance")
-            _element->type = TILE_ELEMENT_TYPE_ENTRANCE;
+            _element->SetTypeN(TileElementTypeN::Entrance);
         else if (value == "wall")
-            _element->type = TILE_ELEMENT_TYPE_WALL;
+            _element->SetTypeN(TileElementTypeN::Wall);
         else if (value == "large_scenery")
-            _element->type = TILE_ELEMENT_TYPE_LARGE_SCENERY;
+            _element->SetTypeN(TileElementTypeN::LargeScenery);
         else if (value == "banner")
-            _element->type = TILE_ELEMENT_TYPE_BANNER;
+            _element->SetTypeN(TileElementTypeN::Banner);
         else
         {
             std::puts("Element type not recognised!");

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -37,23 +37,23 @@ namespace OpenRCT2::Scripting
 
     std::string ScTileElement::type_get() const
     {
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
                 return "surface";
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 return "footpath";
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 return "track";
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
                 return "small_scenery";
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 return "entrance";
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
                 return "wall";
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
                 return "large_scenery";
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
                 return "banner";
             default:
                 return "unknown";
@@ -134,15 +134,15 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::slope_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Surface:
             {
                 auto el = _element->AsSurface();
                 duk_push_int(ctx, el->GetSlope());
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetSlope());
@@ -159,22 +159,19 @@ namespace OpenRCT2::Scripting
     void ScTileElement::slope_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        const auto type = _element->GetTypeN();
+
+        if (type == TileElementTypeN::Surface)
         {
-            case TILE_ELEMENT_TYPE_SURFACE:
-            {
-                auto el = _element->AsSurface();
-                el->SetSlope(value);
-                Invalidate();
-                break;
-            }
-            case TILE_ELEMENT_TYPE_WALL:
-            {
-                auto el = _element->AsWall();
-                el->SetSlope(value);
-                Invalidate();
-                break;
-            }
+            auto el = _element->AsSurface();
+            el->SetSlope(value);
+            Invalidate();
+        }
+        else if (type == TileElementTypeN::Wall)
+        {
+            auto el = _element->AsWall();
+            el->SetSlope(value);
+            Invalidate();
         }
     }
 
@@ -378,15 +375,15 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::sequence_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetSequenceIndex());
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto el = _element->AsTrack();
                 if (get_ride(el->GetRideIndex())->type != RIDE_TYPE_MAZE)
@@ -395,7 +392,7 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, el->GetSequenceIndex());
@@ -412,16 +409,16 @@ namespace OpenRCT2::Scripting
     void ScTileElement::sequence_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetSequenceIndex(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto el = _element->AsTrack();
                 if (get_ride(el->GetRideIndex())->type != RIDE_TYPE_MAZE)
@@ -431,22 +428,24 @@ namespace OpenRCT2::Scripting
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetSequenceIndex(value);
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
     DukValue ScTileElement::ride_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto el = _element->AsPath();
                 if (el->IsQueue() && el->GetRideIndex() != RIDE_ID_NULL)
@@ -455,13 +454,13 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto el = _element->AsTrack();
                 duk_push_int(ctx, EnumValue(el->GetRideIndex()));
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, EnumValue(el->GetRideIndex()));
@@ -478,9 +477,9 @@ namespace OpenRCT2::Scripting
     void ScTileElement::ride_set(int32_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto el = _element->AsPath();
                 if (!el->HasAddition())
@@ -490,29 +489,31 @@ namespace OpenRCT2::Scripting
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto el = _element->AsTrack();
                 el->SetRideIndex(static_cast<ride_id_t>(value));
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetRideIndex(static_cast<ride_id_t>(value));
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
     DukValue ScTileElement::station_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto el = _element->AsPath();
                 if (el->IsQueue() && el->GetRideIndex() != RIDE_ID_NULL)
@@ -521,7 +522,7 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto el = _element->AsTrack();
                 if (el->IsStation())
@@ -530,7 +531,7 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, el->GetStationIndex());
@@ -547,29 +548,31 @@ namespace OpenRCT2::Scripting
     void ScTileElement::station_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto el = _element->AsPath();
                 el->SetStationIndex(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto el = _element->AsTrack();
                 el->SetStationIndex(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetStationIndex(value);
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
@@ -727,33 +730,33 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::object_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto el = _element->AsPath();
                 duk_push_int(ctx, el->GetLegacyPathEntryIndex());
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 duk_push_int(ctx, el->GetEntryIndex());
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetEntryIndex());
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetEntryIndex());
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, el->GetEntranceType());
@@ -773,43 +776,45 @@ namespace OpenRCT2::Scripting
         ThrowIfGameStateNotMutable();
 
         auto index = FromDuk<ObjectEntryIndex>(value);
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto el = _element->AsPath();
                 el->SetLegacyPathEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 el->SetEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetEntranceType(index);
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
@@ -892,21 +897,21 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::primaryColour_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 duk_push_int(ctx, el->GetPrimaryColour());
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetPrimaryColour());
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetPrimaryColour());
@@ -923,50 +928,52 @@ namespace OpenRCT2::Scripting
     void ScTileElement::primaryColour_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 el->SetPrimaryColour(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetPrimaryColour(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetPrimaryColour(value);
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
     DukValue ScTileElement::secondaryColour_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 duk_push_int(ctx, el->GetSecondaryColour());
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetSecondaryColour());
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetSecondaryColour());
@@ -983,29 +990,31 @@ namespace OpenRCT2::Scripting
     void ScTileElement::secondaryColour_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 el->SetSecondaryColour(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetSecondaryColour(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetSecondaryColour(value);
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
@@ -1043,29 +1052,31 @@ namespace OpenRCT2::Scripting
     void ScTileElement::bannerIndex_set(uint16_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetBannerIndex(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetBannerIndex(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
             {
                 auto el = _element->AsBanner();
                 el->SetIndex(value);
                 Invalidate();
                 break;
             }
+            default:
+                break;
         }
     }
 
@@ -1488,16 +1499,16 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::direction_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
             {
                 auto el = _element->AsBanner();
                 duk_push_int(ctx, el->GetPosition());
                 break;
             }
-            case TILE_ELEMENT_TYPE_PATH:
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Path:
+            case TileElementTypeN::Surface:
             {
                 duk_push_null(ctx);
                 break;
@@ -1513,17 +1524,17 @@ namespace OpenRCT2::Scripting
     void ScTileElement::direction_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetType())
+        switch (_element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
             {
                 auto el = _element->AsBanner();
                 el->SetPosition(value);
                 Invalidate();
                 break;
             }
-            case TILE_ELEMENT_TYPE_PATH:
-            case TILE_ELEMENT_TYPE_SURFACE:
+            case TileElementTypeN::Path:
+            case TileElementTypeN::Surface:
             {
                 break;
             }

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -37,23 +37,23 @@ namespace OpenRCT2::Scripting
 
     std::string ScTileElement::type_get() const
     {
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 return "surface";
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 return "footpath";
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 return "track";
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
                 return "small_scenery";
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 return "entrance";
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
                 return "wall";
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
                 return "large_scenery";
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
                 return "banner";
             default:
                 return "unknown";
@@ -63,21 +63,21 @@ namespace OpenRCT2::Scripting
     void ScTileElement::type_set(std::string value)
     {
         if (value == "surface")
-            _element->SetTypeN(TileElementTypeN::Surface);
+            _element->SetType(TileElementType::Surface);
         else if (value == "footpath")
-            _element->SetTypeN(TileElementTypeN::Path);
+            _element->SetType(TileElementType::Path);
         else if (value == "track")
-            _element->SetTypeN(TileElementTypeN::Track);
+            _element->SetType(TileElementType::Track);
         else if (value == "small_scenery")
-            _element->SetTypeN(TileElementTypeN::SmallScenery);
+            _element->SetType(TileElementType::SmallScenery);
         else if (value == "entrance")
-            _element->SetTypeN(TileElementTypeN::Entrance);
+            _element->SetType(TileElementType::Entrance);
         else if (value == "wall")
-            _element->SetTypeN(TileElementTypeN::Wall);
+            _element->SetType(TileElementType::Wall);
         else if (value == "large_scenery")
-            _element->SetTypeN(TileElementTypeN::LargeScenery);
+            _element->SetType(TileElementType::LargeScenery);
         else if (value == "banner")
-            _element->SetTypeN(TileElementTypeN::Banner);
+            _element->SetType(TileElementType::Banner);
         else
         {
             std::puts("Element type not recognised!");
@@ -134,15 +134,15 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::slope_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
             {
                 auto el = _element->AsSurface();
                 duk_push_int(ctx, el->GetSlope());
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetSlope());
@@ -159,15 +159,15 @@ namespace OpenRCT2::Scripting
     void ScTileElement::slope_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        const auto type = _element->GetTypeN();
+        const auto type = _element->GetType();
 
-        if (type == TileElementTypeN::Surface)
+        if (type == TileElementType::Surface)
         {
             auto el = _element->AsSurface();
             el->SetSlope(value);
             Invalidate();
         }
-        else if (type == TileElementTypeN::Wall)
+        else if (type == TileElementType::Wall)
         {
             auto el = _element->AsWall();
             el->SetSlope(value);
@@ -375,15 +375,15 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::sequence_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetSequenceIndex());
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto el = _element->AsTrack();
                 if (get_ride(el->GetRideIndex())->type != RIDE_TYPE_MAZE)
@@ -392,7 +392,7 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, el->GetSequenceIndex());
@@ -409,16 +409,16 @@ namespace OpenRCT2::Scripting
     void ScTileElement::sequence_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetSequenceIndex(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto el = _element->AsTrack();
                 if (get_ride(el->GetRideIndex())->type != RIDE_TYPE_MAZE)
@@ -428,7 +428,7 @@ namespace OpenRCT2::Scripting
                 }
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetSequenceIndex(value);
@@ -443,9 +443,9 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::ride_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto el = _element->AsPath();
                 if (el->IsQueue() && el->GetRideIndex() != RIDE_ID_NULL)
@@ -454,13 +454,13 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto el = _element->AsTrack();
                 duk_push_int(ctx, EnumValue(el->GetRideIndex()));
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, EnumValue(el->GetRideIndex()));
@@ -477,9 +477,9 @@ namespace OpenRCT2::Scripting
     void ScTileElement::ride_set(int32_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto el = _element->AsPath();
                 if (!el->HasAddition())
@@ -489,14 +489,14 @@ namespace OpenRCT2::Scripting
                 }
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto el = _element->AsTrack();
                 el->SetRideIndex(static_cast<ride_id_t>(value));
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetRideIndex(static_cast<ride_id_t>(value));
@@ -511,9 +511,9 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::station_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto el = _element->AsPath();
                 if (el->IsQueue() && el->GetRideIndex() != RIDE_ID_NULL)
@@ -522,7 +522,7 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto el = _element->AsTrack();
                 if (el->IsStation())
@@ -531,7 +531,7 @@ namespace OpenRCT2::Scripting
                     duk_push_null(ctx);
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, el->GetStationIndex());
@@ -548,23 +548,23 @@ namespace OpenRCT2::Scripting
     void ScTileElement::station_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto el = _element->AsPath();
                 el->SetStationIndex(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto el = _element->AsTrack();
                 el->SetStationIndex(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetStationIndex(value);
@@ -730,33 +730,33 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::object_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto el = _element->AsPath();
                 duk_push_int(ctx, el->GetLegacyPathEntryIndex());
                 break;
             }
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 duk_push_int(ctx, el->GetEntryIndex());
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetEntryIndex());
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetEntryIndex());
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 duk_push_int(ctx, el->GetEntranceType());
@@ -776,37 +776,37 @@ namespace OpenRCT2::Scripting
         ThrowIfGameStateNotMutable();
 
         auto index = FromDuk<ObjectEntryIndex>(value);
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto el = _element->AsPath();
                 el->SetLegacyPathEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 el->SetEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetEntryIndex(index);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto el = _element->AsEntrance();
                 el->SetEntranceType(index);
@@ -897,21 +897,21 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::primaryColour_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 duk_push_int(ctx, el->GetPrimaryColour());
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetPrimaryColour());
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetPrimaryColour());
@@ -928,23 +928,23 @@ namespace OpenRCT2::Scripting
     void ScTileElement::primaryColour_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 el->SetPrimaryColour(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetPrimaryColour(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetPrimaryColour(value);
@@ -959,21 +959,21 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::secondaryColour_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 duk_push_int(ctx, el->GetSecondaryColour());
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 duk_push_int(ctx, el->GetSecondaryColour());
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 duk_push_int(ctx, el->GetSecondaryColour());
@@ -990,23 +990,23 @@ namespace OpenRCT2::Scripting
     void ScTileElement::secondaryColour_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto el = _element->AsSmallScenery();
                 el->SetSecondaryColour(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetSecondaryColour(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetSecondaryColour(value);
@@ -1052,23 +1052,23 @@ namespace OpenRCT2::Scripting
     void ScTileElement::bannerIndex_set(uint16_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto el = _element->AsLargeScenery();
                 el->SetBannerIndex(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto el = _element->AsWall();
                 el->SetBannerIndex(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
             {
                 auto el = _element->AsBanner();
                 el->SetIndex(value);
@@ -1268,7 +1268,7 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::surfaceObject_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        if (_element->GetTypeN() == TileElementTypeN::Path)
+        if (_element->GetType() == TileElementType::Path)
         {
             auto el = _element->AsPath();
             auto index = el->GetSurfaceEntryIndex();
@@ -1291,7 +1291,7 @@ namespace OpenRCT2::Scripting
     void ScTileElement::surfaceObject_set(const DukValue& value)
     {
         ThrowIfGameStateNotMutable();
-        if (_element->GetTypeN() == TileElementTypeN::Path)
+        if (_element->GetType() == TileElementType::Path)
         {
             auto el = _element->AsPath();
             el->SetSurfaceEntryIndex(FromDuk<ObjectEntryIndex>(value));
@@ -1302,7 +1302,7 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::railingsObject_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        if (_element->GetTypeN() == TileElementTypeN::Path)
+        if (_element->GetType() == TileElementType::Path)
         {
             auto el = _element->AsPath();
             auto index = el->GetRailingsEntryIndex();
@@ -1325,7 +1325,7 @@ namespace OpenRCT2::Scripting
     void ScTileElement::railingsObject_set(const DukValue& value)
     {
         ThrowIfGameStateNotMutable();
-        if (_element->GetTypeN() == TileElementTypeN::Path)
+        if (_element->GetType() == TileElementType::Path)
         {
             auto el = _element->AsPath();
             el->SetRailingsEntryIndex(FromDuk<ObjectEntryIndex>(value));
@@ -1499,16 +1499,16 @@ namespace OpenRCT2::Scripting
     DukValue ScTileElement::direction_get() const
     {
         auto ctx = GetContext()->GetScriptEngine().GetContext();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
             {
                 auto el = _element->AsBanner();
                 duk_push_int(ctx, el->GetPosition());
                 break;
             }
-            case TileElementTypeN::Path:
-            case TileElementTypeN::Surface:
+            case TileElementType::Path:
+            case TileElementType::Surface:
             {
                 duk_push_null(ctx);
                 break;
@@ -1524,17 +1524,17 @@ namespace OpenRCT2::Scripting
     void ScTileElement::direction_set(uint8_t value)
     {
         ThrowIfGameStateNotMutable();
-        switch (_element->GetTypeN())
+        switch (_element->GetType())
         {
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
             {
                 auto el = _element->AsBanner();
                 el->SetPosition(value);
                 Invalidate();
                 break;
             }
-            case TileElementTypeN::Path:
-            case TileElementTypeN::Surface:
+            case TileElementType::Path:
+            case TileElementType::Surface:
             {
                 break;
             }

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -94,7 +94,7 @@ static ride_id_t banner_get_ride_index_at(const CoordsXYZ& bannerCoords)
         return resultRideIndex;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         ride_id_t rideIndex = tileElement->AsTrack()->GetRideIndex();

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -282,15 +282,15 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
     Ride* ride;
 
     res.ErrorMessage = STR_OBJECT_IN_THE_WAY;
-    switch (tileElement->GetType())
+    switch (tileElement->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_SURFACE:
+        case TileElementTypeN::Surface:
             res.ErrorMessage = STR_RAISE_OR_LOWER_LAND_FIRST;
             break;
-        case TILE_ELEMENT_TYPE_PATH:
+        case TileElementTypeN::Path:
             res.ErrorMessage = STR_FOOTPATH_IN_THE_WAY;
             break;
-        case TILE_ELEMENT_TYPE_TRACK:
+        case TileElementTypeN::Track:
             ride = get_ride(tileElement->AsTrack()->GetRideIndex());
             if (ride != nullptr)
             {
@@ -300,7 +300,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
                 ride->FormatNameTo(ft);
             }
             break;
-        case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+        case TileElementTypeN::SmallScenery:
         {
             auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
@@ -309,7 +309,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             ft.Add<rct_string_id>(stringId);
             break;
         }
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
             switch (tileElement->AsEntrance()->GetEntranceType())
             {
                 case ENTRANCE_TYPE_RIDE_ENTRANCE:
@@ -323,7 +323,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
                     break;
             }
             break;
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Wall:
         {
             auto* wallEntry = tileElement->AsWall()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
@@ -332,7 +332,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             ft.Add<rct_string_id>(stringId);
             break;
         }
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
         {
             auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
@@ -341,5 +341,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             ft.Add<rct_string_id>(stringId);
             break;
         }
+        case TileElementTypeN::Banner:
+            break;
     }
 }

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -21,7 +21,7 @@
 static int32_t map_place_clear_func(
     TileElement** tile_element, const CoordsXY& coords, uint8_t flags, money32* price, bool is_scenery)
 {
-    if ((*tile_element)->GetTypeN() != TileElementTypeN::SmallScenery)
+    if ((*tile_element)->GetType() != TileElementType::SmallScenery)
         return 1;
 
     if (is_scenery && !(flags & GAME_COMMAND_FLAG_PATH_SCENERY))
@@ -84,14 +84,14 @@ static bool MapLoc68BABCShouldContinue(
 
     // Crossing mode 1: building track over path
     auto tileElement = *tileElementPtr;
-    if (crossingMode == 1 && canBuildCrossing && tileElement->GetTypeN() == TileElementTypeN::Path
+    if (crossingMode == 1 && canBuildCrossing && tileElement->GetType() == TileElementType::Path
         && tileElement->GetBaseZ() == pos.baseZ && !tileElement->AsPath()->IsQueue() && !tileElement->AsPath()->IsSloped())
     {
         return true;
     }
     // Crossing mode 2: building path over track
     else if (
-        crossingMode == 2 && canBuildCrossing && tileElement->GetTypeN() == TileElementTypeN::Track
+        crossingMode == 2 && canBuildCrossing && tileElement->GetType() == TileElementType::Track
         && tileElement->GetBaseZ() == pos.baseZ && tileElement->AsTrack()->GetTrackType() == TrackElemType::Flat)
     {
         auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
@@ -146,7 +146,7 @@ GameActions::Result MapCanConstructWithClearAt(
 
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Surface)
+        if (tileElement->GetType() != TileElementType::Surface)
         {
             if (pos.baseZ < tileElement->GetClearanceZ() && pos.clearanceZ > tileElement->GetBaseZ()
                 && !(tileElement->IsGhost()))
@@ -195,7 +195,7 @@ GameActions::Result MapCanConstructWithClearAt(
         }
 
         // Only allow building crossings directly on a flat surface tile.
-        if (tileElement->GetTypeN() == TileElementTypeN::Surface
+        if (tileElement->GetType() == TileElementType::Surface
             && (tileElement->AsSurface()->GetSlope()) == TILE_ELEMENT_SLOPE_FLAT && tileElement->GetBaseZ() == pos.baseZ)
         {
             canBuildCrossing = true;
@@ -282,15 +282,15 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
     Ride* ride;
 
     res.ErrorMessage = STR_OBJECT_IN_THE_WAY;
-    switch (tileElement->GetTypeN())
+    switch (tileElement->GetType())
     {
-        case TileElementTypeN::Surface:
+        case TileElementType::Surface:
             res.ErrorMessage = STR_RAISE_OR_LOWER_LAND_FIRST;
             break;
-        case TileElementTypeN::Path:
+        case TileElementType::Path:
             res.ErrorMessage = STR_FOOTPATH_IN_THE_WAY;
             break;
-        case TileElementTypeN::Track:
+        case TileElementType::Track:
             ride = get_ride(tileElement->AsTrack()->GetRideIndex());
             if (ride != nullptr)
             {
@@ -300,7 +300,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
                 ride->FormatNameTo(ft);
             }
             break;
-        case TileElementTypeN::SmallScenery:
+        case TileElementType::SmallScenery:
         {
             auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
@@ -309,7 +309,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             ft.Add<rct_string_id>(stringId);
             break;
         }
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
             switch (tileElement->AsEntrance()->GetEntranceType())
             {
                 case ENTRANCE_TYPE_RIDE_ENTRANCE:
@@ -323,7 +323,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
                     break;
             }
             break;
-        case TileElementTypeN::Wall:
+        case TileElementType::Wall:
         {
             auto* wallEntry = tileElement->AsWall()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
@@ -332,7 +332,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             ft.Add<rct_string_id>(stringId);
             break;
         }
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
         {
             auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
             res.ErrorMessage = STR_X_IN_THE_WAY;
@@ -341,7 +341,7 @@ void map_obstruction_set_error_text(TileElement* tileElement, GameActions::Resul
             ft.Add<rct_string_id>(stringId);
             break;
         }
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
             break;
     }
 }

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -143,7 +143,7 @@ void maze_entrance_hedge_replacement(const CoordsXYE& entrance)
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
             continue;
@@ -180,7 +180,7 @@ void maze_entrance_hedge_removal(const CoordsXYE& entrance)
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
             continue;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -857,9 +857,9 @@ static void loc_6A6D7E(
             return;
         do
         {
-            switch (tileElement->GetType())
+            switch (tileElement->GetTypeN())
             {
-                case TILE_ELEMENT_TYPE_PATH:
+                case TileElementTypeN::Path:
                     if (tileElement->GetBaseZ() == initialTileElementPos.z)
                     {
                         if (!tileElement->AsPath()->IsSloped() || tileElement->AsPath()->GetSlopeDirection() == direction)
@@ -882,7 +882,7 @@ static void loc_6A6D7E(
                         return;
                     }
                     break;
-                case TILE_ELEMENT_TYPE_TRACK:
+                case TileElementTypeN::Track:
                     if (initialTileElementPos.z == tileElement->GetBaseZ())
                     {
                         auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
@@ -918,7 +918,7 @@ static void loc_6A6D7E(
                         return;
                     }
                     break;
-                case TILE_ELEMENT_TYPE_ENTRANCE:
+                case TileElementTypeN::Entrance:
                     if (initialTileElementPos.z == tileElement->GetBaseZ())
                     {
                         if (entrance_has_direction(
@@ -941,6 +941,8 @@ static void loc_6A6D7E(
                             return;
                         }
                     }
+                    break;
+                default:
                     break;
             }
 
@@ -2175,9 +2177,9 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
         if (tileElement == elementToBeRemoved)
             continue;
 
-        switch (tileElement->GetType())
+        switch (tileElement->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 if (tileElement->base_height == coords.z)
                 {
                     if (!tileElement->AsPath()->IsSloped())
@@ -2194,7 +2196,7 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
                         return true;
                 }
                 break;
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 if (tileElement->base_height == coords.z)
                 {
                     auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
@@ -2218,7 +2220,7 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
                     }
                 }
                 break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 if (tileElement->base_height == coords.z)
                 {
                     if (entrance_has_direction(*(tileElement->AsEntrance()), coords.direction - tileElement->GetDirection()))

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -121,7 +121,7 @@ TileElement* map_get_footpath_element(const CoordsXYZ& coords)
     {
         if (tileElement == nullptr)
             break;
-        if (tileElement->GetTypeN() == TileElementTypeN::Path && tileElement->GetBaseZ() == coords.z)
+        if (tileElement->GetType() == TileElementType::Path && tileElement->GetBaseZ() == coords.z)
             return tileElement;
     } while (!(tileElement++)->IsLastForTile());
 
@@ -363,7 +363,7 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
     *tileElement = info.Element;
     if (info.SpriteType == ViewportInteractionItem::Ride
         && viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)
-        && (*tileElement)->GetTypeN() == TileElementTypeN::Entrance)
+        && (*tileElement)->GetType() == TileElementType::Entrance)
     {
         int32_t directions = (*tileElement)->AsEntrance()->GetDirections();
         if (directions & 0x0F)
@@ -380,7 +380,7 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
     info = get_map_coordinates_from_pos_window(
         window, screenCoords,
         EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath, ViewportInteractionItem::Ride));
-    if (info.SpriteType == ViewportInteractionItem::Ride && (*tileElement)->GetTypeN() == TileElementTypeN::Entrance)
+    if (info.SpriteType == ViewportInteractionItem::Ride && (*tileElement)->GetType() == TileElementType::Entrance)
     {
         int32_t directions = (*tileElement)->AsEntrance()->GetDirections();
         if (directions & 0x0F)
@@ -458,7 +458,7 @@ bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction)
         return false;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
         if (tileElement->IsGhost())
             continue;
@@ -486,7 +486,7 @@ static PathElement* footpath_connect_corners_get_neighbour(const CoordsXYZ& foot
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
         auto pathElement = tileElement->AsPath();
         if (pathElement->IsQueue())
@@ -662,7 +662,7 @@ static TileElement* footpath_get_element(const CoordsXYRangedZ& footpathPos, int
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
 
         if (footpathPos.clearanceZ == tileElement->GetBaseZ())
@@ -773,7 +773,7 @@ static bool footpath_disconnect_queue_from_path(const CoordsXY& footpathPos, Til
 
 static void loc_6A6FD2(const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* initialTileElement, bool query)
 {
-    if ((initialTileElement)->GetTypeN() == TileElementTypeN::Path)
+    if ((initialTileElement)->GetType() == TileElementType::Path)
     {
         if (!query)
         {
@@ -804,7 +804,7 @@ static void loc_6A6F1F(
             }
             else
             {
-                if ((initialTileElement)->GetTypeN() == TileElementTypeN::Path && initialTileElement->AsPath()->IsQueue())
+                if ((initialTileElement)->GetType() == TileElementType::Path && initialTileElement->AsPath()->IsQueue())
                 {
                     if (footpath_disconnect_queue_from_path(targetPos, tileElement, 0))
                     {
@@ -857,9 +857,9 @@ static void loc_6A6D7E(
             return;
         do
         {
-            switch (tileElement->GetTypeN())
+            switch (tileElement->GetType())
             {
-                case TileElementTypeN::Path:
+                case TileElementType::Path:
                     if (tileElement->GetBaseZ() == initialTileElementPos.z)
                     {
                         if (!tileElement->AsPath()->IsSloped() || tileElement->AsPath()->GetSlopeDirection() == direction)
@@ -882,7 +882,7 @@ static void loc_6A6D7E(
                         return;
                     }
                     break;
-                case TileElementTypeN::Track:
+                case TileElementType::Track:
                     if (initialTileElementPos.z == tileElement->GetBaseZ())
                     {
                         auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
@@ -918,7 +918,7 @@ static void loc_6A6D7E(
                         return;
                     }
                     break;
-                case TileElementTypeN::Entrance:
+                case TileElementType::Entrance:
                     if (initialTileElementPos.z == tileElement->GetBaseZ())
                     {
                         if (entrance_has_direction(
@@ -960,7 +960,7 @@ static void loc_6A6C85(
             { tileElementPos, tileElementPos.element->GetBaseZ(), tileElementPos.element->GetClearanceZ() }, direction))
         return;
 
-    if (tileElementPos.element->GetTypeN() == TileElementTypeN::Entrance)
+    if (tileElementPos.element->GetType() == TileElementType::Entrance)
     {
         if (!entrance_has_direction(
                 *(tileElementPos.element->AsEntrance()), direction - tileElementPos.element->GetDirection()))
@@ -969,7 +969,7 @@ static void loc_6A6C85(
         }
     }
 
-    if (tileElementPos.element->GetTypeN() == TileElementTypeN::Track)
+    if (tileElementPos.element->GetType() == TileElementType::Track)
     {
         auto ride = get_ride(tileElementPos.element->AsTrack()->GetRideIndex());
         if (ride == nullptr)
@@ -997,7 +997,7 @@ static void loc_6A6C85(
     }
 
     auto pos = CoordsXYZ{ tileElementPos, tileElementPos.element->GetBaseZ() };
-    if (tileElementPos.element->GetTypeN() == TileElementTypeN::Path)
+    if (tileElementPos.element->GetType() == TileElementType::Path)
     {
         if (tileElementPos.element->AsPath()->IsSloped())
         {
@@ -1036,7 +1036,7 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
 
     neighbour_list_sort(&neighbourList);
 
-    if (tileElement->GetTypeN() == TileElementTypeN::Path && tileElement->AsPath()->IsQueue())
+    if (tileElement->GetType() == TileElementType::Path && tileElement->AsPath()->IsQueue())
     {
         ride_id_t rideIndex = RIDE_ID_NULL;
         uint8_t entranceIndex = 255;
@@ -1070,7 +1070,7 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
         loc_6A6C85({ footpathPos, tileElement }, neighbour.direction, flags, false, nullptr);
     }
 
-    if (tileElement->GetTypeN() == TileElementTypeN::Path)
+    if (tileElement->GetType() == TileElementType::Path)
     {
         footpath_connect_corners(footpathPos, tileElement->AsPath());
     }
@@ -1095,7 +1095,7 @@ void footpath_chain_ride_queue(
     lastQueuePathElement = nullptr;
     for (;;)
     {
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             lastPathElement = tileElement;
             lastPath = curQueuePos;
@@ -1118,7 +1118,7 @@ void footpath_chain_ride_queue(
             {
                 if (lastQueuePathElement == tileElement)
                     continue;
-                if (tileElement->GetTypeN() != TileElementTypeN::Path)
+                if (tileElement->GetType() != TileElementType::Path)
                     continue;
                 if (tileElement->GetBaseZ() == baseZ)
                 {
@@ -1246,7 +1246,7 @@ void footpath_update_queue_chains()
             {
                 do
                 {
-                    if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+                    if (tileElement->GetType() != TileElementType::Entrance)
                         continue;
                     if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
                         continue;
@@ -1376,7 +1376,7 @@ static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, i
     // Encapsulate the tile skipping logic to make do-while more readable
     auto SkipTileElement = [](int32_t ste_flags, TileElement* ste_tileElement, int32_t& ste_slopeDirection,
                               int32_t ste_direction, const CoordsXYZ& ste_targetPos) {
-        if (ste_tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (ste_tileElement->GetType() != TileElementType::Path)
             return true;
 
         if (ste_tileElement->AsPath()->IsSloped()
@@ -1441,9 +1441,9 @@ static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, i
                 // Loop over all elements and cull appropriate edges
                 do
                 {
-                    if (tileElement[elementIndex].GetTypeN() == TileElementTypeN::Path)
+                    if (tileElement[elementIndex].GetType() == TileElementType::Path)
                         break;
-                    if (tileElement[elementIndex].GetTypeN() != TileElementTypeN::Banner)
+                    if (tileElement[elementIndex].GetType() != TileElementType::Banner)
                     {
                         continue;
                     }
@@ -1800,7 +1800,7 @@ static void footpath_clear_wide(const CoordsXY& footpathPos)
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
         tileElement->AsPath()->SetWide(false);
     } while (!(tileElement++)->IsLastForTile());
@@ -1819,7 +1819,7 @@ static TileElement* footpath_can_be_wide(const CoordsXYZ& footpathPos)
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
         if (footpathPos.z != tileElement->GetBaseZ())
             continue;
@@ -1866,7 +1866,7 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
 
         if (tileElement->AsPath()->IsQueue())
@@ -2045,8 +2045,8 @@ bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
  */
 void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElement* tileElement)
 {
-    const auto elementType = tileElement->GetTypeN();
-    if (elementType == TileElementTypeN::Path)
+    const auto elementType = tileElement->GetType();
+    if (elementType == TileElementType::Path)
     {
         if (tileElement->AsPath()->IsQueue())
         {
@@ -2061,7 +2061,7 @@ void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElem
             tileElement->AsPath()->SetRideIndex(RIDE_ID_NULL);
         }
     }
-    else if (elementType == TileElementTypeN::Entrance)
+    else if (elementType == TileElementType::Entrance)
     {
         if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
         {
@@ -2103,7 +2103,7 @@ static void footpath_remove_edges_towards_here(
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
         if (tileElement->GetBaseZ() != targetFootPathPos.z)
             continue;
@@ -2134,7 +2134,7 @@ static void footpath_remove_edges_towards(const CoordsXYRangedZ& footPathPos, in
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
 
         if (footPathPos.clearanceZ == tileElement->GetBaseZ())
@@ -2177,9 +2177,9 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
         if (tileElement == elementToBeRemoved)
             continue;
 
-        switch (tileElement->GetTypeN())
+        switch (tileElement->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 if (tileElement->base_height == coords.z)
                 {
                     if (!tileElement->AsPath()->IsSloped())
@@ -2196,7 +2196,7 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
                         return true;
                 }
                 break;
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 if (tileElement->base_height == coords.z)
                 {
                     auto ride = get_ride(tileElement->AsTrack()->GetRideIndex());
@@ -2220,7 +2220,7 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
                     }
                 }
                 break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 if (tileElement->base_height == coords.z)
                 {
                     if (entrance_has_direction(*(tileElement->AsEntrance()), coords.direction - tileElement->GetDirection()))
@@ -2249,7 +2249,7 @@ static void footpath_fix_corners_around(const TileCoordsXY& footpathPos, TileEle
     };
 
     // Sloped paths don't create filled corners, so no need to remove any
-    if (pathElement->GetTypeN() == TileElementTypeN::Path && pathElement->AsPath()->IsSloped())
+    if (pathElement->GetType() == TileElementType::Path && pathElement->AsPath()->IsSloped())
         return;
 
     for (int32_t xOffset = -1; xOffset <= 1; xOffset++)
@@ -2266,7 +2266,7 @@ static void footpath_fix_corners_around(const TileCoordsXY& footpathPos, TileEle
                 continue;
             do
             {
-                if (tileElement->GetTypeN() != TileElementTypeN::Path)
+                if (tileElement->GetType() != TileElementType::Path)
                     continue;
                 if (tileElement->AsPath()->IsSloped())
                     continue;
@@ -2289,7 +2289,7 @@ static void footpath_fix_corners_around(const TileCoordsXY& footpathPos, TileEle
  */
 void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement)
 {
-    if (tileElement->GetTypeN() == TileElementTypeN::Track)
+    if (tileElement->GetType() == TileElementType::Track)
     {
         auto rideIndex = tileElement->AsTrack()->GetRideIndex();
         auto ride = get_ride(rideIndex);
@@ -2306,7 +2306,7 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
     for (uint8_t direction = 0; direction < 4; direction++)
     {
         int32_t z1 = tileElement->base_height;
-        if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        if (tileElement->GetType() == TileElementType::Path)
         {
             if (tileElement->AsPath()->IsSloped())
             {
@@ -2325,7 +2325,7 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
         // to.
         if (!tile_element_wants_path_connection_towards({ TileCoordsXY{ footpathPos }, z1, direction }, tileElement))
         {
-            bool isQueue = tileElement->GetTypeN() == TileElementTypeN::Path ? tileElement->AsPath()->IsQueue() : false;
+            bool isQueue = tileElement->GetType() == TileElementType::Path ? tileElement->AsPath()->IsQueue() : false;
             int32_t z0 = z1 - 2;
             footpath_remove_edges_towards(
                 { footpathPos + CoordsDirectionDelta[direction], z0 * COORDS_Z_STEP, z1 * COORDS_Z_STEP }, direction, isQueue);
@@ -2344,7 +2344,7 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
         footpath_fix_corners_around(tileFootpathPos, tileElement);
     }
 
-    if (tileElement->GetTypeN() == TileElementTypeN::Path)
+    if (tileElement->GetType() == TileElementType::Path)
         tileElement->AsPath()->SetEdgesAndCorners(0);
 }
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -154,7 +154,7 @@ void SetTileElements(std::vector<TileElement>&& tileElements)
 static TileElement GetDefaultSurfaceElement()
 {
     TileElement el;
-    el.ClearAs(TILE_ELEMENT_TYPE_SURFACE);
+    el.ClearAs(TileElementTypeN::Surface);
     el.SetLastForTile(true);
     el.base_height = 14;
     el.clearance_height = 14;
@@ -433,7 +433,7 @@ void map_init(int32_t size)
     for (int32_t i = 0; i < numTiles; i++)
     {
         auto* element = &tileElements[i];
-        element->ClearAs(TILE_ELEMENT_TYPE_SURFACE);
+        element->ClearAs(TileElementTypeN::Surface);
         element->SetLastForTile(true);
         element->base_height = 14;
         element->clearance_height = 14;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1116,24 +1116,26 @@ void map_remove_all_rides()
     tile_element_iterator_begin(&it);
     do
     {
-        switch (it.element->GetType())
+        switch (it.element->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
                 if (it.element->AsPath()->IsQueue())
                 {
                     it.element->AsPath()->SetHasQueueBanner(false);
                     it.element->AsPath()->SetRideIndex(RIDE_ID_NULL);
                 }
                 break;
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
                 if (it.element->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                     break;
                 [[fallthrough]];
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
                 footpath_queue_chain_reset();
                 footpath_remove_edges_at(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
                 tile_element_remove(it.element);
                 tile_element_iterator_restart_for_tile(&it);
+                break;
+            default:
                 break;
         }
     } while (tile_element_iterator_next(&it));
@@ -1515,9 +1517,9 @@ void map_extend_boundary_surface()
 static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
 {
     TileElement* element = *elementPtr;
-    switch (element->GetType())
+    switch (element->GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_SURFACE:
+        case TileElementTypeN::Surface:
             element->base_height = MINIMUM_LAND_HEIGHT;
             element->clearance_height = MINIMUM_LAND_HEIGHT;
             element->owner = 0;
@@ -1532,7 +1534,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             // The rest of the elements are removed from the array, so the pointer doesn't need to be updated.
             (*elementPtr)++;
             break;
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
         {
             int32_t rotation = element->GetDirectionWithOffset(1);
             auto seqLoc = loc;
@@ -1554,7 +1556,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             }
             break;
         }
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Wall:
         {
             CoordsXYZD wallLocation = { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() };
             auto wallRemoveAction = WallRemoveAction(wallLocation);
@@ -1566,7 +1568,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             }
         }
         break;
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
         {
             auto removeSceneryAction = LargeSceneryRemoveAction(
                 { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() }, element->AsLargeScenery()->GetSequenceIndex());
@@ -1578,7 +1580,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             }
         }
         break;
-        case TILE_ELEMENT_TYPE_BANNER:
+        case TileElementTypeN::Banner:
         {
             auto bannerRemoveAction = BannerRemoveAction(
                 { loc.x, loc.y, element->GetBaseZ(), element->AsBanner()->GetPosition() });

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2263,9 +2263,9 @@ uint16_t check_max_allowable_land_rights_for_tile(const CoordsXYZ& tileMapPos)
     auto tilePos = TileCoordsXYZ{ tileMapPos };
     do
     {
-        int32_t type = tileElement->GetType();
-        if (type == TILE_ELEMENT_TYPE_PATH
-            || (type == TILE_ELEMENT_TYPE_ENTRANCE
+        auto type = tileElement->GetTypeN();
+        if (type == TileElementTypeN::Path
+            || (type == TileElementTypeN::Entrance
                 && tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE))
         {
             destOwnership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -154,7 +154,7 @@ void SetTileElements(std::vector<TileElement>&& tileElements)
 static TileElement GetDefaultSurfaceElement()
 {
     TileElement el;
-    el.ClearAs(TileElementTypeN::Surface);
+    el.ClearAs(TileElementType::Surface);
     el.SetLastForTile(true);
     el.base_height = 14;
     el.clearance_height = 14;
@@ -433,7 +433,7 @@ void map_init(int32_t size)
     for (int32_t i = 0; i < numTiles; i++)
     {
         auto* element = &tileElements[i];
-        element->ClearAs(TileElementTypeN::Surface);
+        element->ClearAs(TileElementType::Surface);
         element->SetLastForTile(true);
         element->base_height = 14;
         element->clearance_height = 14;
@@ -700,7 +700,7 @@ bool map_coord_is_connected(const TileCoordsXYZ& loc, uint8_t faceDirection)
 
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
 
         uint8_t slopeDirection = tileElement->AsPath()->GetSlopeDirection();
@@ -1116,20 +1116,20 @@ void map_remove_all_rides()
     tile_element_iterator_begin(&it);
     do
     {
-        switch (it.element->GetTypeN())
+        switch (it.element->GetType())
         {
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
                 if (it.element->AsPath()->IsQueue())
                 {
                     it.element->AsPath()->SetHasQueueBanner(false);
                     it.element->AsPath()->SetRideIndex(RIDE_ID_NULL);
                 }
                 break;
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
                 if (it.element->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
                     break;
                 [[fallthrough]];
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
                 footpath_queue_chain_reset();
                 footpath_remove_edges_at(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
                 tile_element_remove(it.element);
@@ -1236,7 +1236,7 @@ static TileElement* AllocateTileElements(size_t numElementsOnTile, size_t numNew
  *
  *  rct2: 0x0068B1F6
  */
-TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementTypeN type)
+TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type)
 {
     const auto& tileLoc = TileCoordsXYZ(loc);
 
@@ -1280,7 +1280,7 @@ TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants
     // Insert new map element
     auto* insertedElement = newTileElement;
     newTileElement->type = 0;
-    newTileElement->SetTypeN(type);
+    newTileElement->SetType(type);
     newTileElement->SetBaseZ(loc.z);
     newTileElement->Flags = 0;
     newTileElement->SetLastForTile(isLastForTile);
@@ -1517,9 +1517,9 @@ void map_extend_boundary_surface()
 static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
 {
     TileElement* element = *elementPtr;
-    switch (element->GetTypeN())
+    switch (element->GetType())
     {
-        case TileElementTypeN::Surface:
+        case TileElementType::Surface:
             element->base_height = MINIMUM_LAND_HEIGHT;
             element->clearance_height = MINIMUM_LAND_HEIGHT;
             element->owner = 0;
@@ -1534,7 +1534,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             // The rest of the elements are removed from the array, so the pointer doesn't need to be updated.
             (*elementPtr)++;
             break;
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
         {
             int32_t rotation = element->GetDirectionWithOffset(1);
             auto seqLoc = loc;
@@ -1556,7 +1556,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             }
             break;
         }
-        case TileElementTypeN::Wall:
+        case TileElementType::Wall:
         {
             CoordsXYZD wallLocation = { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() };
             auto wallRemoveAction = WallRemoveAction(wallLocation);
@@ -1568,7 +1568,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             }
         }
         break;
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
         {
             auto removeSceneryAction = LargeSceneryRemoveAction(
                 { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() }, element->AsLargeScenery()->GetSequenceIndex());
@@ -1580,7 +1580,7 @@ static void clear_element_at(const CoordsXY& loc, TileElement** elementPtr)
             }
         }
         break;
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
         {
             auto bannerRemoveAction = BannerRemoveAction(
                 { loc.x, loc.y, element->GetBaseZ(), element->AsBanner()->GetPosition() });
@@ -1651,7 +1651,7 @@ LargeSceneryElement* map_get_large_scenery_segment(const CoordsXYZD& sceneryPos,
     auto sceneryTilePos = TileCoordsXYZ{ sceneryPos };
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::LargeScenery)
+        if (tileElement->GetType() != TileElementType::LargeScenery)
             continue;
         if (tileElement->base_height != sceneryTilePos.z)
             continue;
@@ -1673,7 +1673,7 @@ EntranceElement* map_get_park_entrance_element_at(const CoordsXYZ& entranceCoord
     {
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 continue;
 
             if (tileElement->base_height != entranceTileCoords.z)
@@ -1699,7 +1699,7 @@ EntranceElement* map_get_ride_entrance_element_at(const CoordsXYZ& entranceCoord
     {
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 continue;
 
             if (tileElement->base_height != entranceTileCoords.z)
@@ -1725,7 +1725,7 @@ EntranceElement* map_get_ride_exit_element_at(const CoordsXYZ& exitCoords, bool 
     {
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 continue;
 
             if (tileElement->base_height != exitTileCoords.z)
@@ -1751,7 +1751,7 @@ SmallSceneryElement* map_get_small_scenery_element_at(const CoordsXYZ& sceneryCo
     {
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+            if (tileElement->GetType() != TileElementType::SmallScenery)
                 continue;
             if (tileElement->AsSmallScenery()->GetSceneryQuadrant() != quadrant)
                 continue;
@@ -1967,10 +1967,10 @@ bool map_surface_is_blocked(const CoordsXY& mapCoords)
         if (base_z < tileElement->base_height)
             continue;
 
-        if (tileElement->GetTypeN() == TileElementTypeN::Path || tileElement->GetTypeN() == TileElementTypeN::Wall)
+        if (tileElement->GetType() == TileElementType::Path || tileElement->GetType() == TileElementType::Wall)
             continue;
 
-        if (tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+        if (tileElement->GetType() != TileElementType::SmallScenery)
             return true;
 
         auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
@@ -2009,7 +2009,7 @@ TrackElement* map_get_track_element_at(const CoordsXYZ& trackPos)
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->GetBaseZ() != trackPos.z)
             continue;
@@ -2034,7 +2034,7 @@ TileElement* map_get_track_element_at_of_type(const CoordsXYZ& trackPos, track_t
     auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->base_height != trackTilePos.z)
             continue;
@@ -2061,7 +2061,7 @@ TileElement* map_get_track_element_at_of_type_seq(const CoordsXYZ& trackPos, tra
     {
         if (tileElement == nullptr)
             break;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->base_height != trackTilePos.z)
             continue;
@@ -2138,7 +2138,7 @@ TileElement* map_get_track_element_at_of_type_from_ride(const CoordsXYZ& trackPo
     auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->base_height != trackTilePos.z)
             continue;
@@ -2167,7 +2167,7 @@ TileElement* map_get_track_element_at_from_ride(const CoordsXYZ& trackPos, ride_
     auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->base_height != trackTilePos.z)
             continue;
@@ -2195,7 +2195,7 @@ TileElement* map_get_track_element_at_with_direction_from_ride(const CoordsXYZD&
     auto trackTilePos = TileCoordsXYZ{ trackPos };
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
         if (tileElement->base_height != trackTilePos.z)
             continue;
@@ -2218,7 +2218,7 @@ WallElement* map_get_wall_element_at(const CoordsXYRangedZ& coords)
     {
         do
         {
-            if (tileElement->GetTypeN() == TileElementTypeN::Wall && coords.baseZ < tileElement->GetClearanceZ()
+            if (tileElement->GetType() == TileElementType::Wall && coords.baseZ < tileElement->GetClearanceZ()
                 && coords.clearanceZ > tileElement->GetBaseZ())
             {
                 return tileElement->AsWall();
@@ -2237,7 +2237,7 @@ WallElement* map_get_wall_element_at(const CoordsXYZD& wallCoords)
         return nullptr;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
         if (tileElement->base_height != tileWallCoords.z)
             continue;
@@ -2263,9 +2263,9 @@ uint16_t check_max_allowable_land_rights_for_tile(const CoordsXYZ& tileMapPos)
     auto tilePos = TileCoordsXYZ{ tileMapPos };
     do
     {
-        auto type = tileElement->GetTypeN();
-        if (type == TileElementTypeN::Path
-            || (type == TileElementTypeN::Entrance
+        auto type = tileElement->GetType();
+        if (type == TileElementType::Path
+            || (type == TileElementType::Entrance
                 && tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE))
         {
             destOwnership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -189,7 +189,7 @@ void map_remove_all_rides();
 void map_invalidate_map_selection_tiles();
 void map_invalidate_selection_rect();
 bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements = 1);
-TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementTypeN type);
+TileElement* tile_element_insert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type);
 
 template<typename T> T* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants)
 {

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -617,12 +617,12 @@ void AutoCreateMapAnimations()
     {
         auto el = it.element;
         auto loc = CoordsXYZ{ TileCoordsXY(it.x, it.y).ToCoordsXY(), el->GetBaseZ() };
-        switch (el->GetType())
+        switch (el->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_BANNER:
+            case TileElementTypeN::Banner:
                 map_animation_create(MAP_ANIMATION_TYPE_BANNER, loc);
                 break;
-            case TILE_ELEMENT_TYPE_WALL:
+            case TileElementTypeN::Wall:
             {
                 auto wallEl = el->AsWall();
                 auto* entry = wallEl->GetEntry();
@@ -633,7 +633,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
             {
                 auto sceneryEl = el->AsSmallScenery();
                 auto* sceneryEntry = sceneryEl->GetEntry();
@@ -643,7 +643,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+            case TileElementTypeN::LargeScenery:
             {
                 auto sceneryEl = el->AsLargeScenery();
                 auto entry = sceneryEl->GetEntry();
@@ -653,7 +653,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::Path:
             {
                 auto path = el->AsPath();
                 if (path->HasQueueBanner())
@@ -662,7 +662,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_ENTRANCE:
+            case TileElementTypeN::Entrance:
             {
                 auto entrance = el->AsEntrance();
                 switch (entrance->GetEntranceType())
@@ -679,7 +679,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TILE_ELEMENT_TYPE_TRACK:
+            case TileElementTypeN::Track:
             {
                 auto track = el->AsTrack();
                 switch (track->GetTrackType())
@@ -699,6 +699,8 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
+            case TileElementTypeN::Surface:
+                break;
         }
     }
 }

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -98,7 +98,7 @@ static bool map_animation_invalidate_ride_entrance(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+        if (tileElement->GetType() != TileElementType::Entrance)
             continue;
         if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
             continue;
@@ -135,7 +135,7 @@ static bool map_animation_invalidate_queue_banner(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Path)
+        if (tileElement->GetType() != TileElementType::Path)
             continue;
         if (!(tileElement->AsPath()->IsQueue()))
             continue;
@@ -168,7 +168,7 @@ static bool map_animation_invalidate_small_scenery(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+        if (tileElement->GetType() != TileElementType::SmallScenery)
             continue;
         if (tileElement->IsGhost())
             continue;
@@ -233,7 +233,7 @@ static bool map_animation_invalidate_park_entrance(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+        if (tileElement->GetType() != TileElementType::Entrance)
             continue;
         if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
             continue;
@@ -263,7 +263,7 @@ static bool map_animation_invalidate_track_waterfall(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TrackElemType::Waterfall)
@@ -292,7 +292,7 @@ static bool map_animation_invalidate_track_rapids(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TrackElemType::Rapids)
@@ -321,7 +321,7 @@ static bool map_animation_invalidate_track_onridephoto(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TrackElemType::OnRidePhoto)
@@ -360,7 +360,7 @@ static bool map_animation_invalidate_track_whirlpool(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TrackElemType::Whirlpool)
@@ -389,7 +389,7 @@ static bool map_animation_invalidate_track_spinningtunnel(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Track)
+        if (tileElement->GetType() != TileElementType::Track)
             continue;
 
         if (tileElement->AsTrack()->GetTrackType() == TrackElemType::SpinningTunnel)
@@ -427,7 +427,7 @@ static bool map_animation_invalidate_banner(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Banner)
+        if (tileElement->GetType() != TileElementType::Banner)
             continue;
         map_invalidate_tile_zoom1({ loc, loc.z, loc.z + 16 });
         return false;
@@ -453,7 +453,7 @@ static bool map_animation_invalidate_large_scenery(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::LargeScenery)
+        if (tileElement->GetType() != TileElementType::LargeScenery)
             continue;
 
         auto* sceneryEntry = tileElement->AsLargeScenery()->GetEntry();
@@ -487,7 +487,7 @@ static bool map_animation_invalidate_wall_door(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
 
         auto* wallEntry = tileElement->AsWall()->GetEntry();
@@ -548,7 +548,7 @@ static bool map_animation_invalidate_wall(const CoordsXYZ& loc)
     {
         if (tileElement->base_height != tileLoc.z)
             continue;
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
 
         auto* wallEntry = tileElement->AsWall()->GetEntry();
@@ -617,12 +617,12 @@ void AutoCreateMapAnimations()
     {
         auto el = it.element;
         auto loc = CoordsXYZ{ TileCoordsXY(it.x, it.y).ToCoordsXY(), el->GetBaseZ() };
-        switch (el->GetTypeN())
+        switch (el->GetType())
         {
-            case TileElementTypeN::Banner:
+            case TileElementType::Banner:
                 map_animation_create(MAP_ANIMATION_TYPE_BANNER, loc);
                 break;
-            case TileElementTypeN::Wall:
+            case TileElementType::Wall:
             {
                 auto wallEl = el->AsWall();
                 auto* entry = wallEl->GetEntry();
@@ -633,7 +633,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
             {
                 auto sceneryEl = el->AsSmallScenery();
                 auto* sceneryEntry = sceneryEl->GetEntry();
@@ -643,7 +643,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TileElementTypeN::LargeScenery:
+            case TileElementType::LargeScenery:
             {
                 auto sceneryEl = el->AsLargeScenery();
                 auto entry = sceneryEl->GetEntry();
@@ -653,7 +653,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TileElementTypeN::Path:
+            case TileElementType::Path:
             {
                 auto path = el->AsPath();
                 if (path->HasQueueBanner())
@@ -662,7 +662,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TileElementTypeN::Entrance:
+            case TileElementType::Entrance:
             {
                 auto entrance = el->AsEntrance();
                 switch (entrance->GetEntranceType())
@@ -679,7 +679,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TileElementTypeN::Track:
+            case TileElementType::Track:
             {
                 auto track = el->AsTrack();
                 switch (track->GetTrackType())
@@ -699,7 +699,7 @@ void AutoCreateMapAnimations()
                 }
                 break;
             }
-            case TileElementTypeN::Surface:
+            case TileElementType::Surface:
                 break;
         }
     }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -121,7 +121,7 @@ void update_park_fences(const CoordsXY& coords)
         // If an entrance element do not place flags around surface
         do
         {
-            if (tileElement->GetTypeN() != TileElementTypeN::Entrance)
+            if (tileElement->GetType() != TileElementType::Entrance)
                 continue;
 
             if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
@@ -342,7 +342,7 @@ int32_t Park::CalculateParkSize() const
     tile_element_iterator_begin(&it);
     do
     {
-        if (it.element->GetTypeN() == TileElementTypeN::Surface)
+        if (it.element->GetType() == TileElementType::Surface)
         {
             if (it.element->AsSurface()->GetOwnership() & (OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED | OWNERSHIP_OWNED))
             {

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -81,11 +81,11 @@ void scenery_update_tile(const CoordsXY& sceneryPos)
                 continue;
         }
 
-        if (tileElement->GetTypeN() == TileElementTypeN::SmallScenery)
+        if (tileElement->GetType() == TileElementType::SmallScenery)
         {
             tileElement->AsSmallScenery()->UpdateAge(sceneryPos);
         }
-        else if (tileElement->GetTypeN() == TileElementTypeN::Path)
+        else if (tileElement->GetType() == TileElementType::Path)
         {
             if (tileElement->AsPath()->HasAddition() && !tileElement->AsPath()->AdditionIsGhost())
             {
@@ -141,15 +141,15 @@ void SmallSceneryElement::UpdateAge(const CoordsXY& sceneryPos)
         if (tileElementAbove->IsGhost())
             continue;
 
-        switch (tileElementAbove->GetTypeN())
+        switch (tileElementAbove->GetType())
         {
-            case TileElementTypeN::LargeScenery:
-            case TileElementTypeN::Entrance:
-            case TileElementTypeN::Path:
+            case TileElementType::LargeScenery:
+            case TileElementType::Entrance:
+            case TileElementType::Path:
                 map_invalidate_tile_zoom1({ sceneryPos, tileElementAbove->GetBaseZ(), tileElementAbove->GetClearanceZ() });
                 IncreaseAge(sceneryPos);
                 return;
-            case TileElementTypeN::SmallScenery:
+            case TileElementType::SmallScenery:
                 sceneryEntry = tileElementAbove->AsSmallScenery()->GetEntry();
                 if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_VOFFSET_CENTRE))
                 {
@@ -194,7 +194,7 @@ void scenery_remove_ghost_tool_placement()
             if (tileElement == nullptr)
                 break;
 
-            if (tileElement->GetTypeN() != TileElementTypeN::Path)
+            if (tileElement->GetType() != TileElementType::Path)
                 continue;
 
             if (tileElement->GetBaseZ() != gSceneryGhostPosition.z)

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -141,21 +141,23 @@ void SmallSceneryElement::UpdateAge(const CoordsXY& sceneryPos)
         if (tileElementAbove->IsGhost())
             continue;
 
-        switch (tileElementAbove->GetType())
+        switch (tileElementAbove->GetTypeN())
         {
-            case TILE_ELEMENT_TYPE_LARGE_SCENERY:
-            case TILE_ELEMENT_TYPE_ENTRANCE:
-            case TILE_ELEMENT_TYPE_PATH:
+            case TileElementTypeN::LargeScenery:
+            case TileElementTypeN::Entrance:
+            case TileElementTypeN::Path:
                 map_invalidate_tile_zoom1({ sceneryPos, tileElementAbove->GetBaseZ(), tileElementAbove->GetClearanceZ() });
                 IncreaseAge(sceneryPos);
                 return;
-            case TILE_ELEMENT_TYPE_SMALL_SCENERY:
+            case TileElementTypeN::SmallScenery:
                 sceneryEntry = tileElementAbove->AsSmallScenery()->GetEntry();
                 if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_VOFFSET_CENTRE))
                 {
                     IncreaseAge(sceneryPos);
                     return;
                 }
+                break;
+            default:
                 break;
         }
     }

--- a/src/openrct2/world/Surface.cpp
+++ b/src/openrct2/world/Surface.cpp
@@ -173,7 +173,7 @@ void SurfaceElement::UpdateGrassLength(const CoordsXY& coords)
         else
         {
             tileElementAbove++;
-            if (tileElementAbove->GetTypeN() == TileElementTypeN::Wall)
+            if (tileElementAbove->GetType() == TileElementType::Wall)
                 continue;
             // Grass should not be affected by ghost elements.
             if (tileElementAbove->IsGhost())

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -101,9 +101,10 @@ ride_id_t TileElement::GetRideIndex() const
     }
 }
 
-void TileElement::ClearAs(uint8_t newType)
+void TileElement::ClearAs(TileElementTypeN newType)
 {
-    type = newType;
+    type = 0;
+    SetTypeN(newType);
     Flags = 0;
     base_height = MINIMUM_LAND_HEIGHT;
     clearance_height = MINIMUM_LAND_HEIGHT;

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -31,9 +31,9 @@ bool tile_element_is_underground(TileElement* tileElement)
 
 BannerIndex TileElement::GetBannerIndex() const
 {
-    switch (GetType())
+    switch (GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
         {
             auto* sceneryEntry = AsLargeScenery()->GetEntry();
             if (sceneryEntry == nullptr || sceneryEntry->scrolling_mode == SCROLLING_MODE_NONE)
@@ -41,7 +41,7 @@ BannerIndex TileElement::GetBannerIndex() const
 
             return AsLargeScenery()->GetBannerIndex();
         }
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Wall:
         {
             auto* wallEntry = AsWall()->GetEntry();
             if (wallEntry == nullptr || wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
@@ -49,7 +49,7 @@ BannerIndex TileElement::GetBannerIndex() const
 
             return AsWall()->GetBannerIndex();
         }
-        case TILE_ELEMENT_TYPE_BANNER:
+        case TileElementTypeN::Banner:
             return AsBanner()->GetIndex();
         default:
             return BANNER_INDEX_NULL;
@@ -58,15 +58,15 @@ BannerIndex TileElement::GetBannerIndex() const
 
 void TileElement::SetBannerIndex(BannerIndex bannerIndex)
 {
-    switch (GetType())
+    switch (GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_WALL:
+        case TileElementTypeN::Wall:
             AsWall()->SetBannerIndex(bannerIndex);
             break;
-        case TILE_ELEMENT_TYPE_LARGE_SCENERY:
+        case TileElementTypeN::LargeScenery:
             AsLargeScenery()->SetBannerIndex(bannerIndex);
             break;
-        case TILE_ELEMENT_TYPE_BANNER:
+        case TileElementTypeN::Banner:
             AsBanner()->SetIndex(bannerIndex);
             break;
         default:
@@ -88,13 +88,13 @@ void TileElement::RemoveBannerEntry()
 
 ride_id_t TileElement::GetRideIndex() const
 {
-    switch (GetType())
+    switch (GetTypeN())
     {
-        case TILE_ELEMENT_TYPE_TRACK:
+        case TileElementTypeN::Track:
             return AsTrack()->GetRideIndex();
-        case TILE_ELEMENT_TYPE_ENTRANCE:
+        case TileElementTypeN::Entrance:
             return AsEntrance()->GetRideIndex();
-        case TILE_ELEMENT_TYPE_PATH:
+        case TileElementTypeN::Path:
             return AsPath()->GetRideIndex();
         default:
             return RIDE_ID_NULL;

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -25,15 +25,15 @@ bool tile_element_is_underground(TileElement* tileElement)
         tileElement++;
         if ((tileElement - 1)->IsLastForTile())
             return false;
-    } while (tileElement->GetTypeN() != TileElementTypeN::Surface);
+    } while (tileElement->GetType() != TileElementType::Surface);
     return true;
 }
 
 BannerIndex TileElement::GetBannerIndex() const
 {
-    switch (GetTypeN())
+    switch (GetType())
     {
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
         {
             auto* sceneryEntry = AsLargeScenery()->GetEntry();
             if (sceneryEntry == nullptr || sceneryEntry->scrolling_mode == SCROLLING_MODE_NONE)
@@ -41,7 +41,7 @@ BannerIndex TileElement::GetBannerIndex() const
 
             return AsLargeScenery()->GetBannerIndex();
         }
-        case TileElementTypeN::Wall:
+        case TileElementType::Wall:
         {
             auto* wallEntry = AsWall()->GetEntry();
             if (wallEntry == nullptr || wallEntry->scrolling_mode == SCROLLING_MODE_NONE)
@@ -49,7 +49,7 @@ BannerIndex TileElement::GetBannerIndex() const
 
             return AsWall()->GetBannerIndex();
         }
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
             return AsBanner()->GetIndex();
         default:
             return BANNER_INDEX_NULL;
@@ -58,15 +58,15 @@ BannerIndex TileElement::GetBannerIndex() const
 
 void TileElement::SetBannerIndex(BannerIndex bannerIndex)
 {
-    switch (GetTypeN())
+    switch (GetType())
     {
-        case TileElementTypeN::Wall:
+        case TileElementType::Wall:
             AsWall()->SetBannerIndex(bannerIndex);
             break;
-        case TileElementTypeN::LargeScenery:
+        case TileElementType::LargeScenery:
             AsLargeScenery()->SetBannerIndex(bannerIndex);
             break;
-        case TileElementTypeN::Banner:
+        case TileElementType::Banner:
             AsBanner()->SetIndex(bannerIndex);
             break;
         default:
@@ -88,23 +88,23 @@ void TileElement::RemoveBannerEntry()
 
 ride_id_t TileElement::GetRideIndex() const
 {
-    switch (GetTypeN())
+    switch (GetType())
     {
-        case TileElementTypeN::Track:
+        case TileElementType::Track:
             return AsTrack()->GetRideIndex();
-        case TileElementTypeN::Entrance:
+        case TileElementType::Entrance:
             return AsEntrance()->GetRideIndex();
-        case TileElementTypeN::Path:
+        case TileElementType::Path:
             return AsPath()->GetRideIndex();
         default:
             return RIDE_ID_NULL;
     }
 }
 
-void TileElement::ClearAs(TileElementTypeN newType)
+void TileElement::ClearAs(TileElementType newType)
 {
     type = 0;
-    SetTypeN(newType);
+    SetType(newType);
     Flags = 0;
     base_height = MINIMUM_LAND_HEIGHT;
     clearance_height = MINIMUM_LAND_HEIGHT;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -36,7 +36,7 @@ constexpr const uint8_t OWNER_MASK = 0b00001111;
 
 #pragma pack(push, 1)
 
-enum class TileElementTypeN : uint8_t
+enum class TileElementType : uint8_t
 {
     Surface = 0,
     Path = 1,
@@ -68,8 +68,8 @@ struct TileElementBase
 
     void Remove();
 
-    TileElementTypeN GetTypeN() const;
-    void SetTypeN(TileElementTypeN newType);
+    TileElementType GetType() const;
+    void SetType(TileElementType newType);
 
     Direction GetDirection() const;
     void SetDirection(Direction direction);
@@ -99,7 +99,7 @@ struct TileElementBase
         if constexpr (std::is_same_v<TType, TileElement>)
             return reinterpret_cast<const TileElement*>(this);
         else
-            return GetTypeN() == TType::ElementType ? reinterpret_cast<const TType*>(this) : nullptr;
+            return GetType() == TType::ElementType ? reinterpret_cast<const TType*>(this) : nullptr;
     }
 
     template<typename TType> TType* as()
@@ -107,7 +107,7 @@ struct TileElementBase
         if constexpr (std::is_same_v<TType, TileElement>)
             return reinterpret_cast<TileElement*>(this);
         else
-            return GetTypeN() == TType::ElementType ? reinterpret_cast<TType*>(this) : nullptr;
+            return GetType() == TType::ElementType ? reinterpret_cast<TType*>(this) : nullptr;
     }
 
     const SurfaceElement* AsSurface() const
@@ -185,7 +185,7 @@ struct TileElement : public TileElementBase
     uint8_t pad_05[3];
     uint8_t pad_08[8];
 
-    void ClearAs(TileElementTypeN newType);
+    void ClearAs(TileElementType newType);
 
     ride_id_t GetRideIndex() const;
 
@@ -197,7 +197,7 @@ assert_struct_size(TileElement, 16);
 
 struct SurfaceElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::Surface;
+    static constexpr TileElementType ElementType = TileElementType::Surface;
 
 private:
     uint8_t Slope;
@@ -244,7 +244,7 @@ assert_struct_size(SurfaceElement, 16);
 
 struct PathElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::Path;
+    static constexpr TileElementType ElementType = TileElementType::Path;
 
 private:
     ObjectEntryIndex SurfaceIndex;  // 5
@@ -334,7 +334,7 @@ assert_struct_size(PathElement, 16);
 
 struct TrackElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::Track;
+    static constexpr TileElementType ElementType = TileElementType::Track;
 
 private:
     track_type_t TrackType;
@@ -435,7 +435,7 @@ assert_struct_size(TrackElement, 16);
 
 struct SmallSceneryElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::SmallScenery;
+    static constexpr TileElementType ElementType = TileElementType::SmallScenery;
 
 private:
     ObjectEntryIndex entryIndex; // 5
@@ -468,7 +468,7 @@ assert_struct_size(SmallSceneryElement, 16);
 
 struct LargeSceneryElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::LargeScenery;
+    static constexpr TileElementType ElementType = TileElementType::LargeScenery;
 
 private:
     ObjectEntryIndex EntryIndex;
@@ -506,7 +506,7 @@ assert_struct_size(LargeSceneryElement, 16);
 
 struct WallElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::Wall;
+    static constexpr TileElementType ElementType = TileElementType::Wall;
 
 private:
     ObjectEntryIndex entryIndex; // 05
@@ -551,7 +551,7 @@ assert_struct_size(WallElement, 16);
 
 struct EntranceElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::Entrance;
+    static constexpr TileElementType ElementType = TileElementType::Entrance;
 
 private:
     uint8_t entranceType;      // 5
@@ -596,7 +596,7 @@ assert_struct_size(EntranceElement, 16);
 
 struct BannerElement : TileElementBase
 {
-    static constexpr TileElementTypeN ElementType = TileElementTypeN::Banner;
+    static constexpr TileElementType ElementType = TileElementType::Banner;
 
 private:
     BannerIndex index;    // 5

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -36,18 +36,6 @@ constexpr const uint8_t OWNER_MASK = 0b00001111;
 
 #pragma pack(push, 1)
 
-enum
-{
-    TILE_ELEMENT_TYPE_SURFACE = (0 << 2),
-    TILE_ELEMENT_TYPE_PATH = (1 << 2),
-    TILE_ELEMENT_TYPE_TRACK = (2 << 2),
-    TILE_ELEMENT_TYPE_SMALL_SCENERY = (3 << 2),
-    TILE_ELEMENT_TYPE_ENTRANCE = (4 << 2),
-    TILE_ELEMENT_TYPE_WALL = (5 << 2),
-    TILE_ELEMENT_TYPE_LARGE_SCENERY = (6 << 2),
-    TILE_ELEMENT_TYPE_BANNER = (7 << 2),
-};
-
 enum class TileElementTypeN : uint8_t
 {
     Surface = 0,
@@ -79,8 +67,6 @@ struct TileElementBase
     uint8_t owner;            // 4
 
     void Remove();
-
-    uint8_t GetType() const;
 
     TileElementTypeN GetTypeN() const;
     void SetTypeN(TileElementTypeN newType);

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -199,7 +199,7 @@ struct TileElement : public TileElementBase
     uint8_t pad_05[3];
     uint8_t pad_08[8];
 
-    void ClearAs(uint8_t newType);
+    void ClearAs(TileElementTypeN newType);
 
     ride_id_t GetRideIndex() const;
 

--- a/src/openrct2/world/TileElementBase.cpp
+++ b/src/openrct2/world/TileElementBase.cpp
@@ -10,12 +10,12 @@
 #include "Map.h"
 #include "TileElement.h"
 
-TileElementTypeN TileElementBase::GetTypeN() const
+TileElementType TileElementBase::GetType() const
 {
-    return static_cast<TileElementTypeN>((this->type & TILE_ELEMENT_TYPE_MASK) >> 2);
+    return static_cast<TileElementType>((this->type & TILE_ELEMENT_TYPE_MASK) >> 2);
 }
 
-void TileElementBase::SetTypeN(TileElementTypeN newType)
+void TileElementBase::SetType(TileElementType newType)
 {
     this->type &= ~TILE_ELEMENT_TYPE_MASK;
     this->type |= ((EnumValue(newType) << 2) & TILE_ELEMENT_TYPE_MASK);

--- a/src/openrct2/world/TileElementBase.cpp
+++ b/src/openrct2/world/TileElementBase.cpp
@@ -10,11 +10,6 @@
 #include "Map.h"
 #include "TileElement.h"
 
-uint8_t TileElementBase::GetType() const
-{
-    return this->type & TILE_ELEMENT_TYPE_MASK;
-}
-
 TileElementTypeN TileElementBase::GetTypeN() const
 {
     return static_cast<TileElementTypeN>((this->type & TILE_ELEMENT_TYPE_MASK) >> 2);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -223,9 +223,9 @@ namespace OpenRCT2::TileInspector
             {
                 return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
             }
-            switch (tileElement->GetType())
+            switch (tileElement->GetTypeN())
             {
-                case TILE_ELEMENT_TYPE_PATH:
+                case TileElementTypeN::Path:
                     if (tileElement->AsPath()->IsSloped())
                     {
                         newRotation = (tileElement->AsPath()->GetSlopeDirection() + 1) & TILE_ELEMENT_DIRECTION_MASK;
@@ -236,7 +236,7 @@ namespace OpenRCT2::TileInspector
                     tileElement->AsPath()->SetEdges((pathEdges << 1) | (pathEdges >> 3));
                     tileElement->AsPath()->SetCorners((pathCorners << 1) | (pathCorners >> 3));
                     break;
-                case TILE_ELEMENT_TYPE_ENTRANCE:
+                case TileElementTypeN::Entrance:
                 {
                     // Update element rotation
                     newRotation = tileElement->GetDirectionWithOffset(1);
@@ -267,13 +267,13 @@ namespace OpenRCT2::TileInspector
                     }
                     break;
                 }
-                case TILE_ELEMENT_TYPE_TRACK:
-                case TILE_ELEMENT_TYPE_SMALL_SCENERY:
-                case TILE_ELEMENT_TYPE_WALL:
+                case TileElementTypeN::Track:
+                case TileElementTypeN::SmallScenery:
+                case TileElementTypeN::Wall:
                     newRotation = tileElement->GetDirectionWithOffset(1);
                     tileElement->SetDirection(newRotation);
                     break;
-                case TILE_ELEMENT_TYPE_BANNER:
+                case TileElementTypeN::Banner:
                 {
                     uint8_t unblockedEdges = tileElement->AsBanner()->GetAllowedEdges();
                     unblockedEdges = (unblockedEdges << 1 | unblockedEdges >> 3) & 0xF;
@@ -281,6 +281,9 @@ namespace OpenRCT2::TileInspector
                     tileElement->AsBanner()->SetPosition((tileElement->AsBanner()->GetPosition() + 1) & 3);
                     break;
                 }
+                case TileElementTypeN::Surface:
+                case TileElementTypeN::LargeScenery:
+                    break;
             }
 
             map_invalidate_tile_full(loc);

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -111,7 +111,7 @@ namespace OpenRCT2::TileInspector
             {
                 do
                 {
-                    if (tileElement->GetTypeN() != TileElementTypeN::LargeScenery)
+                    if (tileElement->GetType() != TileElementType::LargeScenery)
                         continue;
 
                     if (tileElement->GetDirection() != direction)
@@ -223,9 +223,9 @@ namespace OpenRCT2::TileInspector
             {
                 return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
             }
-            switch (tileElement->GetTypeN())
+            switch (tileElement->GetType())
             {
-                case TileElementTypeN::Path:
+                case TileElementType::Path:
                     if (tileElement->AsPath()->IsSloped())
                     {
                         newRotation = (tileElement->AsPath()->GetSlopeDirection() + 1) & TILE_ELEMENT_DIRECTION_MASK;
@@ -236,7 +236,7 @@ namespace OpenRCT2::TileInspector
                     tileElement->AsPath()->SetEdges((pathEdges << 1) | (pathEdges >> 3));
                     tileElement->AsPath()->SetCorners((pathCorners << 1) | (pathCorners >> 3));
                     break;
-                case TileElementTypeN::Entrance:
+                case TileElementType::Entrance:
                 {
                     // Update element rotation
                     newRotation = tileElement->GetDirectionWithOffset(1);
@@ -267,13 +267,13 @@ namespace OpenRCT2::TileInspector
                     }
                     break;
                 }
-                case TileElementTypeN::Track:
-                case TileElementTypeN::SmallScenery:
-                case TileElementTypeN::Wall:
+                case TileElementType::Track:
+                case TileElementType::SmallScenery:
+                case TileElementType::Wall:
                     newRotation = tileElement->GetDirectionWithOffset(1);
                     tileElement->SetDirection(newRotation);
                     break;
-                case TileElementTypeN::Banner:
+                case TileElementType::Banner:
                 {
                     uint8_t unblockedEdges = tileElement->AsBanner()->GetAllowedEdges();
                     unblockedEdges = (unblockedEdges << 1 | unblockedEdges >> 3) & 0xF;
@@ -281,8 +281,8 @@ namespace OpenRCT2::TileInspector
                     tileElement->AsBanner()->SetPosition((tileElement->AsBanner()->GetPosition() + 1) & 3);
                     break;
                 }
-                case TileElementTypeN::Surface:
-                case TileElementTypeN::LargeScenery:
+                case TileElementType::Surface:
+                case TileElementType::LargeScenery:
                     break;
             }
 
@@ -350,7 +350,7 @@ namespace OpenRCT2::TileInspector
             // The occupiedQuadrants will be automatically set when the element is copied over, so it's not necessary to set
             // them correctly _here_.
             TileElement* const pastedElement = tile_element_insert(
-                { loc, element.GetBaseZ() }, 0b0000, TileElementTypeN::Surface);
+                { loc, element.GetBaseZ() }, 0b0000, TileElementType::Surface);
 
             bool lastForTile = pastedElement->IsLastForTile();
             *pastedElement = element;
@@ -469,7 +469,7 @@ namespace OpenRCT2::TileInspector
 
         if (isExecuting)
         {
-            if (tileElement->GetTypeN() == TileElementTypeN::Entrance)
+            if (tileElement->GetType() == TileElementType::Entrance)
             {
                 uint8_t entranceType = tileElement->AsEntrance()->GetEntranceType();
                 if (entranceType != ENTRANCE_TYPE_PARK_ENTRANCE)
@@ -614,7 +614,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const pathElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (pathElement == nullptr || pathElement->GetTypeN() != TileElementTypeN::Path)
+        if (pathElement == nullptr || pathElement->GetType() != TileElementType::Path)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -636,7 +636,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const pathElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (pathElement == nullptr || pathElement->GetTypeN() != TileElementTypeN::Path)
+        if (pathElement == nullptr || pathElement->GetType() != TileElementType::Path)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -658,7 +658,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const pathElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (pathElement == nullptr || pathElement->GetTypeN() != TileElementTypeN::Path)
+        if (pathElement == nullptr || pathElement->GetType() != TileElementType::Path)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -681,7 +681,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const entranceElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (entranceElement == nullptr || entranceElement->GetTypeN() != TileElementTypeN::Entrance)
+        if (entranceElement == nullptr || entranceElement->GetType() != TileElementType::Entrance)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         auto ride = get_ride(entranceElement->AsEntrance()->GetRideIndex());
@@ -721,7 +721,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const wallElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (wallElement == nullptr || wallElement->GetTypeN() != TileElementTypeN::Wall)
+        if (wallElement == nullptr || wallElement->GetType() != TileElementType::Wall)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -745,7 +745,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const wallElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (wallElement == nullptr || wallElement->GetTypeN() != TileElementTypeN::Wall)
+        if (wallElement == nullptr || wallElement->GetType() != TileElementType::Wall)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -773,7 +773,7 @@ namespace OpenRCT2::TileInspector
 
         TileElement* const trackElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (trackElement == nullptr || trackElement->GetTypeN() != TileElementTypeN::Track)
+        if (trackElement == nullptr || trackElement->GetType() != TileElementType::Track)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -846,7 +846,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const trackElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (trackElement == nullptr || trackElement->GetTypeN() != TileElementTypeN::Track)
+        if (trackElement == nullptr || trackElement->GetType() != TileElementType::Track)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -928,7 +928,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const trackElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (trackElement == nullptr || trackElement->GetTypeN() != TileElementTypeN::Track)
+        if (trackElement == nullptr || trackElement->GetType() != TileElementType::Track)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -951,7 +951,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const trackElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (trackElement == nullptr || trackElement->GetTypeN() != TileElementTypeN::Track)
+        if (trackElement == nullptr || trackElement->GetType() != TileElementType::Track)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -974,7 +974,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const tileElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (tileElement == nullptr || tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+        if (tileElement == nullptr || tileElement->GetType() != TileElementType::SmallScenery)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -1001,7 +1001,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const tileElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (tileElement == nullptr || tileElement->GetTypeN() != TileElementTypeN::SmallScenery)
+        if (tileElement == nullptr || tileElement->GetType() != TileElementType::SmallScenery)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)
@@ -1025,7 +1025,7 @@ namespace OpenRCT2::TileInspector
     {
         TileElement* const bannerElement = map_get_nth_element_at(loc, elementIndex);
 
-        if (bannerElement == nullptr || bannerElement->GetTypeN() != TileElementTypeN::Banner)
+        if (bannerElement == nullptr || bannerElement->GetType() != TileElementType::Banner)
             return GameActions::Result(GameActions::Status::Unknown, STR_NONE, STR_NONE);
 
         if (isExecuting)

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -65,7 +65,7 @@ void wall_remove_intersecting_walls(const CoordsXYRangedZ& wallPos, Direction di
         return;
     do
     {
-        if (tileElement->GetTypeN() != TileElementTypeN::Wall)
+        if (tileElement->GetType() != TileElementType::Wall)
             continue;
 
         if (tileElement->GetClearanceZ() <= wallPos.baseZ || tileElement->GetBaseZ() >= wallPos.clearanceZ)

--- a/test/testpaint/generate.cpp
+++ b/test/testpaint/generate.cpp
@@ -437,7 +437,7 @@ private:
         for (int direction = 0; direction < 4; direction++)
         {
             TileElement tileElement = {};
-            tileElement.SetTypeN(TileElementTypeN::Track);
+            tileElement.SetType(TileElementType::Track);
             tileElement.SetLastForTile(true);
             tileElement.AsTrack()->SetTrackType(trackType);
             tileElement.base_height = 3;


### PR DESCRIPTION
This just leaves the RCT12TileElementType to be refactored, which will be in a PR of its own.