### PR TITLE
Improved: [#16251] Plugin API handles null values better.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Improved: [#3517] Cheats are now saved with the park.
 - Improved: [#10150] Ride stations are now properly checked if they’re sheltered.
 - Improved: [#10664, #16072] Visibility status can be modified directly in the Tile Inspector's list.
+- Improved: [#16251] Plugin API handles null values better.
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15998] Cannot set map size to the actual maximum.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -585,15 +585,13 @@ declare global {
     }
 
     type TileElementType =
-        "surface" | "footpath" | "track" | "small_scenery" | "wall" | "entrance" | "large_scenery" | "banner"
-        /** This only exist to retrieve the types for existing corrupt elements. For hiding elements, use the isHidden field instead. */
-        | "openrct2_corrupt_deprecated";
+        "surface" | "footpath" | "track" | "small_scenery" | "wall" | "entrance" | "large_scenery" | "banner";
 
     type Direction = 0 | 1 | 2 | 3;
 
     type TileElement =
         SurfaceElement | FootpathElement | TrackElement | SmallSceneryElement | WallElement | EntranceElement
-        | LargeSceneryElement | BannerElement | CorruptElement;
+        | LargeSceneryElement | BannerElement;
 
     interface BaseTileElement {
         type: TileElementType;
@@ -624,9 +622,9 @@ declare global {
     interface FootpathElement extends BaseTileElement {
         type: "footpath";
 
-        object: number;
-        surfaceObject: number;
-        railingsObject: number;
+        object: number | null; /** Legacy footpaths, still in use. */
+        surfaceObject: number | null; /** NSF footpaths */
+        railingsObject: number | null; /** NSF footpaths */
 
         edges: number;
         corners: number;
@@ -697,8 +695,8 @@ declare global {
         ride: number;
         station: number;
         sequence: number;
-        footpathObject: number;
-        footpathSurfaceObject: number;
+        footpathObject: number | null;
+        footpathSurfaceObject: number | null;
     }
 
     interface LargeSceneryElement extends BaseTileElement {
@@ -716,10 +714,6 @@ declare global {
         type: "banner";
         direction: Direction;
         bannerIndex: number;
-    }
-
-    interface CorruptElement extends BaseTileElement {
-        type: "openrct2_corrupt_deprecated";
     }
 
     /**
@@ -2686,7 +2680,7 @@ declare global {
          * Gets the image index range for a predefined set of images.
          * @param name The name of the image set.
          */
-        getPredefinedRange(name: string) : ImageIndexRange | null;
+        getPredefinedRange(name: string): ImageIndexRange | null;
 
         /**
          * Gets the list of available ranges of unallocated images.

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 41;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 42;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/world/ScTileElement.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.hpp
@@ -79,34 +79,34 @@ namespace OpenRCT2::Scripting
         void parkFences_set(uint8_t value);
 
         DukValue trackType_get() const;
-        void trackType_set(uint8_t value);
+        void trackType_set(uint16_t value);
 
         DukValue rideType_get() const;
         void rideType_set(uint16_t value);
 
         DukValue sequence_get() const;
-        void sequence_set(uint8_t value);
+        void sequence_set(const DukValue& value);
 
         DukValue ride_get() const;
-        void ride_set(int32_t value);
+        void ride_set(const DukValue& value);
 
         DukValue station_get() const;
-        void station_set(uint8_t value);
+        void station_set(const DukValue& value);
 
         DukValue hasChainLift_get() const;
         void hasChainLift_set(bool value);
 
         DukValue mazeEntry_get() const;
-        void mazeEntry_set(uint16_t value);
+        void mazeEntry_set(const DukValue& value);
 
         DukValue colourScheme_get() const;
-        void colourScheme_set(uint8_t value);
+        void colourScheme_set(const DukValue& value);
 
         DukValue seatRotation_get() const;
-        void seatRotation_set(uint8_t value);
+        void seatRotation_set(const DukValue& value);
 
         DukValue brakeBoosterSpeed_get() const;
-        void brakeBoosterSpeed_set(uint8_t value);
+        void brakeBoosterSpeed_set(const DukValue& value);
 
         DukValue isInverted_get() const;
         void isInverted_set(bool value);
@@ -142,7 +142,7 @@ namespace OpenRCT2::Scripting
         void tertiaryColour_set(uint8_t value);
 
         DukValue bannerIndex_get() const;
-        void bannerIndex_set(uint16_t value);
+        void bannerIndex_set(const DukValue& value);
 
         // Deprecated in favor of seperate 'edges' and 'corners' properties,
         // left here to maintain compatibility with older plugins.
@@ -182,13 +182,13 @@ namespace OpenRCT2::Scripting
         void railingsObject_set(const DukValue& value);
 
         DukValue additionStatus_get() const;
-        void additionStatus_set(uint8_t value);
+        void additionStatus_set(const DukValue& value);
 
         DukValue isAdditionBroken_get() const;
-        void isAdditionBroken_set(bool value);
+        void isAdditionBroken_set(const DukValue& value);
 
         DukValue isAdditionGhost_get() const;
-        void isAdditionGhost_set(bool value);
+        void isAdditionGhost_set(const DukValue& value);
 
         DukValue footpathObject_get() const;
         void footpathObject_set(const DukValue& value);


### PR DESCRIPTION
The plugin API throws a lot of errors in situations where users do not expect it. This PR tries to improve this for all `TileElement`s.
Goals of this PR:
- `element.prop = element.prop` should not throw an error
- `element.prop = element.prop` should not change any data
- `element.prop = [value]` should do nothing if `prop` is not in use.
- `element.prop = null` should do nothing if `prop` is in use and `null` is no meaningful value in this context.
- If `element.prop = [value];` changed the property's value, `element.prop` should then return `[value]`.
- `element.prop` should return `null` if `prop` is not in use.

The third and fourth are important because e.g. `footpath.additionStatus` shares memory with `footpath.rideIndex`.

Changes in the API specification:
- Removed `CorruptElement` (deprecated).
- Made `footpath.object`, `footpath.surfaceObject`, `footpath.railingsObject`, `entrance.footpathObject` and `entrance.footpathSurfaceObject` nullable.
- (Added a missing space.)

Changes in the API implementation:
- Increased `OPENRCT2_PLUGIN_API_VERSION`.
- Fixed `ScTileElement::trackType_set` to accept `uint16_t` value.
- For each nullable property, setters can now handle null values without throwing an error. For details, see `ScTileElement.cpp` or `ScTileElement.hpp`.