### PR TITLE
#16198: Implement custom BitSet and replace std::bitset

### DIFF
--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -14,9 +14,12 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2/Context.h>
 #include <openrct2/Input.h>
+#include <openrct2/core/BitSet.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/sprites.h>
+
+using namespace OpenRCT2;
 
 // The maximum number of rows to list before items overflow into new columns
 constexpr int32_t DROPDOWN_TEXT_MAX_ROWS = 32;
@@ -47,8 +50,8 @@ int32_t gDropdownNumItems;
 rct_string_id gDropdownItemsFormat[Dropdown::ItemsMaxSize];
 int64_t gDropdownItemsArgs[Dropdown::ItemsMaxSize];
 static ImageId _dropdownItemsImages[Dropdown::ItemsMaxSize];
-static std::bitset<Dropdown::ItemsMaxSize> _dropdownItemsChecked = {};
-static std::bitset<Dropdown::ItemsMaxSize> _dropdownItemsDisabled = {};
+static BitSet<Dropdown::ItemsMaxSize> _dropdownItemsChecked = {};
+static BitSet<Dropdown::ItemsMaxSize> _dropdownItemsDisabled = {};
 bool gDropdownIsColour;
 int32_t gDropdownLastColourHover;
 int32_t gDropdownHighlightedIndex;

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -13,11 +13,14 @@
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Game.h>
 #include <openrct2/actions/ParkMarketingAction.h>
+#include <openrct2/core/BitSet.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/ride/RideData.h>
 #include <openrct2/ride/ShopItem.h>
+
+using namespace OpenRCT2;
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_NONE;
 static constexpr const int32_t WH = 109;
