### PR TITLE
Fix #16197. Park award time and type accidentally swapped

### DIFF
--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1616,8 +1616,8 @@ static void WindowParkAwardsPaint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t count = 0;
     for (const auto& award : GetAwards())
     {
-        gfx_draw_sprite(dpi, ImageId(ParkAwards[award.Type].sprite), screenCoords);
-        DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, ParkAwards[award.Type].text);
+        gfx_draw_sprite(dpi, ImageId(ParkAwards[EnumValue(award.Type)].sprite), screenCoords);
+        DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, ParkAwards[EnumValue(award.Type)].text);
 
         screenCoords.y += 32;
         count++;

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -72,9 +72,9 @@ std::vector<Award>& GetAwards()
     return _currentAwards;
 }
 
-bool award_is_positive(int32_t type)
+bool award_is_positive(ParkAward type)
 {
-    return AwardPositiveMap[type];
+    return AwardPositiveMap[EnumValue(type)];
 }
 
 #pragma region Award checks
@@ -584,9 +584,9 @@ static constexpr const award_deserved_check _awardChecks[] = {
     award_is_deserved_best_gentle_rides,
 };
 
-static bool award_is_deserved(int32_t awardType, int32_t activeAwardTypes)
+static bool award_is_deserved(ParkAward awardType, int32_t activeAwardTypes)
 {
-    return _awardChecks[awardType](activeAwardTypes);
+    return _awardChecks[EnumValue(awardType)](activeAwardTypes);
 }
 
 #pragma endregion
@@ -609,27 +609,27 @@ void award_update_all()
         int32_t activeAwardTypes = 0;
         for (auto& award : _currentAwards)
         {
-            activeAwardTypes |= (1 << award.Type);
+            activeAwardTypes |= (1 << EnumValue(award.Type));
         }
 
         // Check if there was a free award entry
         if (_currentAwards.size() < MAX_AWARDS)
         {
             // Get a random award type not already active
-            uint16_t awardType;
+            ParkAward awardType;
             do
             {
-                awardType = (((scenario_rand() & 0xFF) * 17) >> 8) & 0xFF;
-            } while (activeAwardTypes & (1 << awardType));
+                awardType = static_cast<ParkAward>((((scenario_rand() & 0xFF) * EnumValue(ParkAward::Count)) >> 8) & 0xFF);
+            } while (activeAwardTypes & (1 << EnumValue(awardType)));
 
             // Check if award is deserved
             if (award_is_deserved(awardType, activeAwardTypes))
             {
                 // Add award
-                _currentAwards.push_back(Award{ awardType, 5u });
+                _currentAwards.push_back(Award{ 5u, awardType });
                 if (gConfigNotifications.park_award)
                 {
-                    News::AddItemToQueue(News::ItemType::Award, AwardNewsStrings[awardType], 0, {});
+                    News::AddItemToQueue(News::ItemType::Award, AwardNewsStrings[EnumValue(awardType)], 0, {});
                 }
                 window_invalidate_by_class(WC_PARK_INFORMATION);
             }

--- a/src/openrct2/management/Award.h
+++ b/src/openrct2/management/Award.h
@@ -13,13 +13,7 @@
 
 #include <vector>
 
-struct Award
-{
-    uint16_t Time;
-    uint16_t Type;
-};
-
-enum class ParkAward : uint8_t
+enum class ParkAward : uint16_t
 {
     MostUntidy,
     MostTidy,
@@ -38,13 +32,19 @@ enum class ParkAward : uint8_t
     MostDazzlingRideColours,
     MostConfusingLayout,
     BestGentleRides,
-    Count
+    Count // Count must be less than 32
+};
+
+struct Award
+{
+    uint16_t Time;
+    ParkAward Type;
 };
 
 #define MAX_AWARDS 4
 
 std::vector<Award>& GetAwards();
 
-bool award_is_positive(int32_t type);
+bool award_is_positive(ParkAward type);
 void award_reset();
 void award_update_all();

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -40,7 +40,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2137,7 +2137,7 @@ namespace RCT1
             {
                 if (src.time != 0)
                 {
-                    awards.push_back(Award{ src.type, src.time });
+                    awards.push_back(Award{ src.time, static_cast<ParkAward>(src.type) });
                 }
             }
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -360,7 +360,7 @@ namespace RCT2
             {
                 if (src.time != 0)
                 {
-                    awards.push_back(Award{ src.type, src.time });
+                    awards.push_back(Award{ src.time, static_cast<ParkAward>(src.type) });
                 }
             }
 


### PR DESCRIPTION
Mistake caused by incorrect types so I went and also made it type safe.