### PR TITLE
Make `srcX` and `srcY` work with indexed images

### DIFF
--- a/src/openrct2/drawing/ImageImporter.cpp
+++ b/src/openrct2/drawing/ImageImporter.cpp
@@ -92,6 +92,7 @@ std::vector<int32_t> ImageImporter::GetPixels(
 
     if (flags & IMPORT_FLAGS::KEEP_PALETTE)
     {
+        palettedSrc += srcX + srcY * pitch;
         for (uint32_t y = 0; y < height; y++)
         {
             for (uint32_t x = 0; x < width; x++)


### PR DESCRIPTION
Currently, the .parkobj loader ignores the `srcX` and `srcY` properties if the "palette":"keep" flag is set. This PR fixes that.