@@ -95,7 +98,7 @@ private:
      */
     void GetShopItems()
     {
-        std::bitset<EnumValue(ShopItem::Count)> items = {};
+        BitSet<EnumValue(ShopItem::Count)> items = {};
         for (auto& curRide : GetRideManager())
         {
             auto rideEntry = curRide.GetRideEntry();

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -148,7 +148,7 @@ namespace OpenRCT2
         static constexpr storage_block_type block_init_value{};
         static constexpr storage_block_type block_mask_value = static_cast<storage_block_type>(~block_init_value);
 
-        static constexpr bool requires_trim = byte_aligned_bitsize != capacity_bits;
+        static constexpr bool requires_trim = TBitSize != capacity_bits;
 
     public:
         using block_type = storage_block_type;

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -1,0 +1,514 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace OpenRCT2
+{
+    namespace Detail
+    {
+        namespace BitSet
+        {
+            static constexpr size_t byte_bits = std::numeric_limits<std::underlying_type_t<std::byte>>::digits;
+
+            static constexpr size_t round_bits(size_t v)
+            {
+                const auto reminder = v % byte_bits;
+                if (reminder == 0u)
+                    return v;
+                return v + (byte_bits - (v % byte_bits));
+            }
+#ifdef _DEBUG
+            static_assert(round_bits(1) == 8);
+            static_assert(round_bits(4) == 8);
+            static_assert(round_bits(8) == 8);
+            static_assert(round_bits(9) == 16);
+#endif
+
+            // Returns the amount of bytes required for a single block.
+            static constexpr size_t storage_byte_size(size_t numBits)
+            {
+                numBits = round_bits(numBits);
+                if (numBits >= std::numeric_limits<uintptr_t>::digits)
+                    return sizeof(uintptr_t);
+
+                const auto numBytes = numBits / byte_bits;
+                auto mask = 1u;
+                while (mask < numBytes)
+                {
+                    mask <<= 1u;
+                }
+                return mask;
+            }
+
+            // TODO: Replace with std::popcount when C++20 is enabled.
+            template<typename T> static constexpr size_t popcount(const T val)
+            {
+                size_t res = 0;
+                auto x = static_cast<std::make_unsigned_t<T>>(val);
+                while (x > 0u)
+                {
+                    if (x & 1u)
+                        res++;
+                    x >>= 1u;
+                }
+                return res;
+            }
+
+#ifdef _DEBUG
+            static_assert(storage_byte_size(1) == 1);
+            static_assert(storage_byte_size(4) == 1);
+            static_assert(storage_byte_size(8) == 1);
+            static_assert(storage_byte_size(9) == 2);
+#endif
+
+            template<size_t TByteSize> struct storage_block_type;
+
+            template<> struct storage_block_type<1>
+            {
+                using value_type = uint8_t;
+            };
+
+            template<> struct storage_block_type<2>
+            {
+                using value_type = uint16_t;
+            };
+
+            template<> struct storage_block_type<4>
+            {
+                using value_type = uint32_t;
+            };
+
+            template<> struct storage_block_type<8>
+            {
+                using value_type = uint64_t;
+            };
+
+            template<size_t TBitSize> struct storage_block_type_aligned
+            {
+                using value_type = typename storage_block_type<storage_byte_size(TBitSize)>::value_type;
+            };
+        } // namespace BitSet
+    }     // namespace Detail
+
+    template<uint32_t TBitSize> class BitSet
+    {
+    public:
+        static constexpr size_t storage_capacity_bits = Detail::BitSet::round_bits(TBitSize);
+        static constexpr size_t storage_capacity_bytes = storage_capacity_bits / Detail::BitSet::byte_bits;
+
+        using storage_block_type = typename Detail::BitSet::storage_block_type_aligned<storage_capacity_bits>::value_type;
+
+        static constexpr storage_block_type value_zero = storage_block_type{ 0u };
+        static constexpr storage_block_type value_one = storage_block_type{ 1u };
+
+        static constexpr size_t block_type_bit_size = sizeof(storage_block_type) * Detail::BitSet::byte_bits;
+        static constexpr size_t block_count = storage_capacity_bits / block_type_bit_size;
+
+        static constexpr storage_block_type block_init_value{};
+        static constexpr storage_block_type block_mask_value = ~block_init_value;
+
+        static constexpr bool requires_trim = TBitSize != storage_capacity_bits;
+
+        using storage_data = std::array<storage_block_type, block_count>;
+
+        // Proxy object to access the bits as single value.
+        template<typename T> class reference_base
+        {
+            T& storage_;
+            const size_t blockIndex_;
+            const size_t blockOffset_;
+
+        public:
+            constexpr reference_base(T& data, size_t blockIndex, size_t blockOffset) noexcept
+                : storage_(data)
+                , blockIndex_(blockIndex)
+                , blockOffset_(blockOffset)
+            {
+            }
+
+            constexpr reference_base& operator=(const bool value) noexcept
+            {
+                if (!value)
+                    storage_[blockIndex_] &= ~(value_one << blockOffset_);
+                else
+                    storage_[blockIndex_] |= (value_one << blockOffset_);
+                return *this;
+            }
+
+            constexpr reference_base& operator=(const reference_base& value) noexcept
+            {
+                return reference_base::operator=(value.value());
+            }
+
+            constexpr bool value() const noexcept
+            {
+                return (storage_[blockIndex_] & (value_one << blockOffset_)) != value_zero;
+            }
+
+            constexpr operator bool() const noexcept
+            {
+                return value();
+            }
+        };
+
+        using reference = reference_base<storage_data>;
+        using const_reference = reference_base<const storage_data>;
+
+        template<typename T, typename TValue> class iterator_base
+        {
+            T* _bitset{};
+            size_t _pos{};
+
+        public:
+            constexpr iterator_base() = default;
+
+            constexpr iterator_base(T* bset, size_t pos)
+                : _bitset(bset)
+                , _pos(pos)
+            {
+            }
+
+            constexpr auto operator*() const
+            {
+                const auto blockIndex = compute_block_index(_pos);
+                const auto blockOffset = compute_block_offset(_pos);
+                return TValue(_bitset->data(), blockIndex, blockOffset);
+            }
+
+            constexpr bool operator==(iterator_base other) const
+            {
+                return _bitset == other._bitset && _pos == other._pos;
+            }
+
+            constexpr bool operator!=(iterator_base other) const
+            {
+                return !(*this == other);
+            }
+
+            constexpr iterator_base& operator++()
+            {
+                _pos++;
+                return *this;
+            }
+
+            constexpr iterator_base operator++(int)
+            {
+                iterator_base res = *this;
+                ++(*this);
+                return res;
+            }
+
+            constexpr iterator_base& operator--()
+            {
+                _pos--;
+                return *this;
+            }
+
+            constexpr iterator_base operator--(int)
+            {
+                iterator_base res = *this;
+                --(*this);
+                return res;
+            }
+
+        public:
+            using difference_type = std::size_t;
+            using value_type = TValue;
+            using pointer = const TValue*;
+            using reference = const TValue&;
+            using iterator_category = std::forward_iterator_tag;
+        };
+
+        using iterator = iterator_base<BitSet, reference>;
+        using const_iterator = iterator_base<const BitSet, const_reference>;
+
+    private:
+        storage_data data_{};
+
+    public:
+        constexpr BitSet() = default;
+
+        constexpr BitSet(const storage_block_type val)
+            : data_{ val }
+        {
+        }
+
+        constexpr BitSet(const std::initializer_list<size_t>& indices)
+        {
+            for (auto idx : indices)
+            {
+                set(idx, true);
+            }
+        }
+
+        constexpr size_t size() const noexcept
+        {
+            return TBitSize;
+        }
+
+        constexpr size_t count() const noexcept
+        {
+            size_t numBits = 0;
+            for (auto& data : data_)
+            {
+                numBits += Detail::BitSet::popcount(data);
+            }
+            return numBits;
+        }
+
+        constexpr size_t capacity() const noexcept
+        {
+            return storage_capacity_bits;
+        }
+
+        constexpr storage_data& data() noexcept
+        {
+            return data_;
+        }
+
+        constexpr const storage_data& data() const noexcept
+        {
+            return data_;
+        }
+
+        constexpr BitSet& set(size_t index, bool value) noexcept
+        {
+            const auto blockIndex = compute_block_index(index);
+            const auto blockOffset = compute_block_offset(index);
+            if (!value)
+                data_[blockIndex] &= ~(value_one << blockOffset);
+            else
+                data_[blockIndex] |= (value_one << blockOffset);
+            return *this;
+        }
+
+        constexpr bool get(size_t index) const noexcept
+        {
+            const auto blockIndex = compute_block_index(index);
+            const auto blockOffset = compute_block_offset(index);
+            return (data_[blockIndex] & (value_one << blockOffset)) != value_zero;
+        }
+
+        constexpr bool operator[](const size_t index) const noexcept
+        {
+            const auto blockIndex = compute_block_index(index);
+            const auto blockOffset = compute_block_offset(index);
+            const_reference ref(data_, blockIndex, blockOffset);
+            return ref.value();
+        }
+
+        constexpr reference operator[](const size_t index) noexcept
+        {
+            const auto blockIndex = compute_block_index(index);
+            const auto blockOffset = compute_block_offset(index);
+            return reference(data_, blockIndex, blockOffset);
+        }
+
+        constexpr BitSet& flip() noexcept
+        {
+            for (auto& data : data_)
+            {
+                data ^= block_mask_value;
+            }
+            if constexpr (requires_trim)
+            {
+                trim();
+            }
+            return *this;
+        }
+
+        constexpr BitSet& reset() noexcept
+        {
+            std::fill(data_.begin(), data_.end(), block_init_value);
+            if constexpr (requires_trim)
+            {
+                trim();
+            }
+            return *this;
+        }
+
+        constexpr const_iterator begin() const noexcept
+        {
+            return const_iterator(this, 0);
+        }
+
+        constexpr const_iterator end() const noexcept
+        {
+            return const_iterator(this, size());
+        }
+
+        constexpr iterator begin() noexcept
+        {
+            return iterator(this, 0);
+        }
+
+        constexpr iterator end() noexcept
+        {
+            return iterator(this, size());
+        }
+
+        template<class TChar = char, class TTraits = std::char_traits<TChar>, class TAlloc = std::allocator<TChar>>
+        std::basic_string<TChar, TTraits, TAlloc> to_string(TChar zero = TChar{ '0' }, TChar one = TChar{ '1' }) const
+        {
+            std::basic_string<TChar, TTraits, TAlloc> res;
+            res.resize(TBitSize);
+            for (size_t i = 0; i < TBitSize; ++i)
+            {
+                // Printed as little-endian.
+                res[TBitSize - i - 1] = get(i) ? one : zero;
+            }
+            return res;
+        }
+
+        constexpr BitSet operator^(const BitSet& other) const noexcept
+        {
+            BitSet res = *this;
+            for (size_t i = 0; i < data_.size(); i++)
+            {
+                res.data_[i] ^= other.data_[i];
+            }
+            if constexpr (requires_trim)
+            {
+                res.trim();
+            }
+            return res;
+        }
+
+        constexpr BitSet& operator^=(const BitSet& other) noexcept
+        {
+            *this = *this ^ other;
+            return *this;
+        }
+
+        constexpr BitSet operator|(const BitSet& other) const noexcept
+        {
+            BitSet res = *this;
+            for (size_t i = 0; i < data_.size(); i++)
+            {
+                res.data_[i] |= other.data_[i];
+            }
+            if constexpr (requires_trim)
+            {
+                res.trim();
+            }
+            return res;
+        }
+
+        constexpr BitSet& operator|=(const BitSet& other) noexcept
+        {
+            *this = *this | other;
+            return *this;
+        }
+
+        constexpr BitSet operator&(const BitSet& other) const noexcept
+        {
+            BitSet res = *this;
+            for (size_t i = 0; i < data_.size(); i++)
+            {
+                res.data_[i] &= other.data_[i];
+            }
+            if constexpr (requires_trim)
+            {
+                res.trim();
+            }
+            return res;
+        }
+
+        constexpr BitSet& operator&=(const BitSet& other) noexcept
+        {
+            *this = *this & other;
+            return *this;
+        }
+
+        constexpr BitSet operator~() const noexcept
+        {
+            BitSet res = *this;
+            for (size_t i = 0; i < data_.size(); i++)
+            {
+                res.data_[i] = ~res.data_[i];
+            }
+            if constexpr (requires_trim)
+            {
+                res.trim();
+            }
+            return res;
+        }
+
+        constexpr bool operator<(const BitSet& other) const noexcept
+        {
+            return std::lexicographical_compare(data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::less);
+        }
+
+        constexpr bool operator<=(const BitSet& other) const noexcept
+        {
+            return std::lexicographical_compare(
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::less_equal);
+        }
+
+        constexpr bool operator>(const BitSet& other) const noexcept
+        {
+            return std::lexicographical_compare(
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::greater);
+        }
+
+        constexpr bool operator>=(const BitSet& other) const noexcept
+        {
+            return std::lexicographical_compare(
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::greater_equal);
+        }
+
+    private:
+        static constexpr size_t compute_block_index(size_t idx) noexcept
+        {
+            if constexpr (block_count == 1)
+            {
+                return 0;
+            }
+            else
+            {
+                return idx / block_type_bit_size;
+            }
+        }
+
+        static constexpr size_t compute_block_offset(size_t idx) noexcept
+        {
+            if constexpr (block_count == 1)
+            {
+                return idx;
+            }
+            else
+            {
+                return idx % block_type_bit_size;
+            }
+        }
+
+        // Some operations require to trim of the excess.
+        constexpr void trim() noexcept
+        {
+            const auto byteIdx = TBitSize / block_type_bit_size;
+            const auto bitIdx = TBitSize % block_type_bit_size;
+            if constexpr (bitIdx == 0)
+                return;
+
+            auto trimMask = block_mask_value;
+            trimMask <<= (block_type_bit_size - bitIdx);
+            trimMask >>= (block_type_bit_size - bitIdx);
+
+            data_[byteIdx] &= trimMask;
+        }
+    };
+
+} // namespace OpenRCT2

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <string>
 
@@ -118,7 +119,7 @@ namespace OpenRCT2
         static constexpr size_t block_count = storage_capacity_bits / block_type_bit_size;
 
         static constexpr storage_block_type block_init_value{};
-        static constexpr storage_block_type block_mask_value = ~block_init_value;
+        static constexpr storage_block_type block_mask_value = static_cast<storage_block_type>(~block_init_value);
 
         static constexpr bool requires_trim = TBitSize != storage_capacity_bits;
 
@@ -449,25 +450,26 @@ namespace OpenRCT2
 
         constexpr bool operator<(const BitSet& other) const noexcept
         {
-            return std::lexicographical_compare(data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::less);
+            return std::lexicographical_compare(
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::less<storage_block_type>{});
         }
 
         constexpr bool operator<=(const BitSet& other) const noexcept
         {
             return std::lexicographical_compare(
-                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::less_equal);
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::less_equal<storage_block_type>{});
         }
 
         constexpr bool operator>(const BitSet& other) const noexcept
         {
             return std::lexicographical_compare(
-                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::greater);
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::greater<storage_block_type>{});
         }
 
         constexpr bool operator>=(const BitSet& other) const noexcept
         {
             return std::lexicographical_compare(
-                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::greater_equal);
+                data_.begin(), data_.end(), other.data_.begin(), other.data_.end(), std::greater_equal<storage_block_type>{});
         }
 
     private:

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -404,14 +404,7 @@ namespace OpenRCT2
         constexpr BitSet operator^(const BitSet& other) const noexcept
         {
             BitSet res = *this;
-            for (size_t i = 0; i < _data.size(); i++)
-            {
-                res._data[i] ^= other._data[i];
-            }
-            if constexpr (RequiresTrim)
-            {
-                res.Trim();
-            }
+            ApplyOp<std::bit_xor<BlockType>>(res, other, std::make_index_sequence<BlockCount>{});
             return res;
         }
 
@@ -424,14 +417,7 @@ namespace OpenRCT2
         constexpr BitSet operator|(const BitSet& other) const noexcept
         {
             BitSet res = *this;
-            for (size_t i = 0; i < _data.size(); i++)
-            {
-                res._data[i] |= other._data[i];
-            }
-            if constexpr (RequiresTrim)
-            {
-                res.Trim();
-            }
+            ApplyOp<std::bit_or<BlockType>>(res, other, std::make_index_sequence<BlockCount>{});
             return res;
         }
 
@@ -444,14 +430,7 @@ namespace OpenRCT2
         constexpr BitSet operator&(const BitSet& other) const noexcept
         {
             BitSet res = *this;
-            for (size_t i = 0; i < _data.size(); i++)
-            {
-                res._data[i] &= other._data[i];
-            }
-            if constexpr (RequiresTrim)
-            {
-                res.Trim();
-            }
+            ApplyOp<std::bit_and<BlockType>>(res, other, std::make_index_sequence<BlockCount>{});
             return res;
         }
 
@@ -500,6 +479,17 @@ namespace OpenRCT2
         }
 
     private:
+        template<typename TOperator, size_t... TIndex>
+        void ApplyOp(BitSet& dst, const BitSet& src, std::index_sequence<TIndex...>) const
+        {
+            TOperator op{};
+            ((dst._data[TIndex] = op(dst._data[TIndex], src._data[TIndex])), ...);
+            if constexpr (RequiresTrim)
+            {
+                dst.Trim();
+            }
+        }
+
         static constexpr size_t ComputeBlockIndex(size_t idx) noexcept
         {
             if constexpr (BlockCount == 1)

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -103,7 +103,7 @@ namespace OpenRCT2
         } // namespace BitSet
     }     // namespace Detail
 
-    template<uint32_t TBitSize> class BitSet
+    template<size_t TBitSize> class BitSet
     {
     public:
         static constexpr size_t storage_capacity_bits = Detail::BitSet::round_bits(TBitSize);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1854,9 +1854,9 @@ Ride* Guest::FindBestRideToGoOn()
     return mostExcitingRide;
 }
 
-std::bitset<MAX_RIDES> Guest::FindRidesToGoOn()
+BitSet<MAX_RIDES> Guest::FindRidesToGoOn()
 {
-    std::bitset<MAX_RIDES> rideConsideration;
+    BitSet<MAX_RIDES> rideConsideration;
 
     // FIX  Originally checked for a toy, likely a mistake and should be a map,
     //      but then again this seems to only allow the peep to go on
@@ -3111,7 +3111,7 @@ template<typename T> static void peep_head_for_nearest_ride(Guest* peep, bool co
         }
     }
 
-    std::bitset<MAX_RIDES> rideConsideration;
+    BitSet<MAX_RIDES> rideConsideration;
     if (!considerOnlyCloseRides && (peep->HasItem(ShopItem::Map)))
     {
         // Consider all rides in the park

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -9,12 +9,11 @@
 
 #pragma once
 
+#include "../core/BitSet.hpp"
 #include "../management/Finance.h"
 #include "../ride/Ride.h"
 #include "../ride/ShopItem.h"
 #include "Peep.h"
-
-#include <bitset>
 
 #define PEEP_MAX_THOUGHTS 5
 
@@ -32,6 +31,8 @@
 #define PEEP_MAX_TOILET 255
 #define PEEP_MAX_NAUSEA 255
 #define PEEP_MAX_THIRST 255
+
+using namespace OpenRCT2;
 
 enum class PeepThoughtType : uint8_t
 {
@@ -419,7 +420,7 @@ private:
     void MakePassingPeepsSick(Guest* passingPeep);
     void GivePassingPeepsIceCream(Guest* passingPeep);
     Ride* FindBestRideToGoOn();
-    std::bitset<MAX_RIDES> FindRidesToGoOn();
+    BitSet<MAX_RIDES> FindRidesToGoOn();
     bool FindVehicleToEnter(Ride* ride, std::vector<uint8_t>& car_array);
     void GoToRideEntrance(Ride* ride);
 };

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -32,8 +32,6 @@
 #define PEEP_MAX_NAUSEA 255
 #define PEEP_MAX_THIRST 255
 
-using namespace OpenRCT2;
-
 enum class PeepThoughtType : uint8_t
 {
     CantAffordRide = 0,   // "I can't afford"
@@ -420,7 +418,7 @@ private:
     void MakePassingPeepsSick(Guest* passingPeep);
     void GivePassingPeepsIceCream(Guest* passingPeep);
     Ride* FindBestRideToGoOn();
-    BitSet<MAX_RIDES> FindRidesToGoOn();
+    OpenRCT2::BitSet<MAX_RIDES> FindRidesToGoOn();
     bool FindVehicleToEnter(Ride* ride, std::vector<uint8_t>& car_array);
     void GoToRideEntrance(Ride* ride);
 };

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="config\IniReader.hpp" />
     <ClInclude Include="config\IniWriter.hpp" />
     <ClInclude Include="Context.h" />
+    <ClInclude Include="core\BitSet.hpp" />
     <ClInclude Include="core\ChecksumStream.h" />
     <ClInclude Include="core\CircularBuffer.h" />
     <ClInclude Include="core\Collections.hpp" />

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -13,6 +13,7 @@
 #include "../OpenRCT2.h"
 #include "../actions/ParkSetResearchFundingAction.h"
 #include "../config/Config.h"
+#include "../core/BitSet.hpp"
 #include "../core/Guard.hpp"
 #include "../core/Memory.hpp"
 #include "../interface/Window.h"
@@ -35,6 +36,8 @@
 
 #include <algorithm>
 #include <iterator>
+
+using namespace OpenRCT2;
 
 static constexpr const int32_t _researchRate[] = {
     0,
@@ -966,7 +969,7 @@ bool ResearchItem::operator==(const ResearchItem& rhs) const
     return (entryIndex == rhs.entryIndex && baseRideType == rhs.baseRideType && type == rhs.type);
 }
 
-static std::bitset<RIDE_TYPE_COUNT> _seenRideType = {};
+static BitSet<RIDE_TYPE_COUNT> _seenRideType = {};
 
 static void research_update_first_of_type(ResearchItem* researchItem)
 {

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1936,7 +1936,7 @@ static void get_ride_queue_end(TileCoordsXYZ& loc)
  * appropriate.
  */
 static StationIndex guest_pathfinding_select_random_station(
-    const Guest* guest, int32_t numEntranceStations, std::bitset<MAX_STATIONS>& entranceStations)
+    const Guest* guest, int32_t numEntranceStations, BitSet<MAX_STATIONS>& entranceStations)
 {
     int32_t select = guest->GuestNumRides % numEntranceStations;
     while (select > 0)
@@ -2174,7 +2174,7 @@ int32_t guest_path_finding(Guest* peep)
     StationIndex closestStationNum = 0;
 
     int32_t numEntranceStations = 0;
-    std::bitset<MAX_STATIONS> entranceStations = {};
+    BitSet<MAX_STATIONS> entranceStations = {};
 
     for (StationIndex stationNum = 0; stationNum < MAX_STATIONS; ++stationNum)
     {

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -23,6 +23,8 @@
 #include <bitset>
 #include <cstring>
 
+using namespace OpenRCT2;
+
 static bool _peepPathFindIsStaff;
 static int8_t _peepPathFindNumJunctions;
 static int8_t _peepPathFindMaxJunctions;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -15,6 +15,7 @@
 #include "../ParkImporter.h"
 #include "../actions/WallPlaceAction.h"
 #include "../audio/audio.h"
+#include "../core/BitSet.hpp"
 #include "../core/Collections.hpp"
 #include "../core/Console.hpp"
 #include "../core/FileStream.h"
@@ -119,8 +120,8 @@ namespace RCT1
         ObjectEntryIndex _footpathRailingsTypeToEntryMap[4]{};
 
         // Research
-        std::bitset<MAX_RIDE_OBJECTS> _researchRideEntryUsed{};
-        std::bitset<EnumValue(RideType::Count)> _researchRideTypeUsed{};
+        BitSet<MAX_RIDE_OBJECTS> _researchRideEntryUsed{};
+        BitSet<EnumValue(RideType::Count)> _researchRideTypeUsed{};
 
         // Scenario repository - used for determining scenario name
         IScenarioRepository* _scenarioRepository = GetScenarioRepository();
@@ -422,7 +423,7 @@ namespace RCT1
         {
             size_t researchListCount;
             const ResearchItem* researchList = GetResearchList(&researchListCount);
-            std::bitset<EnumValue(RideType::Count)> rideTypeInResearch = GetRideTypesPresentInResearchList(
+            BitSet<EnumValue(RideType::Count)> rideTypeInResearch = GetRideTypesPresentInResearchList(
                 researchList, researchListCount);
             for (size_t i = 0; i < researchListCount; i++)
             {
@@ -2052,10 +2053,10 @@ namespace RCT1
             }
         }
 
-        static std::bitset<EnumValue(RideType::Count)> GetRideTypesPresentInResearchList(
+        static BitSet<EnumValue(RideType::Count)> GetRideTypesPresentInResearchList(
             const RCT1::ResearchItem* researchList, size_t researchListCount)
         {
-            std::bitset<EnumValue(RideType::Count)> ret = {};
+            BitSet<EnumValue(RideType::Count)> ret = {};
 
             for (size_t i = 0; i < researchListCount; i++)
             {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -73,7 +73,6 @@
 #include "../world/TilePointerIndex.hpp"
 
 #include <algorithm>
-#include <bitset>
 
 namespace RCT2
 {
@@ -91,7 +90,7 @@ namespace RCT2
         S6Data _s6{};
         uint8_t _gameVersion = 0;
         bool _isSV7 = false;
-        BitSet<Limits::MaxRidesInPark> _isFlatRide{};
+        OpenRCT2::BitSet<Limits::MaxRidesInPark> _isFlatRide{};
         ObjectEntryIndex _pathToSurfaceMap[16];
         ObjectEntryIndex _pathToQueueSurfaceMap[16];
         ObjectEntryIndex _pathToRailingMap[16];

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -91,7 +91,7 @@ namespace RCT2
         S6Data _s6{};
         uint8_t _gameVersion = 0;
         bool _isSV7 = false;
-        std::bitset<Limits::MaxRidesInPark> _isFlatRide{};
+        BitSet<Limits::MaxRidesInPark> _isFlatRide{};
         ObjectEntryIndex _pathToSurfaceMap[16];
         ObjectEntryIndex _pathToQueueSurfaceMap[16];
         ObjectEntryIndex _pathToRailingMap[16];

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -18,6 +18,7 @@
 #include "../ParkImporter.h"
 #include "../audio/audio.h"
 #include "../config/Config.h"
+#include "../core/BitSet.hpp"
 #include "../core/Guard.hpp"
 #include "../core/Random.hpp"
 #include "../entity/Duck.h"
@@ -53,7 +54,6 @@
 #include "ScenarioSources.h"
 
 #include <algorithm>
-#include <bitset>
 
 const rct_string_id ScenarioCategoryStringIds[SCENARIO_CATEGORY_COUNT] = {
     STR_BEGINNER_PARKS, STR_CHALLENGING_PARKS,    STR_EXPERT_PARKS, STR_REAL_PARKS, STR_OTHER_PARKS,
@@ -658,7 +658,7 @@ ObjectiveStatus Objective::CheckParkValueBy() const
 ObjectiveStatus Objective::Check10RollerCoasters() const
 {
     auto rcs = 0;
-    std::bitset<MAX_RIDE_OBJECTS> type_already_counted;
+    BitSet<MAX_RIDE_OBJECTS> type_already_counted;
     for (const auto& ride : GetRideManager())
     {
         if (ride.status == RideStatus::Open && ride.excitement >= RIDE_RATING(6, 00) && ride.subtype != OBJECT_ENTRY_INDEX_NULL)
@@ -757,7 +757,7 @@ ObjectiveStatus Objective::CheckMonthlyRideIncome() const
  */
 ObjectiveStatus Objective::Check10RollerCoastersLength() const
 {
-    std::bitset<MAX_RIDE_OBJECTS> type_already_counted;
+    BitSet<MAX_RIDE_OBJECTS> type_already_counted;
     auto rcs = 0;
     for (const auto& ride : GetRideManager())
     {

--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -1,0 +1,228 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <openrct2/core/BitSet.hpp>
+
+using namespace OpenRCT2;
+
+TEST(BitTest, test_index_construction)
+{
+    BitSet<64> bits({ 0u, 2u, 4u, 6u, 8u, 10u });
+#ifdef _M_X64
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint64_t>);
+#else
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint32_t>);
+#endif
+    constexpr auto size = sizeof(bits);
+    static_assert(size == 8u);
+
+    ASSERT_EQ(bits.data()[0], 0b10101010101);
+    ASSERT_EQ(bits.to_string(), std::string("0000000000000000000000000000000000000000000000000000010101010101"));
+}
+
+TEST(BitTest, test_basic)
+{
+    BitSet<8> bits;
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
+    constexpr auto size = sizeof(bits);
+    static_assert(size == sizeof(uint8_t));
+
+    bits[0] = true;
+    ASSERT_EQ(bits[0], true);
+    bits[6] = true;
+    ASSERT_EQ(bits[6], true);
+    bits[0] = false;
+    ASSERT_EQ(bits[0], false);
+    bits[0] = bits[6];
+    ASSERT_EQ(bits[0], true);
+    ASSERT_EQ(bits.data()[0u], 0b01000001);
+    ASSERT_EQ(bits.to_string(), std::string("01000001"));
+}
+
+TEST(BitTest, test_flip)
+{
+    BitSet<8> bits;
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
+    constexpr auto size = sizeof(bits);
+    static_assert(size == sizeof(uint8_t));
+
+    bits.flip();
+    ASSERT_EQ(bits.data()[0u], 0xFFu);
+    bits.flip();
+    ASSERT_EQ(bits.data()[0u], 0x00u);
+}
+
+TEST(BitTest, test_trim8)
+{
+    BitSet<5> bits;
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
+    constexpr auto size = sizeof(bits);
+    static_assert(size == sizeof(uint8_t));
+
+    bits.flip();
+    ASSERT_EQ(bits[5], false);
+    ASSERT_EQ(bits[6], false);
+    ASSERT_EQ(bits[7], false);
+    ASSERT_EQ(bits.data()[0u], 0b00011111);
+}
+
+TEST(BitTest, test_trim16)
+{
+    BitSet<14> bits;
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint16_t>);
+    constexpr auto size = sizeof(bits);
+    static_assert(size == sizeof(uint16_t));
+
+    bits.flip();
+    ASSERT_EQ(bits[14], false);
+    ASSERT_EQ(bits[15], false);
+    ASSERT_EQ(bits.data()[0u], 0b0011111111111111);
+    ASSERT_EQ(bits.to_string(), std::string("11111111111111"));
+}
+
+TEST(BitTest, test_big)
+{
+    BitSet<256> bits;
+    constexpr auto size = sizeof(bits);
+    static_assert(size == 32u);
+
+    bits.flip();
+#ifdef _M_X64
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint64_t>);
+    ASSERT_EQ(bits.data()[0], ~0ULL);
+    ASSERT_EQ(bits.data()[1], ~0ULL);
+    ASSERT_EQ(bits.data()[2], ~0ULL);
+    ASSERT_EQ(bits.data()[3], ~0ULL);
+#else
+    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint32_t>);
+    ASSERT_EQ(bits.data()[0], ~0UL);
+    ASSERT_EQ(bits.data()[1], ~0UL);
+    ASSERT_EQ(bits.data()[2], ~0UL);
+    ASSERT_EQ(bits.data()[3], ~0UL);
+    ASSERT_EQ(bits.data()[4], ~0UL);
+    ASSERT_EQ(bits.data()[5], ~0UL);
+    ASSERT_EQ(bits.data()[6], ~0UL);
+    ASSERT_EQ(bits.data()[7], ~0UL);
+#endif
+}
+
+TEST(BitTest, test_xor5)
+{
+    BitSet<5> bits1({ 0u, 2u, 4u });
+    BitSet<5> bits2({ 0u, 1u, 3u });
+
+    auto res = bits1 ^ bits2;
+    ASSERT_EQ(res.data()[0], 0b11110);
+    ASSERT_EQ(res.to_string(), "11110");
+}
+
+TEST(BitTest, test_xor15)
+{
+    BitSet<15> bits1({ 0u, 2u, 4u });
+    BitSet<15> bits2({ 0u, 1u, 3u, 14u });
+
+    auto res = bits1 ^ bits2;
+    ASSERT_EQ(res.data()[0], 0b0100000000011110);
+    ASSERT_EQ(res.to_string(), "100000000011110");
+}
+
+TEST(BitTest, test_or5)
+{
+    BitSet<5> bits1({ 0u, 2u, 4u });
+    BitSet<5> bits2({ 0u, 1u, 3u });
+
+    auto res = bits1 | bits2;
+    ASSERT_EQ(res.data()[0], 0b11111);
+    ASSERT_EQ(res.to_string(), "11111");
+}
+
+TEST(BitTest, test_or15)
+{
+    BitSet<15> bits1({ 0u, 2u, 4u });
+    BitSet<15> bits2({ 0u, 1u, 3u, 14u });
+
+    auto res = bits1 | bits2;
+    ASSERT_EQ(res.data()[0], 0b0100000000011111);
+    ASSERT_EQ(res.to_string(), "100000000011111");
+}
+
+TEST(BitTest, test_and5)
+{
+    BitSet<5> bits1({ 0u, 2u, 4u });
+    BitSet<5> bits2({ 0u, 1u, 3u });
+
+    auto res = bits1 & bits2;
+    ASSERT_EQ(res.data()[0], 0b1);
+    ASSERT_EQ(res.to_string(), "00001");
+}
+
+TEST(BitTest, test_and15)
+{
+    BitSet<15> bits1({ 0u, 2u, 4u });
+    BitSet<15> bits2({ 0u, 1u, 3u, 14u });
+
+    auto res = bits1 & bits2;
+    ASSERT_EQ(res.data()[0], 0b1);
+    ASSERT_EQ(res.to_string(), "000000000000001");
+}
+
+TEST(BitTest, test_neg5)
+{
+    BitSet<5> bits1({ 0u, 2u, 4u });
+
+    auto res = ~bits1;
+    ASSERT_EQ(res.data()[0], 0b01010);
+    ASSERT_EQ(res.to_string(), "01010");
+}
+
+TEST(BitTest, test_neg15)
+{
+    BitSet<15> bits1({ 0u, 2u, 4u });
+
+    auto res = ~bits1;
+    ASSERT_EQ(res.data()[0], 0b111111111101010);
+    ASSERT_EQ(res.to_string(), "111111111101010");
+}
+
+TEST(BitTest, test_count)
+{
+    BitSet<31> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
+    ASSERT_EQ(bits1.count(), 10u);
+}
+
+TEST(BitTest, test_iterator)
+{
+    BitSet<31> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
+
+    int totalBits = 0;
+    for (auto v : bits1)
+    {
+        if (v)
+            totalBits++;
+    }
+    ASSERT_EQ(totalBits, 10);
+}
+
+TEST(BitTest, test_iterator_const)
+{
+    BitSet<31> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
+
+    int totalBits = 0;
+    auto test = [&](const auto& b) {
+        for (auto v : b)
+        {
+            if (v)
+                totalBits++;
+        }
+    };
+
+    test(bits1);
+    ASSERT_EQ(totalBits, 10);
+}

--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -14,7 +14,7 @@ using namespace OpenRCT2;
 
 TEST(BitTest, test_index_construction)
 {
-    BitSet<64> bits({ 0u, 2u, 4u, 6u, 8u, 10u });
+    BitSet<64u> bits({ 0u, 2u, 4u, 6u, 8u, 10u });
 #ifdef _M_X64
     static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint64_t>);
 #else
@@ -23,13 +23,13 @@ TEST(BitTest, test_index_construction)
     constexpr auto size = sizeof(bits);
     static_assert(size == 8u);
 
-    ASSERT_EQ(bits.data()[0], 0b10101010101);
+    ASSERT_EQ(bits.data()[0], 0b10101010101U);
     ASSERT_EQ(bits.to_string(), std::string("0000000000000000000000000000000000000000000000000000010101010101"));
 }
 
 TEST(BitTest, test_basic)
 {
-    BitSet<8> bits;
+    BitSet<8u> bits;
     static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
@@ -42,13 +42,13 @@ TEST(BitTest, test_basic)
     ASSERT_EQ(bits[0], false);
     bits[0] = bits[6];
     ASSERT_EQ(bits[0], true);
-    ASSERT_EQ(bits.data()[0u], 0b01000001);
+    ASSERT_EQ(bits.data()[0u], 0b01000001U);
     ASSERT_EQ(bits.to_string(), std::string("01000001"));
 }
 
 TEST(BitTest, test_flip)
 {
-    BitSet<8> bits;
+    BitSet<8u> bits;
     static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
@@ -61,7 +61,7 @@ TEST(BitTest, test_flip)
 
 TEST(BitTest, test_trim8)
 {
-    BitSet<5> bits;
+    BitSet<5u> bits;
     static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
@@ -70,12 +70,12 @@ TEST(BitTest, test_trim8)
     ASSERT_EQ(bits[5], false);
     ASSERT_EQ(bits[6], false);
     ASSERT_EQ(bits[7], false);
-    ASSERT_EQ(bits.data()[0u], 0b00011111);
+    ASSERT_EQ(bits.data()[0u], 0b00011111u);
 }
 
 TEST(BitTest, test_trim16)
 {
-    BitSet<14> bits;
+    BitSet<14u> bits;
     static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint16_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint16_t));
@@ -83,13 +83,13 @@ TEST(BitTest, test_trim16)
     bits.flip();
     ASSERT_EQ(bits[14], false);
     ASSERT_EQ(bits[15], false);
-    ASSERT_EQ(bits.data()[0u], 0b0011111111111111);
+    ASSERT_EQ(bits.data()[0u], 0b0011111111111111u);
     ASSERT_EQ(bits.to_string(), std::string("11111111111111"));
 }
 
 TEST(BitTest, test_big)
 {
-    BitSet<256> bits;
+    BitSet<256u> bits;
     constexpr auto size = sizeof(bits);
     static_assert(size == 32u);
 
@@ -115,28 +115,28 @@ TEST(BitTest, test_big)
 
 TEST(BitTest, test_xor5)
 {
-    BitSet<5> bits1({ 0u, 2u, 4u });
-    BitSet<5> bits2({ 0u, 1u, 3u });
+    BitSet<5u> bits1({ 0u, 2u, 4u });
+    BitSet<5u> bits2({ 0u, 1u, 3u });
 
     auto res = bits1 ^ bits2;
-    ASSERT_EQ(res.data()[0], 0b11110);
+    ASSERT_EQ(res.data()[0], 0b11110u);
     ASSERT_EQ(res.to_string(), "11110");
 }
 
 TEST(BitTest, test_xor15)
 {
-    BitSet<15> bits1({ 0u, 2u, 4u });
-    BitSet<15> bits2({ 0u, 1u, 3u, 14u });
+    BitSet<15u> bits1({ 0u, 2u, 4u });
+    BitSet<15u> bits2({ 0u, 1u, 3u, 14u });
 
     auto res = bits1 ^ bits2;
-    ASSERT_EQ(res.data()[0], 0b0100000000011110);
+    ASSERT_EQ(res.data()[0], 0b0100000000011110u);
     ASSERT_EQ(res.to_string(), "100000000011110");
 }
 
 TEST(BitTest, test_or5)
 {
-    BitSet<5> bits1({ 0u, 2u, 4u });
-    BitSet<5> bits2({ 0u, 1u, 3u });
+    BitSet<5u> bits1({ 0u, 2u, 4u });
+    BitSet<5u> bits2({ 0u, 1u, 3u });
 
     auto res = bits1 | bits2;
     ASSERT_EQ(res.data()[0], 0b11111);
@@ -145,18 +145,18 @@ TEST(BitTest, test_or5)
 
 TEST(BitTest, test_or15)
 {
-    BitSet<15> bits1({ 0u, 2u, 4u });
-    BitSet<15> bits2({ 0u, 1u, 3u, 14u });
+    BitSet<15u> bits1({ 0u, 2u, 4u });
+    BitSet<15u> bits2({ 0u, 1u, 3u, 14u });
 
     auto res = bits1 | bits2;
-    ASSERT_EQ(res.data()[0], 0b0100000000011111);
+    ASSERT_EQ(res.data()[0], 0b0100000000011111u);
     ASSERT_EQ(res.to_string(), "100000000011111");
 }
 
 TEST(BitTest, test_and5)
 {
-    BitSet<5> bits1({ 0u, 2u, 4u });
-    BitSet<5> bits2({ 0u, 1u, 3u });
+    BitSet<5u> bits1({ 0u, 2u, 4u });
+    BitSet<5u> bits2({ 0u, 1u, 3u });
 
     auto res = bits1 & bits2;
     ASSERT_EQ(res.data()[0], 0b1);
@@ -165,8 +165,8 @@ TEST(BitTest, test_and5)
 
 TEST(BitTest, test_and15)
 {
-    BitSet<15> bits1({ 0u, 2u, 4u });
-    BitSet<15> bits2({ 0u, 1u, 3u, 14u });
+    BitSet<15u> bits1({ 0u, 2u, 4u });
+    BitSet<15u> bits2({ 0u, 1u, 3u, 14u });
 
     auto res = bits1 & bits2;
     ASSERT_EQ(res.data()[0], 0b1);
@@ -175,31 +175,31 @@ TEST(BitTest, test_and15)
 
 TEST(BitTest, test_neg5)
 {
-    BitSet<5> bits1({ 0u, 2u, 4u });
+    BitSet<5u> bits1({ 0u, 2u, 4u });
 
     auto res = ~bits1;
-    ASSERT_EQ(res.data()[0], 0b01010);
+    ASSERT_EQ(res.data()[0], 0b01010u);
     ASSERT_EQ(res.to_string(), "01010");
 }
 
 TEST(BitTest, test_neg15)
 {
-    BitSet<15> bits1({ 0u, 2u, 4u });
+    BitSet<15u> bits1({ 0u, 2u, 4u });
 
     auto res = ~bits1;
-    ASSERT_EQ(res.data()[0], 0b111111111101010);
+    ASSERT_EQ(res.data()[0], 0b111111111101010u);
     ASSERT_EQ(res.to_string(), "111111111101010");
 }
 
 TEST(BitTest, test_count)
 {
-    BitSet<31> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
+    BitSet<31u> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
     ASSERT_EQ(bits1.count(), 10u);
 }
 
 TEST(BitTest, test_iterator)
 {
-    BitSet<31> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
+    BitSet<31u> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
 
     int totalBits = 0;
     for (auto v : bits1)
@@ -212,7 +212,7 @@ TEST(BitTest, test_iterator)
 
 TEST(BitTest, test_iterator_const)
 {
-    BitSet<31> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
+    BitSet<31u> bits1({ 0u, 2u, 4u, 7u, 9u, 12u, 16u, 19u, 22u, 29u });
 
     int totalBits = 0;
     auto test = [&](const auto& b) {

--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -103,7 +103,7 @@ TEST(BitTest, test_big)
     ASSERT_EQ(bits.data()[3], ~0ULL);
 #else
     static_assert(std::is_same_v<decltype(bits)::block_type, uint32_t>);
-    static_assert(bits.data().size() ==);
+    static_assert(bits.data().size() == 8);
     ASSERT_EQ(bits.data()[0], ~0UL);
     ASSERT_EQ(bits.data()[1], ~0UL);
     ASSERT_EQ(bits.data()[2], ~0UL);

--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -16,9 +16,9 @@ TEST(BitTest, test_index_construction)
 {
     BitSet<64u> bits({ 0u, 2u, 4u, 6u, 8u, 10u });
 #ifdef _M_X64
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint64_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint64_t>);
 #else
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint32_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint32_t>);
 #endif
     constexpr auto size = sizeof(bits);
     static_assert(size == 8u);
@@ -30,7 +30,7 @@ TEST(BitTest, test_index_construction)
 TEST(BitTest, test_basic)
 {
     BitSet<8u> bits;
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
 
@@ -49,7 +49,7 @@ TEST(BitTest, test_basic)
 TEST(BitTest, test_flip)
 {
     BitSet<8u> bits;
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
 
@@ -62,7 +62,7 @@ TEST(BitTest, test_flip)
 TEST(BitTest, test_trim8)
 {
     BitSet<5u> bits;
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint8_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
 
@@ -76,7 +76,7 @@ TEST(BitTest, test_trim8)
 TEST(BitTest, test_trim16)
 {
     BitSet<14u> bits;
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint16_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint16_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint16_t));
 
@@ -95,13 +95,15 @@ TEST(BitTest, test_big)
 
     bits.flip();
 #ifdef _M_X64
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint64_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint64_t>);
+    static_assert(bits.data().size() == 4);
     ASSERT_EQ(bits.data()[0], ~0ULL);
     ASSERT_EQ(bits.data()[1], ~0ULL);
     ASSERT_EQ(bits.data()[2], ~0ULL);
     ASSERT_EQ(bits.data()[3], ~0ULL);
 #else
-    static_assert(std::is_same_v<decltype(bits)::storage_block_type, uint32_t>);
+    static_assert(std::is_same_v<decltype(bits)::block_type, uint32_t>);
+    static_assert(bits.data().size() ==);
     ASSERT_EQ(bits.data()[0], ~0UL);
     ASSERT_EQ(bits.data()[1], ~0UL);
     ASSERT_EQ(bits.data()[2], ~0UL);

--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -16,9 +16,9 @@ TEST(BitTest, test_index_construction)
 {
     BitSet<64u> bits({ 0u, 2u, 4u, 6u, 8u, 10u });
 #ifdef _M_X64
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint64_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint64_t>);
 #else
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint32_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint32_t>);
 #endif
     constexpr auto size = sizeof(bits);
     static_assert(size == 8u);
@@ -30,7 +30,7 @@ TEST(BitTest, test_index_construction)
 TEST(BitTest, test_basic)
 {
     BitSet<8u> bits;
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint8_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
 
@@ -49,7 +49,7 @@ TEST(BitTest, test_basic)
 TEST(BitTest, test_flip)
 {
     BitSet<8u> bits;
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint8_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
 
@@ -62,7 +62,7 @@ TEST(BitTest, test_flip)
 TEST(BitTest, test_trim8)
 {
     BitSet<5u> bits;
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint8_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint8_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint8_t));
 
@@ -76,7 +76,7 @@ TEST(BitTest, test_trim8)
 TEST(BitTest, test_trim16)
 {
     BitSet<14u> bits;
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint16_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint16_t>);
     constexpr auto size = sizeof(bits);
     static_assert(size == sizeof(uint16_t));
 
@@ -95,14 +95,14 @@ TEST(BitTest, test_big)
 
     bits.flip();
 #ifdef _M_X64
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint64_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint64_t>);
     static_assert(bits.data().size() == 4);
     ASSERT_EQ(bits.data()[0], ~0ULL);
     ASSERT_EQ(bits.data()[1], ~0ULL);
     ASSERT_EQ(bits.data()[2], ~0ULL);
     ASSERT_EQ(bits.data()[3], ~0ULL);
 #else
-    static_assert(std::is_same_v<decltype(bits)::block_type, uint32_t>);
+    static_assert(std::is_same_v<decltype(bits)::BlockType, uint32_t>);
     static_assert(bits.data().size() == 8);
     ASSERT_EQ(bits.data()[0], ~0UL);
     ASSERT_EQ(bits.data()[1], ~0UL);

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -56,6 +56,7 @@
     <ClInclude Include="TestData.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="BitSetTests.cpp" />
     <ClCompile Include="CircularBuffer.cpp" />
     <ClCompile Include="CLITests.cpp" />
     <ClCompile Include="CryptTests.cpp" />


### PR DESCRIPTION
A few key differences to std::bitset
```cpp
sizeof(BitSet<1>) == 1
sizeof(BitSet<15>) == 2
sizeof(BitSet<24>) == 4
sizeof(BitSet<44>) == 8
```
Where std::bitset
```cpp
sizeof(std::bitset<1>) == sizeof(size_t)
sizeof(std::bitset<15>) == sizeof(size_t)
sizeof(std::bitset<24>) == sizeof(size_t)
sizeof(std::bitset<44>) == sizeof(size_t)
```

Also supports initialization for indices:
```cpp
BitSet<12> bits({1, 5, 9});
// Has bit 1, 5, 9 set.
```

Construction for biggest possible value:
```cpp
BitSet<64> bits(0xDEADBEEFF00ULL);
// Assigns the 64 bit value.
```
In case of
```cpp
BitSet<128> bits(0xDEADBEEFF00ULL);
```
Would only be able to assign the first 64 bits.

Also to note: Currently shift and rotate is not implemented, we don't really use it and can be done when needed as they can be quite complex for when its bigger than the pointer size.

Closes #16198